### PR TITLE
Update demo pipeline for multi-period testing

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -21,6 +21,7 @@ jobs:
     - run: scripts/setup_env.sh
     - run: python scripts/generate_demo.py
     - run: python -m trend_analysis.run_analysis -c config/demo.yml
+    - run: python scripts/run_multi_demo.py
     - uses: actions/upload-artifact@v4
       with:
         name: demo‑exports

--- a/config/demo.yml
+++ b/config/demo.yml
@@ -32,3 +32,10 @@ export:
 run:
   seed: 42                      # makes demo deterministic
 
+multi_period:
+  frequency: M                  # monthly periods
+  in_sample_len: 36             # 3 years in-sample
+  out_sample_len: 12            # 1 year out-of-sample
+  start: "2018-01"
+  end: "2024-12"
+

--- a/scripts/generate_demo.py
+++ b/scripts/generate_demo.py
@@ -2,6 +2,7 @@
 Generate a 10‑year monthly return series for 20
 fake managers and dump to CSV + XLSX.
 """
+
 import numpy as np
 import pandas as pd
 import os

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Run the multi-period demo using the generated data."""
+from trend_analysis.config import load
+from trend_analysis.multi_period import run as run_mp
+
+cfg = load("config/demo.yml")
+results = run_mp(cfg)
+print(f"Generated {len(results)} period results")
+if not results:
+    raise SystemExit("Multi-period demo produced no results")


### PR DESCRIPTION
## Summary
- generate demo data (black formatting cleanup)
- configure multi-period run for demo
- add multi-period demo script
- update workflow to run multi-period analysis

## Testing
- `ruff check .`
- `black --check .`
- `mypy trend_analysis`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d16051b5c8331bf79946388fee887