### PR TITLE
Merge indices into benchmark handling

### DIFF
--- a/tests/legacy_metrics.py
+++ b/tests/legacy_metrics.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 from pandas import DataFrame, Series
+from trend_analysis.metrics import information_ratio
 
 
 def _validate_input(obj: Series | DataFrame) -> None:
@@ -171,5 +172,6 @@ def max_drawdown(returns: Series | DataFrame, axis: int = 0) -> Series | float:
 
     return _apply(returns, _calc, axis)
 
-annualize_return  = annual_return
+
+annualize_return = annual_return
 information_ratio = info_ratio = information_ratio

--- a/tests/test_export_formatter.py
+++ b/tests/test_export_formatter.py
@@ -43,12 +43,6 @@ def test_make_summary_formatter_registers_and_runs():
         "in_sample_stats": {"fund": (5, 5, 5, 5, 5, 5)},
         "out_sample_stats": {"fund": (6, 6, 6, 6, 6, 6)},
         "fund_weights": {"fund": 0.5},
-        "index_stats": {
-            "idx": {
-                "in_sample": (7, 7, 7, 7, 7, 7),
-                "out_sample": (8, 8, 8, 8, 8, 8),
-            }
-        },
     }
     fmt = make_summary_formatter(res, "a", "b", "c", "d")
     assert "summary" in FORMATTERS_EXCEL
@@ -67,7 +61,6 @@ def test_format_summary_text_basic():
         "in_sample_stats": {"fund": (5, 5, 5, 5, 5, 5)},
         "out_sample_stats": {"fund": (6, 6, 6, 6, 6, 6)},
         "fund_weights": {"fund": 0.5},
-        "index_stats": {},
     }
     text = format_summary_text(res, "a", "b", "c", "d")
     assert "Vol-Adj Trend Analysis" in text
@@ -103,7 +96,6 @@ def test_export_to_excel_backward_compat_sheet_formatter(tmp_path):
         "in_sample_stats": {},
         "out_sample_stats": {},
         "fund_weights": {},
-        "index_stats": {},
     }
 
     sheet_formatter = make_summary_formatter(res, "a", "b", "c", "d")
@@ -135,7 +127,6 @@ def test_make_summary_formatter_handles_nan(tmp_path):
         "in_sample_stats": {"fund": (5, 5, 5, float("nan"), 5, 5)},
         "out_sample_stats": {"fund": (6, 6, 6, 6, 6, 6)},
         "fund_weights": {"fund": 0.5},
-        "index_stats": {},
     }
     fmt = make_summary_formatter(res, "a", "b", "c", "d")
     ws = DummyWS()
@@ -154,7 +145,6 @@ def test_make_summary_formatter_with_benchmarks():
         "in_sample_stats": {"fund": (5, 5, 5, 5, 5, 5)},
         "out_sample_stats": {"fund": (6, 6, 6, 6, 6, 6)},
         "fund_weights": {"fund": 1.0},
-        "index_stats": {},
         "benchmark_ir": {"spx": {"fund": 0.1, "equal_weight": 0.2, "user_weight": 0.3}},
     }
     fmt = make_summary_formatter(res, "a", "b", "c", "d")

--- a/tests/test_metric_vectorise_param.py
+++ b/tests/test_metric_vectorise_param.py
@@ -1,4 +1,6 @@
-import numpy as np, pandas as pd, pytest
+import numpy as np
+import pandas as pd
+import pytest
 import trend_analysis.metrics as M
 import tests.legacy_metrics as L
 

--- a/tests/test_rank_transform.py
+++ b/tests/test_rank_transform.py
@@ -1,5 +1,7 @@
-import numpy as np, pandas as pd
+import numpy as np
+import pandas as pd
 from trend_analysis.core.rank_selection import _apply_transform
+
 
 def test_apply_transform_zscore():
     s = pd.Series([0.1, 0.2, 0.0, 0.3], index=list("ABCD"))

--- a/tests/test_run_analysis.py
+++ b/tests/test_run_analysis.py
@@ -2,12 +2,11 @@ import pandas as pd
 import numpy as np
 from trend_analysis.pipeline import run_analysis, Stats, calc_portfolio_returns
 from trend_analysis.metrics import (
-    annual_return,
-    volatility,
+    annualize_return,
+    annualize_volatility,
     sharpe_ratio,
     sortino_ratio,
     max_drawdown,
-    information_ratio
 )
 
 

--- a/trend_analysis/export.py
+++ b/trend_analysis/export.py
@@ -136,16 +136,6 @@ def make_summary_formatter(
             row += 1
 
         row += 1
-        for idx, pair in res.get("index_stats", {}).items():
-            in_idx = pair["in_sample"]
-            out_idx = pair["out_sample"]
-            ws.write(row, 0, idx, bold)
-            ws.write(row, 1, safe(""))
-            vals = pct(in_idx) + pct(out_idx)
-            fmts = ([num2] * 5 + [red]) * 2
-            for col, (v, fmt) in enumerate(zip(vals, fmts), start=2):
-                ws.write(row, col, safe(v), fmt)
-            row += 1
 
     return fmt_summary
 
@@ -232,13 +222,6 @@ def format_summary_text(
         ]
         vals.extend(extra)
         rows.append([fund, weight, *vals])
-
-    if res.get("index_stats"):
-        rows.append([None] * len(columns))  # pragma: no cover - optional branch
-        for idx, pair in res["index_stats"].items():  # pragma: no cover
-            vals = pct(pair["in_sample"]) + pct(pair["out_sample"])  # pragma: no cover
-            vals.extend([float("nan")] * len(bench_labels))
-            rows.append([idx, None, *vals])  # pragma: no cover
 
     df = pd.DataFrame(rows, columns=columns)
     df_formatted = df.map(safe)


### PR DESCRIPTION
## Summary
- treat optional indices as additional benchmarks
- simplify exporter to drop index rows
- adjust export formatter tests
- fix lint issues

## Testing
- `ruff check .`
- `black --check .`
- `mypy trend_analysis`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68661a1591f883318b6ee8275758830c