### PR TITLE
Add weight history check to multi-period demo

### DIFF
--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 """Run the multi-period demo using the generated data."""
 from trend_analysis.config import load
-from trend_analysis.multi_period import run as run_mp
+from trend_analysis.multi_period import run as run_mp, run_schedule
+from trend_analysis.selector import RankSelector
+from trend_analysis.weighting import AdaptiveBayesWeighting
 
 cfg = load("config/demo.yml")
 results = run_mp(cfg)
@@ -9,3 +11,11 @@ num_periods = len(results)
 print(f"Generated {num_periods} period results")
 if num_periods <= 1:
     raise SystemExit("Multi-period demo produced insufficient results")
+
+score_frames = {r["period"][3]: r["score_frame"] for r in results}
+selector = RankSelector(top_n=3, rank_column="Sharpe")
+weighting = AdaptiveBayesWeighting(max_w=None)
+portfolio = run_schedule(score_frames, selector, weighting, rank_column="Sharpe")
+print(f"Weight history generated for {len(portfolio.history)} periods")
+if len(portfolio.history) != num_periods:
+    raise SystemExit("Weight schedule did not cover all periods")


### PR DESCRIPTION
## Summary
- extend `run_multi_demo.py` to exercise phase‑2 features
- ensure the generated weight history matches number of periods

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686da731d318833192a6b6a454606115