### PR TITLE
Add console summary formatting

### DIFF
--- a/tests/test_export_formatter.py
+++ b/tests/test_export_formatter.py
@@ -8,6 +8,7 @@ from trend_analysis.export import (
     make_summary_formatter,
     export_to_excel,
     FORMATTERS_EXCEL,
+    format_summary_text,
 )
 
 
@@ -52,6 +53,22 @@ def test_make_summary_formatter_registers_and_runs():
     wb = DummyWB()
     fmt(ws, wb)
     assert ws.rows[0][2][0] == "Vol-Adj Trend Analysis"
+
+
+def test_format_summary_text_basic():
+    res = {
+        "in_ew_stats": (1, 1, 1, 1, 1),
+        "out_ew_stats": (2, 2, 2, 2, 2),
+        "in_user_stats": (3, 3, 3, 3, 3),
+        "out_user_stats": (4, 4, 4, 4, 4),
+        "in_sample_stats": {"fund": (5, 5, 5, 5, 5)},
+        "out_sample_stats": {"fund": (6, 6, 6, 6, 6)},
+        "fund_weights": {"fund": 0.5},
+        "index_stats": {},
+    }
+    text = format_summary_text(res, "a", "b", "c", "d")
+    assert "Vol-Adj Trend Analysis" in text
+    assert "fund" in text
 
 
 def test_export_to_excel_invokes_formatter(tmp_path):

--- a/tests/test_run_analysis_cli_default.py
+++ b/tests/test_run_analysis_cli_default.py
@@ -1,0 +1,38 @@
+import pandas as pd
+from pathlib import Path
+
+from trend_analysis import run_analysis
+
+
+def _write_cfg(path: Path, csv: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "version: '1'",
+                f"data: {{csv_path: '{csv}'}}",
+                "preprocessing: {}",
+                "vol_adjust: {target_vol: 1.0}",
+                "sample_split: {in_start: '2020-01', in_end: '2020-03', out_start: '2020-04', out_end: '2020-06'}",
+                "portfolio: {}",
+                "metrics: {}",
+                "export: {}",
+                "run: {}",
+            ]
+        )
+    )
+
+
+def _make_df():
+    dates = pd.date_range("2020-01-31", periods=6, freq="ME")
+    return pd.DataFrame({"Date": dates, "RF": 0.0, "A": 0.01})
+
+
+def test_cli_default_output(tmp_path, capsys):
+    csv = tmp_path / "data.csv"
+    _make_df().to_csv(csv, index=False)
+    cfg = tmp_path / "cfg.yml"
+    _write_cfg(cfg, csv)
+    rc = run_analysis.main(["-c", str(cfg)])
+    captured = capsys.readouterr().out
+    assert rc == 0
+    assert "Vol-Adj Trend Analysis" in captured

--- a/trend_analysis/run_analysis.py
+++ b/trend_analysis/run_analysis.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 
 from trend_analysis.config import load
-from trend_analysis import pipeline
+from trend_analysis import pipeline, export
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -22,12 +22,19 @@ def main(argv: list[str] | None = None) -> int:
         result = pipeline.run_full(cfg)
         print(result if result else "No results")
     else:
-        result = pipeline.run(cfg)
-        if result.empty:
+        res = pipeline.run_full(cfg)
+        if not res:
             print("No results")
         else:
-            # Show fund names (index) and column headers for clarity
-            print(result.to_string())
+            split = cfg.sample_split
+            text = export.format_summary_text(
+                res,
+                split.get("in_start"),
+                split.get("in_end"),
+                split.get("out_start"),
+                split.get("out_end"),
+            )
+            print(text)
     return 0
 
 


### PR DESCRIPTION
## Summary
- print user-friendly summary table in CLI
- implement `format_summary_text`
- test new formatting behaviour

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685cfac22d008331b17328a012df165a