### PR TITLE
Refine multi-period export notes

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -477,3 +477,7 @@ Multi-period exports shall produce an Excel workbook with one sheet per period p
 
 The Phase-1 metrics export shall produce one Excel worksheet per period using the exact same formatting as the single-period report. A final `summary` tab aggregates portfolio performance across all periods in the identical layout. CSV and JSON exports consolidate all period tables into a single `*_periods.*` file and place the combined results in a matching `*_summary.*` file. Implementation starts in `export_phase1_workbook()` and `export_phase1_multi_metrics()` which build their frames via `workbook_frames_from_results()`.
 
+### 2025-11-08 UPDATE — PHASE-1 MULTI-PERIOD WORKBOOK GOAL
+
+The outstanding goal is unchanged: each multi-period run should yield a Phase‑1 style workbook with **one sheet per period** and a final `summary` sheet aggregating portfolio returns. The summary tab must mirror the columns and formatting of the individual period sheets. CSV and JSON outputs bundle all period tables into a single `*_periods.*` file alongside a matching `*_summary.*` file. Current work focuses on finishing `export_phase1_workbook()` and surfacing these helpers via the public API.
+

--- a/src/trend_analysis/__init__.py
+++ b/src/trend_analysis/__init__.py
@@ -13,6 +13,7 @@ from .export import (
     metrics_from_result,
     combined_summary_result,
     flat_frames_from_results,
+    export_phase1_workbook,
     export_phase1_multi_metrics,
     export_multi_period_metrics,
 )
@@ -37,6 +38,7 @@ __all__ = [
     "metrics_from_result",
     "combined_summary_result",
     "flat_frames_from_results",
+    "export_phase1_workbook",
     "export_phase1_multi_metrics",
     "export_multi_period_metrics",
 ]


### PR DESCRIPTION
## Summary
- describe the still-open target to emit a Phase‑1 workbook with one sheet per period and an aggregated summary
- expose `export_phase1_workbook` through the package API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870868e8ee083319b11d5addc969c03