### PR TITLE
Implement ordered sheets and clarify spec

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,9 +8,14 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
-    -    id: flake8
-          args: [--max-line-length=120, --extend-ignore=F401,E501,F821]
-          exclude: >
+-   repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+    -   id: flake8
+        args:
+        - --max-line-length=120
+        - --extend-ignore=F401,E501,F821
+        exclude: >
             ( ^Old/|
               ^notebooks/|
               ^tests/legacy_metrics\.py )

--- a/src/trend_analysis/export.py
+++ b/src/trend_analysis/export.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, cast
+from collections import OrderedDict
 import inspect
 
 import pandas as pd
@@ -541,10 +542,10 @@ def combined_summary_frame(results: Iterable[Mapping[str, object]]) -> pd.DataFr
 
 def period_frames_from_results(
     results: Iterable[Mapping[str, object]],
-) -> dict[str, pd.DataFrame]:
+) -> "OrderedDict[str, pd.DataFrame]":
     """Return a mapping of sheet names to summary frames for each period."""
 
-    frames: dict[str, pd.DataFrame] = {}
+    frames: "OrderedDict[str, pd.DataFrame]" = OrderedDict()
     for idx, res in enumerate(results, start=1):
         period = res.get("period")
         if isinstance(period, (list, tuple)) and len(period) >= 4:
@@ -557,7 +558,7 @@ def period_frames_from_results(
 
 def workbook_frames_from_results(
     results: Iterable[Mapping[str, object]],
-) -> dict[str, pd.DataFrame]:
+) -> "OrderedDict[str, pd.DataFrame]":
     """Return per-period frames plus a combined summary frame."""
 
     results_list = list(results)

--- a/tests/test_multi_period_export.py
+++ b/tests/test_multi_period_export.py
@@ -203,3 +203,14 @@ def test_export_phase1_workbook_content(tmp_path):
     df_summary = book["summary"]
     assert list(df_first.columns) == list(df_summary.columns)
     assert df_summary.iloc[0, 0] == "Equal Weight"
+
+
+def test_export_phase1_workbook_order(tmp_path):
+    df = make_df()
+    cfg = make_cfg()
+    results = run_mp(cfg, df)
+    out = tmp_path / "res.xlsx"
+    export_phase1_workbook(results, str(out))
+    book = pd.ExcelFile(out)
+    expected = [str(r["period"][3]) for r in results] + ["summary"]
+    assert book.sheet_names == expected


### PR DESCRIPTION
## Summary
- clarify multi-period metrics export spec in Agents docs
- use `OrderedDict` for deterministic workbook sheet order
- verify ordering with new unit test
- fix pre-commit configuration

## Testing
- `pre-commit run --files Agents.md src/trend_analysis/export.py tests/test_multi_period_export.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68709a3dfa288331bb315cd9cf6d061b