### PR TITLE
Fix export formatting in notebook

### DIFF
--- a/Vol_Adj_Trend_Analysis1.4.TrEx.ipynb
+++ b/Vol_Adj_Trend_Analysis1.4.TrEx.ipynb
@@ -54,7 +54,7 @@
     "    register_metric,\n",
     "    METRIC_REGISTRY,\n",
     ")\n",
-    "from trend_analysis.export import make_summary_formatter, FORMATTERS_EXCEL\n"
+    "from trend_analysis.export import make_summary_formatter, export_to_excel\n"
    ]
   },
   {
@@ -522,33 +522,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ───────────────────────────────────────────────────────────────\n",
-    "#  5 · EXPORT  (NaN-safe, weight-format fix)\n",
-    "# ───────────────────────────────────────────────────────────────\n",
-    "# ───────── 5 · EXPORT  (final, bug-free) ───────────────────────\n",
-    "# ───────── 5 · EXPORT  (self-healing index section) ───────────\n",
-    "# ───────── 5 · EXPORT  (final safe version) ───────────────────\n",
-    "\n",
-    "def export_to_excel(\n",
-    "    data: dict[str, pd.DataFrame],\n",
-    "    output_path: str,\n",
-    "    default_format: Optional[Callable] = None\n",
-    ") -> None:\n",
-    "    \"\"\"\n",
-    "    Exports each DataFrame in `data` to its own sheet in `output_path`.\n",
-    "    Applies a registered formatter for each category (sheet name).\n",
-    "    If no formatter is found, applies `default_format` if provided.\n",
-    "\n",
-    "    For the Summary sheet, data is written starting at row 5 to make room for custom headers.\n",
-    "    \"\"\"\n",
-    "    startrows = {\"summary\": 5}\n",
-    "    with pd.ExcelWriter(output_path, engine=\"xlsxwriter\") as writer:\n",
-    "        for category, df in data.items():\n",
-    "            startrow = startrows.get(category, 0)\n",
-    "            df.to_excel(writer, sheet_name=category, index=False, startrow=startrow, header=True)\n",
-    "            fn = FORMATTERS_EXCEL.get(category, default_format)\n",
-    "            if fn: fn(writer.sheets[category], writer.book)\n",
-    "    # Workbook is auto-saved and closed by the context manager\n"
+    "# Deprecated local export_to_excel; use trend_analysis.export.export_to_excel\\n"
    ]
   },
   {
@@ -583,27 +557,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "687e0d59-d17a-41c8-b991-1d91d29a22d1",
    "metadata": {
     "outputId": "795bb6da-96a0-42e2-c760-7d516fd82610"
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5f61f0b0de1d45a4a880943a6f31decc",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(HTML(value='<h4>1. Load data</h4>'), ToggleButtons(description='Source:', options=(('Local', 'l…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# ===============================================================\n",
     "#            STREAMLINED ANALYSIS UI  (phase-2 clean)\n",
@@ -788,8 +747,7 @@
     "        if indices: print(\"📊 Indices:\", indices)\n",
     "\n",
     "        fname=f\"IS_{in_start.value}_{out_start.value}.xlsx\"\n",
-    "        # register only the combined summary formatter\n",
-    "        make_summary_formatter(\n",
+    "        formatter = make_summary_formatter(\n",
     "            res,\n",
     "            in_start.value,\n",
     "            in_end.value,\n",
@@ -797,17 +755,13 @@
     "            out_end.value\n",
     "        )\n",
     "\n",
-    "        # Build a minimal data dict with just the 'summary' sheet.\n",
-    "        # The formatter will populate all rows (portfolio, funds, spacer, indices).\n",
     "        data = {\n",
     "            \"summary\": pd.DataFrame()\n",
     "        }\n",
     "\n",
     "        print(\"Sheets to write:\", list(data.keys()))\n",
-    "        print(\"Formatters:\", list(FORMATTERS_EXCEL.keys()))\n",
     "\n",
-    "        # Export — this will call fmt_summary(ws, wb) on the 'summary' sheet.\n",
-    "        export_to_excel(data, fname)\n",
+    "        export_to_excel(data, fname, formatter)\n",
     "        print(\"Workbook saved as\", fname)\n",
     "\n",
     "run_btn.on_click(_run)\n",
@@ -831,18 +785,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "d599f6a9-8055-42be-abf1-fd2ab3efee44",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['Date', 'Risk-Free Rate', 'Quantum Capital', 'Crescent Strategies', 'Echo Advisors', 'Quantum Group', 'Quantum LP', 'Meridian Capital', 'Adaptive Partners', 'Echo Strategies', 'Vista LP', 'Adaptive Group', 'Echo Group', 'Meridian Strategies', 'Axiom LP', 'Crescent Capital', 'Sentinel Management', 'Ascent Holdings', 'Sentinel Strategies', 'Ascent Partners', 'Quantum Management', 'Quantum Investments', 'Ascent LP', 'Axiom Group', 'Crescent LP', 'Echo Partners', 'Adaptive Strategies', 'Crescent Partners', 'Meridian Holdings', 'Axiom Investments', 'Sentinel Investments', 'Ascent Strategies', 'Forge Advisors', 'Vista Strategies', 'Sentinel Global', 'Ascent Capital', 'Echo Capital', 'Ascent Management', 'Echo LP', 'Axiom Management', 'Axiom Advisors', 'Crescent Advisors', 'Vista Holdings', 'Forge Management', 'Sentinel Group', 'Axiom Partners', 'Sentinel Advisors', 'Meridian LP', 'Crescent Group', 'Crescent Management', 'Adaptive Holdings', 'Vista Advisors', 'Vista Partners', 'Forge Strategies', 'Vista Capital', 'Forge Investments', 'Axiom Capital', 'Forge Partners', 'Quantum Global', 'Sentinel Holdings', 'Ascent Global', 'Vista Global', 'Quantum Strategies', 'Forge Group', 'Adaptive Investments', 'Echo Holdings', 'Axiom Strategies', 'Forge LP', 'Meridian Global', 'Adaptive Management', 'Meridian Advisors', 'Crescent Global', 'Axiom Global', 'Echo Management', 'Adaptive Advisors', 'Axiom Holdings', 'Meridian Group', 'Adaptive Capital', 'Forge Global', 'Vista Group', 'Sentinel Capital', 'Sentinel Partners', 'Forge Capital', 'Echo Investments', 'Adaptive Global', 'Quantum Partners', 'Crescent Holdings', 'Ascent Advisors', 'Quantum Advisors', 'Ascent Group', 'Quantum Holdings', 'Sentinel LP', 'Meridian Investments', 'Meridian Partners', 'Meridian Management', 'Forge Holdings', 'Echo Global', 'Ascent Investments', 'Adaptive LP', 'Crescent Investments', 'Vista Investments', 'Vista Management', 'EqualWeight_60', 'EqualWeight_40']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# 1. Run the cell that defines load_csv and call it\n",
     "dt = load_csv(\"/Users/teacher/Library/CloudStorage/Dropbox/Learning/Code/Trend Modeling Project/hedge_fund_returns_with_indexes.csv\")\n",


### PR DESCRIPTION
## Summary
- import export_to_excel from trend_analysis.export
- deprecate custom export_to_excel helper
- pass formatter from make_summary_formatter to export_to_excel
- strip notebook outputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bf72f6b20833181c42eda1df2b941