### PR TITLE
Restore manual weight total display

### DIFF
--- a/trend_analysis/core/rank_selection.py
+++ b/trend_analysis/core/rank_selection.py
@@ -434,6 +434,7 @@ def build_ui() -> widgets.VBox:
     manual_box.layout.display = "none"
     manual_checks: list[widgets.Checkbox] = []
     manual_weights: list[widgets.FloatText] = []
+    manual_total_lbl = widgets.Label("Total weight: 0 %")
 
     # track whether the user progressed past the first step
     rank_unlocked = False
@@ -504,15 +505,25 @@ def build_ui() -> widgets.VBox:
             funds = funds_all
         manual_checks.clear()
         manual_weights.clear()
+
+        def _update_total(*_: Any) -> None:
+            tot = sum(
+                wt.value for chk, wt in zip(manual_checks, manual_weights) if chk.value
+            )
+            manual_total_lbl.value = f"Total weight: {tot:.0f} %"
+
         rows = []
         for f in funds:
             chk = widgets.Checkbox(value=False, description=f)
             wt = widgets.FloatText(value=0.0, layout=widgets.Layout(width="80px"))
+            chk.observe(_update_total, "value")
+            wt.observe(_update_total, "value")
             manual_checks.append(chk)
             manual_weights.append(wt)
             rows.append(widgets.HBox([chk, wt]))
-        manual_box.children = rows
+        manual_box.children = rows + [manual_total_lbl]
         manual_box.layout.display = "flex"
+        _update_total()
 
     def _update_inclusion_fields(*_: Any) -> None:
         topn_int.layout.display = "flex" if incl_dd.value == "top_n" else "none"


### PR DESCRIPTION
## Summary
- display the running weight total in manual mode

## Testing
- `ruff check trend_analysis/core/rank_selection.py`
- `black trend_analysis/core/rank_selection.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f4c0c4efc833197704e6a4c7ce9d2