### PR TITLE
Implement risk-free fund helper

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -51,3 +51,18 @@ def test_load_csv_null_dates(tmp_path):
     assert df is not None
 
 
+def test_identify_risk_free_fund_basic():
+    dates = pd.date_range("2020-01-31", periods=3, freq="M")
+    df = pd.DataFrame({
+        "Date": dates,
+        "A": [0.02, 0.01, 0.03],
+        "B": [0.01, 0.01, 0.01],
+    })
+    assert data_mod.identify_risk_free_fund(df) == "B"
+
+
+def test_identify_risk_free_fund_no_numeric():
+    df = pd.DataFrame({"Date": ["2020-01-01"], "A": ["x"]})
+    assert data_mod.identify_risk_free_fund(df) is None
+
+

--- a/trend_analysis/data.py
+++ b/trend_analysis/data.py
@@ -42,3 +42,21 @@ def load_csv(path: str) -> Optional[pd.DataFrame]:
         logger.warning(f"Null values found in 'Date' column of {path}")
 
     return df
+
+
+def identify_risk_free_fund(df: pd.DataFrame) -> Optional[str]:
+    """Return the column with the lowest standard deviation.
+
+    Columns named 'Date' or non-numeric dtypes are ignored. ``None`` is
+    returned when no suitable columns are found.
+    """
+
+    num_cols = [c for c in df.select_dtypes("number").columns if c != "Date"]
+    if not num_cols:
+        return None
+    rf = df[num_cols].std(skipna=True).idxmin()
+    logger.info("Risk-free column: %s", rf)
+    return rf
+
+
+__all__ = ["load_csv", "identify_risk_free_fund"]


### PR DESCRIPTION
## Summary
- add helper `identify_risk_free_fund` in `trend_analysis.data`
- test risk-free helper in `tests/test_data.py`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b77437ee08331b6be6fd9ff3348b5