### PR TITLE
Enhance demo for phase 2

### DIFF
--- a/scripts/generate_demo.py
+++ b/scripts/generate_demo.py
@@ -16,10 +16,12 @@ periods = 120  # 10 years * 12 months
 dates = pd.date_range(start, periods=periods, freq="M")
 
 rng = np.random.default_rng(42)
-data = {
-    f"Mgr_{i:02d}": rng.normal(loc=0.006, scale=0.04, size=periods)
-    for i in range(1, 21)
-}
+data = {}
+for i in range(1, 21):
+    base = rng.normal(loc=0.006, scale=0.04, size=periods)
+    drift = rng.normal(scale=0.002, size=periods).cumsum()
+    data[f"Mgr_{i:02d}"] = base + drift
+
 df = pd.DataFrame(data, index=dates)
 df.index.name = "Date"
 

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -39,6 +39,8 @@ weights = list(portfolio.history.values())
 if len(weights) > 1 and all(w.equals(weights[0]) for w in weights[1:]):
     raise SystemExit("Weights did not change across periods")
 
-fund_sets = [set(sf.index) for sf in score_frames.values()]
+fund_sets = [set(w.index) for w in portfolio.history.values()]
 if len(fund_sets) > 1 and all(fund_sets[0] == fs for fs in fund_sets[1:]):
     raise SystemExit("Fund selection identical across periods")
+
+print("Multi-period demo checks passed")


### PR DESCRIPTION
## Summary
- make demo data vary over time so multi-period selection changes
- verify selection sets using weighted portfolios
- print confirmation when the demo succeeds

## Testing
- `bash scripts/setup_env.sh`
- `pytest --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_686dc2da7d54833190565460efe2f650