### PR TITLE
Fix FORMATTERS_EXCEL import

### DIFF
--- a/Vol_Adj_Trend_Analysis1.4.TrEx.ipynb
+++ b/Vol_Adj_Trend_Analysis1.4.TrEx.ipynb
@@ -54,7 +54,7 @@
     "    register_metric,\n",
     "    METRIC_REGISTRY,\n",
     ")\n",
-    "from trend_analysis.export import make_summary_formatter\n"
+    "from trend_analysis.export import make_summary_formatter, FORMATTERS_EXCEL\n"
    ]
   },
   {

--- a/trend_analysis/export.py
+++ b/trend_analysis/export.py
@@ -167,6 +167,7 @@ def export_data(
 
 
 __all__ = [
+    "FORMATTERS_EXCEL",
     "register_formatter_excel",
     "make_summary_formatter",
     "export_to_excel",


### PR DESCRIPTION
## Summary
- expose `FORMATTERS_EXCEL` via `trend_analysis.export.__all__`
- import the formatter registry in the 1.4 notebook

## Testing
- `ruff check trend_analysis tests`
- `black --check trend_analysis tests` *(fails: would reformat)*
- `mypy trend_analysis` *(fails: missing stubs)*
- `pytest -q` *(fails: AttributeError in Config)*

------
https://chatgpt.com/codex/tasks/task_e_685b9398a0a083318bad2ec4ab452c5b