### PR TITLE
Implement combined summary export

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -374,3 +374,11 @@ Implement helpers so every multi‑period run yields one workbook tab (or file)
 per period containing the full Phase‑1 style summary table.  Excel sheets are
 formatted via ``make_period_formatter`` while CSV/JSON outputs receive the same
 rows using ``summary_frame_from_result``.
+
+### 2025‑07‑12 UPDATE — COMBINED SUMMARY SHEET
+
+Multi‑period exports must also include a ``summary`` sheet aggregating portfolio
+performance across all periods.  The sheet uses the **same** format as the
+per‑period tabs and is generated via ``make_period_formatter`` on a result
+dictionary produced by ``combined_summary_result(results)``.  CSV/JSON formats
+write a ``_summary`` file derived from ``summary_frame_from_result``.

--- a/src/trend_analysis/__init__.py
+++ b/src/trend_analysis/__init__.py
@@ -11,6 +11,7 @@ from .export import (
     export_to_json,
     export_data,
     metrics_from_result,
+    combined_summary_result,
     export_multi_period_metrics,
 )
 
@@ -32,5 +33,6 @@ __all__ = [
     "export_to_json",
     "export_data",
     "metrics_from_result",
+    "combined_summary_result",
     "export_multi_period_metrics",
 ]

--- a/src/trend_analysis/export.py
+++ b/src/trend_analysis/export.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Iterable, Mapping, cast
 import inspect
 
 import pandas as pd
+import numpy as np
 
 Formatter = Callable[[pd.DataFrame], pd.DataFrame]
 
@@ -457,6 +458,68 @@ def summary_frame_from_result(res: Mapping[str, object]) -> pd.DataFrame:
     return pd.DataFrame(rows, columns=columns)
 
 
