### PR TITLE
Fix rank_selection syntax error

### DIFF
--- a/trend_analysis/core/rank_selection.py
+++ b/trend_analysis/core/rank_selection.py
@@ -466,7 +466,6 @@ def build_ui() -> widgets.VBox:
                     selection_mode=mode,
                     custom_weights=custom_weights,
                     rank_kwargs=rank_kwargs,
-                    custom_weights=custom_weights,
                     manual_funds=manual_funds,
                 )
                 if res is None:


### PR DESCRIPTION
## Summary
- remove duplicate keyword argument in `rank_selection`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cd68ed3488331b6a086b0753525ac