### PR TITLE
Add CLI export and tests

### DIFF
--- a/tests/test_export_formatter.py
+++ b/tests/test_export_formatter.py
@@ -107,3 +107,34 @@ def test_export_to_excel_backward_compat_sheet_formatter(tmp_path):
     out = tmp_path / "out.xlsx"
     export_to_excel({"summary": df}, str(out), formatter=sheet_formatter)
     assert out.exists()
+
+def test_format_summary_text_no_index_stats():
+    res = {
+        "in_ew_stats": (1, 1, 1, 1, 1),
+        "out_ew_stats": (2, 2, 2, 2, 2),
+        "in_user_stats": (3, 3, 3, 3, 3),
+        "out_user_stats": (4, 4, 4, 4, 4),
+        "in_sample_stats": {"fund": (5, 5, 5, 5, 5)},
+        "out_sample_stats": {"fund": (6, 6, 6, 6, 6)},
+        "fund_weights": {"fund": 0.5},
+    }
+    text = format_summary_text(res, "a", "b", "c", "d")
+    assert "fund" in text
+
+
+def test_make_summary_formatter_handles_nan(tmp_path):
+    res = {
+        "in_ew_stats": (1, 1, 1, 1, float("nan")),
+        "out_ew_stats": (2, 2, 2, 2, 2),
+        "in_user_stats": (3, 3, 3, 3, 3),
+        "out_user_stats": (4, 4, 4, 4, 4),
+        "in_sample_stats": {"fund": (5, 5, float("nan"), 5, 5)},
+        "out_sample_stats": {"fund": (6, 6, 6, 6, 6)},
+        "fund_weights": {"fund": 0.5},
+        "index_stats": {},
+    }
+    fmt = make_summary_formatter(res, "a", "b", "c", "d")
+    ws = DummyWS()
+    wb = DummyWB()
+    fmt(ws, wb)
+    assert ws.rows[0][2][0] == "Vol-Adj Trend Analysis"

--- a/tests/test_run_analysis_cli_export.py
+++ b/tests/test_run_analysis_cli_export.py
@@ -1,0 +1,40 @@
+import pandas as pd
+from pathlib import Path
+
+from trend_analysis import run_analysis
+
+
+def _write_cfg(path: Path, csv: Path, out_dir: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "version: '1'",
+                f"data: {{csv_path: '{csv}'}}",
+                "preprocessing: {}",
+                "vol_adjust: {target_vol: 1.0}",
+                "sample_split: {in_start: '2020-01', in_end: '2020-03', out_start: '2020-04', out_end: '2020-06'}",
+                "portfolio: {}",
+                "metrics: {}",
+                f"export: {{directory: '{out_dir}', formats: ['csv']}}",
+                "run: {}",
+            ]
+        )
+    )
+
+
+def _make_df():
+    dates = pd.date_range("2020-01-31", periods=6, freq="ME")
+    return pd.DataFrame({"Date": dates, "RF": 0.0, "A": 0.01})
+
+
+def test_cli_exports_files(tmp_path):
+    csv = tmp_path / "data.csv"
+    _make_df().to_csv(csv, index=False)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    cfg = tmp_path / "cfg.yml"
+    _write_cfg(cfg, csv, out_dir)
+    rc = run_analysis.main(["-c", str(cfg)])
+    assert rc == 0
+    assert (out_dir / "analysis_in_sample.csv").exists()
+    assert (out_dir / "analysis_out_sample.csv").exists()

--- a/tests/test_run_full.py
+++ b/tests/test_run_full.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from trend_analysis.pipeline import run_full, run
 from trend_analysis.config import Config
@@ -39,3 +40,34 @@ def test_run_full_matches_run(tmp_path):
     assert not summary.empty
     stats = detailed["out_sample_stats"]
     assert set(summary.index) == set(stats.keys())
+
+def test_run_full_missing_csv_key(tmp_path):
+    cfg = Config(
+        version="1",
+        data={},
+        preprocessing={},
+        vol_adjust={},
+        sample_split={},
+        portfolio={},
+        metrics={},
+        export={},
+        run={},
+    )
+    with pytest.raises(KeyError):
+        run_full(cfg)
+
+
+def test_run_full_missing_file(tmp_path):
+    cfg = Config(
+        version="1",
+        data={"csv_path": str(tmp_path / "missing.csv")},
+        preprocessing={},
+        vol_adjust={},
+        sample_split={},
+        portfolio={},
+        metrics={},
+        export={},
+        run={},
+    )
+    with pytest.raises(FileNotFoundError):
+        run_full(cfg)

--- a/trend_analysis/run_analysis.py
+++ b/trend_analysis/run_analysis.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import argparse
 
+from pathlib import Path
+
 from trend_analysis.config import load
 from trend_analysis import pipeline, export
 
@@ -35,6 +37,16 @@ def main(argv: list[str] | None = None) -> int:
                 split.get("out_end"),
             )
             print(text)
+            export_cfg = cfg.export
+            out_dir = export_cfg.get("directory")
+            out_formats = export_cfg.get("formats")
+            if out_dir and out_formats:
+                data = {
+                    "in_sample": res["in_sample_scaled"],
+                    "out_sample": res["out_sample_scaled"],
+                }
+                prefix = Path(out_dir) / "analysis"
+                export.export_data(data, str(prefix), formats=out_formats)
     return 0
 
 


### PR DESCRIPTION
## Summary
- enable exporting results via config options
- test CLI export behavior
- cover additional branches in export and pipeline

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685d438045f083318bdc57be9c98b534