### PR TITLE
Add score_frame edge tests & ensure 100% coverage

### DIFF
--- a/tests/test_metrics_edgecases.py
+++ b/tests/test_metrics_edgecases.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import numpy as np
+import pytest
+from trend_analysis import metrics
+
+
+def test_available_metrics_and_empty_like():
+    assert "annual_return" in metrics.available_metrics()
+    df = pd.DataFrame({"a": [0.1]})
+    res = metrics._empty_like(df, "foo")
+    assert isinstance(res, pd.Series)
+    assert res.isna().all()
+
+
+def test_check_shapes_mismatch():
+    s = pd.Series([0.1, 0.2])
+    df = pd.DataFrame({"a": [0.1, 0.2]})
+    with pytest.raises(ValueError):
+        metrics._check_shapes(df, s, "oops")
+
+
+def test_max_drawdown_type_error():
+    with pytest.raises(TypeError):
+        metrics.max_drawdown([0.1, -0.1])  # type: ignore[arg-type]
+
+
+def test_information_ratio_edge_cases():
+    short = pd.Series([0.1])
+    assert np.isnan(metrics.information_ratio(short, benchmark=0.0))
+    df = pd.DataFrame({"a": [0.02, 0.03], "b": [0.01, 0.02]})
+    bench = pd.DataFrame({"m": [0.01, 0.01]})
+    ir = metrics.information_ratio(df, bench)
+    assert isinstance(ir, pd.Series) and set(ir.index) == {"a", "b"}

--- a/tests/test_pipeline_indices.py
+++ b/tests/test_pipeline_indices.py
@@ -4,12 +4,14 @@ from trend_analysis.pipeline import run_analysis
 
 def make_df():
     dates = pd.date_range("2020-01-31", periods=6, freq="ME")
-    return pd.DataFrame({
-        "Date": dates,
-        "RF": 0.0,
-        "A": 0.01,
-        "SPX": 0.02,
-    })
+    return pd.DataFrame(
+        {
+            "Date": dates,
+            "RF": 0.0,
+            "A": 0.01,
+            "SPX": 0.02,
+        }
+    )
 
 
 def test_indices_promoted_to_benchmarks():
@@ -40,6 +42,7 @@ def test_missing_benchmark_column_ignored():
         benchmarks={"foo": "FOO"},
     )
     assert "foo" not in res["benchmark_ir"]
+
 
 def test_indices_already_in_benchmarks():
     df = make_df()

--- a/tests/test_pipeline_indices.py
+++ b/tests/test_pipeline_indices.py
@@ -1,0 +1,57 @@
+import pandas as pd
+from trend_analysis.pipeline import run_analysis
+
+
+def make_df():
+    dates = pd.date_range("2020-01-31", periods=6, freq="ME")
+    return pd.DataFrame({
+        "Date": dates,
+        "RF": 0.0,
+        "A": 0.01,
+        "SPX": 0.02,
+    })
+
+
+def test_indices_promoted_to_benchmarks():
+    df = make_df()
+    res = run_analysis(
+        df,
+        "2020-01",
+        "2020-03",
+        "2020-04",
+        "2020-06",
+        1.0,
+        0.0,
+        indices_list=["SPX"],
+    )
+    assert "SPX" in res["benchmark_ir"]
+
+
+def test_missing_benchmark_column_ignored():
+    df = make_df()
+    res = run_analysis(
+        df,
+        "2020-01",
+        "2020-03",
+        "2020-04",
+        "2020-06",
+        1.0,
+        0.0,
+        benchmarks={"foo": "FOO"},
+    )
+    assert "foo" not in res["benchmark_ir"]
+
+def test_indices_already_in_benchmarks():
+    df = make_df()
+    res = run_analysis(
+        df,
+        "2020-01",
+        "2020-03",
+        "2020-04",
+        "2020-06",
+        1.0,
+        0.0,
+        indices_list=["SPX"],
+        benchmarks={"SPX": "SPX"},
+    )
+    assert list(res["benchmark_ir"].keys()) == ["SPX"]

--- a/tests/test_score_frame.py
+++ b/tests/test_score_frame.py
@@ -1,3 +1,4 @@
+import pytest
 import pandas as pd
 from pathlib import Path
 from trend_analysis.pipeline import single_period_run
@@ -29,3 +30,22 @@ def test_column_order_respects_config():
     cfg = RiskStatsConfig(metrics_to_run=["Volatility", "AnnualReturn"])
     sf = single_period_run(df, "2020-01", "2020-03", stats_cfg=cfg)
     assert sf.columns.tolist() == cfg.metrics_to_run
+
+def test_single_period_run_string_dates():
+    df = make_df()[["Date", "A", "B"]]
+    df["Date"] = df["Date"].astype(str)
+    sf = single_period_run(df, "2020-01", "2020-03")
+    assert sf.attrs["insample_len"] == 3
+
+
+def test_single_period_run_missing_date():
+    df = make_df()[["A", "B"]]
+    with pytest.raises(ValueError):
+        single_period_run(df, "2020-01", "2020-03")
+
+
+def test_single_period_run_no_metrics():
+    df = make_df()[["Date", "A"]]
+    cfg = RiskStatsConfig(metrics_to_run=[])
+    with pytest.raises(ValueError):
+        single_period_run(df, "2020-01", "2020-03", stats_cfg=cfg)

--- a/tests/test_score_frame.py
+++ b/tests/test_score_frame.py
@@ -31,6 +31,7 @@ def test_column_order_respects_config():
     sf = single_period_run(df, "2020-01", "2020-03", stats_cfg=cfg)
     assert sf.columns.tolist() == cfg.metrics_to_run
 
+
 def test_single_period_run_string_dates():
     df = make_df()[["Date", "A", "B"]]
     df["Date"] = df["Date"].astype(str)

--- a/trend_analysis/metrics.py
+++ b/trend_analysis/metrics.py
@@ -131,7 +131,7 @@ def sharpe_ratio(
     if isinstance(risk_free, DataFrame):
         raise ValueError("sharpe_ratio: risk_free cannot be a DataFrame")
     if isinstance(returns, Series) and isinstance(risk_free, DataFrame):
-        raise ValueError("sharpe_ratio: Series vs DataFrame not supported")
+        raise ValueError("sharpe_ratio: Series vs DataFrame not supported")  # pragma: no cover - unreachable
     _check_shapes(returns, risk_free, "sharpe_ratio")
 
     excess = returns - risk_free

--- a/trend_analysis/metrics.py
+++ b/trend_analysis/metrics.py
@@ -131,7 +131,9 @@ def sharpe_ratio(
     if isinstance(risk_free, DataFrame):
         raise ValueError("sharpe_ratio: risk_free cannot be a DataFrame")
     if isinstance(returns, Series) and isinstance(risk_free, DataFrame):
-        raise ValueError("sharpe_ratio: Series vs DataFrame not supported")  # pragma: no cover - unreachable
+        raise ValueError(
+            "sharpe_ratio: Series vs DataFrame not supported"
+        )  # pragma: no cover - unreachable
     _check_shapes(returns, risk_free, "sharpe_ratio")
 
     excess = returns - risk_free


### PR DESCRIPTION
## Summary
- cover edge cases for metrics and pipeline
- test score_frame helper behaviour with invalid configs
- ensure all branches execute

## Testing
- `pytest --cov=trend_analysis --cov-branch -q`

------
https://chatgpt.com/codex/tasks/task_e_68663f855cac833196748803e3bfb163