### PR TITLE
Implement consolidated multi-period csv/json output

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -409,3 +409,11 @@ period and a `summary` tab combining portfolio returns. CSV and JSON formats
 receive one file per period plus a `_summary` file. Implementation has started in
 `export.workbook_frames_from_results` and the updated
 `export.export_multi_period_metrics` helper.
+
+### 2025-08-20 UPDATE — CONSOLIDATED CSV/JSON OUTPUT
+
+The design goal remains one Excel worksheet per period plus a `summary` tab.
+CSV and JSON exports now consolidate all period tables into **one** file named
+`*_periods.*` with an accompanying `*_summary.*` file holding the aggregated
+portfolio returns.  Raw metrics, when requested, follow the same pattern under
+`metrics.*` and `metrics_summary.*`.

--- a/src/trend_analysis/export.py
+++ b/src/trend_analysis/export.py
@@ -593,8 +593,17 @@ def export_multi_period_metrics(
     results_list = list(results)
 
     if other_formats:
-        other_data.update(workbook_frames_from_results(results_list))
+        frames = workbook_frames_from_results(results_list)
+        period_frames = [(k, v) for k, v in frames.items() if k != "summary"]
+        combined = pd.concat(
+            [df.assign(Period=name) for name, df in period_frames],
+            ignore_index=True,
+        ) if period_frames else pd.DataFrame()
+        other_data["periods"] = combined
+        if "summary" in frames:
+            other_data["summary"] = frames["summary"]
         if include_metrics:
+            metrics_frames: list[pd.DataFrame] = []
             for idx, res in enumerate(results_list, start=1):
                 period = res.get("period")
                 sheet = (
@@ -602,7 +611,11 @@ def export_multi_period_metrics(
                     if isinstance(period, (list, tuple)) and len(period) >= 4
                     else f"period_{idx}"
                 )
-                other_data[f"metrics_{sheet}"] = metrics_from_result(res)
+                metrics = metrics_from_result(res)
+                metrics.insert(0, "Period", sheet)
+                metrics_frames.append(metrics)
+            if metrics_frames:
+                other_data["metrics"] = pd.concat(metrics_frames, ignore_index=True)
             if results_list:
                 other_data["metrics_summary"] = metrics_from_result(
                     combined_summary_result(results_list)

--- a/src/trend_analysis/export.py
+++ b/src/trend_analysis/export.py
@@ -534,7 +534,7 @@ def combined_summary_result(
 
 def period_frames_from_results(
     results: Iterable[Mapping[str, object]],
-) -> Mapping[str, pd.DataFrame]:
+) -> dict[str, pd.DataFrame]:
     """Return a mapping of sheet names to summary frames for each period."""
 
     frames: dict[str, pd.DataFrame] = {}
@@ -550,7 +550,7 @@ def period_frames_from_results(
 
 def workbook_frames_from_results(
     results: Iterable[Mapping[str, object]],
-) -> Mapping[str, pd.DataFrame]:
+) -> dict[str, pd.DataFrame]:
     """Return per-period frames plus a combined summary frame."""
 
     results_list = list(results)
@@ -595,10 +595,14 @@ def export_multi_period_metrics(
     if other_formats:
         frames = workbook_frames_from_results(results_list)
         period_frames = [(k, v) for k, v in frames.items() if k != "summary"]
-        combined = pd.concat(
-            [df.assign(Period=name) for name, df in period_frames],
-            ignore_index=True,
-        ) if period_frames else pd.DataFrame()
+        combined = (
+            pd.concat(
+                [df.assign(Period=name) for name, df in period_frames],
+                ignore_index=True,
+            )
+            if period_frames
+            else pd.DataFrame()
+        )
         other_data["periods"] = combined
         if "summary" in frames:
             other_data["summary"] = frames["summary"]
@@ -655,7 +659,6 @@ def export_multi_period_metrics(
                 make_period_formatter("summary", summary, "", "", "", "")
             if include_metrics:
                 excel_data["metrics_summary"] = metrics_from_result(summary)
-
 
     if excel_formats:
         export_data(excel_data, output_path, formats=excel_formats)

--- a/tests/test_multi_period_export.py
+++ b/tests/test_multi_period_export.py
@@ -84,13 +84,10 @@ def test_export_multi_period_metrics(tmp_path):
     results = run_mp(cfg, df)
     out = tmp_path / "res"
     export_multi_period_metrics(results, str(out), formats=["csv"])
-    first_period = results[0]["period"][3]
-    second_period = results[1]["period"][3]
-    p1 = out.with_name(f"{out.stem}_{first_period}.csv")
-    p2 = out.with_name(f"{out.stem}_{second_period}.csv")
+    periods_path = out.with_name(f"{out.stem}_periods.csv")
     summ = out.with_name(f"{out.stem}_summary.csv")
-    assert p1.exists() and p2.exists() and summ.exists()
-    df_read = pd.read_csv(p1, index_col=0)
+    assert periods_path.exists() and summ.exists()
+    df_read = pd.read_csv(periods_path, index_col=0)
     assert "Name" in df_read.columns
     assert df_read.iloc[0, 0] == "Equal Weight"
 


### PR DESCRIPTION
## Summary
- document consolidated multi-period export behaviour
- aggregate csv/json period data in a single file
- adjust tests for new naming convention

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eb4285d408331b70a3e3b99910768