### PR TITLE
Fix Stats field ordering

### DIFF
--- a/trend_analysis/pipeline.py
+++ b/trend_analysis/pipeline.py
@@ -31,8 +31,8 @@ class _Stats:
     vol: float
     sharpe: float
     sortino: float
-    max_drawdown: float
     information_ratio: float
+    max_drawdown: float
 
 
 def calc_portfolio_returns(weights: np.ndarray, returns_df: pd.DataFrame) -> pd.Series:


### PR DESCRIPTION
## Summary
- move information_ratio field before max_drawdown in `_Stats`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686630527bcc83319858a556e46bb328