### PR TITLE
Clarify dependency installs before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This repository contains experiments and utilities for analyzing volatility-adju
    ```bash
    ./scripts/setup_env.sh
    ```
-   This bootstraps a `.venv` directory and installs everything from
-   `requirements.txt`, which includes `pandas`, `numpy`, `matplotlib`,
-   `ipywidgets` and `xlsxwriter`.
+  This bootstraps a `.venv` directory and installs everything from
+  `requirements.txt`, which includes `pandas`, `numpy`, `matplotlib`,
+  `ipywidgets`, `PyYAML` and `xlsxwriter`.
 2. Launch Jupyter Lab or Jupyter Notebook:
    ```bash
    jupyter lab
@@ -63,7 +63,7 @@ are comparable across scales.
 
 ## Testing
 
-Install the project dependencies before running the test suite. This can be done using the setup script, which
+Install the project dependencies (such as `pandas`, `numpy` and `PyYAML`) before running the test suite. This can be done using the setup script, which
 creates a virtual environment and installs everything from `requirements.txt`
 (including `pytest`):
 


### PR DESCRIPTION
## Summary
- mention PyYAML in setup instructions
- emphasise that pandas, numpy and PyYAML must be installed before running tests

## Testing
- `pip install -r requirements.txt`
- `pytest --maxfail=1 --cov trend_analysis --cov-branch`

------
https://chatgpt.com/codex/tasks/task_e_685dc47d95b48331bf75e3b635e0b0b6