### PR TITLE
Implement output config alias

### DIFF
--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -41,3 +41,27 @@ def test_env_var_override(tmp_path, monkeypatch):
     cfg = config.load()
     assert cfg.version == "42"
     monkeypatch.delenv("TREND_CFG", raising=False)
+
+
+def test_output_alias(tmp_path):
+    cfg_file = tmp_path / "alias.yml"
+    cfg_file.write_text(
+        "\n".join(
+            [
+                "version: '1'",
+                "data: {}",
+                "preprocessing: {}",
+                "vol_adjust: {}",
+                "sample_split: {}",
+                "portfolio: {}",
+                "metrics: {}",
+                "output: {format: csv, path: '" + str(tmp_path / "res") + "'}",
+                "run: {}",
+            ]
+        )
+    )
+    cfg = config.load(str(cfg_file))
+    assert cfg.export["formats"] == ["csv"]
+    assert cfg.export["directory"] == str(tmp_path)
+    assert cfg.export["filename"] == "res"
+

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -64,4 +64,3 @@ def test_output_alias(tmp_path):
     assert cfg.export["formats"] == ["csv"]
     assert cfg.export["directory"] == str(tmp_path)
     assert cfg.export["filename"] == "res"
-

--- a/trend_analysis/config.py
+++ b/trend_analysis/config.py
@@ -45,6 +45,7 @@ class Config(BaseModel):
     benchmarks: dict[str, str] = {}
     metrics: dict[str, Any]
     export: dict[str, Any]
+    output: dict[str, Any] | None = None
     run: dict[str, Any]
     multi_period: dict[str, Any] | None = None
     jobs: int | None = None
@@ -85,6 +86,19 @@ def load(path: str | Path | None = None) -> Config:
         data = yaml.safe_load(fh)
         if not isinstance(data, dict):
             raise TypeError("Config file must contain a mapping")
+
+    out_cfg = data.pop("output", None)
+    if isinstance(out_cfg, dict):
+        export_cfg = data.setdefault("export", {})
+        fmt = out_cfg.get("format")
+        if fmt:
+            export_cfg["formats"] = [fmt] if isinstance(fmt, str) else list(fmt)
+        path_val = out_cfg.get("path")
+        if path_val:
+            p = Path(path_val)
+            export_cfg.setdefault("directory", str(p.parent) if p.parent else ".")
+            export_cfg.setdefault("filename", p.name)
+
     return Config(**data)
 
 

--- a/trend_analysis/run_analysis.py
+++ b/trend_analysis/run_analysis.py
@@ -46,6 +46,7 @@ def main(argv: list[str] | None = None) -> int:
             export_cfg = cfg.export
             out_dir = export_cfg.get("directory")
             out_formats = export_cfg.get("formats")
+            filename = export_cfg.get("filename", "analysis")
             if not out_dir and not out_formats:
                 out_dir = "outputs"  # pragma: no cover - defaults
                 out_formats = ["excel"]
@@ -64,7 +65,7 @@ def main(argv: list[str] | None = None) -> int:
                     data["summary"] = pd.DataFrame()
                     export.export_to_excel(
                         data,
-                        str(Path(out_dir) / "analysis.xlsx"),
+                        str(Path(out_dir) / f"{filename}.xlsx"),
                         default_sheet_formatter=sheet_formatter,
                     )
                     other = [
@@ -72,11 +73,11 @@ def main(argv: list[str] | None = None) -> int:
                     ]
                     if other:
                         export.export_data(
-                            data, str(Path(out_dir) / "analysis"), formats=other
+                            data, str(Path(out_dir) / filename), formats=other
                         )  # pragma: no cover - file I/O
                 else:
                     export.export_data(
-                        data, str(Path(out_dir) / "analysis"), formats=out_formats
+                        data, str(Path(out_dir) / filename), formats=out_formats
                     )  # pragma: no cover - file I/O
     return 0
 


### PR DESCRIPTION
## Summary
- support `output` config section as alias for `export`
- use optional filename when exporting
- test loading of new `output` fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686819786bf48331af9a12203b3060ac