### PR TITLE
Implement multi-period rebalancing engine

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,57 @@
+import pandas as pd
+import numpy as np
+
+from trend_analysis.multi_period import engine
+
+
+def make_df() -> pd.DataFrame:
+    dates = pd.date_range("2019-12-31", periods=60, freq="ME")
+    data = {"Date": dates}
+    for i in range(5):
+        data[f"F{i}"] = 0.01 * (i + 1)
+    return pd.DataFrame(data)
+
+
+def make_cfg(df: pd.DataFrame, tmp_path) -> dict:
+    return {
+        "dataframe": df,
+        "data": {"csv_path": ""},
+        "vol_adjust": {"target_vol": 1.0},
+        "run": {"monthly_cost": 0.0},
+        "portfolio": {},
+        "multi_period": {
+            "frequency": "A",
+            "in_sample_len": 1,
+            "out_sample_len": 1,
+            "start": "2020",
+            "end": "2023",
+            "triggers": {"sigma1": {"sigma": 1, "periods": 1}},
+            "min_funds": 2,
+            "max_funds": 5,
+            "weight_curve": {"anchors": [[0, 1.0], [100, 1.0]]},
+        },
+        "checkpoint_dir": str(tmp_path / "chk"),
+        "random_seed": 0,
+    }
+
+
+def fake_single_period_run(*args, **kwargs):
+    df = args[0]
+    funds = [c for c in df.columns if c != "Date"]
+    score = pd.DataFrame(
+        {
+            "zscore": np.linspace(-1.5, 1.5, len(funds)),
+            "rank": np.arange(1, len(funds) + 1),
+        },
+        index=funds,
+    )
+    return {"score_frame": score, "selected_funds": funds}
+
+
+def test_engine_run_summary(tmp_path, monkeypatch):
+    df = make_df()
+    cfg = make_cfg(df, tmp_path)
+    monkeypatch.setattr(engine, "single_period_run", fake_single_period_run)
+    result = engine.run(cfg)
+    assert isinstance(result["summary"], pd.DataFrame)
+    assert len(result["summary"]) == 3

--- a/trend_analysis/multi_period/engine.py
+++ b/trend_analysis/multi_period/engine.py
@@ -2,9 +2,69 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Dict
 
+import pandas as pd
 
-def run(cfg: Dict[str, Any]) -> Dict[str, object]:  # noqa: D401
-    """Return an empty result for now; will iterate periods later."""
-    return {}
+from ..data import load_csv
+from ..pipeline import single_period_run
+from .scheduler import generate_periods
+from .replacer import Rebalancer
+
+
+def run(cfg: Dict[str, Any]) -> Dict[str, object]:
+    """Execute multi-period backtest based on ``cfg``."""
+
+    schedule = generate_periods(cfg)
+
+    df = cfg.get("dataframe")
+    if df is None:
+        path = cfg["data"]["csv_path"]
+        df = load_csv(path)
+        if df is None:
+            raise FileNotFoundError(path)
+
+    reb = Rebalancer(cfg)
+    weights = pd.Series(dtype=float)
+    results: Dict[str, Any] = {}
+    summary_rows: list[pd.Series] = []
+
+    for period in schedule:
+        res = single_period_run(
+            df,
+            period.in_start,
+            period.in_end,
+            period.out_start,
+            period.out_end,
+            cfg["vol_adjust"].get("target_vol", 1.0),
+            cfg.get("run", {}).get("monthly_cost", 0.0),
+            selection_mode=cfg.get("portfolio", {}).get("selection_mode", "all"),
+            random_n=cfg.get("portfolio", {}).get("random_n", 8),
+            rank_kwargs=cfg.get("portfolio", {}).get("rank"),
+            manual_funds=cfg.get("portfolio", {}).get("manual_list"),
+            indices_list=cfg.get("portfolio", {}).get("indices_list"),
+            seed=cfg.get("random_seed", 42),
+        )
+        if res is None:
+            continue
+
+        score = res.get("score_frame", pd.DataFrame())
+        weights = reb.apply_triggers(weights, score)
+        res["weights"] = weights
+        results[period.out_end] = res
+        summary_rows.append(weights)
+
+        chk_dir = cfg.get("checkpoint_dir")
+        if chk_dir:
+            Path(chk_dir).mkdir(parents=True, exist_ok=True)
+            out_file = Path(chk_dir) / f"{period.out_end}.parquet"
+            weights.to_frame("weight").to_parquet(out_file)
+
+    summary = (
+        pd.DataFrame(summary_rows, index=[p.out_end for p in schedule])
+        if summary_rows
+        else pd.DataFrame()
+    )
+
+    return {"periods": results, "summary": summary}


### PR DESCRIPTION
## Summary
- flesh out `Rebalancer` to handle strike rules, additions and weighting
- implement multi-period `engine.run`
- add integration tests for engine behaviour

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686356b4ffe0833189b187bae4ea3fb2