### PR TITLE
Implement helper for per-period export

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -392,3 +392,7 @@ period using the same summary table produced by
 returns across all periods, formatted identically to each individual period
 sheet.  Work is in progress to expose this via a new ``run_multi_analysis`` CLI
 that calls ``export.export_multi_period_metrics``.
+
+### 2025-07-20 UPDATE — MULTI-PERIOD OUTPUT SPEC
+
+The pending export work shall produce an Excel workbook with one worksheet per period and a final `summary` sheet. Each tab uses the exact Phase‑ style summary table via `make_period_formatter`. CSV and JSON exports mirror this by writing one file per period plus a `_summary` file. A new helper `period_frames_from_results()` converts a sequence of result dictionaries into the mapping consumed by `export_multi_period_metrics`.

--- a/src/trend_analysis/export.py
+++ b/src/trend_analysis/export.py
@@ -532,6 +532,22 @@ def combined_summary_result(
     }
 
 
+def period_frames_from_results(
+    results: Iterable[Mapping[str, object]],
+) -> Mapping[str, pd.DataFrame]:
+    """Return a mapping of sheet names to summary frames for each period."""
+
+    frames: dict[str, pd.DataFrame] = {}
+    for idx, res in enumerate(results, start=1):
+        period = res.get("period")
+        if isinstance(period, (list, tuple)) and len(period) >= 4:
+            sheet = str(period[3])
+        else:
+            sheet = f"period_{idx}"
+        frames[sheet] = summary_frame_from_result(res)
+    return frames
+
+
 def export_multi_period_metrics(
     results: Iterable[Mapping[str, object]],
     output_path: str,
@@ -621,5 +637,6 @@ __all__ = [
     "metrics_from_result",
     "combined_summary_result",
     "summary_frame_from_result",
+    "period_frames_from_results",
     "export_multi_period_metrics",
 ]

--- a/tests/test_multi_period_export.py
+++ b/tests/test_multi_period_export.py
@@ -9,6 +9,7 @@ from trend_analysis.export import (
     summary_frame_from_result,
     combined_summary_result,
     export_multi_period_metrics,
+    period_frames_from_results,
 )
 
 
@@ -64,6 +65,17 @@ def test_combined_summary_result_basic():
     df_sum = summary_frame_from_result(summary)
     assert "OS MaxDD" in df_sum.columns
     assert df_sum.iloc[0, 0] == "Equal Weight"
+
+
+def test_period_frames_from_results_basic():
+    df = make_df()
+    cfg = make_cfg()
+    results = run_mp(cfg, df)
+    frames = period_frames_from_results(results)
+    assert len(frames) == len(results)
+    key = str(results[0]["period"][3])
+    assert key in frames
+    assert "OS MaxDD" in frames[key].columns
 
 
 def test_export_multi_period_metrics(tmp_path):


### PR DESCRIPTION
## Summary
- document the multi-period export goal in `Agents.md`
- add `period_frames_from_results` helper to build a sheet/file map
- test the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ea876f0048331a5d2d3d4cecd2862