### PR TITLE
Add test helper script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - run: pip install -r requirements.txt pytest pytest-cov
-      - run: pytest --cov trend_analysis --cov-branch
+      - run: ./scripts/run_tests.sh
 
   build-wheel:
     if: startsWith(github.ref, 'refs/tags/')

--- a/README.md
+++ b/README.md
@@ -80,3 +80,10 @@ Once the dependencies are installed, run the tests with coverage enabled:
 ```bash
 pytest --cov trend_analysis --cov-branch
 ```
+
+Alternatively, you can use the helper script which installs the requirements
+and then executes the test suite in one step:
+
+```bash
+./scripts/run_tests.sh
+```

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Run tests after ensuring dependencies are installed.
+
+set -euo pipefail
+
+pip install -r requirements.txt pytest
+pytest --cov trend_analysis --cov-branch "$@"


### PR DESCRIPTION
## Summary
- add a `run_tests.sh` script to ensure requirements are installed before running pytest
- document the new script in the README
- use the helper in CI

## Testing
- `ruff check .`
- `black --check .`
- `mypy --strict trend_analysis`
- `pytest --cov trend_analysis --cov-branch`

------
https://chatgpt.com/codex/tasks/task_e_685cc6997ab08331be360e123b811570