### PR TITLE
Fix CSV export to include row labels

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -25,7 +25,7 @@ def test_export_data(tmp_path):
     assert (tmp_path / "report_sheet1.json").exists()
     assert (tmp_path / "report_sheet2.json").exists()
 
-    read = pd.read_csv(tmp_path / "report_sheet1.csv")
+    read = pd.read_csv(tmp_path / "report_sheet1.csv", index_col=0)
     pd.testing.assert_frame_equal(read, df1)
 
 

--- a/trend_analysis/export.py
+++ b/trend_analysis/export.py
@@ -239,7 +239,9 @@ def export_to_csv(
     for name, df in data.items():
         formatted = _apply_format(df, formatter)
         formatted.to_csv(
-            prefix.with_name(f"{prefix.stem}_{name}.csv"), index=False, header=True
+            prefix.with_name(f"{prefix.stem}_{name}.csv"),
+            index=True,
+            header=True,
         )
 
 


### PR DESCRIPTION
## Summary
- include DataFrame indices when exporting to CSV
- adapt export tests for updated behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb83d07848331b436d7d66f21a70d