### PR TITLE
Add setup script for local env

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ This repository contains experiments and utilities for analyzing volatility-adju
 
 ## Setup
 
-1. Install the required Python packages:
+1. Create a virtual environment and install the required packages:
    ```bash
-   pip install -r requirements.txt
+   ./scripts/setup_env.sh
    ```
-   The `requirements.txt` file lists common data analysis libraries
-   including `pandas`, `numpy`, `matplotlib`, `ipywidgets`, and
-   `xlsxwriter`.
+   This bootstraps a `.venv` directory and installs everything from
+   `requirements.txt`, which includes `pandas`, `numpy`, `matplotlib`,
+   `ipywidgets` and `xlsxwriter`.
 2. Launch Jupyter Lab or Jupyter Notebook:
    ```bash
    jupyter lab

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Setup a local Python virtual environment and install dependencies.
+set -euo pipefail
+
+ENV_DIR=".venv"
+
+python3 -m venv "$ENV_DIR"
+# shellcheck source=/dev/null
+source "$ENV_DIR/bin/activate"
+
+pip install --upgrade pip
+pip install -r requirements.txt
+
+echo "Environment setup complete. Activate with 'source $ENV_DIR/bin/activate'."


### PR DESCRIPTION
## Summary
- add `scripts/setup_env.sh` for creating a virtual environment and installing dependencies
- document the script in `README`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ba05cdbc88331b6f5d4be21af8d16