### PR TITLE
Fix CSV date parsing for widget

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -66,3 +66,15 @@ def test_identify_risk_free_fund_basic():
 def test_identify_risk_free_fund_no_numeric():
     df = pd.DataFrame({"Date": ["2020-01-01"], "A": ["x"]})
     assert data_mod.identify_risk_free_fund(df) is None
+
+
+def test_ensure_datetime_coerces():
+    df = pd.DataFrame({"Date": ["2020-01-01"], "A": [1]})
+    out = data_mod.ensure_datetime(df)
+    assert pd.api.types.is_datetime64_any_dtype(out["Date"])
+
+
+def test_ensure_datetime_missing_column():
+    df = pd.DataFrame({"X": [1]})
+    out = data_mod.ensure_datetime(df)
+    assert "X" in out.columns and "Date" not in out.columns

--- a/trend_analysis/core/rank_selection.py
+++ b/trend_analysis/core/rank_selection.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 import ipywidgets as widgets
 from .. import metrics as _metrics
-from ..data import load_csv, identify_risk_free_fund
+from ..data import load_csv, identify_risk_free_fund, ensure_datetime
 
 
 @dataclass
@@ -343,6 +343,7 @@ def build_ui() -> widgets.VBox:
                 if df is None:
                     print("Failed to load")
                     return
+                df = ensure_datetime(df)
                 session["df"] = df
                 rf = identify_risk_free_fund(df) or "RF"
                 session["rf"] = rf

--- a/trend_analysis/data.py
+++ b/trend_analysis/data.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional
 import pandas as pd
+from pandas.api.types import is_datetime64_any_dtype
 
 logger = logging.getLogger(__name__)
 
@@ -65,4 +66,14 @@ def identify_risk_free_fund(df: pd.DataFrame) -> Optional[str]:
     return str(rf)
 
 
-__all__ = ["load_csv", "identify_risk_free_fund"]
+def ensure_datetime(df: pd.DataFrame, column: str = "Date") -> pd.DataFrame:
+    """Coerce ``column`` to datetime if needed."""
+    if column in df.columns and not is_datetime64_any_dtype(df[column]):
+        try:
+            df[column] = pd.to_datetime(df[column], format="%m/%d/%y")
+        except Exception:
+            df[column] = pd.to_datetime(df[column], errors="coerce")
+    return df
+
+
+__all__ = ["load_csv", "identify_risk_free_fund", "ensure_datetime"]


### PR DESCRIPTION
## Summary
- ensure CSVs loaded via the UI always parse the Date column
- expose `ensure_datetime` helper in `trend_analysis.data`
- call this helper in the widget logic so index selection shows up
- cover new helper with unit tests

## Testing
- `ruff check .`
- `black --check .`
- `mypy trend_analysis`
- `pytest --cov trend_analysis --cov-branch -q`

------
https://chatgpt.com/codex/tasks/task_e_685cee32a59c8331b4cdd7f3986167ee