### PR TITLE
Handle new period freq aliases

### DIFF
--- a/tests/test_multi_period_stub.py
+++ b/tests/test_multi_period_stub.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import warnings
 import yaml
 from trend_analysis.multi_period.scheduler import generate_periods
 
@@ -10,3 +11,11 @@ def test_scheduler_generates_periods():
     assert periods, "Scheduler returned empty list"
     first = periods[0]
     assert first.in_start < first.out_start, "Period tuple ordering incorrect"
+
+
+def test_frequency_alias_resolves_without_warning():
+    cfg = yaml.safe_load(Path("config/defaults.yml").read_text())
+    cfg["multi_period"]["frequency"] = "M"
+    with warnings.catch_warnings(record=True) as w:
+        _ = generate_periods(cfg)
+    assert not w, "Unexpected warnings when using frequency 'M'"

--- a/trend_analysis/multi_period/scheduler.py
+++ b/trend_analysis/multi_period/scheduler.py
@@ -1,5 +1,7 @@
-"""
-Generate (in‑sample, out‑sample) period tuples for the multi‑period engine.
+"""Generate (in-sample, out-sample) period tuples for the multi-period engine.
+
+Uses the new pandas offset aliases ``ME``/``QE``/``YE`` for month-, quarter-,
+and year-end periods.
 """
 
 from __future__ import annotations
@@ -12,7 +14,14 @@ import pandas as pd
 # ----------------------------------------------------------------------
 PeriodTuple = namedtuple("PeriodTuple", ["in_start", "in_end", "out_start", "out_end"])
 
-FREQ_MAP = {"M": "M", "Q": "Q", "A": "Y"}
+FREQ_MAP = {
+    "M": "ME",
+    "ME": "ME",
+    "Q": "QE",
+    "QE": "QE",
+    "A": "YE",
+    "YE": "YE",
+}
 
 
 def generate_periods(cfg: Dict[str, Any]) -> List[PeriodTuple]:
@@ -25,12 +34,13 @@ def generate_periods(cfg: Dict[str, Any]) -> List[PeriodTuple]:
     """
     mp = cast(Dict[str, Any], cfg.get("multi_period", {}))
 
-    freq = FREQ_MAP[str(mp["frequency"])]
+    freq_alias = FREQ_MAP[str(mp["frequency"])]
+    offset = pd.tseries.frequencies.to_offset(freq_alias)
     in_len = int(mp["in_sample_len"])
     out_len = int(mp["out_sample_len"])
 
-    start = pd.Period(str(mp["start"]), freq)
-    last = pd.Period(str(mp["end"]), freq)
+    start = pd.Period(str(mp["start"]), offset)
+    last = pd.Period(str(mp["end"]), offset)
 
     periods: List[PeriodTuple] = []
     in_start = start


### PR DESCRIPTION
## Summary
- update scheduler to use ME/QE/YE aliases
- allow old frequency strings
- add regression test verifying monthly alias

## Testing
- `ruff check --fix trend_analysis/multi_period/scheduler.py tests/test_multi_period_stub.py`
- `black --check trend_analysis/multi_period/scheduler.py tests/test_multi_period_stub.py`
- `pytest tests/test_multi_period_stub.py::test_scheduler_generates_periods tests/test_multi_period_stub.py::test_frequency_alias_resolves_without_warning -q`

------
https://chatgpt.com/codex/tasks/task_e_686130f639dc8331bdbf55b5769ee604