### PR TITLE
Fix manual selection UI bug

### DIFF
--- a/trend_analysis/core/rank_selection.py
+++ b/trend_analysis/core/rank_selection.py
@@ -442,15 +442,8 @@ def build_ui() -> widgets.VBox:
                 dates = df["Date"].dt.to_period("M")
                 start = dates.min()
 
-                custom_weights: dict[str, float] | None = None
                 mode = mode_dd.value
                 if mode_dd.value == "manual":
-                    mode = "manual"
-                    custom_weights = {
-                        fund: wt.value
-                        for fund, (ck, wt) in manual_controls.items()
-                        if ck.value
-                    }
                     if not custom_weights:
                         print("No funds selected")
                         return


### PR DESCRIPTION
## Summary
- drop reference to undeclared `manual_controls`
- rely on previously collected `manual_checks` and `manual_weights`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685cd78146b08331bbfe7be2fd9e48fd