### PR TITLE
Implement per-period workbook helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__/
 # test artefacts
 .coverage
 outputs/
+.venv/

--- a/Agents.md
+++ b/Agents.md
@@ -417,3 +417,13 @@ CSV and JSON exports now consolidate all period tables into **one** file named
 `*_periods.*` with an accompanying `*_summary.*` file holding the aggregated
 portfolio returns.  Raw metrics, when requested, follow the same pattern under
 `metrics.*` and `metrics_summary.*`.
+
+### 2025-08-30 UPDATE — PER-PERIOD PHASE‑1 WORKBOOK
+
+Implementation work continues to realise the original goal: multi‑period runs
+should emit an Excel workbook with **one tab per period** using the exact
+Phase‑1 summary layout.  A final `summary` sheet aggregates portfolio returns
+across all periods in the same format.  CSV and JSON outputs mirror this by
+bundling all period tables into a single `*_periods.*` file alongside a
+`*_summary.*` file.  Helper `export_phase1_workbook()` now begins the build
+out of this feature.

--- a/src/trend_analysis/export.py
+++ b/src/trend_analysis/export.py
@@ -561,6 +561,51 @@ def workbook_frames_from_results(
     return frames
 
 
+def export_phase1_workbook(
+    results: Iterable[Mapping[str, object]],
+    output_path: str,
+) -> None:
+    """Export a Phase-1 style workbook for ``results``.
+
+    Each period becomes its own sheet and a final ``summary`` sheet aggregates
+    portfolio returns across all periods using the same formatting.
+    """
+
+    results_list = list(results)
+    frames = {}
+    reset_formatters_excel()
+
+    for idx, res in enumerate(results_list, start=1):
+        period = res.get("period")
+        if isinstance(period, (list, tuple)) and len(period) >= 4:
+            in_s, in_e, out_s, out_e = map(str, period[:4])
+            sheet = str(period[3])
+        else:
+            in_s = in_e = out_s = out_e = ""
+            sheet = f"period_{idx}"
+        frames[sheet] = summary_frame_from_result(res)
+        make_period_formatter(sheet, res, in_s, in_e, out_s, out_e)
+
+    if results_list:
+        summary = combined_summary_result(results_list)
+        frames["summary"] = summary_frame_from_result(summary)
+        first = results_list[0].get("period")
+        last = results_list[-1].get("period")
+        if isinstance(first, (list, tuple)) and isinstance(last, (list, tuple)):
+            make_period_formatter(
+                "summary",
+                summary,
+                str(first[0]),
+                str(first[1]),
+                str(last[2]),
+                str(last[3]),
+            )
+        else:
+            make_period_formatter("summary", summary, "", "", "", "")
+
+    export_to_excel(frames, output_path)
+
+
 def export_multi_period_metrics(
     results: Iterable[Mapping[str, object]],
     output_path: str,
@@ -699,5 +744,6 @@ __all__ = [
     "summary_frame_from_result",
     "period_frames_from_results",
     "workbook_frames_from_results",
+    "export_phase1_workbook",
     "export_multi_period_metrics",
 ]

--- a/tests/test_multi_period_export.py
+++ b/tests/test_multi_period_export.py
@@ -9,6 +9,7 @@ from trend_analysis.export import (
     summary_frame_from_result,
     combined_summary_result,
     export_multi_period_metrics,
+    export_phase1_workbook,
     period_frames_from_results,
 )
 
@@ -108,3 +109,18 @@ def test_export_multi_period_metrics_excel(tmp_path):
     assert "summary" in book.sheet_names
     df_read = pd.read_excel(path, sheet_name=first_period, header=None)
     assert "Vol-Adj Trend Analysis" in df_read.iloc[0, 0]
+
+
+def test_export_phase1_workbook(tmp_path):
+    df = make_df()
+    cfg = make_cfg()
+    results = run_mp(cfg, df)
+    out = tmp_path / "res.xlsx"
+    export_phase1_workbook(results, str(out))
+    assert out.exists()
+    first_period = str(results[0]["period"][3])
+    second_period = str(results[1]["period"][3])
+    book = pd.ExcelFile(out)
+    assert first_period in book.sheet_names
+    assert second_period in book.sheet_names
+    assert "summary" in book.sheet_names


### PR DESCRIPTION
## Summary
- document multi-period Phase-1 workbook target
- begin helper to export Phase‑1 style workbook with summary sheet
- test new export helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ebb9e57b08331ba02203e96edfa71