### PR TITLE
Improve multi-period demo validation

### DIFF
--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -25,3 +25,6 @@ portfolio = run_schedule(score_frames, selector, weighting, rank_column="Sharpe"
 print(f"Weight history generated for {len(portfolio.history)} periods")
 if len(portfolio.history) != num_periods:
     raise SystemExit("Weight schedule did not cover all periods")
+weights = list(portfolio.history.values())
+if len(weights) > 1 and all(w.equals(weights[0]) for w in weights[1:]):
+    raise SystemExit("Weights did not change across periods")


### PR DESCRIPTION
## Summary
- enhance the demo to verify that weights differ across periods

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686daefdae5c8331a16456755a13b160