### PR TITLE
Add Next button behaviour

### DIFF
--- a/trend_analysis/core/rank_selection.py
+++ b/trend_analysis/core/rank_selection.py
@@ -325,20 +325,32 @@ def build_ui():
     )
     rank_box.layout.display = "none"
 
+    # track whether the user progressed past the first step
+    rank_unlocked = False
+
     run_btn = widgets.Button(description="Run")
     output = widgets.Output()
 
+    def _next_action(_):
+        nonlocal rank_unlocked
+        rank_unlocked = not rank_unlocked
+        next_btn_1.layout.display = "none"
+        _update_rank_vis()
+
     def _update_rank_vis(*_):
-        show = mode_dd.value == "rank" or use_rank_ck.value
+        show = rank_unlocked and (mode_dd.value == "rank" or use_rank_ck.value)
         rank_box.layout.display = "flex" if show else "none"
         _update_blended_vis()
 
     def _update_blended_vis(*_):
-        show = metric_dd.value == "blended" and (
-            mode_dd.value == "rank" or use_rank_ck.value
+        show = (
+            rank_unlocked
+            and metric_dd.value == "blended"
+            and (mode_dd.value == "rank" or use_rank_ck.value)
         )
         blended_box.layout.display = "flex" if show else "none"
 
+    next_btn_1.on_click(_next_action)
     mode_dd.observe(_update_rank_vis, "value")
     use_rank_ck.observe(_update_rank_vis, "value")
     metric_dd.observe(_update_blended_vis, "value")


### PR DESCRIPTION
## Summary
- toggle rank selection controls when Next is clicked
- hide the Next button after use
- keep rank widget visibility responsive to manual changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c5270c1a883318831138a73edd768