### PR TITLE
Fix missing import in workbook

### DIFF
--- a/Vol_Adj_Trend_Analysis1.4.TrEx.ipynb
+++ b/Vol_Adj_Trend_Analysis1.4.TrEx.ipynb
@@ -46,7 +46,7 @@
     "import ipywidgets as widgets\n",
     "from ipyfilechooser import FileChooser\n",
     "from IPython.display import display, clear_output\n",
-    "from trend_analysis.data import load_csv\n",
+    "from trend_analysis.data import load_csv, identify_risk_free_fund\n",
     "from trend_analysis.core.rank_selection import (\n",
     "    FundSelectionConfig,\n",
     "    RiskStatsConfig,\n",


### PR DESCRIPTION
## Summary
- import `identify_risk_free_fund` in main notebook to avoid NameError

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b83a32b808331a7f98d5cef599baf