### PR TITLE
UI: show/hide inclusion controls

### DIFF
--- a/trend_analysis/core/rank_selection.py
+++ b/trend_analysis/core/rank_selection.py
@@ -332,6 +332,7 @@ def build_ui():
         show = mode_dd.value == "rank" or use_rank_ck.value
         rank_box.layout.display = "flex" if show else "none"
         _update_blended_vis()
+        _update_inclusion_fields()
 
     def _update_blended_vis(*_):
         show = metric_dd.value == "blended" and (
@@ -339,9 +340,17 @@ def build_ui():
         )
         blended_box.layout.display = "flex" if show else "none"
 
+    def _update_inclusion_fields(*_):
+        topn_int.layout.display = "flex" if incl_dd.value == "top_n" else "none"
+        pct_flt.layout.display = "flex" if incl_dd.value == "top_pct" else "none"
+        thresh_f.layout.display = (
+            "flex" if incl_dd.value == "threshold" else "none"
+        )
+
     mode_dd.observe(_update_rank_vis, "value")
     use_rank_ck.observe(_update_rank_vis, "value")
     metric_dd.observe(_update_blended_vis, "value")
+    incl_dd.observe(_update_inclusion_fields, "value")
 
     def _run_action(_btn):
         rank_kwargs = None
@@ -400,6 +409,7 @@ def build_ui():
         [mode_dd, vol_ck, use_rank_ck, next_btn_1, rank_box, out_fmt, run_btn, output]
     )
     _update_rank_vis()
+    _update_inclusion_fields()
     return ui
 
 


### PR DESCRIPTION
## Summary
- update the rank-selection UI to toggle inclusion controls
- add `_update_inclusion_fields` callback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c526cf0ac83319e817e0c3019c184