### PR TITLE
Implement reset and persistent GUI state

### DIFF
--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -50,11 +50,14 @@ def test_list_builtin_cfgs():
 
 def test_state_persistence(tmp_path, monkeypatch):
     path = tmp_path / "state.yml"
+    pkl = path.with_suffix(".pkl")
     monkeypatch.setattr(gui.app, "STATE_FILE", path)
-    store = gui.ParamStore(cfg={"x": 1})
+    monkeypatch.setattr(gui.app, "WEIGHT_STATE_FILE", pkl)
+    store = gui.ParamStore(cfg={"x": 1}, weight_state={"a": 1.0})
     gui.save_state(store)
     loaded = gui.load_state()
     assert loaded.cfg == {"x": 1}
+    assert loaded.weight_state == {"a": 1.0}
 
 
 def test_build_config_from_store():
@@ -82,3 +85,16 @@ def test_manual_override_fallback(monkeypatch):
     widget = gui.app._build_manual_override(store)
     assert isinstance(widget, VBox)
     assert isinstance(widget.children[0], Label)
+
+
+def test_reset_weight_state(tmp_path, monkeypatch):
+    path = tmp_path / "state.yml"
+    pkl = path.with_suffix(".pkl")
+    monkeypatch.setattr(gui.app, "STATE_FILE", path)
+    monkeypatch.setattr(gui.app, "WEIGHT_STATE_FILE", pkl)
+    store = gui.ParamStore(cfg={}, weight_state={"a": 1})
+    gui.save_state(store)
+    assert pkl.exists()
+    gui.reset_weight_state(store)
+    assert store.weight_state is None
+    assert not pkl.exists()

--- a/trend_analysis/gui/__init__.py
+++ b/trend_analysis/gui/__init__.py
@@ -4,6 +4,7 @@ from .app import (
     launch,
     load_state,
     save_state,
+    reset_weight_state,
     build_config_dict,
     build_config_from_store,
 )
@@ -15,6 +16,7 @@ __all__ = [
     "launch",
     "load_state",
     "save_state",
+    "reset_weight_state",
     "build_config_dict",
     "build_config_from_store",
     "register_plugin",

--- a/trend_analysis/gui/store.py
+++ b/trend_analysis/gui/store.py
@@ -14,6 +14,7 @@ class ParamStore:
     cfg: dict[str, Any] = field(default_factory=dict)
     theme: str = "system"
     dirty: bool = False
+    weight_state: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return self.cfg


### PR DESCRIPTION
## Summary
- persist AdaptiveBayesWeighting state alongside GUI YAML
- add helper to reset persisted weighting state
- expose reset function in GUI package
- include a reset button in the GUI
- test persistence and reset logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868c8131bc88331a2069efb87ac9a3b