### PR TITLE
Integrate information ratio metric

### DIFF
--- a/tests/test_export_formatter.py
+++ b/tests/test_export_formatter.py
@@ -36,15 +36,18 @@ class DummyWB:
 def test_make_summary_formatter_registers_and_runs():
     FORMATTERS_EXCEL.clear()
     res = {
-        "in_ew_stats": (1, 1, 1, 1, 1),
-        "out_ew_stats": (2, 2, 2, 2, 2),
-        "in_user_stats": (3, 3, 3, 3, 3),
-        "out_user_stats": (4, 4, 4, 4, 4),
-        "in_sample_stats": {"fund": (5, 5, 5, 5, 5)},
-        "out_sample_stats": {"fund": (6, 6, 6, 6, 6)},
+        "in_ew_stats": (1, 1, 1, 1, 1, 1),
+        "out_ew_stats": (2, 2, 2, 2, 2, 2),
+        "in_user_stats": (3, 3, 3, 3, 3, 3),
+        "out_user_stats": (4, 4, 4, 4, 4, 4),
+        "in_sample_stats": {"fund": (5, 5, 5, 5, 5, 5)},
+        "out_sample_stats": {"fund": (6, 6, 6, 6, 6, 6)},
         "fund_weights": {"fund": 0.5},
         "index_stats": {
-            "idx": {"in_sample": (7, 7, 7, 7, 7), "out_sample": (8, 8, 8, 8, 8)}
+            "idx": {
+                "in_sample": (7, 7, 7, 7, 7, 7),
+                "out_sample": (8, 8, 8, 8, 8, 8),
+            }
         },
     }
     fmt = make_summary_formatter(res, "a", "b", "c", "d")
@@ -57,12 +60,12 @@ def test_make_summary_formatter_registers_and_runs():
 
 def test_format_summary_text_basic():
     res = {
-        "in_ew_stats": (1, 1, 1, 1, 1),
-        "out_ew_stats": (2, 2, 2, 2, 2),
-        "in_user_stats": (3, 3, 3, 3, 3),
-        "out_user_stats": (4, 4, 4, 4, 4),
-        "in_sample_stats": {"fund": (5, 5, 5, 5, 5)},
-        "out_sample_stats": {"fund": (6, 6, 6, 6, 6)},
+        "in_ew_stats": (1, 1, 1, 1, 1, 1),
+        "out_ew_stats": (2, 2, 2, 2, 2, 2),
+        "in_user_stats": (3, 3, 3, 3, 3, 3),
+        "out_user_stats": (4, 4, 4, 4, 4, 4),
+        "in_sample_stats": {"fund": (5, 5, 5, 5, 5, 5)},
+        "out_sample_stats": {"fund": (6, 6, 6, 6, 6, 6)},
         "fund_weights": {"fund": 0.5},
         "index_stats": {},
     }
