### PR TITLE
Implement metric registry config

### DIFF
--- a/tests/test_run_full.py
+++ b/tests/test_run_full.py
@@ -83,3 +83,12 @@ def test_run_full_with_benchmarks(tmp_path):
     assert "spx" in res["benchmark_ir"]
     assert "equal_weight" in res["benchmark_ir"]["spx"]
     assert "A" in res["benchmark_ir"]["spx"]
+
+
+def test_run_full_respects_metric_registry(tmp_path):
+    df = make_df()
+    cfg = make_cfg(tmp_path, df)
+    cfg.metrics = {"registry": ["sharpe_ratio", "volatility"]}
+    res = run_full(cfg)
+    sf = res["score_frame"]
+    assert sf.columns.tolist() == ["Sharpe", "Volatility"]

--- a/trend_analysis/core/rank_selection.py
+++ b/trend_analysis/core/rank_selection.py
@@ -8,7 +8,7 @@ This module implements the `rank` selection mode described in Agents.md. Funds c
 # =============================================================================
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, cast
+from typing import Any, Callable, Dict, List, Iterable, cast
 from ..export import Formatter
 import io
 import numpy as np
@@ -159,6 +159,22 @@ class RiskStatsConfig:
 
 
 METRIC_REGISTRY: Dict[str, Callable[..., float | pd.Series | np.floating]] = {}
+
+# Map snake_case config names to the canonical registry keys.
+_METRIC_ALIASES: dict[str, str] = {
+    "annual_return": "AnnualReturn",
+    "volatility": "Volatility",
+    "sharpe_ratio": "Sharpe",
+    "sortino_ratio": "Sortino",
+    "max_drawdown": "MaxDrawdown",
+    "information_ratio": "InformationRatio",
+}
+
+
+def canonical_metric_list(names: Iterable[str]) -> list[str]:
+    """Return registry keys normalised from ``names``."""
+
+    return [_METRIC_ALIASES.get(n, n) for n in names]
 
 
 def register_metric(
@@ -751,4 +767,5 @@ __all__ = [
     "rank_select_funds",
     "select_funds",
     "build_ui",
+    "canonical_metric_list",
 ]


### PR DESCRIPTION
## Summary
- normalize metric names from config with `canonical_metric_list`
- honour `metrics.registry` when running the pipeline
- test `run_full` with custom metric list

## Testing
- `ruff check trend_analysis tests`
- `mypy --strict trend_analysis`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686808b703f083318e9aa24d82bb53d0