### PR TITLE
Add multi-period export CLI

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -382,3 +382,13 @@ performance across all periods.  The sheet uses the **same** format as the
 per‑period tabs and is generated via ``make_period_formatter`` on a result
 dictionary produced by ``combined_summary_result(results)``.  CSV/JSON formats
 write a ``_summary`` file derived from ``summary_frame_from_result``.
+
+### 2025‑07‑13 UPDATE — MULTI‑PERIOD EXPORT ROADMAP
+
+The backlog still includes emitting a Phase‑1 style workbook with **one tab per
+period** for multi‑period runs.  CSV and JSON outputs must create one file per
+period using the same summary table produced by
+``summary_frame_from_result``.  A ``summary`` sheet/file aggregates portfolio
+returns across all periods, formatted identically to each individual period
+sheet.  Work is in progress to expose this via a new ``run_multi_analysis`` CLI
+that calls ``export.export_multi_period_metrics``.

--- a/src/trend_analysis/run_multi_analysis.py
+++ b/src/trend_analysis/run_multi_analysis.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import cast
+
+from trend_analysis.config import load
+from trend_analysis import export
+from trend_analysis.multi_period import run as run_mp
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for multi-period analysis."""
+    parser = argparse.ArgumentParser(prog="trend-analysis-multi")
+    parser.add_argument("-c", "--config", help="Path to YAML config")
+    parser.add_argument(
+        "--detailed",
+        action="store_true",
+        help="Print per-period summary tables",
+    )
+    args = parser.parse_args(argv)
+
+    cfg = load(args.config)
+    results = run_mp(cfg)
+    if not results:
+        print("No results")  # pragma: no cover - trivial branch
+        return 0
+
+    if args.detailed:
+        for res in results:  # pragma: no cover - human output
+            period = cast(
+                tuple[str, str, str, str], res.get("period", ("", "", "", ""))
+            )
+            text = export.format_summary_text(
+                res,
+                period[0],
+                period[1],
+                period[2],
+                period[3],
+            )
+            print(text)
+            print()
+
+    export_cfg = cfg.export
+    out_dir = export_cfg.get("directory")
+    out_formats = export_cfg.get("formats")
+    filename = export_cfg.get("filename", "analysis")
+    if not out_dir and not out_formats:
+        out_dir = "outputs"  # pragma: no cover - defaults
+        out_formats = ["excel"]
+    if out_dir and out_formats:
+        export.export_multi_period_metrics(
+            results,
+            str(Path(out_dir) / filename),
+            formats=out_formats,
+        )  # pragma: no cover - file I/O
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    raise SystemExit(main())

--- a/tests/test_run_multi_analysis_cli.py
+++ b/tests/test_run_multi_analysis_cli.py
@@ -12,6 +12,7 @@ def _write_cfg(path: Path, csv: Path, out_dir: Path) -> None:
                 f"data: {{csv_path: '{csv}'}}",
                 "preprocessing: {}",
                 "vol_adjust: {target_vol: 1.0}",
+                "sample_split: {in_start: '2020-01', in_end: '2020-03', out_start: '2020-04', out_end: '2020-06'}",
                 "multi_period: {frequency: M, in_sample_len: 2, out_sample_len: 1, start: '2020-01', end: '2020-03'}",
                 "portfolio: {}",
                 "metrics: {}",

--- a/tests/test_run_multi_analysis_cli.py
+++ b/tests/test_run_multi_analysis_cli.py
@@ -1,0 +1,40 @@
+import pandas as pd
+from pathlib import Path
+
+from trend_analysis import run_multi_analysis
+
+
+def _write_cfg(path: Path, csv: Path, out_dir: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "version: '1'",
+                f"data: {{csv_path: '{csv}'}}",
+                "preprocessing: {}",
+                "vol_adjust: {target_vol: 1.0}",
+                "multi_period: {frequency: M, in_sample_len: 2, out_sample_len: 1, start: '2020-01', end: '2020-03'}",
+                "portfolio: {}",
+                "metrics: {}",
+                f"export: {{directory: '{out_dir}', formats: ['csv']}}",
+                "run: {}",
+            ]
+        )
+    )
+
+
+def _make_df():
+    dates = pd.date_range("2020-01-31", periods=4, freq="ME")
+    return pd.DataFrame({"Date": dates, "RF": 0.0, "A": 0.01})
+
+
+def test_multi_cli_exports_files(tmp_path):
+    csv = tmp_path / "data.csv"
+    _make_df().to_csv(csv, index=False)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    cfg = tmp_path / "cfg.yml"
+    _write_cfg(cfg, csv, out_dir)
+    rc = run_multi_analysis.main(["-c", str(cfg)])
+    assert rc == 0
+    files = list(out_dir.glob("analysis_*.csv"))
+    assert files, "no output files"


### PR DESCRIPTION
## Summary
- document multi-period export roadmap
- implement `run_multi_analysis` CLI to export one file per period
- test multi-period CLI behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e9c61f7948331a7239e107d522535