### PR TITLE
Continue phase-2 engine tasks

### DIFF
--- a/tests/test_multi_period_engine.py
+++ b/tests/test_multi_period_engine.py
@@ -2,7 +2,9 @@ import pandas as pd
 import yaml
 from pathlib import Path
 from trend_analysis.config import Config
-from trend_analysis.multi_period import run as run_mp
+from trend_analysis.multi_period import run as run_mp, run_schedule, Portfolio
+from trend_analysis.selector import RankSelector
+from trend_analysis.weighting import EqualWeight
 
 
 def make_df():
@@ -30,3 +32,14 @@ def test_multi_period_run_returns_results():
     out = run_mp(cfg, df)
     assert isinstance(out, list)
     assert out, "no period results returned"
+
+
+def test_run_schedule_generates_weight_history():
+    sf = pd.read_csv(Path("tests/fixtures/score_frame_2025-06-30.csv"), index_col=0)
+    frames = {"2025-06-30": sf, "2025-07-31": sf}
+    selector = RankSelector(top_n=1, rank_column="Sharpe")
+    weighting = EqualWeight()
+    portfolio = run_schedule(frames, selector, weighting)
+    assert isinstance(portfolio, Portfolio)
+    assert list(portfolio.history.keys()) == ["2025-06-30", "2025-07-31"]
+    assert list(portfolio.history["2025-06-30"].index) == ["A"]

--- a/trend_analysis/multi_period/__init__.py
+++ b/trend_analysis/multi_period/__init__.py
@@ -1,5 +1,5 @@
 """Multi‑period back‑tester package (Phase 2)."""
 
-from .engine import run
+from .engine import run, Portfolio, run_schedule
 
-__all__ = ["run"]
+__all__ = ["run", "Portfolio", "run_schedule"]

--- a/trend_analysis/multi_period/engine.py
+++ b/trend_analysis/multi_period/engine.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Dict, List
+from dataclasses import dataclass, field
+from typing import Dict, List, Mapping
 
 import pandas as pd
 
@@ -10,6 +11,39 @@ from ..config import Config
 from ..data import load_csv
 from ..pipeline import _run_analysis
 from .scheduler import generate_periods
+
+
+@dataclass
+class Portfolio:
+    """Minimal container for weight history."""
+
+    history: Dict[str, pd.Series] = field(default_factory=dict)
+
+    def rebalance(self, date: str | pd.Timestamp, weights: pd.DataFrame | pd.Series) -> None:
+        """Store weights for the given date."""
+        if isinstance(weights, pd.DataFrame):
+            if "weight" in weights.columns:
+                series = weights["weight"]
+            else:
+                series = weights.squeeze()
+        else:
+            series = weights
+        self.history[str(pd.to_datetime(date).date())] = series.astype(float)
+
+
+def run_schedule(
+    score_frames: Mapping[str, pd.DataFrame],
+    selector: object,
+    weighting: "BaseWeighting",
+) -> Portfolio:
+    """Apply selection and weighting across ``score_frames``."""
+
+    pf = Portfolio()
+    for date in sorted(score_frames):
+        selected, _ = selector.select(score_frames[date])
+        weights = weighting.weight(selected)
+        pf.rebalance(date, weights)
+    return pf
 
 
 def run(cfg: Config, df: pd.DataFrame | None = None) -> List[Dict[str, object]]:


### PR DESCRIPTION
## Summary
- implement `Portfolio` and `run_schedule` in the multi-period engine
- expose new API through `multi_period.__init__`
- test the schedule loop with selectors and weighting classes

## Testing
- `pip install xlsxwriter`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68678b7131b8833185fb764d9ec0a735