### PR TITLE
Update demo to exercise multi-period engine

### DIFF
--- a/config/demo.yml
+++ b/config/demo.yml
@@ -2,7 +2,7 @@
 version: "1"                      # whatever your defaults.yml uses
 
 data:
-  path: demo/demo_returns.csv   # <– written by generate_demo.py
+  csv_path: demo/demo_returns.csv   # <– written by generate_demo.py
   frequency: ME                  # monthly data
 
 preprocessing:

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -5,6 +5,7 @@ from trend_analysis.multi_period import run as run_mp
 
 cfg = load("config/demo.yml")
 results = run_mp(cfg)
-print(f"Generated {len(results)} period results")
-if not results:
-    raise SystemExit("Multi-period demo produced no results")
+num_periods = len(results)
+print(f"Generated {num_periods} period results")
+if num_periods <= 1:
+    raise SystemExit("Multi-period demo produced insufficient results")


### PR DESCRIPTION
## Summary
- fix `config/demo.yml` to use `csv_path` so CLI works
- fail `run_multi_demo.py` if only one period is produced

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686da3a0711883318a4ed01ddda61d03