### PR TITLE
Implement AdaptiveBayesWeighting and GUI controls

### DIFF
--- a/tests/test_adaptive_bayes.py
+++ b/tests/test_adaptive_bayes.py
@@ -1,0 +1,43 @@
+import pandas as pd
+from numpy.testing import assert_allclose
+from trend_analysis.weighting import AdaptiveBayesWeighting, ScorePropSimple
+
+
+def make_scores(a=1.0, b=0.0, c=0.0):
+    return pd.Series({"A": a, "B": b, "C": c})
+
+
+def test_drift_toward_winner():
+    w = AdaptiveBayesWeighting(max_w=None)
+    df = pd.DataFrame(index=["A", "B", "C"])
+    w1 = w.weight(df)["weight"]
+    w.update(make_scores(2.0, 0.0, -1.0), 30)
+    w2 = w.weight(df)["weight"]
+    w.update(make_scores(2.0, 0.0, -1.0), 30)
+    w3 = w.weight(df)["weight"]
+    assert w3["A"] > w2["A"] > w1["A"]
+
+
+def test_sum_to_one():
+    w = AdaptiveBayesWeighting(max_w=None)
+    df = pd.DataFrame(index=["A", "B"])
+    weights = w.weight(df)
+    assert_allclose(weights["weight"].sum(), 1.0, rtol=1e-12)
+
+
+def test_clip_respects_max_w():
+    w = AdaptiveBayesWeighting(max_w=0.6)
+    df = pd.DataFrame(index=["A", "B"])
+    w.update(pd.Series({"A": 10.0, "B": -5.0}), 30)
+    out = w.weight(df)
+    assert out["weight"].max() <= 0.6 + 1e-9
+
+
+def test_half_life_zero_equals_simple():
+    df = pd.DataFrame({"Sharpe": [1.0, 2.0]}, index=["A", "B"])
+    scores = df["Sharpe"]
+    w = AdaptiveBayesWeighting(half_life=0, max_w=None)
+    w.update(scores, 30)
+    out = w.weight(df)["weight"]
+    exp = ScorePropSimple("Sharpe").weight(df)["weight"]
+    assert_allclose(out.values, exp.values)

--- a/trend_analysis/gui/app.py
+++ b/trend_analysis/gui/app.py
@@ -10,10 +10,10 @@ import pandas as pd
 
 from pathlib import Path
 from .store import ParamStore
-from .plugins import discover_plugins
+from .plugins import discover_plugins, iter_plugins
 from .utils import list_builtin_cfgs, debounce
 from ..config import Config
-from .. import pipeline, export
+from .. import pipeline, export, weighting
 
 STATE_FILE = Path.home() / ".trend_gui_state.yml"
 
@@ -234,6 +234,55 @@ def _build_manual_override(store: ParamStore) -> widgets.Widget:
     return box
 
 
+def _build_weighting_options(store: ParamStore) -> widgets.Widget:
+    """Return weighting method dropdown and param sliders."""
+    weight_cfg = (
+        store.cfg.setdefault("portfolio", {}).setdefault("weighting", {"name": "equal", "params": {}})
+    )
+    options = {
+        "equal": weighting.EqualWeight,
+        "score_prop": weighting.ScorePropSimple,
+        "score_prop_bayes": weighting.ScorePropBayesian,
+        "adaptive_bayes": weighting.AdaptiveBayesWeighting,
+    }
+    for plugin in iter_plugins():
+        name = plugin.__name__.lower()
+        options[name] = plugin
+
+    method_dd = widgets.Dropdown(options=list(options), value=weight_cfg.get("name", "equal"), description="Weighting")
+    params = weight_cfg.setdefault("params", {})
+    hl = widgets.IntSlider(value=params.get("half_life", 90), min=30, max=365, description="half_life")
+    os_sl = widgets.FloatSlider(value=params.get("obs_sigma", 0.25), min=0.0, max=1.0, step=0.01, description="obs_sigma")
+    mw_sl = widgets.FloatSlider(value=params.get("max_w", 0.20), min=0.0, max=0.5, step=0.01, description="max_w")
+    pt_sl = widgets.FloatSlider(value=params.get("prior_tau", 1.0), min=0.0, max=5.0, step=0.1, description="prior_tau")
+    adv_box = widgets.VBox([hl, os_sl, mw_sl, pt_sl])
+
+    def _store_weight(_: Any = None) -> None:
+        weight_cfg["name"] = method_dd.value
+        params["half_life"] = int(hl.value)
+        params["obs_sigma"] = float(os_sl.value)
+        params["max_w"] = float(mw_sl.value)
+        params["prior_tau"] = float(pt_sl.value)
+        store.dirty = True
+
+    method_dd.observe(_store_weight, names="value")
+
+    @debounce(300)
+    def _on_param(_: Any) -> None:
+        _store_weight()
+
+    for wdg in (hl, os_sl, mw_sl, pt_sl):
+        wdg.observe(_on_param, names="value")
+
+    def _toggle_adv(change: dict[str, Any]) -> None:
+        adv_box.layout.display = "flex" if change["new"] == "adaptive_bayes" else "none"
+
+    method_dd.observe(_toggle_adv, names="value")
+    _toggle_adv({"new": method_dd.value})
+
+    return widgets.VBox([method_dd, adv_box])
+
+
 def launch() -> widgets.Widget:
     """Return the root widget for the Trend Model GUI."""
     store = load_state()
