### PR TITLE
Enhance AdaptiveBayesWeighting persistence

### DIFF
--- a/tests/test_adaptive_bayes.py
+++ b/tests/test_adaptive_bayes.py
@@ -41,3 +41,13 @@ def test_half_life_zero_equals_simple():
     out = w.weight(df)["weight"]
     exp = ScorePropSimple("Sharpe").weight(df)["weight"]
     assert_allclose(out.values, exp.values)
+
+
+def test_state_roundtrip():
+    w = AdaptiveBayesWeighting(max_w=None)
+    df = pd.DataFrame(index=["A", "B"])
+    w.update(pd.Series({"A": 1.0, "B": 0.5}), 30)
+    state = w.get_state()
+    w2 = AdaptiveBayesWeighting(max_w=None)
+    w2.set_state(state)
+    assert_allclose(w.weight(df)["weight"].values, w2.weight(df)["weight"].values)

--- a/trend_analysis/weighting.py
+++ b/trend_analysis/weighting.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Any
+
 import pandas as pd
 import numpy as np
 
@@ -142,6 +145,20 @@ class AdaptiveBayesWeighting(BaseWeighting):
                 else:
                     w /= total
         return pd.DataFrame({"weight": w}, index=candidates.index)
+
+    def get_state(self) -> dict[str, Any]:
+        """Return a serialisable representation of the posterior state."""
+        return {
+            "mean": None if self.mean is None else self.mean.to_dict(),
+            "tau": None if self.tau is None else self.tau.to_dict(),
+        }
+
+    def set_state(self, state: Mapping[str, Any]) -> None:
+        """Load posterior state from ``state``."""
+        mean = state.get("mean")
+        tau = state.get("tau")
+        self.mean = None if mean is None else pd.Series(mean, dtype=float)
+        self.tau = None if tau is None else pd.Series(tau, dtype=float)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- expose `AdaptiveBayesWeighting.get_state()` and `set_state()` for GUI persistence
- cover new behaviour with a unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686942abffb88331887d9ff6706212e4