### PR TITLE
Clarify loops and centralize exports module

### DIFF
--- a/exports.py
+++ b/exports.py
@@ -1,98 +1,10 @@
-"""Unified export functions for trend analysis results."""
+"""Temporary re-export of ``trend_analysis.export`` for backward compatibility."""
 
-from __future__ import annotations
+from trend_analysis.export import *  # noqa: F401,F403
 
-from pathlib import Path
-from typing import Callable, Iterable, Mapping
-
-import pandas as pd
-
-Formatter = Callable[[pd.DataFrame], pd.DataFrame]
-
-
-def _ensure_dir(path: Path) -> None:
-    """Create parent directories for the given path."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-
-
-def _apply_format(df: pd.DataFrame, formatter: Formatter | None) -> pd.DataFrame:
-    """Return ``df`` after applying the optional ``formatter``."""
-    return formatter(df) if formatter else df
-
-
-def export_to_excel(
-    data: Mapping[str, pd.DataFrame],
-    output_path: str,
-    formatter: Formatter | None = None,
-) -> None:
-    """Export dataframes to an Excel workbook."""
-    path = Path(output_path)
-    _ensure_dir(path)
-    with pd.ExcelWriter(path) as writer:
-        for sheet, df in data.items():
-            formatted = _apply_format(df, formatter)
-            formatted.to_excel(writer, sheet_name=sheet, index=False)
-
-
-def export_to_csv(
-    data: Mapping[str, pd.DataFrame],
-    output_path: str,
-    formatter: Formatter | None = None,
-) -> None:
-    """Export each dataframe to an individual CSV file using ``output_path`` as prefix."""
-    prefix = Path(output_path)
-    _ensure_dir(prefix)
-    for name, df in data.items():
-        formatted = _apply_format(df, formatter)
-        formatted.to_csv(prefix.with_name(f"{prefix.stem}_{name}.csv"), index=False)
-
-
-def export_to_json(
-    data: Mapping[str, pd.DataFrame],
-    output_path: str,
-    formatter: Formatter | None = None,
-) -> None:
-    """Export each dataframe to an individual JSON file using ``output_path`` as prefix."""
-    prefix = Path(output_path)
-    _ensure_dir(prefix)
-    for name, df in data.items():
-        formatted = _apply_format(df, formatter)
-        formatted.to_json(
-            prefix.with_name(f"{prefix.stem}_{name}.json"), orient="records", indent=2
-        )
-
-
-EXPORTERS: dict[
-    str, Callable[[Mapping[str, pd.DataFrame], str, Formatter | None], None]
-] = {
-    "xlsx": export_to_excel,
-    "csv": export_to_csv,
-    "json": export_to_json,
-}
-
-
-def export_data(
-    data: Mapping[str, pd.DataFrame],
-    output_path: str,
-    formats: Iterable[str],
-    formatter: Formatter | None = None,
-) -> None:
-    """Export ``data`` to the specified ``formats``.
-
-    Parameters
-    ----------
-    data:
-        Mapping of sheet names to DataFrames.
-    output_path:
-        Base path for exported files. Extension will be replaced per format.
-    formats:
-        Iterable of format strings, e.g. ["xlsx", "csv", "json"].
-    formatter:
-        Optional function applied to each DataFrame before saving.
-    """
-    for fmt in formats:
-        exporter = EXPORTERS.get(fmt)
-        if exporter is None:
-            raise ValueError(f"Unsupported format: {fmt}")
-        path = str(Path(output_path).with_suffix(f".{fmt}"))
-        exporter(data, path, formatter)
+__all__ = [
+    "export_to_excel",
+    "export_to_csv",
+    "export_to_json",
+    "export_data",
+]

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -3,7 +3,7 @@ import pathlib
 import pandas as pd
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
-from exports import export_data
+from trend_analysis.export import export_data
 
 
 def test_export_data(tmp_path):

--- a/trend_analysis/analyze.py
+++ b/trend_analysis/analyze.py
@@ -57,6 +57,8 @@ def run_analysis(
     in_sample = df.loc[in_mask, selected]
     out_sample = df.loc[out_mask, selected]
 
+    # Iterating over the small ``selected`` list keeps the logic easy to read
+    # and the performance impact negligible compared to a vectorised approach.
     good = [
         c
         for c in selected
@@ -66,10 +68,14 @@ def run_analysis(
     selected = good
 
     if w_dict is None:
+        # Explicitly loop over ``selected`` to build the weights dictionary.
+        # The list is tiny, so clarity is preferred over micro-optimisation.
         w_dict = {f: 1 / len(selected) for f in selected} if selected else {}
     result: Dict[str, object] = {
         "selected_funds": selected,
         "fund_weights": w_dict,
+        # Calculate means per fund using small dictionary comprehensions for
+        # readability since only a handful of columns are involved.
         "in_sample_mean": {f: float(in_sample[f].mean()) for f in selected},
         "out_sample_mean": {f: float(out_sample[f].mean()) for f in selected},
         "dropped": dropped,

--- a/trend_analysis/export.py
+++ b/trend_analysis/export.py
@@ -1,0 +1,98 @@
+"""Export helpers for trend analysis results."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Iterable, Mapping
+
+import pandas as pd
+
+Formatter = Callable[[pd.DataFrame], pd.DataFrame]
+
+
+def _ensure_dir(path: Path) -> None:
+    """Create parent directories for the given path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _apply_format(df: pd.DataFrame, formatter: Formatter | None) -> pd.DataFrame:
+    """Return ``df`` after applying the optional ``formatter``."""
+    return formatter(df) if formatter else df
+
+
+def export_to_excel(
+    data: Mapping[str, pd.DataFrame],
+    output_path: str,
+    formatter: Formatter | None = None,
+) -> None:
+    """Export dataframes to an Excel workbook."""
+    path = Path(output_path)
+    _ensure_dir(path)
+    with pd.ExcelWriter(path) as writer:
+        # We must iterate over the mapping of DataFrames so each becomes its own
+        # sheet. A vectorised approach would obscure the intent here.
+        for sheet, df in data.items():
+            formatted = _apply_format(df, formatter)
+            formatted.to_excel(writer, sheet_name=sheet, index=False)
+
+
+def export_to_csv(
+    data: Mapping[str, pd.DataFrame],
+    output_path: str,
+    formatter: Formatter | None = None,
+) -> None:
+    """Export each dataframe to an individual CSV file using ``output_path`` as prefix."""
+    prefix = Path(output_path)
+    _ensure_dir(prefix)
+    # Looping over the ``data`` dictionary ensures each frame gets its own file.
+    for name, df in data.items():
+        formatted = _apply_format(df, formatter)
+        formatted.to_csv(prefix.with_name(f"{prefix.stem}_{name}.csv"), index=False)
+
+
+def export_to_json(
+    data: Mapping[str, pd.DataFrame],
+    output_path: str,
+    formatter: Formatter | None = None,
+) -> None:
+    """Export each dataframe to an individual JSON file using ``output_path`` as prefix."""
+    prefix = Path(output_path)
+    _ensure_dir(prefix)
+    # Iterate over the mapping so each DataFrame is written to its own JSON file.
+    for name, df in data.items():
+        formatted = _apply_format(df, formatter)
+        formatted.to_json(
+            prefix.with_name(f"{prefix.stem}_{name}.json"), orient="records", indent=2
+        )
+
+
+EXPORTERS: dict[
+    str, Callable[[Mapping[str, pd.DataFrame], str, Formatter | None], None]
+] = {
+    "xlsx": export_to_excel,
+    "csv": export_to_csv,
+    "json": export_to_json,
+}
+
+
+def export_data(
+    data: Mapping[str, pd.DataFrame],
+    output_path: str,
+    formats: Iterable[str],
+    formatter: Formatter | None = None,
+) -> None:
+    """Export ``data`` to the specified ``formats``."""
+    for fmt in formats:
+        exporter = EXPORTERS.get(fmt)
+        if exporter is None:
+            raise ValueError(f"Unsupported format: {fmt}")
+        path = str(Path(output_path).with_suffix(f".{fmt}"))
+        exporter(data, path, formatter)
+
+
+__all__ = [
+    "export_to_excel",
+    "export_to_csv",
+    "export_to_json",
+    "export_data",
+]


### PR DESCRIPTION
## Summary
- document why list/dict comprehensions are used in `analyze.run_analysis`
- move export helpers to `trend_analysis/export.py` with comments
- keep `exports.py` as temporary re-export module
- adjust export tests for new import path

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a370985588331b477d46a23f32278