### PR TITLE
Improve single_period_run docs

### DIFF
--- a/trend_analysis/pipeline.py
+++ b/trend_analysis/pipeline.py
@@ -57,6 +57,13 @@ def single_period_run(
         Inclusive period in ``YYYY-MM`` format.
     stats_cfg : RiskStatsConfig | None
         Metric configuration; defaults to ``RiskStatsConfig()``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Table of metric values (index = fund code).  The frame is pure
+        and carries ``insample_len`` and ``period`` metadata so callers
+        can reason about the analysed window.
     """
     from .core.rank_selection import RiskStatsConfig, _compute_metric_series
 


### PR DESCRIPTION
## Summary
- clarify the score frame semantics in `single_period_run`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68669d498d4483318a4794adf6d97954