### PR TITLE
Improve multi-period demo with rebalancer

### DIFF
--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -12,6 +12,7 @@ from trend_analysis.multi_period import (
     run_schedule,
     scheduler,
 )
+from trend_analysis.multi_period.replacer import Rebalancer
 from trend_analysis.selector import RankSelector
 from trend_analysis.weighting import AdaptiveBayesWeighting
 
@@ -35,7 +36,14 @@ if result_periods != sched_tuples:
 score_frames = {r["period"][3]: r["score_frame"] for r in results}
 selector = RankSelector(top_n=3, rank_column="Sharpe")
 weighting = AdaptiveBayesWeighting(max_w=None)
-portfolio = run_schedule(score_frames, selector, weighting, rank_column="Sharpe")
+rebalancer = Rebalancer(cfg.model_dump())
+portfolio = run_schedule(
+    score_frames,
+    selector,
+    weighting,
+    rank_column="Sharpe",
+    rebalancer=rebalancer,
+)
 print(f"Weight history generated for {len(portfolio.history)} periods")
 if len(portfolio.history) != num_periods:
     raise SystemExit("Weight schedule did not cover all periods")


### PR DESCRIPTION
## Summary
- integrate `Rebalancer` with `run_schedule`
- exercise rebalancing logic in `run_multi_demo.py`

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686de782ee6c83318559bf37fba0845b