### PR TITLE
Fix missing formatter import in notebook

### DIFF
--- a/Vol_Adj_Trend_Analysis1.4.TrEx.ipynb
+++ b/Vol_Adj_Trend_Analysis1.4.TrEx.ipynb
@@ -54,6 +54,7 @@
     "    register_metric,\n",
     "    METRIC_REGISTRY,\n",
     ")\n"
+    "from trend_analysis.export import make_summary_formatter\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- add missing `make_summary_formatter` import in `Vol_Adj_Trend_Analysis1.4.TrEx.ipynb`

## Testing
- `ruff check .` *(fails: Found 639 errors)*
- `black --check .` *(fails: would reformat 14 files)*
- `mypy trend_analysis` *(fails: found 17 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b8d86c47083318ea51335256eabad