### PR TITLE
Remove deprecated pd.date_range alias

### DIFF
--- a/tests/test_analyze_module.py
+++ b/tests/test_analyze_module.py
@@ -4,13 +4,15 @@ from trend_analysis import analyze
 
 
 def _make_df():
-    dates = pd.date_range("2020-01-31", periods=6, freq="M")
-    return pd.DataFrame({
-        "Date": dates,
-        "A": [np.nan, 0.02, 0.03, 0.03, 0.02, 0.01],
-        "B": [0.02, 0.01, 0.02, 0.01, 0.03, 0.02],
-        "RF": 0.0,
-    })
+    dates = pd.date_range("2020-01-31", periods=6, freq="ME")
+    return pd.DataFrame(
+        {
+            "Date": dates,
+            "A": [np.nan, 0.02, 0.03, 0.03, 0.02, 0.01],
+            "B": [0.02, 0.01, 0.02, 0.01, 0.03, 0.02],
+            "RF": 0.0,
+        }
+    )
 
 
 def test_run_analysis_drop_and_weights():
@@ -44,5 +46,3 @@ def test_run_analysis_custom_weights():
         "2020-06",
     )
     assert res["fund_weights"] == {"A": 0.2, "B": 0.8}
-
-

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -52,17 +52,17 @@ def test_load_csv_null_dates(tmp_path):
 
 
 def test_identify_risk_free_fund_basic():
-    dates = pd.date_range("2020-01-31", periods=3, freq="M")
-    df = pd.DataFrame({
-        "Date": dates,
-        "A": [0.02, 0.01, 0.03],
-        "B": [0.01, 0.01, 0.01],
-    })
+    dates = pd.date_range("2020-01-31", periods=3, freq="ME")
+    df = pd.DataFrame(
+        {
+            "Date": dates,
+            "A": [0.02, 0.01, 0.03],
+            "B": [0.01, 0.01, 0.01],
+        }
+    )
     assert data_mod.identify_risk_free_fund(df) == "B"
 
 
 def test_identify_risk_free_fund_no_numeric():
     df = pd.DataFrame({"Date": ["2020-01-01"], "A": ["x"]})
     assert data_mod.identify_risk_free_fund(df) is None
-
-

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,7 +14,12 @@ def make_cfg(tmp_path, df):
         "data": {"csv_path": str(csv)},
         "preprocessing": {},
         "vol_adjust": {"target_vol": 1.0},
-        "sample_split": {"in_start": "2020-01", "in_end": "2020-03", "out_start": "2020-04", "out_end": "2020-06"},
+        "sample_split": {
+            "in_start": "2020-01",
+            "in_end": "2020-03",
+            "out_start": "2020-04",
+            "out_end": "2020-06",
+        },
         "portfolio": {},
         "metrics": {},
         "export": {},
@@ -24,12 +29,14 @@ def make_cfg(tmp_path, df):
 
 
 def make_df():
-    dates = pd.date_range("2020-01-31", periods=6, freq="M")
-    return pd.DataFrame({
-        "Date": dates,
-        "RF": 0.0,
-        "A": [0.02, 0.01, 0.03, 0.04, 0.02, 0.01],
-    })
+    dates = pd.date_range("2020-01-31", periods=6, freq="ME")
+    return pd.DataFrame(
+        {
+            "Date": dates,
+            "RF": 0.0,
+            "A": [0.02, 0.01, 0.03, 0.04, 0.02, 0.01],
+        }
+    )
 
 
 def test_run_returns_dataframe(tmp_path):
@@ -40,7 +47,9 @@ def test_run_returns_dataframe(tmp_path):
 
 
 def test_run_returns_empty_when_no_funds(tmp_path, monkeypatch):
-    df = pd.DataFrame({"Date": pd.date_range("2020-01-31", periods=1, freq="M"), "RF": 0.0})
+    df = pd.DataFrame(
+        {"Date": pd.date_range("2020-01-31", periods=1, freq="ME"), "RF": 0.0}
+    )
     cfg = make_cfg(tmp_path, df)
     result = pipeline.run(cfg)
     assert result.empty
@@ -65,7 +74,9 @@ def test_env_override(tmp_path, monkeypatch):
 
 
 def test_run_analysis_none():
-    res = pipeline.run_analysis(None, "2020-01", "2020-03", "2020-04", "2020-06", 1.0, 0.0)
+    res = pipeline.run_analysis(
+        None, "2020-01", "2020-03", "2020-04", "2020-06", 1.0, 0.0
+    )
     assert res is None
 
 
@@ -78,13 +89,19 @@ def test_run_analysis_missing_date():
 def test_run_analysis_string_dates():
     df = make_df()
     df["Date"] = df["Date"].astype(str)
-    res = pipeline.run_analysis(df, "2020-01", "2020-03", "2020-04", "2020-06", 1.0, 0.0)
+    res = pipeline.run_analysis(
+        df, "2020-01", "2020-03", "2020-04", "2020-06", 1.0, 0.0
+    )
     assert res is not None
 
 
 def test_run_analysis_no_funds():
-    df = pd.DataFrame({"Date": pd.date_range("2020-01-31", periods=3, freq="M"), "RF": 0.0})
-    res = pipeline.run_analysis(df, "2020-01", "2020-02", "2020-03", "2020-03", 1.0, 0.0)
+    df = pd.DataFrame(
+        {"Date": pd.date_range("2020-01-31", periods=3, freq="ME"), "RF": 0.0}
+    )
+    res = pipeline.run_analysis(
+        df, "2020-01", "2020-02", "2020-03", "2020-03", 1.0, 0.0
+    )
     assert res is None
 
 

--- a/tests/test_run_analysis.py
+++ b/tests/test_run_analysis.py
@@ -11,7 +11,7 @@ from trend_analysis.metrics import (
 
 
 def make_df():
-    dates = pd.date_range("2020-01-31", periods=6, freq="M")
+    dates = pd.date_range("2020-01-31", periods=6, freq="ME")
     data = {
         "Date": dates,
         "RF": 0.0,


### PR DESCRIPTION
## Summary
- switch pandas date_range freq from `M` to `ME` in tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7c2d33f88331afcc9fcb5ad4cfa5