### PR TITLE
Add detailed output option

### DIFF
--- a/tests/test_run_analysis_cli.py
+++ b/tests/test_run_analysis_cli.py
@@ -1,0 +1,38 @@
+import pandas as pd
+from pathlib import Path
+
+from trend_analysis import run_analysis
+
+
+def _write_cfg(path: Path, csv: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "version: '1'",
+                f"data: {{csv_path: '{csv}'}}",
+                "preprocessing: {}",
+                "vol_adjust: {target_vol: 1.0}",
+                "sample_split: {in_start: '2020-01', in_end: '2020-03', out_start: '2020-04', out_end: '2020-06'}",
+                "portfolio: {}",
+                "metrics: {}",
+                "export: {}",
+                "run: {}",
+            ]
+        )
+    )
+
+
+def _make_df():
+    dates = pd.date_range("2020-01-31", periods=6, freq="ME")
+    return pd.DataFrame({"Date": dates, "RF": 0.0, "A": 0.01})
+
+
+def test_cli_detailed(tmp_path, capsys):
+    csv = tmp_path / "data.csv"
+    _make_df().to_csv(csv, index=False)
+    cfg = tmp_path / "cfg.yml"
+    _write_cfg(cfg, csv)
+    rc = run_analysis.main(["-c", str(cfg), "--detailed"])
+    captured = capsys.readouterr().out
+    assert rc == 0
+    assert "selected_funds" in captured

--- a/tests/test_run_full.py
+++ b/tests/test_run_full.py
@@ -1,0 +1,41 @@
+import pandas as pd
+
+from trend_analysis.pipeline import run_full, run
+from trend_analysis.config import Config
+
+
+def make_cfg(tmp_path, df):
+    csv = tmp_path / "data.csv"
+    df.to_csv(csv, index=False)
+    cfg = Config(
+        version="1",
+        data={"csv_path": str(csv)},
+        preprocessing={},
+        vol_adjust={"target_vol": 1.0},
+        sample_split={
+            "in_start": "2020-01",
+            "in_end": "2020-03",
+            "out_start": "2020-04",
+            "out_end": "2020-06",
+        },
+        portfolio={},
+        metrics={},
+        export={},
+        run={},
+    )
+    return cfg
+
+
+def make_df():
+    dates = pd.date_range("2020-01-31", periods=6, freq="ME")
+    return pd.DataFrame({"Date": dates, "RF": 0.0, "A": 0.01})
+
+
+def test_run_full_matches_run(tmp_path):
+    cfg = make_cfg(tmp_path, make_df())
+    detailed = run_full(cfg)
+    summary = run(cfg)
+    assert isinstance(detailed, dict)
+    assert not summary.empty
+    stats = detailed["out_sample_stats"]
+    assert set(summary.index) == set(stats.keys())

--- a/trend_analysis/pipeline.py
+++ b/trend_analysis/pipeline.py
@@ -243,4 +243,34 @@ def run(cfg: Config) -> pd.DataFrame:
     return pd.DataFrame({k: vars(v) for k, v in stats.items()}).T
 
 
-__all__ = ["Stats", "calc_portfolio_returns", "run_analysis", "run"]
+def run_full(cfg: Config) -> dict[str, object]:
+    """Return the full analysis results based on ``cfg``."""
+    csv_path = cfg.data.get("csv_path")
+    if csv_path is None:
+        raise KeyError("cfg.data['csv_path'] must be provided")
+
+    df = load_csv(csv_path)
+    if df is None:
+        raise FileNotFoundError(csv_path)
+
+    split = cfg.sample_split
+    res = _run_analysis(
+        df,
+        cast(str, split.get("in_start")),
+        cast(str, split.get("in_end")),
+        cast(str, split.get("out_start")),
+        cast(str, split.get("out_end")),
+        cfg.vol_adjust.get("target_vol", 1.0),
+        cfg.run.get("monthly_cost", 0.0),
+        selection_mode=cfg.portfolio.get("selection_mode", "all"),
+        random_n=cfg.portfolio.get("random_n", 8),
+        custom_weights=cfg.portfolio.get("custom_weights"),
+        rank_kwargs=cfg.portfolio.get("rank"),
+        manual_funds=cfg.portfolio.get("manual_list"),
+        indices_list=cfg.portfolio.get("indices_list"),
+        seed=cfg.portfolio.get("random_seed", 42),
+    )
+    return {} if res is None else res
+
+
+__all__ = ["Stats", "calc_portfolio_returns", "run_analysis", "run", "run_full"]

--- a/trend_analysis/run_analysis.py
+++ b/trend_analysis/run_analysis.py
@@ -10,15 +10,24 @@ def main(argv: list[str] | None = None) -> int:
     """CLI entry point for the trend analysis pipeline."""
     parser = argparse.ArgumentParser(prog="trend-analysis")
     parser.add_argument("-c", "--config", help="Path to YAML config")
+    parser.add_argument(
+        "--detailed",
+        action="store_true",
+        help="Print comprehensive result dictionary",
+    )
     args = parser.parse_args(argv)
 
     cfg = load(args.config)
-    result = pipeline.run(cfg)
-    if result.empty:
-        print("No results")
+    if args.detailed:
+        result = pipeline.run_full(cfg)
+        print(result if result else "No results")
     else:
-        # Show fund names (index) and column headers for clarity
-        print(result.to_string())
+        result = pipeline.run(cfg)
+        if result.empty:
+            print("No results")
+        else:
+            # Show fund names (index) and column headers for clarity
+            print(result.to_string())
     return 0
 
 


### PR DESCRIPTION
## Summary
- add optional detailed output via pipeline.run_full and run_analysis flag
- test run_full and CLI detailed mode

## Testing
- `ruff check .`
- `black --check .`
- `mypy -p trend_analysis`
- `pytest --cov trend_analysis --cov-branch`

------
https://chatgpt.com/codex/tasks/task_e_685cf2d423988331bac76c0a2633cc42