### PR TITLE
Fix notebook JSON after import addition

### DIFF
--- a/Vol_Adj_Trend_Analysis1.4.TrEx.ipynb
+++ b/Vol_Adj_Trend_Analysis1.4.TrEx.ipynb
@@ -53,7 +53,8 @@
     "    select_funds,\n",
     "    register_metric,\n",
     "    METRIC_REGISTRY,\n",
-    ")\n"
+    ")\n",
+    "from trend_analysis.export import make_summary_formatter\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- repair JSON syntax in `Vol_Adj_Trend_Analysis1.4.TrEx.ipynb` after adding the missing formatter import

## Testing
- `ruff check .` *(fails: Found 665 errors)*
- `black --check .` *(fails: would reformat 14 files)*
- `mypy trend_analysis` *(fails: found 18 errors in 7 files)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_685b8d86c47083318ea51335256eabad