### PR TITLE
Fix export helper availability

### DIFF
--- a/trend_analysis/__init__.py
+++ b/trend_analysis/__init__.py
@@ -1,13 +1,28 @@
 """Trend analysis package."""
 
-from . import metrics, config, data, pipeline
+from . import metrics, config, data, pipeline, export
 from .data import load_csv, identify_risk_free_fund
+from .export import (
+    register_formatter_excel,
+    make_summary_formatter,
+    export_to_excel,
+    export_to_csv,
+    export_to_json,
+    export_data,
+)
 
 __all__ = [
     "metrics",
     "config",
     "data",
     "pipeline",
+    "export",
     "load_csv",
     "identify_risk_free_fund",
+    "register_formatter_excel",
+    "make_summary_formatter",
+    "export_to_excel",
+    "export_to_csv",
+    "export_to_json",
+    "export_data",
 ]


### PR DESCRIPTION
## Summary
- expose export helper functions in the trend_analysis package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b8bbad84083318d3fa2f984ecb461