### PR TITLE
Improve Phase-2 demo coverage

### DIFF
--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -25,4 +25,3 @@ portfolio = run_schedule(score_frames, selector, weighting, rank_column="Sharpe"
 print(f"Weight history generated for {len(portfolio.history)} periods")
 if len(portfolio.history) != num_periods:
     raise SystemExit("Weight schedule did not cover all periods")
-

--- a/tests/test_multi_period_engine.py
+++ b/tests/test_multi_period_engine.py
@@ -32,6 +32,7 @@ def test_multi_period_run_returns_results():
     out = run_mp(cfg, df)
     assert isinstance(out, list)
     assert out, "no period results returned"
+    assert len(out) > 1, "Multi-period run produced only a single period"
 
 
 def test_run_schedule_generates_weight_history():


### PR DESCRIPTION
## Summary
- extend `test_multi_period_run_returns_results` to ensure more than one period

## Testing
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_686dab16deb08331bf9d58bf0ff055e2