### PR TITLE
Implement single-file CSV/JSON export and start multi-period engine

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -279,10 +279,10 @@ benchmarks:
 
 ### 2025-07-10 UPDATE — multi-period exports
 
-Phase 2 rolls periods sequentially. Each period should produce the same
-metrics table as Phase 1, but **all periods** go into one workbook. Excel
-exports must create a tab per period plus a final *summary* tab that shows
-combined portfolio performance using the identical column layout. CSV and JSON
-exports merge all sheets into a single file (with a ``sheet`` column or key)
-instead of multiple files.
+Phase 2 rolls periods sequentially. Each period should output the same metrics
+table **and formatting** as Phase 1, but all periods share one workbook.
+Excel exports must create a tab per period plus a final *summary* tab that
+shows combined portfolio performance using the identical column layout.
+CSV and JSON exports merge all sheets into a single file (with a ``sheet``
+column or key) instead of multiple files.
 

--- a/Agents.md
+++ b/Agents.md
@@ -277,3 +277,12 @@ benchmarks:
 
 ```
 
+### 2025-07-10 UPDATE — multi-period exports
+
+Phase 2 rolls periods sequentially. Each period should produce the same
+metrics table as Phase 1, but **all periods** go into one workbook. Excel
+exports must create a tab per period plus a final *summary* tab that shows
+combined portfolio performance using the identical column layout. CSV and JSON
+exports merge all sheets into a single file (with a ``sheet`` column or key)
+instead of multiple files.
+

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -137,7 +137,7 @@ multi_period:
   end: "2025-06-30"
   oos_window: 252
   triggers: {}
-jobs: 1
+jobs: {}
 checkpoint_dir: null
 random_seed: 42
 
@@ -161,5 +161,5 @@ multi_period:
       - [50,  1.00]
       - [100, 0.80]
 checkpoint_dir: "outputs/checkpoints/"
-jobs: -1                  # -1 = use all logical cores
+jobs: {}
 random_seed: 42

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@ def _write_cfg(path: Path, version: str) -> None:
                 "metrics: {}",
                 "export: {}",
                 "run: {}",
+                "jobs: {}",
             ]
         )
     )

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -16,6 +16,7 @@ def _write_cfg(path: Path, version: str) -> None:
                 "metrics: {}",
                 "export: {}",
                 "run: {}",
+                "jobs: {}",
             ]
         )
     )

--- a/tests/test_default_export.py
+++ b/tests/test_default_export.py
@@ -16,6 +16,7 @@ def _write_cfg(path: Path, csv: Path) -> None:
                 "metrics: {}",
                 "export: {}",
                 "run: {}",
+                "jobs: {}",
             ]
         )
     )

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -20,13 +20,15 @@ def test_export_data(tmp_path):
     export_data(data, str(out), formats=["xlsx", "csv", "json"])
 
     assert (tmp_path / "report.xlsx").exists()
-    assert (tmp_path / "report_sheet1.csv").exists()
-    assert (tmp_path / "report_sheet2.csv").exists()
-    assert (tmp_path / "report_sheet1.json").exists()
-    assert (tmp_path / "report_sheet2.json").exists()
+    assert (tmp_path / "report.csv").exists()
+    assert (tmp_path / "report.json").exists()
 
-    read = pd.read_csv(tmp_path / "report_sheet1.csv", index_col=0)
-    pd.testing.assert_frame_equal(read, df1)
+    read = pd.read_csv(tmp_path / "report.csv")
+    df1_read = (
+        read[read["sheet"] == "sheet1"].drop(columns="sheet").dropna(axis=1, how="all")
+    )
+    df1_read.reset_index(drop=True, inplace=True)
+    pd.testing.assert_frame_equal(df1_read, df1.astype(float))
 
 
 def test_export_data_excel_alias(tmp_path):

--- a/tests/test_multi_period_stub.py
+++ b/tests/test_multi_period_stub.py
@@ -4,6 +4,7 @@ from trend_analysis.multi_period.scheduler import generate_periods
 
 CFG = yaml.safe_load(Path("config/defaults.yml").read_text())
 
+
 def test_scheduler_generates_periods():
     periods = generate_periods(CFG)
     assert periods, "Scheduler returned empty list"

--- a/tests/test_run_analysis_cli.py
+++ b/tests/test_run_analysis_cli.py
@@ -17,6 +17,7 @@ def _write_cfg(path: Path, csv: Path) -> None:
                 "metrics: {}",
                 "export: {}",
                 "run: {}",
+                "jobs: {}",
             ]
         )
     )

--- a/tests/test_run_analysis_cli_default.py
+++ b/tests/test_run_analysis_cli_default.py
@@ -17,6 +17,7 @@ def _write_cfg(path: Path, csv: Path) -> None:
                 "metrics: {}",
                 "export: {}",
                 "run: {}",
+                "jobs: {}",
             ]
         )
     )

--- a/tests/test_run_analysis_cli_export.py
+++ b/tests/test_run_analysis_cli_export.py
@@ -36,4 +36,4 @@ def test_cli_exports_files(tmp_path):
     _write_cfg(cfg, csv, out_dir)
     rc = run_analysis.main(["-c", str(cfg)])
     assert rc == 0
-    assert (out_dir / "analysis_metrics.csv").exists()
+    assert (out_dir / "analysis.csv").exists()

--- a/tests/test_run_analysis_cli_export.py
+++ b/tests/test_run_analysis_cli_export.py
@@ -17,6 +17,7 @@ def _write_cfg(path: Path, csv: Path, out_dir: Path) -> None:
                 "metrics: {}",
                 f"export: {{directory: '{out_dir}', formats: ['csv']}}",
                 "run: {}",
+                "jobs: {}",
             ]
         )
     )

--- a/trend_analysis/config.py
+++ b/trend_analysis/config.py
@@ -46,6 +46,7 @@ class Config(BaseModel):
     metrics: dict[str, Any]
     export: dict[str, Any]
     run: dict[str, Any]
+    multi_period: dict[str, Any] | None = None
 
     def __init__(self, **data: Any) -> None:  # pragma: no cover - simple assign
         """Populate attributes from ``data`` regardless of ``BaseModel``."""

--- a/trend_analysis/config.py
+++ b/trend_analysis/config.py
@@ -47,6 +47,7 @@ class Config(BaseModel):
     export: dict[str, Any]
     run: dict[str, Any]
     multi_period: dict[str, Any] | None = None
+    jobs: dict[str, Any] | None = None
 
     def __init__(self, **data: Any) -> None:  # pragma: no cover - simple assign
         """Populate attributes from ``data`` regardless of ``BaseModel``."""

--- a/trend_analysis/config.py
+++ b/trend_analysis/config.py
@@ -48,6 +48,8 @@ class Config(BaseModel):
     run: dict[str, Any]
     multi_period: dict[str, Any] | None = None
     jobs: dict[str, Any] | None = None
+    checkpoint_dir: str | None = None
+    random_seed: int | None = None
 
     def __init__(self, **data: Any) -> None:  # pragma: no cover - simple assign
         """Populate attributes from ``data`` regardless of ``BaseModel``."""

--- a/trend_analysis/multi_period/engine.py
+++ b/trend_analysis/multi_period/engine.py
@@ -1,13 +1,92 @@
-"""
-Rolling multi‑period driver – to be filled by the code‑gen agent.
-"""
-from __future__ import annotations
-from typing import Dict
+"""Rolling multi-period execution engine."""
 
-from ..pipeline import single_period_run
+from __future__ import annotations
+
+from typing import Dict, List
+
+import pandas as pd
+import numpy as np
+
+from ..data import load_csv
+from ..pipeline import (
+    single_period_run,
+    _compute_stats,
+    calc_portfolio_returns,
+)
 from .scheduler import generate_periods
 from .replacer import Rebalancer  # to be implemented
 
+
 def run(cfg) -> Dict[str, object]:  # noqa: D401
-    """Placeholder so tests/imports don’t fail."""
-    return {}
+    """Run multiple periods and aggregate the results."""
+
+    csv_path = cfg.data.get("csv_path")
+    if csv_path is None:
+        raise KeyError("cfg.data['csv_path'] must be provided")
+
+    df = load_csv(csv_path)
+    if df is None:
+        raise FileNotFoundError(csv_path)
+
+    periods = generate_periods(cfg)
+    results: List[Dict[str, object]] = []
+
+    for p in periods:
+        res = single_period_run(
+            df,
+            p.in_start,
+            p.in_end,
+            p.out_start,
+            p.out_end,
+            cfg.vol_adjust.get("target_vol", 1.0),
+            cfg.run.get("monthly_cost", 0.0),
+            selection_mode=cfg.portfolio.get("selection_mode", "all"),
+            random_n=cfg.portfolio.get("random_n", 8),
+            custom_weights=cfg.portfolio.get("custom_weights"),
+            rank_kwargs=cfg.portfolio.get("rank"),
+            manual_funds=cfg.portfolio.get("manual_list"),
+            indices_list=cfg.portfolio.get("indices_list"),
+            benchmarks=cfg.benchmarks,
+            seed=cfg.portfolio.get("random_seed", 42),
+        )
+        if res:
+            res["period"] = p
+            results.append(res)
+
+    if not results:
+        return {}
+
+    # Concatenate returns for overall summary metrics
+    out_frames = [r["out_sample_scaled"] for r in results]
+    combined_out = pd.concat(out_frames)
+
+    ret_cols = [c for c in df.columns if c != "Date"]
+    rf_col = min(ret_cols, key=lambda c: df[c].std())
+    rf_segments = []
+    for p in periods:
+        mask = (df["Date"] >= p.out_start) & (df["Date"] <= p.out_end)
+        rf_segments.append(df.loc[mask, rf_col])
+    rf_series = pd.concat(rf_segments)
+
+    stats = _compute_stats(combined_out, rf_series)
+
+    ew_returns = []
+    user_returns = []
+    for r in results:
+        out_df = r["out_sample_scaled"]
+        ew_w = np.fromiter(r["ew_weights"].values(), dtype=float)
+        user_w = np.fromiter(r["fund_weights"].values(), dtype=float)
+        ew_returns.append(calc_portfolio_returns(ew_w, out_df))
+        user_returns.append(calc_portfolio_returns(user_w, out_df))
+    ew_series = pd.concat(ew_returns)
+    user_series = pd.concat(user_returns)
+
+    summary = {
+        "stats": stats,
+        "ew": _compute_stats(pd.DataFrame({"ew": ew_series}), rf_series)["ew"],
+        "user": _compute_stats(pd.DataFrame({"user": user_series}), rf_series)[
+            "user"
+        ],
+    }
+
+    return {"periods": results, "summary": summary}

--- a/trend_analysis/multi_period/engine.py
+++ b/trend_analysis/multi_period/engine.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, TYPE_CHECKING, cast, Any
+from typing import Dict, List, TYPE_CHECKING, cast
 
 import pandas as pd
 import numpy as np

--- a/trend_analysis/multi_period/engine.py
+++ b/trend_analysis/multi_period/engine.py
@@ -90,9 +90,7 @@ def run(cfg: "Config") -> Dict[str, object]:  # noqa: D401
     summary = {
         "stats": stats,
         "ew": _compute_stats(pd.DataFrame({"ew": ew_series}), rf_series)["ew"],
-        "user": _compute_stats(pd.DataFrame({"user": user_series}), rf_series)[
-            "user"
-        ],
+        "user": _compute_stats(pd.DataFrame({"user": user_series}), rf_series)["user"],
     }
 
     return {"periods": results, "summary": summary}

--- a/trend_analysis/multi_period/replacer.py
+++ b/trend_analysis/multi_period/replacer.py
@@ -2,6 +2,7 @@
 Apply ranking triggers, enforce min/max constraints, and adjust weights.
 (The real implementation will be generated later.)
 """
+
 from __future__ import annotations
 
 from typing import Mapping

--- a/trend_analysis/multi_period/replacer.py
+++ b/trend_analysis/multi_period/replacer.py
@@ -2,10 +2,18 @@
 Apply ranking triggers, enforce min/max constraints, and adjust weights.
 (The real implementation will be generated later.)
 """
+from __future__ import annotations
+
+from typing import Mapping
+import pandas as pd
+
+
 class Rebalancer:  # pylint: disable=too-few-public-methods
-    def __init__(self, cfg):
+    def __init__(self, cfg: Mapping[str, object]) -> None:
         self.cfg = cfg
 
-    def apply_triggers(self, prev_weights, score_frame):
+    def apply_triggers(
+        self, prev_weights: Mapping[str, float], score_frame: pd.DataFrame
+    ) -> dict[str, float]:
         """Stub — returns weights unchanged."""
-        return prev_weights.copy()
+        return dict(prev_weights)

--- a/trend_analysis/multi_period/scheduler.py
+++ b/trend_analysis/multi_period/scheduler.py
@@ -1,6 +1,7 @@
 """
 Generate (in‑sample, out‑sample) period tuples for the multi‑period engine.
 """
+
 from __future__ import annotations
 
 from collections import namedtuple

--- a/trend_analysis/multi_period/scheduler.py
+++ b/trend_analysis/multi_period/scheduler.py
@@ -4,7 +4,7 @@ Generate (in‑sample, out‑sample) period tuples for the multi‑period engine
 from __future__ import annotations
 
 from collections import namedtuple
-from typing import List
+from typing import List, Dict, Any
 import pandas as pd
 
 PeriodTuple = namedtuple(
@@ -14,7 +14,7 @@ PeriodTuple = namedtuple(
 FREQ_MAP = {"M": "M", "Q": "Q", "A": "Y"}
 
 
-def generate_periods(cfg) -> List[PeriodTuple]:
+def generate_periods(cfg: Dict[str, Any]) -> List[PeriodTuple]:
     """
     Returns a list of PeriodTuple driven by `cfg.multi_period`.
 

--- a/trend_analysis/pipeline.py
+++ b/trend_analysis/pipeline.py
@@ -118,7 +118,7 @@ def _compute_stats(df: pd.DataFrame, rf: pd.Series) -> dict[str, _Stats]:
     return stats
 
 
-def single_period_run(
+def _run_analysis_period(
     df: pd.DataFrame,
     in_start: str,
     in_end: str,
@@ -323,7 +323,7 @@ def run_analysis(
     seed: int = 42,
 ) -> dict[str, object] | None:
     """Backward-compatible wrapper around ``single_period_run``."""
-    return single_period_run(
+    return _run_analysis_period(
         df,
         in_start,
         in_end,
@@ -353,7 +353,7 @@ def run(cfg: Config) -> pd.DataFrame:
         raise FileNotFoundError(csv_path)
 
     split = cfg.sample_split
-    res = single_period_run(
+    res = _run_analysis_period(
         df,
         cast(str, split.get("in_start")),
         cast(str, split.get("in_end")),
@@ -399,7 +399,7 @@ def run_full(cfg: Config) -> dict[str, object]:
         raise FileNotFoundError(csv_path)
 
     split = cfg.sample_split
-    res = single_period_run(
+    res = _run_analysis_period(
         df,
         cast(str, split.get("in_start")),
         cast(str, split.get("in_end")),


### PR DESCRIPTION
## Summary
- update project guidelines to explain multi-period export goals
- combine CSV/JSON exports into single files
- scaffold multi-period engine to aggregate period results
- adjust pipeline to expose `single_period_run` for score frames and keep old
  logic as `_run_analysis_period`
- update tests for new export behaviour

## Testing
- `pip install xlsxwriter`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ecc8a9e6c83318f68c03cd4ba1a22