### PR TITLE
Add score_frame period assertion test

### DIFF
--- a/tests/test_score_frame.py
+++ b/tests/test_score_frame.py
@@ -37,6 +37,7 @@ def test_single_period_run_string_dates():
     df["Date"] = df["Date"].astype(str)
     sf = single_period_run(df, "2020-01", "2020-03")
     assert sf.attrs["insample_len"] == 3
+    assert sf.attrs["period"] == ("2020-01", "2020-03")
 
 
 def test_single_period_run_missing_date():


### PR DESCRIPTION
## Summary
- add missing metadata assertion for `score_frame`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866a12be2588331814eff1c3dfe2189