### PR TITLE
Implement per-period summary export

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -367,3 +367,10 @@ The original design goal is that each back‑test period should produce an Excel
 worksheet indistinguishable from the Phase‑1 summary.  CSV and JSON exports must
 likewise emit one file per period.  This behaviour has yet to be fully realised
 in code and tests.
+
+### 2025‑07‑11 UPDATE — PER‑PERIOD SUMMARY TABLES
+
+Implement helpers so every multi‑period run yields one workbook tab (or file)
+per period containing the full Phase‑1 style summary table.  Excel sheets are
+formatted via ``make_period_formatter`` while CSV/JSON outputs receive the same
+rows using ``summary_frame_from_result``.

--- a/src/trend_analysis/export.py
+++ b/src/trend_analysis/export.py
@@ -211,7 +211,8 @@ def format_summary_text(
         a = to_tuple(t)
         return [a[0] * 100, a[1] * 100, a[2], a[3], a[4], a[5] * 100]
 
-    bench_labels = list(res.get("benchmark_ir", {}))
+    bench_map = cast(Mapping[str, Mapping[str, float]], res.get("benchmark_ir", {}))
+    bench_labels = list(bench_map)
     columns = [
         "Name",
         "Weight",
@@ -386,6 +387,76 @@ def metrics_from_result(res: Mapping[str, object]) -> pd.DataFrame:
     return df
 
 
+def summary_frame_from_result(res: Mapping[str, object]) -> pd.DataFrame:
+    """Return a DataFrame mirroring the Phase-1 summary table."""
+
+    from .pipeline import _Stats  # lazy import to avoid cycle
+
+    def to_tuple(obj: Any) -> tuple[float, float, float, float, float, float]:
+        if isinstance(obj, tuple):
+            return cast(tuple[float, float, float, float, float, float], obj)
+        s = cast(_Stats, obj)
+        return (
+            float(s.cagr),
+            float(s.vol),
+            float(s.sharpe),
+            float(s.sortino),
+            float(s.information_ratio),
+            float(s.max_drawdown),
+        )
+
+    def pct(t: Any) -> list[float]:
+        a = to_tuple(t)
+        return [a[0] * 100, a[1] * 100, a[2], a[3], a[4], a[5] * 100]
+
+    bench_map = cast(Mapping[str, Mapping[str, float]], res.get("benchmark_ir", {}))
+    bench_labels = list(bench_map)
+    columns = [
+        "Name",
+        "Weight",
+        "IS CAGR",
+        "IS Vol",
+        "IS Sharpe",
+        "IS Sortino",
+        "IS IR",
+        "IS MaxDD",
+        "OS CAGR",
+        "OS Vol",
+        "OS Sharpe",
+        "OS Sortino",
+        "OS IR",
+    ]
+    columns.extend([f"OS IR {b}" for b in bench_labels])
+    columns.append("OS MaxDD")
+
+    rows: list[list[Any]] = []
+
+    for label, ins, outs in [
+        ("Equal Weight", res["in_ew_stats"], res["out_ew_stats"]),
+        ("User Weight", res["in_user_stats"], res["out_user_stats"]),
+    ]:
+        vals = pct(ins) + pct(outs)
+        extra = [
+            bench_map.get(b, {}).get(
+                "equal_weight" if label == "Equal Weight" else "user_weight",
+                pd.NA,
+            )
+            for b in bench_labels
+        ]
+        rows.append([label, pd.NA, *vals, *extra])
+
+    rows.append([pd.NA] * len(columns))
+
+    for fund, stat_in in cast(Mapping[str, _Stats], res["in_sample_stats"]).items():
+        stat_out = cast(Mapping[str, _Stats], res["out_sample_stats"])[fund]
+        weight = cast(Mapping[str, float], res["fund_weights"])[fund] * 100
+        vals = pct(stat_in) + pct(stat_out)
+        extra = [bench_map.get(b, {}).get(fund, pd.NA) for b in bench_labels]
+        rows.append([fund, weight, *vals, *extra])
+
+    return pd.DataFrame(rows, columns=columns)
+
+
 def export_multi_period_metrics(
     results: Iterable[Mapping[str, object]],
     output_path: str,
@@ -394,12 +465,13 @@ def export_multi_period_metrics(
 ) -> None:
     """Export per-period metrics using the canonical exporters."""
 
-    data: dict[str, pd.DataFrame] = {}
+    excel_formats = [f for f in formats if f.lower() in {"excel", "xlsx"}]
+    other_formats = [f for f in formats if f.lower() not in {"excel", "xlsx"}]
+    excel_data: dict[str, pd.DataFrame] = {}
+    other_data: dict[str, pd.DataFrame] = {}
     reset_formatters_excel()
-    want_excel = any(f.lower() in {"excel", "xlsx"} for f in formats)
 
     for idx, res in enumerate(results, start=1):
-        df = metrics_from_result(res)
         period = res.get("period")
         if isinstance(period, (list, tuple)) and len(period) >= 4:
             in_s, in_e, out_s, out_e = map(str, period[:4])
@@ -407,11 +479,18 @@ def export_multi_period_metrics(
         else:
             in_s = in_e = out_s = out_e = ""
             sheet = f"period_{idx}"
-        data[sheet] = df
-        if want_excel:
+
+        if excel_formats:
+            excel_data[sheet] = pd.DataFrame()
             make_period_formatter(sheet, res, in_s, in_e, out_s, out_e)
 
-    export_data(data, output_path, formats=formats)
+        if other_formats:
+            other_data[sheet] = summary_frame_from_result(res)
+
+    if excel_formats:
+        export_data(excel_data, output_path, formats=excel_formats)
+    if other_formats:
+        export_data(other_data, output_path, formats=other_formats)
 
 
 def export_data(
@@ -443,5 +522,6 @@ __all__ = [
     "export_to_json",
     "export_data",
     "metrics_from_result",
+    "summary_frame_from_result",
     "export_multi_period_metrics",
 ]

--- a/tests/test_multi_period_export.py
+++ b/tests/test_multi_period_export.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 from trend_analysis.config import Config
 from trend_analysis.multi_period import run as run_mp
-from trend_analysis.export import metrics_from_result, export_multi_period_metrics
+from trend_analysis.export import (
+    metrics_from_result,
+    summary_frame_from_result,
+    export_multi_period_metrics,
+)
 
 
 def make_df():
@@ -42,6 +46,15 @@ def test_metrics_from_result_basic():
     assert not df_metrics.empty
 
 
+def test_summary_frame_from_result_basic():
+    df = make_df()
+    cfg = make_cfg()
+    results = run_mp(cfg, df)
+    df_sum = summary_frame_from_result(results[0])
+    assert "OS MaxDD" in df_sum.columns
+    assert df_sum.iloc[0, 0] == "Equal Weight"
+
+
 def test_export_multi_period_metrics(tmp_path):
     df = make_df()
     cfg = make_cfg()
@@ -53,8 +66,9 @@ def test_export_multi_period_metrics(tmp_path):
     p1 = out.with_name(f"{out.stem}_{first_period}.csv")
     p2 = out.with_name(f"{out.stem}_{second_period}.csv")
     assert p1.exists() and p2.exists()
-    df_read = pd.read_csv(p1)
-    assert "cagr" in df_read.columns
+    df_read = pd.read_csv(p1, index_col=0)
+    assert "Name" in df_read.columns
+    assert df_read.iloc[0, 0] == "Equal Weight"
 
 
 def test_export_multi_period_metrics_excel(tmp_path):


### PR DESCRIPTION
## Summary
- clarify per-period summary requirements in Agents docs
- add `summary_frame_from_result` helper
- update `export_multi_period_metrics` to build summary data per period
- test CSV and Excel multi-period exports and new helper

## Testing
- `ruff check .`
- `black --check .`
- `mypy --strict src/trend_analysis`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e82ce47b8833199459ea17baaa55f