### PR TITLE
Fix manual mode defaults and handle metrics

### DIFF
--- a/trend_analysis/core/rank_selection.py
+++ b/trend_analysis/core/rank_selection.py
@@ -123,7 +123,9 @@ register_metric("Sortino")(
         s, pd.Series(risk_free, index=s.index), periods_per_year
     )
 )
-register_metric("MaxDrawdown")(_metrics.max_drawdown)
+register_metric("MaxDrawdown")(
+    lambda s, *, periods_per_year=12, risk_free=0.0: _metrics.max_drawdown(s)
+)
 
 # ===============================================================
 #  NEW: RANK‑BASED FUND SELECTION
@@ -504,10 +506,8 @@ def build_ui() -> widgets.VBox:
         manual_weights.clear()
         rows = []
         for f in funds:
-            chk = widgets.Checkbox(value=True, description=f)
-            wt = widgets.FloatText(
-                value=100 / len(funds), layout=widgets.Layout(width="80px")
-            )
+            chk = widgets.Checkbox(value=False, description=f)
+            wt = widgets.FloatText(value=0.0, layout=widgets.Layout(width="80px"))
             manual_checks.append(chk)
             manual_weights.append(wt)
             rows.append(widgets.HBox([chk, wt]))

--- a/trend_analysis/pipeline.py
+++ b/trend_analysis/pipeline.py
@@ -122,8 +122,11 @@ def _run_analysis(
         sub = df.loc[mask, fund_cols]
         stats_cfg = RiskStatsConfig(risk_free=0.0)
         fund_cols = rank_select_funds(sub, stats_cfg, **(rank_kwargs or {}))
-    elif selection_mode == "manual" and manual_funds:
-        fund_cols = [c for c in fund_cols if c in manual_funds]
+    elif selection_mode == "manual":
+        if manual_funds:
+            fund_cols = [c for c in fund_cols if c in manual_funds]
+        else:
+            fund_cols = []
 
     if not fund_cols:
         return None


### PR DESCRIPTION
## Summary
- ensure rank metrics like `MaxDrawdown` accept the `risk_free` argument
- show blank manual fund selections by default
- treat missing manual selections as no funds selected in the pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f3c80263083319cf412c08e0f886f