@@ -332,6 +381,7 @@ def launch() -> widgets.Widget:
 
     rank_box = _build_rank_options(store)
     manual_box = _build_manual_override(store)
+    weight_box = _build_weighting_options(store)
 
     def _toggle_boxes(change: dict[str, Any]) -> None:
         mode_val = change["new"] if isinstance(change, dict) else mode.value
@@ -354,6 +404,7 @@ def launch() -> widgets.Widget:
             use_ranking,
             rank_box,
             manual_box,
+            weight_box,
             fmt_dd,
             theme,
             run_btn,

--- a/trend_analysis/gui/app.py
+++ b/trend_analysis/gui/app.py
@@ -236,8 +236,8 @@ def _build_manual_override(store: ParamStore) -> widgets.Widget:
 
 def _build_weighting_options(store: ParamStore) -> widgets.Widget:
     """Return weighting method dropdown and param sliders."""
-    weight_cfg = (
-        store.cfg.setdefault("portfolio", {}).setdefault("weighting", {"name": "equal", "params": {}})
+    weight_cfg = store.cfg.setdefault("portfolio", {}).setdefault(
+        "weighting", {"name": "equal", "params": {}}
     )
     options = {
         "equal": weighting.EqualWeight,
@@ -249,12 +249,36 @@ def _build_weighting_options(store: ParamStore) -> widgets.Widget:
         name = plugin.__name__.lower()
         options[name] = plugin
 
-    method_dd = widgets.Dropdown(options=list(options), value=weight_cfg.get("name", "equal"), description="Weighting")
+    method_dd = widgets.Dropdown(
+        options=list(options),
+        value=weight_cfg.get("name", "equal"),
+        description="Weighting",
+    )
     params = weight_cfg.setdefault("params", {})
-    hl = widgets.IntSlider(value=params.get("half_life", 90), min=30, max=365, description="half_life")
-    os_sl = widgets.FloatSlider(value=params.get("obs_sigma", 0.25), min=0.0, max=1.0, step=0.01, description="obs_sigma")
-    mw_sl = widgets.FloatSlider(value=params.get("max_w", 0.20), min=0.0, max=0.5, step=0.01, description="max_w")
-    pt_sl = widgets.FloatSlider(value=params.get("prior_tau", 1.0), min=0.0, max=5.0, step=0.1, description="prior_tau")
+    hl = widgets.IntSlider(
+        value=params.get("half_life", 90), min=30, max=365, description="half_life"
+    )
+    os_sl = widgets.FloatSlider(
+        value=params.get("obs_sigma", 0.25),
+        min=0.0,
+        max=1.0,
+        step=0.01,
+        description="obs_sigma",
+    )
+    mw_sl = widgets.FloatSlider(
+        value=params.get("max_w", 0.20),
+        min=0.0,
+        max=0.5,
+        step=0.01,
+        description="max_w",
+    )
+    pt_sl = widgets.FloatSlider(
+        value=params.get("prior_tau", 1.0),
+        min=0.0,
+        max=5.0,
+        step=0.1,
+        description="prior_tau",
+    )
     adv_box = widgets.VBox([hl, os_sl, mw_sl, pt_sl])
 
     def _store_weight(_: Any = None) -> None:

--- a/trend_analysis/weighting.py
+++ b/trend_analysis/weighting.py
@@ -61,3 +61,92 @@ class ScorePropBayesian(BaseWeighting):
             return EqualWeight().weight(selected)
         w = shrunk / shrunk.sum()
         return pd.DataFrame({"weight": w}, index=selected.index)
+
+
+class AdaptiveBayesWeighting(BaseWeighting):
+    """State-ful Bayesian weighting with exponential decay."""
+
+    def __init__(
+        self,
+        *,
+        half_life: int = 90,
+        obs_sigma: float = 0.25,
+        max_w: float | None = 0.20,
+        prior_mean: str | np.ndarray = "equal",
+        prior_tau: float = 1.0,
+    ) -> None:
+        self.half_life = int(half_life)
+        self.obs_tau = 1.0 / float(obs_sigma) ** 2
+        self.max_w = None if max_w is None else float(max_w)
+        self.prior_mean = prior_mean
+        self.prior_tau = float(prior_tau)
+        self.mean: pd.Series | None = None
+        self.tau: pd.Series | None = None
+
+    def _ensure_index(self, index: pd.Index) -> None:
+        if self.mean is None:
+            if isinstance(self.prior_mean, str) and self.prior_mean == "equal":
+                m = np.repeat(1.0 / len(index), len(index))
+            else:
+                arr = np.asarray(self.prior_mean, dtype=float)
+                if arr.shape[0] != len(index):
+                    raise ValueError("prior_mean length mismatch")
+                m = arr
+            self.mean = pd.Series(m, index=index, dtype=float)
+            self.tau = pd.Series(self.prior_tau, index=index, dtype=float)
+        else:
+            for col in index:
+                if col not in self.mean.index:
+                    self.mean[col] = 1.0 / len(index)
+                    self.tau[col] = self.prior_tau
+
+    def update(self, scores: pd.Series, days: int) -> None:
+        """Update posterior means and precisions with ``scores``."""
+
+        self._ensure_index(scores.index)
+        assert self.mean is not None and self.tau is not None  # for mypy
+
+        if self.half_life > 0:
+            decay = 0.5 ** (days / self.half_life)
+            self.tau *= decay
+        else:
+            self.tau[:] = 0.0
+
+        tau_old = self.tau.loc[scores.index]
+        tau_new = tau_old + self.obs_tau
+        m_old = self.mean.loc[scores.index]
+        m_new = (m_old * tau_old + self.obs_tau * scores.astype(float)) / tau_new
+        self.mean.loc[scores.index] = m_new
+        self.tau.loc[scores.index] = tau_new
+
+    def weight(self, candidates: pd.DataFrame) -> pd.DataFrame:
+        if len(candidates.index) == 0:
+            return pd.DataFrame(columns=["weight"])
+        self._ensure_index(candidates.index)
+        assert self.mean is not None
+        w = self.mean.reindex(candidates.index).fillna(0.0).clip(lower=0.0)
+        if w.sum() == 0:
+            w[:] = 1.0 / len(w)
+        else:
+            w /= w.sum()
+        if self.max_w is not None:
+            cap = self.max_w
+            w = w.clip(upper=cap)
+            total = w.sum()
+            if total < 1.0:
+                deficit = 1.0 - total
+                room = w[w < cap]
+                if not room.empty:
+                    w.loc[room.index] += deficit / len(room)
+                else:
+                    w /= total
+        return pd.DataFrame({"weight": w}, index=candidates.index)
+
+
+__all__ = [
+    "BaseWeighting",
+    "EqualWeight",
+    "ScorePropSimple",
+    "ScorePropBayesian",
+    "AdaptiveBayesWeighting",
+]

--- a/trend_analysis/weighting.py
+++ b/trend_analysis/weighting.py
@@ -95,6 +95,7 @@ class AdaptiveBayesWeighting(BaseWeighting):
             self.mean = pd.Series(m, index=index, dtype=float)
             self.tau = pd.Series(self.prior_tau, index=index, dtype=float)
         else:
+            assert self.tau is not None
             for col in index:
                 if col not in self.mean.index:
                     self.mean[col] = 1.0 / len(index)


### PR DESCRIPTION
## Summary
- implement `AdaptiveBayesWeighting` in `weighting.py`
- expose new sliders via `_build_weighting_options` in GUI
- create tests for AdaptiveBayesWeighting
- install xlsxwriter for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868a8caeef08331ad615a5009699093