### PR TITLE
Implement workbook frames for multi-period metrics

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -400,3 +400,12 @@ The pending export work shall produce an Excel workbook with one worksheet per p
 ### 2025-08-01 UPDATE — PER-PERIOD METRICS WORKBOOK
 
 Phase‑2 back-tests shall emit an Excel workbook with one tab per period formatted identically to the Phase‑1 summary sheet. CSV and JSON outputs produce one file per period in the same table form. In addition, a `summary` tab (and `_summary` file) aggregates portfolio returns across all periods using the identical layout. Implementation is underway in `export.export_multi_period_metrics`.
+
+### 2025-08-10 UPDATE — MULTI-PERIOD PHASE‑1 METRICS EXPORT
+
+Finalise the design goal that each period of a rolling back‑test mirrors the
+Phase‑1 metrics sheet. The exporter shall generate a workbook with one tab per
+period and a `summary` tab combining portfolio returns. CSV and JSON formats
+receive one file per period plus a `_summary` file. Implementation has started in
+`export.workbook_frames_from_results` and the updated
+`export.export_multi_period_metrics` helper.

--- a/src/trend_analysis/export.py
+++ b/src/trend_analysis/export.py
@@ -548,6 +548,19 @@ def period_frames_from_results(
     return frames
 
 
+def workbook_frames_from_results(
+    results: Iterable[Mapping[str, object]],
+) -> Mapping[str, pd.DataFrame]:
+    """Return per-period frames plus a combined summary frame."""
+
+    results_list = list(results)
+    frames = period_frames_from_results(results_list)
+    if results_list:
+        summary = combined_summary_result(results_list)
+        frames["summary"] = summary_frame_from_result(summary)
+    return frames
+
+
 def export_multi_period_metrics(
     results: Iterable[Mapping[str, object]],
     output_path: str,
@@ -578,6 +591,23 @@ def export_multi_period_metrics(
     reset_formatters_excel()
 
     results_list = list(results)
+
+    if other_formats:
+        other_data.update(workbook_frames_from_results(results_list))
+        if include_metrics:
+            for idx, res in enumerate(results_list, start=1):
+                period = res.get("period")
+                sheet = (
+                    str(period[3])
+                    if isinstance(period, (list, tuple)) and len(period) >= 4
+                    else f"period_{idx}"
+                )
+                other_data[f"metrics_{sheet}"] = metrics_from_result(res)
+            if results_list:
+                other_data["metrics_summary"] = metrics_from_result(
+                    combined_summary_result(results_list)
+                )
+
     for idx, res in enumerate(results_list, start=1):
         period = res.get("period")
         if isinstance(period, (list, tuple)) and len(period) >= 4:
@@ -592,11 +622,6 @@ def export_multi_period_metrics(
             make_period_formatter(sheet, res, in_s, in_e, out_s, out_e)
             if include_metrics:
                 excel_data[f"metrics_{sheet}"] = metrics_from_result(res)
-
-        if other_formats:
-            other_data[sheet] = summary_frame_from_result(res)
-            if include_metrics:
-                other_data[f"metrics_{sheet}"] = metrics_from_result(res)
 
     if results_list:
         summary = combined_summary_result(results_list)
@@ -618,10 +643,6 @@ def export_multi_period_metrics(
             if include_metrics:
                 excel_data["metrics_summary"] = metrics_from_result(summary)
 
-        if other_formats:
-            other_data["summary"] = summary_frame_from_result(summary)
-            if include_metrics:
-                other_data["metrics_summary"] = metrics_from_result(summary)
 
     if excel_formats:
         export_data(excel_data, output_path, formats=excel_formats)
@@ -661,5 +682,6 @@ __all__ = [
     "combined_summary_result",
     "summary_frame_from_result",
     "period_frames_from_results",
+    "workbook_frames_from_results",
     "export_multi_period_metrics",
 ]


### PR DESCRIPTION
## Summary
- clarify multi-period export target in Agents docs
- add `workbook_frames_from_results` helper to gather period frames and summary
- update `export_multi_period_metrics` to use the helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eaf331ee88331b8b4f8c24092f262