### PR TITLE
Add full coverage tests for trend_analysis

### DIFF
--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,51 @@
+import sys
+import pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import pandas as pd
+from trend_analysis.analyze import run_analysis
+
+
+def make_df():
+    dates = pd.date_range("2020-01-01", periods=4, freq="M")
+    return pd.DataFrame({
+        "Date": dates,
+        "A": [0.1, 0.2, 0.3, 0.4],
+        "B": [float("nan"), 0.2, 0.1, 0.2],
+    })
+
+
+def test_run_analysis_drops_and_weights():
+    df = make_df()
+    res = run_analysis(
+        df,
+        selected=["A", "B"],
+        w_vec=None,
+        w_dict=None,
+        rf_col="A",
+        in_start="2020-01",
+        in_end="2020-02",
+        out_start="2020-03",
+        out_end="2020-04",
+    )
+    assert res["selected_funds"] == ["A"]
+    assert res["dropped"] == ["B"]
+    assert res["fund_weights"] == {"A": 1.0}
+    assert res["in_sample_mean"]["A"] == 0.1
+    assert res["out_sample_mean"]["A"] == 0.3
+
+
+def test_run_analysis_custom_weights():
+    df = make_df()
+    res = run_analysis(
+        df,
+        selected=["A"],
+        w_vec=None,
+        w_dict={"A": 0.7},
+        rf_col="A",
+        in_start="2020-01",
+        in_end="2020-02",
+        out_start="2020-03",
+        out_end="2020-04",
+    )
+    assert res["selected_funds"] == ["A"]
+    assert res["fund_weights"] == {"A": 0.7}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,3 +9,25 @@ def test_load_defaults():
     cfg = config.load()
     assert cfg.version
     assert "data" in cfg.model_dump()
+
+import yaml
+
+def test_load_custom(tmp_path):
+    cfg_path = tmp_path / "cfg.yml"
+    yaml.dump(
+        {
+            "version": "x",
+            "data": {},
+            "preprocessing": {},
+            "vol_adjust": {},
+            "sample_split": {},
+            "portfolio": {},
+            "metrics": {},
+            "export": {},
+            "run": {},
+        },
+        open(cfg_path, "w"),
+    )
+    cfg = config.load(str(cfg_path))
+    assert cfg.version == "x"
+

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,52 @@
+import logging
+import pandas as pd
+import pytest
+from trend_analysis.data import load_csv
+
+
+def test_load_csv_success(tmp_path, caplog):
+    p = tmp_path / "ok.csv"
+    df = pd.DataFrame({"Date": pd.date_range("2020-01-01", periods=2), "A": [1, 2]})
+    df.to_csv(p, index=False)
+    with caplog.at_level(logging.WARNING):
+        loaded = load_csv(str(p))
+    pd.testing.assert_frame_equal(loaded, df)
+
+
+def test_load_csv_missing_file(tmp_path):
+    assert load_csv(str(tmp_path / "none.csv")) is None
+
+
+def test_load_csv_empty(tmp_path):
+    p = tmp_path / "empty.csv"
+    p.write_text("")
+    assert load_csv(str(p)) is None
+
+
+def test_load_csv_parser_error(tmp_path):
+    p = tmp_path / "bad.csv"
+    p.write_text('A,B\n1,"2')
+    assert load_csv(str(p)) is None
+
+
+def test_load_csv_no_date_column(tmp_path):
+    p = tmp_path / "nodate.csv"
+    pd.DataFrame({"A": [1]}).to_csv(p, index=False)
+    assert load_csv(str(p)) is None
+
+
+def test_load_csv_missing_date_after_read(monkeypatch, tmp_path):
+    def fake_read_csv(*args, **kwargs):
+        return pd.DataFrame({"A": [1]})
+    monkeypatch.setattr(pd, "read_csv", fake_read_csv)
+    assert load_csv("irrelevant.csv") is None
+
+
+def test_load_csv_null_dates(tmp_path, caplog):
+    p = tmp_path / "null.csv"
+    df = pd.DataFrame({"Date": [pd.NaT, pd.Timestamp("2020-01-01")], "A": [1, 2]})
+    df.to_csv(p, index=False)
+    with caplog.at_level(logging.WARNING):
+        loaded = load_csv(str(p))
+    assert "Null values" in caplog.text
+    assert loaded is not None

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,7 @@
+from trend_analysis.io import pct
+
+
+def test_pct():
+    values = (0.1, 0.2, 3.0, 4.0, 0.5)
+    result = pct(values)
+    assert result == [10.0, 20.0, 3.0, 4.0, 50.0]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -6,6 +6,7 @@ from trend_analysis import metrics
 
 import pandas as pd
 import numpy as np
+import pytest
 
 
 def test_annualize_return_series():
@@ -43,3 +44,117 @@ def test_max_drawdown_dataframe():
     wealth = (1 + df["a"]).cumprod()
     expected = (1 - wealth / wealth.cummax()).max()
     assert np.isclose(result["a"], expected)
