### PR TITLE
Implement GUI config loader scaffolding

### DIFF
--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -40,3 +40,17 @@ def test_plugin_discovery(monkeypatch):
     gui.discover_plugins()
 
     assert dummy in list(gui.iter_plugins())
+
+
+def test_list_builtin_cfgs():
+    cfgs = gui.list_builtin_cfgs()
+    assert "defaults" in cfgs
+
+
+def test_state_persistence(tmp_path, monkeypatch):
+    path = tmp_path / "state.yml"
+    monkeypatch.setattr(gui.app, "STATE_FILE", path)
+    store = gui.ParamStore(cfg={"x": 1})
+    gui.save_state(store)
+    loaded = gui.load_state()
+    assert loaded.cfg == {"x": 1}

--- a/trend_analysis/gui/__init__.py
+++ b/trend_analysis/gui/__init__.py
@@ -3,7 +3,7 @@
 from .app import launch, load_state, save_state, build_config_dict
 from .plugins import register_plugin, iter_plugins, discover_plugins
 from .store import ParamStore
-from .utils import debounce
+from .utils import debounce, list_builtin_cfgs
 
 __all__ = [
     "launch",
@@ -15,4 +15,5 @@ __all__ = [
     "discover_plugins",
     "ParamStore",
     "debounce",
+    "list_builtin_cfgs",
 ]

--- a/trend_analysis/gui/app.py
+++ b/trend_analysis/gui/app.py
@@ -39,7 +39,7 @@ def _build_step0(store: ParamStore) -> widgets.Widget:
     upload = widgets.FileUpload(accept=".yml", multiple=False)
     template = widgets.Dropdown(options=list_builtin_cfgs(), description="Template")
     try:
-        from ipydatagrid import DataGrid  # type: ignore
+        from ipydatagrid import DataGrid
 
         grid = DataGrid([], disabled=False)
     except Exception:  # pragma: no cover - optional dep
@@ -50,7 +50,7 @@ def _build_step0(store: ParamStore) -> widgets.Widget:
 
     def refresh_grid() -> None:
         if hasattr(grid, "data"):
-            with grid.hold_trait_notifications():  # type: ignore[attr-defined]
+            with grid.hold_trait_notifications():
                 grid.data = [store.cfg]
 
     def on_upload(change: dict[str, Any]) -> None:

--- a/trend_analysis/gui/app.py
+++ b/trend_analysis/gui/app.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from .store import ParamStore
 from .plugins import discover_plugins
+from .utils import list_builtin_cfgs
 
 STATE_FILE = Path.home() / ".trend_gui_state.yml"
 
@@ -32,6 +33,54 @@ def build_config_dict(store: ParamStore) -> dict[str, object]:
     return dict(store.cfg)
 
 
+def _build_step0(store: ParamStore) -> widgets.Widget:
+    """Return widgets for Step 0 (config loader/editor)."""
+
+    upload = widgets.FileUpload(accept=".yml", multiple=False)
+    template = widgets.Dropdown(options=list_builtin_cfgs(), description="Template")
+    try:
+        from ipydatagrid import DataGrid  # type: ignore
+
+        grid = DataGrid([], disabled=False)
+    except Exception:  # pragma: no cover - optional dep
+        grid = widgets.Label("ipydatagrid not installed")
+
+    save_btn = widgets.Button(description="💾 Save config")
+    download_btn = widgets.Button(description="⬇️ Download")
+
+    def refresh_grid() -> None:
+        if hasattr(grid, "data"):
+            with grid.hold_trait_notifications():  # type: ignore[attr-defined]
+                grid.data = [store.cfg]
+
+    def on_upload(change: dict[str, Any]) -> None:
+        if change["new"]:
+            item = next(iter(upload.value.values()))
+            store.cfg = yaml.safe_load(item["content"].decode("utf-8"))
+            store.dirty = True
+            refresh_grid()
+
+    def on_template(change: dict[str, Any]) -> None:
+        name = change["new"]
+        cfg_dir = Path(__file__).resolve().parents[2] / "config"
+        path = cfg_dir / f"{name}.yml"
+        store.cfg = yaml.safe_load(path.read_text())
+        store.dirty = True
+        refresh_grid()
+
+    def on_save(_: Any) -> None:
+        save_state(store)
+        store.dirty = False
+
+    upload.observe(on_upload, names="value")
+    template.observe(on_template, names="value")
+    save_btn.on_click(on_save)
+
+    return widgets.VBox(
+        [template, upload, grid, widgets.HBox([save_btn, download_btn])]
+    )
+
+
 def launch() -> widgets.Widget:
     """Return the root widget for the Trend Model GUI."""
     store = load_state()
@@ -48,13 +97,21 @@ def launch() -> widgets.Widget:
         description="Theme",
     )
 
+    def on_theme(change: dict[str, Any]) -> None:
+        store.theme = change["new"]
+        store.dirty = True
+
+    theme.observe(on_theme, names="value")
+
     def on_mode(change: dict[str, Any]) -> None:
         store.cfg["mode"] = change["new"]
         store.dirty = True
 
     mode.observe(on_mode, names="value")
 
-    container = widgets.VBox([mode, theme])
+    step0 = _build_step0(store)
+
+    container = widgets.VBox([step0, mode, theme])
     return container
 
 

--- a/trend_analysis/gui/utils.py
+++ b/trend_analysis/gui/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from pathlib import Path
 from collections.abc import Callable
 from typing import Any
 
@@ -33,4 +34,10 @@ def debounce(wait_ms: int = 300) -> Callable[[Callable[..., Any]], Callable[...,
     return decorator
 
 
-__all__ = ["debounce"]
+def list_builtin_cfgs() -> list[str]:
+    """Return names of built-in YAML configs bundled with the package."""
+    cfg_dir = Path(__file__).resolve().parents[2] / "config"
+    return sorted(p.stem for p in cfg_dir.glob("*.yml"))
+
+
+__all__ = ["debounce", "list_builtin_cfgs"]


### PR DESCRIPTION
## Summary
- scaffold config loader widgets for GUI
- expose `list_builtin_cfgs` helper
- wire step0 into GUI launch and update state management
- expand GUI tests for state persistence and config list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868324338888331aad3a4192deae025