### PR TITLE
Implement multi-period export scaffolding

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -286,3 +286,11 @@ shows combined portfolio performance using the identical column layout.
 CSV and JSON exports merge all sheets into a single file (with a ``sheet``
 column or key) instead of multiple files.
 
+### 2025-07-16 UPDATE — multi-period workbook goal
+
+Phase 2's exporter must preserve the Phase 1 table layout for every period.
+All periods write to one workbook: ``period_1``, ``period_2`` … plus a
+``summary`` sheet showing combined portfolio results in the very same format.
+CSV and JSON outputs follow suit by collapsing all sheets into a single file
+with either a ``sheet`` column or key.
+

--- a/tests/test_multi_period_report.py
+++ b/tests/test_multi_period_report.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import pandas as pd
+
+from trend_analysis.config import Config
+from trend_analysis.multi_period.engine import run
+from trend_analysis.multi_period.report import build_frames
+
+
+def make_cfg(tmp_path: Path) -> Config:
+    csv = tmp_path / "data.csv"
+    dates = pd.date_range("2020-01-31", periods=6, freq="ME")
+    pd.DataFrame({"Date": dates, "RF": 0.0, "A": 0.01, "B": 0.02}).to_csv(csv, index=False)
+    return Config(
+        version="1",
+        data={"csv_path": str(csv)},
+        preprocessing={},
+        vol_adjust={"target_vol": 1.0},
+        sample_split={},
+        portfolio={},
+        metrics={},
+        export={},
+        run={},
+        multi_period={
+            "frequency": "M",
+            "in_sample_len": 2,
+            "out_sample_len": 1,
+            "start": "2020-01",
+            "end": "2020-06",
+        },
+    )
+
+
+def test_build_frames_has_summary(tmp_path: Path) -> None:
+    cfg = make_cfg(tmp_path)
+    res = run(cfg)
+    frames = build_frames(res)
+    assert "summary" in frames
+    assert frames["summary"].shape[0] == len(res["summary"]["stats"])
+    assert any(k.startswith("period_") for k in frames)
+

--- a/trend_analysis/multi_period/__init__.py
+++ b/trend_analysis/multi_period/__init__.py
@@ -1,1 +1,5 @@
 """Multi‑period back‑tester package (Phase 2 scaffolding)."""
+
+from .report import build_frames, export_multi_period
+
+__all__ = ["build_frames", "export_multi_period"]

--- a/trend_analysis/multi_period/engine.py
+++ b/trend_analysis/multi_period/engine.py
@@ -33,13 +33,16 @@ def run(cfg: "Config") -> Dict[str, object]:  # noqa: D401
     periods = generate_periods(cfg.model_dump())
     results: List[Dict[str, object]] = []
 
+    def _month(s: str) -> str:
+        return str(pd.Period(s).strftime("%Y-%m"))
+
     for p in periods:
         res = _run_analysis_period(
             df,
-            p.in_start,
-            p.in_end,
-            p.out_start,
-            p.out_end,
+            _month(p.in_start),
+            _month(p.in_end),
+            _month(p.out_start),
+            _month(p.out_end),
             cfg.vol_adjust.get("target_vol", 1.0),
             cfg.run.get("monthly_cost", 0.0),
             selection_mode=cfg.portfolio.get("selection_mode", "all"),

--- a/trend_analysis/multi_period/report.py
+++ b/trend_analysis/multi_period/report.py
@@ -1,0 +1,50 @@
+"""Helpers for multi-period export."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Dict, Iterable
+
+import pandas as pd
+
+from ..export import export_to_excel, export_data
+
+
+def _result_to_frame(res: Mapping[str, Any]) -> pd.DataFrame:
+    """Return a metrics table for a single period."""
+    stats = res.get("out_sample_stats", {})
+    df = pd.DataFrame({k: vars(v) for k, v in stats.items()}).T
+    for label, ir_map in res.get("benchmark_ir", {}).items():
+        col = f"ir_{label}"
+        df[col] = pd.Series(
+            {k: v for k, v in ir_map.items() if k not in {"equal_weight", "user_weight"}}
+        )
+    return df
+
+
+def build_frames(res: Mapping[str, Any]) -> Dict[str, pd.DataFrame]:
+    """Return per-period DataFrames plus a summary frame."""
+    frames: Dict[str, pd.DataFrame] = {}
+    for idx, period_res in enumerate(res.get("periods", []), start=1):
+        frames[f"period_{idx}"] = _result_to_frame(period_res)
+    summary_stats = res.get("summary", {}).get("stats", {})
+    if summary_stats:
+        frames["summary"] = pd.DataFrame({k: vars(v) for k, v in summary_stats.items()}).T
+    return frames
+
+
+def export_multi_period(res: Mapping[str, Any], out_dir: str, formats: Iterable[str]) -> None:
+    """Export multi-period results using the canonical exporters."""
+    frames = build_frames(res)
+    path = Path(out_dir)
+    if any(f.lower() in {"excel", "xlsx"} for f in formats):
+        export_to_excel(frames, str(path / "analysis.xlsx"))
+        other = [f for f in formats if f.lower() not in {"excel", "xlsx"}]
+        if other:
+            export_data(frames, str(path / "analysis"), formats=other)
+    else:
+        export_data(frames, str(path / "analysis"), formats=formats)
+
+
+__all__ = ["build_frames", "export_multi_period"]
+


### PR DESCRIPTION
## Summary
- document Phase 2 workbook requirement
- fix multi-period engine to pass YYYY-MM strings
- add multi-period report helpers
- expose helpers from package and test them

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f276808188331b58e3c9616c0467b