### PR TITLE
Add multi-period export note and JSON test

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -464,3 +464,7 @@ bundle all period tables into a single `*_periods.*` file with a companion
 uses the same helper to emit a single ``*_periods.*`` file plus a matching
 ``*_summary.*`` for CSV/JSON users. Development continues to keep these
 outputs identical to the single-period workbook.
+
+### 2025-10-12 UPDATE — MULTI-PERIOD PHASE-1 METRICS GOAL
+
+The export layer must emit a Phase-1 style workbook with one sheet per period and a final `summary` sheet combining portfolio returns. Each sheet uses `make_period_formatter` so formatting matches the single-period output. CSV and JSON outputs consolidate these tables into a single `*_periods.*` file with a companion `*_summary.*` file. Implementation now begins in `export_phase1_workbook()` and `export_phase1_multi_metrics()` to realise this design.

--- a/tests/test_multi_period_export.py
+++ b/tests/test_multi_period_export.py
@@ -138,6 +138,22 @@ def test_export_phase1_multi_metrics(tmp_path):
     assert df_read.iloc[0, 0] == "Equal Weight"
 
 
+def test_export_phase1_multi_metrics_json(tmp_path):
+    df = make_df()
+    cfg = make_cfg()
+    results = run_mp(cfg, df)
+    out = tmp_path / "res"
+    export_phase1_multi_metrics(results, str(out), formats=["json"])
+    periods_path = out.with_name(f"{out.stem}_periods.json")
+    summary_path = out.with_name(f"{out.stem}_summary.json")
+    assert periods_path.exists() and summary_path.exists()
+    files = list(tmp_path.glob("*.json"))
+    assert {periods_path, summary_path} == set(files)
+    df_read = pd.read_json(periods_path)
+    assert "Period" in df_read.columns
+    assert df_read.loc[0, "Name"] == "Equal Weight"
+
+
 def test_export_phase1_workbook(tmp_path):
     df = make_df()
     cfg = make_cfg()


### PR DESCRIPTION
## Summary
- document goal for Phase-1 style multi-period exports
- test JSON output for phase1 multi metrics

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687074d70cf88331aad50a1c166d7737