### PR TITLE
Fix summary formatter export

### DIFF
--- a/trend_analysis/exports.py
+++ b/trend_analysis/exports.py
@@ -3,6 +3,8 @@
 from trend_analysis.export import *  # noqa: F401,F403
 
 __all__ = [
+    "register_formatter_excel",
+    "make_summary_formatter",
     "export_to_excel",
     "export_to_csv",
     "export_to_json",


### PR DESCRIPTION
## Summary
- add `make_summary_formatter` to temporary `exports` re-export
- ensure backward compatibility for older notebooks expecting the function

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b88f822a88331baef661f8c12ea78