### PR TITLE
Restore valid JSON structure in main notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains experiments and utilities for analyzing volatility-adju
 ## Notebooks
 
 - `Vol_Adj_Trend_Analysis1.2.TrEx.ipynb` – an earlier version of the analysis.
-- `Vol_Adj_Trend_Analysis1.3.TrEx.ipynb` – the current main notebook showing the full workflow.
+- `Vol_Adj_Trend_Analysis1.4.TrEx.ipynb` – the current main notebook showing the full workflow.
 - Additional historical notebooks can be found under `notebooks/old` and `Old/`.
 
 ## Setup
@@ -23,7 +23,7 @@ This repository contains experiments and utilities for analyzing volatility-adju
    # or
    jupyter notebook
    ```
-3. Open `Vol_Adj_Trend_Analysis1.3.TrEx.ipynb` and run the cells in order.
+3. Open `Vol_Adj_Trend_Analysis1.4.TrEx.ipynb` and run the cells in order.
 
 ## Applying patches
 

--- a/Vol_Adj_Trend_Analysis1.4.TrEx.ipynb
+++ b/Vol_Adj_Trend_Analysis1.4.TrEx.ipynb
@@ -839,4 +839,3 @@
  "nbformat": 4,
  "nbformat_minor": 5
 }
-main


### PR DESCRIPTION
## Summary
- reverted the main notebook to the version from before the stray text was appended
- trimmed the extraneous `main` string so the notebook ends with a valid closing brace

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b5776070483319a26df3a7c14a9b6