+
+def test_validate_input_error():
+    with pytest.raises(TypeError):
+        metrics._validate_input([1, 2, 3])
+
+
+def test_annualize_return_edges():
+    assert np.isnan(metrics.annualize_return(pd.Series([], dtype=float)))
+    s = pd.Series([-2.0])
+    assert metrics.annualize_return(s) == -1.0
+    df = pd.DataFrame({"a": [0.01, 0.02], "b": [0.0, 0.0]})
+    res = metrics.annualize_return(df, axis=0)
+    assert isinstance(res, pd.Series)
+
+
+def test_annualize_volatility_short_series():
+    s = pd.Series([0.01])
+    assert np.isnan(metrics.annualize_volatility(s))
+    df = pd.DataFrame({"a": [0.01, 0.02]})
+    assert isinstance(metrics.annualize_volatility(df), pd.Series)
+
+
+def test_sharpe_ratio_branches(monkeypatch):
+    r = pd.DataFrame({"a": [0.02, 0.03, -0.01], "b": [0.01, 0.01, 0.01]})
+    rf = pd.Series([0.0, 0.0, 0.0])
+
+    class WrappedDF(pd.DataFrame):
+        def __init__(self, data=None, **kwargs):
+            if isinstance(data, dict):
+                data = {k: (v if hasattr(v, "__len__") and not isinstance(v, float) else [v]) for k, v in data.items()}
+            super().__init__(data, **kwargs)
+
+    monkeypatch.setattr(metrics, "DataFrame", WrappedDF)
+    r = WrappedDF(r)
+
+    res = metrics.sharpe_ratio(r, rf)
+    assert isinstance(res, (pd.Series, pd.DataFrame))
+    res2 = metrics.sharpe_ratio(r["a"], WrappedDF(WrappedDF(WrappedDF(rf.to_frame("x")))))
+    assert isinstance(res2, pd.Series)
+    assert np.isnan(metrics.sharpe_ratio(pd.Series([0.0, 0.0]), pd.Series([0.0, 0.0])))
+    with pytest.raises(TypeError):
+        metrics.sharpe_ratio([1, 2], rf)
+
+
+def test_sortino_ratio_branches(monkeypatch):
+    r = pd.DataFrame({"a": [0.02, -0.03, 0.01], "b": [-0.01, -0.02, -0.01]})
+    rf = pd.Series([0.0, 0.0, 0.0])
+
+    class WrappedDF(pd.DataFrame):
+        def __init__(self, data=None, **kwargs):
+            if isinstance(data, dict):
+                data = {k: (v if hasattr(v, "__len__") and not isinstance(v, float) else [v]) for k, v in data.items()}
+            super().__init__(data, **kwargs)
+
+    monkeypatch.setattr(metrics, "DataFrame", WrappedDF)
+    r = WrappedDF(r)
+
+    assert isinstance(metrics.sortino_ratio(r, rf), (pd.Series, pd.DataFrame))
+    res = metrics.sortino_ratio(r["a"], WrappedDF(rf.to_frame("x")))
+    assert isinstance(res, pd.Series)
+    assert np.isnan(metrics.sortino_ratio(pd.Series([0.01, 0.02]), pd.Series([0.01, 0.02])))
+    with pytest.raises(TypeError):
+        metrics.sortino_ratio([0.1], rf)
+
+
+def test_max_drawdown_empty_series():
+    assert np.isnan(metrics.max_drawdown(pd.Series(dtype=float)))
+
+
+def test_sharpe_ratio_short_series():
+    r = pd.Series([0.01])
+    rf = pd.Series([0.0])
+    assert np.isnan(metrics.sharpe_ratio(r, rf))
+
+
+def test_sharpe_ratio_typeerror_branch(monkeypatch):
+    monkeypatch.setattr(metrics, "_validate_input", lambda obj: None)
+    class Dummy:
+        pass
+    with pytest.raises(TypeError):
+        metrics.sharpe_ratio(Dummy([0.1]), Dummy([0.2]))
+
+
+def test_sortino_ratio_short_series():
+    r = pd.Series([0.02])
+    rf = pd.Series([0.0])
+    assert np.isnan(metrics.sortino_ratio(r, rf))
+
+
+def test_sortino_ratio_typeerror_branch(monkeypatch):
+    monkeypatch.setattr(metrics, "_validate_input", lambda obj: None)
+    class Dummy:
+        pass
+    with pytest.raises(TypeError):
+        metrics.sortino_ratio(Dummy([0.1]), Dummy([0.2]))
+
+
+def test_sharpe_ratio_dataframe_false_branch(monkeypatch):
+    class MyDF(pd.DataFrame):
+        pass
+    monkeypatch.setattr(metrics, "_validate_input", lambda obj: None)
+    monkeypatch.setattr(metrics, "DataFrame", MyDF)
+    with pytest.raises(TypeError):
+        metrics.sharpe_ratio(pd.DataFrame({"a": [0.1]}), MyDF({"a": [0.1]}))
+
+
+def test_sortino_ratio_dataframe_false_branch(monkeypatch):
+    class MyDF(pd.DataFrame):
+        pass
+    monkeypatch.setattr(metrics, "_validate_input", lambda obj: None)
+    monkeypatch.setattr(metrics, "DataFrame", MyDF)
+    with pytest.raises(TypeError):
+        metrics.sortino_ratio(pd.DataFrame({"a": [0.1]}), MyDF({"a": [0.1]}))
+


### PR DESCRIPTION
## Summary
- add missing unit tests for analyze, config, data, io, and metrics modules
- reach 100% branch coverage for trend_analysis

## Testing
- `pytest --cov=trend_analysis --cov-branch --cov-report term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4103e2288331a082f180c549010f