### PR TITLE
Add per-sheet Excel formatting

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -3,7 +3,13 @@ import pathlib
 import pandas as pd
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
-from trend_analysis.export import export_data
+from trend_analysis.export import (
+    export_data,
+    export_to_excel,
+    register_formatter_excel,
+    reset_formatters_excel,
+    FORMATTERS_EXCEL,
+)
 
 
 def test_export_data(tmp_path):
@@ -21,3 +27,38 @@ def test_export_data(tmp_path):
 
     read = pd.read_csv(tmp_path / "report_sheet1.csv")
     pd.testing.assert_frame_equal(read, df1)
+
+
+def test_export_to_excel_formatters(tmp_path):
+    reset_formatters_excel()
+
+    calls: list[str] = []
+
+    @register_formatter_excel("sheet1")
+    def fmt1(ws, wb):
+        calls.append("fmt1")
+
+    def default(ws, wb):
+        calls.append("default")
+
+    df1 = pd.DataFrame({"A": [1]})
+    df2 = pd.DataFrame({"B": [2]})
+    export_to_excel(
+        {"sheet1": df1, "sheet2": df2},
+        str(tmp_path / "out.xlsx"),
+        default_sheet_formatter=default,
+    )
+
+    assert calls == ["fmt1", "default"]
+
+
+def test_reset_formatters_excel():
+    reset_formatters_excel()
+
+    @register_formatter_excel("foo")
+    def fmt(ws, wb):
+        pass
+
+    assert "foo" in FORMATTERS_EXCEL
+    reset_formatters_excel()
+    assert FORMATTERS_EXCEL == {}

--- a/trend_analysis/__init__.py
+++ b/trend_analysis/__init__.py
@@ -4,6 +4,7 @@ from . import metrics, config, data, pipeline, export
 from .data import load_csv, identify_risk_free_fund
 from .export import (
     register_formatter_excel,
+    reset_formatters_excel,
     make_summary_formatter,
     export_to_excel,
     export_to_csv,
@@ -20,6 +21,7 @@ __all__ = [
     "load_csv",
     "identify_risk_free_fund",
     "register_formatter_excel",
+    "reset_formatters_excel",
     "make_summary_formatter",
     "export_to_excel",
     "export_to_csv",

--- a/trend_analysis/exports.py
+++ b/trend_analysis/exports.py
@@ -4,6 +4,7 @@ from trend_analysis.export import *  # noqa: F401,F403
 
 __all__ = [
     "register_formatter_excel",
+    "reset_formatters_excel",
     "make_summary_formatter",
     "export_to_excel",
     "export_to_csv",


### PR DESCRIPTION
## Summary
- support sheet-level formatters in `export_to_excel`
- expose helper for clearing `FORMATTERS_EXCEL`
- re-export new API surface
- test new helper and behaviour

## Testing
- `black trend_analysis/export.py trend_analysis/__init__.py trend_analysis/exports.py tests/test_exports.py`
- `black --check trend_analysis/export.py trend_analysis/__init__.py trend_analysis/exports.py tests/test_exports.py`
- `ruff check trend_analysis/export.py trend_analysis/__init__.py trend_analysis/exports.py tests/test_exports.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bf71e232c8331bd3f2f38956d4bd7