+def combined_summary_result(results: Iterable[Mapping[str, object]]) -> Mapping[str, object]:
+    """Return an aggregated result dict across all periods."""
+
+    from collections import defaultdict
+
+    from .pipeline import _compute_stats, calc_portfolio_returns
+
+    fund_in: dict[str, list[pd.Series]] = defaultdict(list)
+    fund_out: dict[str, list[pd.Series]] = defaultdict(list)
+    ew_in_series: list[pd.Series] = []
+    ew_out_series: list[pd.Series] = []
+    user_in_series: list[pd.Series] = []
+    user_out_series: list[pd.Series] = []
+    weight_sum: dict[str, float] = defaultdict(float)
+    periods = 0
+
+    for res in results:
+        in_df = cast(pd.DataFrame, res.get("in_sample_scaled"))
+        out_df = cast(pd.DataFrame, res.get("out_sample_scaled"))
+        ew_w = [cast(float, res.get("ew_weights", {}).get(c, 0.0)) for c in in_df.columns]
+        user_w = [cast(float, res.get("fund_weights", {}).get(c, 0.0)) for c in in_df.columns]
+        ew_in_series.append(calc_portfolio_returns(np.array(ew_w), in_df))
+        ew_out_series.append(calc_portfolio_returns(np.array(ew_w), out_df))
+        user_in_series.append(calc_portfolio_returns(np.array(user_w), in_df))
+        user_out_series.append(calc_portfolio_returns(np.array(user_w), out_df))
+        for c in in_df.columns:
+            fund_in[c].append(in_df[c])
+            weight_sum[c] += cast(float, res.get("fund_weights", {}).get(c, 0.0))
+        for c in out_df.columns:
+            fund_out[c].append(out_df[c])
+        periods += 1
+
+    rf_in = pd.Series(0.0, index=pd.concat(ew_in_series).index)
+    rf_out = pd.Series(0.0, index=pd.concat(ew_out_series).index)
+    in_ew_stats = _compute_stats(pd.DataFrame({"ew": pd.concat(ew_in_series)}), rf_in)["ew"]
+    out_ew_stats = _compute_stats(pd.DataFrame({"ew": pd.concat(ew_out_series)}), rf_out)["ew"]
+    in_user_stats = _compute_stats(pd.DataFrame({"user": pd.concat(user_in_series)}), rf_in)["user"]
+    out_user_stats = _compute_stats(pd.DataFrame({"user": pd.concat(user_out_series)}), rf_out)["user"]
+
+    in_stats = {
+        f: _compute_stats(pd.DataFrame({f: pd.concat(s)}), rf_in)[f]
+        for f, s in fund_in.items()
+    }
+    out_stats = {
+        f: _compute_stats(pd.DataFrame({f: pd.concat(s)}), rf_out)[f]
+        for f, s in fund_out.items()
+    }
+
+    fund_weights = {f: weight_sum[f] / periods for f in weight_sum}
+
+    return {
+        "in_ew_stats": in_ew_stats,
+        "out_ew_stats": out_ew_stats,
+        "in_user_stats": in_user_stats,
+        "out_user_stats": out_user_stats,
+        "in_sample_stats": in_stats,
+        "out_sample_stats": out_stats,
+        "fund_weights": fund_weights,
+        "benchmark_ir": {},
+    }
+
+
 def export_multi_period_metrics(
     results: Iterable[Mapping[str, object]],
     output_path: str,
@@ -471,7 +534,8 @@ def export_multi_period_metrics(
     other_data: dict[str, pd.DataFrame] = {}
     reset_formatters_excel()
 
-    for idx, res in enumerate(results, start=1):
+    results_list = list(results)
+    for idx, res in enumerate(results_list, start=1):
         period = res.get("period")
         if isinstance(period, (list, tuple)) and len(period) >= 4:
             in_s, in_e, out_s, out_e = map(str, period[:4])
@@ -486,6 +550,27 @@ def export_multi_period_metrics(
 
         if other_formats:
             other_data[sheet] = summary_frame_from_result(res)
+
+    if results_list:
+        summary = combined_summary_result(results_list)
+        if excel_formats:
+            excel_data["summary"] = pd.DataFrame()
+            first = results_list[0].get("period")
+            last = results_list[-1].get("period")
+            if isinstance(first, (list, tuple)) and isinstance(last, (list, tuple)):
+                make_period_formatter(
+                    "summary",
+                    summary,
+                    str(first[0]),
+                    str(first[1]),
+                    str(last[2]),
+                    str(last[3]),
+                )
+            else:
+                make_period_formatter("summary", summary, "", "", "", "")
+
+        if other_formats:
+            other_data["summary"] = summary_frame_from_result(summary)
 
     if excel_formats:
         export_data(excel_data, output_path, formats=excel_formats)
@@ -522,6 +607,7 @@ __all__ = [
     "export_to_json",
     "export_data",
     "metrics_from_result",
+    "combined_summary_result",
     "summary_frame_from_result",
     "export_multi_period_metrics",
 ]

--- a/tests/test_multi_period_export.py
+++ b/tests/test_multi_period_export.py
@@ -7,6 +7,7 @@ from trend_analysis.multi_period import run as run_mp
 from trend_analysis.export import (
     metrics_from_result,
     summary_frame_from_result,
+    combined_summary_result,
     export_multi_period_metrics,
 )
 
@@ -55,6 +56,16 @@ def test_summary_frame_from_result_basic():
     assert df_sum.iloc[0, 0] == "Equal Weight"
 
 
+def test_combined_summary_result_basic():
+    df = make_df()
+    cfg = make_cfg()
+    results = run_mp(cfg, df)
+    summary = combined_summary_result(results)
+    df_sum = summary_frame_from_result(summary)
+    assert "OS MaxDD" in df_sum.columns
+    assert df_sum.iloc[0, 0] == "Equal Weight"
+
+
 def test_export_multi_period_metrics(tmp_path):
     df = make_df()
     cfg = make_cfg()
@@ -65,7 +76,8 @@ def test_export_multi_period_metrics(tmp_path):
     second_period = results[1]["period"][3]
     p1 = out.with_name(f"{out.stem}_{first_period}.csv")
     p2 = out.with_name(f"{out.stem}_{second_period}.csv")
-    assert p1.exists() and p2.exists()
+    summ = out.with_name(f"{out.stem}_summary.csv")
+    assert p1.exists() and p2.exists() and summ.exists()
     df_read = pd.read_csv(p1, index_col=0)
     assert "Name" in df_read.columns
     assert df_read.iloc[0, 0] == "Equal Weight"
@@ -84,5 +96,6 @@ def test_export_multi_period_metrics_excel(tmp_path):
     book = pd.ExcelFile(path)
     assert first_period in book.sheet_names
     assert second_period in book.sheet_names
+    assert "summary" in book.sheet_names
     df_read = pd.read_excel(path, sheet_name=first_period, header=None)
     assert "Vol-Adj Trend Analysis" in df_read.iloc[0, 0]


### PR DESCRIPTION
## Summary
- document new combined-summary-sheet requirement
- aggregate multi-period results with `combined_summary_result`
- include summary sheet/file when exporting multi-period metrics
- expose helper via package API and test new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e889601e88331ad9bf1c313df75b2