### PR TITLE
Fix export mapping in rank_selection UI

### DIFF
--- a/trend_analysis/core/rank_selection.py
+++ b/trend_analysis/core/rank_selection.py
@@ -571,12 +571,14 @@ def build_ui() -> widgets.VBox:
                         out_end.value,
                     )
                     print(text)
-                    data = {
-                        "in_sample": res["in_sample_scaled"],
-                        "out_sample": res["out_sample_scaled"],
-                    }
+                    data = {"summary": pd.DataFrame()}
                     prefix = f"IS_{in_start.value}_OS_{out_start.value}"
-                    export.export_data(data, prefix, formats=[out_fmt.value])
+                    export.export_data(
+                        data,
+                        prefix,
+                        formats=[out_fmt.value],
+                        formatter=sheet_formatter,
+                    )
             except Exception as exc:
                 print("Error:", exc)
 


### PR DESCRIPTION
## Summary
- update UI export logic to only generate a blank summary sheet
- forward the summary formatter to `export.export_data`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc4831fa08331bc195a3c6ee520d7