### PR TITLE
Fix Excel format alias

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -29,6 +29,14 @@ def test_export_data(tmp_path):
     pd.testing.assert_frame_equal(read, df1)
 
 
+def test_export_data_excel_alias(tmp_path):
+    df = pd.DataFrame({"A": [1]})
+    data = {"sheet": df}
+    out = tmp_path / "alias"
+    export_data(data, str(out), formats=["excel"])
+    assert (tmp_path / "alias.xlsx").exists()
+
+
 def test_export_to_excel_formatters(tmp_path):
     reset_formatters_excel()
 

--- a/trend_analysis/config.py
+++ b/trend_analysis/config.py
@@ -10,7 +10,7 @@ import yaml  # type: ignore[import-untyped]
 from pydantic import BaseModel
 
 
-class Config(BaseModel):
+class Config(BaseModel):  # type: ignore[misc]
     """Typed access to the YAML configuration."""
 
     version: str

--- a/trend_analysis/export.py
+++ b/trend_analysis/export.py
@@ -182,6 +182,8 @@ EXPORTERS: dict[
     str, Callable[[Mapping[str, pd.DataFrame], str, Formatter | None], None]
 ] = {
     "xlsx": export_to_excel,
+    # ``excel`` is kept for backward compatibility with older configs/UI
+    "excel": export_to_excel,
     "csv": export_to_csv,
     "json": export_to_json,
 }
@@ -195,10 +197,12 @@ def export_data(
 ) -> None:
     """Export ``data`` to the specified ``formats``."""
     for fmt in formats:
-        exporter = EXPORTERS.get(fmt)
+        fmt_norm = fmt.lower()
+        fmt_norm = "xlsx" if fmt_norm == "excel" else fmt_norm
+        exporter = EXPORTERS.get(fmt_norm)
         if exporter is None:
             raise ValueError(f"Unsupported format: {fmt}")
-        path = str(Path(output_path).with_suffix(f".{fmt}"))
+        path = str(Path(output_path).with_suffix(f".{fmt_norm}"))
         exporter(data, path, formatter)
 
 


### PR DESCRIPTION
## Summary
- accept `excel` as alias for `xlsx` when exporting data
- adjust output path extension for alias
- silence mypy complaint about pydantic
- test exporting with `excel` alias

## Testing
- `ruff check trend_analysis tests`
- `black --check trend_analysis tests`
- `mypy trend_analysis`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cf0c18d2c8331bcd2798ee144621c