@@ -93,10 +96,10 @@ def test_export_to_excel_invokes_formatter(tmp_path):
 def test_export_to_excel_backward_compat_sheet_formatter(tmp_path):
     df = pd.DataFrame({"A": [1]})
     res = {
-        "in_ew_stats": (0, 0, 0, 0, 0),
-        "out_ew_stats": (0, 0, 0, 0, 0),
-        "in_user_stats": (0, 0, 0, 0, 0),
-        "out_user_stats": (0, 0, 0, 0, 0),
+        "in_ew_stats": (0, 0, 0, 0, 0, 0),
+        "out_ew_stats": (0, 0, 0, 0, 0, 0),
+        "in_user_stats": (0, 0, 0, 0, 0, 0),
+        "out_user_stats": (0, 0, 0, 0, 0, 0),
         "in_sample_stats": {},
         "out_sample_stats": {},
         "fund_weights": {},
@@ -111,12 +114,12 @@ def test_export_to_excel_backward_compat_sheet_formatter(tmp_path):
 
 def test_format_summary_text_no_index_stats():
     res = {
-        "in_ew_stats": (1, 1, 1, 1, 1),
-        "out_ew_stats": (2, 2, 2, 2, 2),
-        "in_user_stats": (3, 3, 3, 3, 3),
-        "out_user_stats": (4, 4, 4, 4, 4),
-        "in_sample_stats": {"fund": (5, 5, 5, 5, 5)},
-        "out_sample_stats": {"fund": (6, 6, 6, 6, 6)},
+        "in_ew_stats": (1, 1, 1, 1, 1, 1),
+        "out_ew_stats": (2, 2, 2, 2, 2, 2),
+        "in_user_stats": (3, 3, 3, 3, 3, 3),
+        "out_user_stats": (4, 4, 4, 4, 4, 4),
+        "in_sample_stats": {"fund": (5, 5, 5, 5, 5, 5)},
+        "out_sample_stats": {"fund": (6, 6, 6, 6, 6, 6)},
         "fund_weights": {"fund": 0.5},
     }
     text = format_summary_text(res, "a", "b", "c", "d")
@@ -125,12 +128,12 @@ def test_format_summary_text_no_index_stats():
 
 def test_make_summary_formatter_handles_nan(tmp_path):
     res = {
-        "in_ew_stats": (1, 1, 1, 1, float("nan")),
-        "out_ew_stats": (2, 2, 2, 2, 2),
-        "in_user_stats": (3, 3, 3, 3, 3),
-        "out_user_stats": (4, 4, 4, 4, 4),
-        "in_sample_stats": {"fund": (5, 5, float("nan"), 5, 5)},
-        "out_sample_stats": {"fund": (6, 6, 6, 6, 6)},
+        "in_ew_stats": (1, 1, 1, 1, 1, float("nan")),
+        "out_ew_stats": (2, 2, 2, 2, 2, 2),
+        "in_user_stats": (3, 3, 3, 3, 3, 3),
+        "out_user_stats": (4, 4, 4, 4, 4, 4),
+        "in_sample_stats": {"fund": (5, 5, 5, float("nan"), 5, 5)},
+        "out_sample_stats": {"fund": (6, 6, 6, 6, 6, 6)},
         "fund_weights": {"fund": 0.5},
         "index_stats": {},
     }

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -43,7 +43,14 @@ def test_run_returns_dataframe(tmp_path):
     cfg = make_cfg(tmp_path, make_df())
     out = pipeline.run(cfg)
     assert not out.empty
-    assert set(out.columns) == {"cagr", "vol", "sharpe", "sortino", "max_drawdown"}
+    assert set(out.columns) == {
+        "cagr",
+        "vol",
+        "sharpe",
+        "sortino",
+        "information_ratio",
+        "max_drawdown",
+    }
 
 
 def test_run_returns_empty_when_no_funds(tmp_path, monkeypatch):

--- a/trend_analysis/export.py
+++ b/trend_analysis/export.py
@@ -52,20 +52,28 @@ def make_summary_formatter(
                 return ""
             return cast(str | float, v)
 
-        def to_tuple(obj: Any) -> tuple[float, float, float, float, float]:
+        def to_tuple(obj: Any) -> tuple[float, float, float, float, float, float]:
             if isinstance(obj, tuple):
-                return cast(tuple[float, float, float, float, float], obj)
+                return cast(tuple[float, float, float, float, float, float], obj)
             return (
                 cast(float, obj.cagr),
                 cast(float, obj.vol),
                 cast(float, obj.sharpe),
                 cast(float, obj.sortino),
+                cast(float, obj.information_ratio),
                 cast(float, obj.max_drawdown),
             )
 
         def pct(t: Any) -> list[float]:
             tup = to_tuple(t)
-            return [tup[0] * 100, tup[1] * 100, tup[2], tup[3], tup[4] * 100]
+            return [
+                tup[0] * 100,
+                tup[1] * 100,
+                tup[2],
+                tup[3],
+                tup[4],
+                tup[5] * 100,
+            ]
 
         ws.write_row(0, 0, ["Vol-Adj Trend Analysis"], bold)
         ws.write_row(1, 0, [f"In:  {in_start} → {in_end}"], bold)
@@ -77,11 +85,13 @@ def make_summary_formatter(
             "IS Vol",
             "IS Sharpe",
             "IS Sortino",
+            "IS IR",
             "IS MaxDD",
             "OS CAGR",
             "OS Vol",
             "OS Sharpe",
             "OS Sortino",
+            "OS IR",
             "OS MaxDD",
         ]
         ws.write_row(4, 0, headers, bold)
@@ -94,7 +104,7 @@ def make_summary_formatter(
             ws.write(row, 0, label, bold)
             ws.write(row, 1, safe(""))
             vals = pct(ins) + pct(outs)
-            fmts = ([num2] * 4 + [red]) * 2
+            fmts = ([num2] * 5 + [red]) * 2
             for col, (v, fmt) in enumerate(zip(vals, fmts), start=2):
                 ws.write(row, col, safe(v), fmt)
             row += 1
@@ -106,7 +116,7 @@ def make_summary_formatter(
             wt = res["fund_weights"][fund]
             ws.write(row, 1, safe(wt * 100), int0)
             vals = pct(stat_in) + pct(stat_out)
-            fmts = ([num2] * 4 + [red]) * 2
+            fmts = ([num2] * 5 + [red]) * 2
             for col, (v, fmt) in enumerate(zip(vals, fmts), start=2):
                 ws.write(row, col, safe(v), fmt)
             row += 1
@@ -118,7 +128,7 @@ def make_summary_formatter(
             ws.write(row, 0, idx, bold)
             ws.write(row, 1, safe(""))
             vals = pct(in_idx) + pct(out_idx)
-            fmts = ([num2] * 4 + [red]) * 2
+            fmts = ([num2] * 5 + [red]) * 2
             for col, (v, fmt) in enumerate(zip(vals, fmts), start=2):
                 ws.write(row, col, safe(v), fmt)
             row += 1
@@ -142,20 +152,21 @@ def format_summary_text(
             return f"{val:.2f}"
         return cast(str, val)
 
-    def to_tuple(obj: Any) -> tuple[float, float, float, float, float]:
+    def to_tuple(obj: Any) -> tuple[float, float, float, float, float, float]:
         if isinstance(obj, tuple):
-            return cast(tuple[float, float, float, float, float], obj)
+            return cast(tuple[float, float, float, float, float, float], obj)
         return (
             cast(float, obj.cagr),
             cast(float, obj.vol),
             cast(float, obj.sharpe),
             cast(float, obj.sortino),
+            cast(float, obj.information_ratio),
             cast(float, obj.max_drawdown),
         )
 
     def pct(t: Any) -> list[float]:
         a = to_tuple(t)
-        return [a[0] * 100, a[1] * 100, a[2], a[3], a[4] * 100]
+        return [a[0] * 100, a[1] * 100, a[2], a[3], a[4], a[5] * 100]
 
     columns = [
         "Name",
@@ -164,11 +175,13 @@ def format_summary_text(
         "IS Vol",
         "IS Sharpe",
         "IS Sortino",
+        "IS IR",
         "IS MaxDD",
         "OS CAGR",
         "OS Vol",
         "OS Sharpe",
         "OS Sortino",
+        "OS IR",
         "OS MaxDD",
     ]
 

--- a/trend_analysis/pipeline.py
+++ b/trend_analysis/pipeline.py
@@ -13,6 +13,7 @@ from .metrics import (
     sharpe_ratio,
     sortino_ratio,
     max_drawdown,
+    information_ratio,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - for static type checking only
@@ -31,6 +32,7 @@ class _Stats:
     sharpe: float
     sortino: float
     max_drawdown: float
+    information_ratio: float
 
 
 def calc_portfolio_returns(weights: np.ndarray, returns_df: pd.DataFrame) -> pd.Series:
@@ -49,6 +51,7 @@ def _compute_stats(df: pd.DataFrame, rf: pd.Series) -> dict[str, _Stats]:
             sharpe=float(sharpe_ratio(df[col], rf)),
             sortino=float(sortino_ratio(df[col], rf)),
             max_drawdown=float(max_drawdown(df[col])),
+            information_ratio=float(information_ratio(df[col], rf)),
         )
     return stats
 


### PR DESCRIPTION
## Summary
- compute information ratio in pipeline stats
- include information ratio in Excel/text exports
- update tests for new information ratio column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f1887d34833189aeefc32a512658