### PR TITLE
Implement consolidated period export

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -495,3 +495,13 @@ with the same columns and formatting. CSV and JSON exports shall mirror this by
 bundling all period tables into a single `<prefix>_periods.*` file together with
 `<prefix>_summary.*` for the aggregated results. Implementation work continues in
 `export_phase1_workbook()` and `export_phase1_multi_metrics()`.
+
+### 2025-12-08 UPDATE — MULTI-PERIOD PHASE-1 EXPORT INITIATIVE
+
+The long-standing objective is for rolling runs to emit a Phase‑1 style
+workbook with **one tab per period** and a final `summary` sheet combining
+portfolio returns.  Each sheet must share the identical columns and
+formatting.  CSV and JSON outputs should deliver a single `<prefix>_periods.*`
+file plus `<prefix>_summary.*` to aggregate the results.  Implementation work
+begins in `export_phase1_workbook()` and `flat_frames_from_results()` to shape
+these consolidated tables.

--- a/src/trend_analysis/export.py
+++ b/src/trend_analysis/export.py
@@ -337,7 +337,7 @@ def export_to_csv(
         formatted = _apply_format(df, formatter)
         formatted.to_csv(
             prefix.with_name(f"{prefix.stem}_{name}.csv"),
-            index=True,
+            index=False,
             header=True,
         )
 
@@ -576,13 +576,12 @@ def flat_frames_from_results(
 
     frames = workbook_frames_from_results(list(results))
     period_frames = [(k, v) for k, v in frames.items() if k != "summary"]
-    combined = (
-        pd.concat(
-            [df.assign(Period=name) for name, df in period_frames], ignore_index=True
-        )
-        if period_frames
-        else pd.DataFrame()
-    )
+    combined_frames = []
+    for name, df in period_frames:
+        df = df.copy()
+        df.insert(0, "Period", name)
+        combined_frames.append(df)
+    combined = pd.concat(combined_frames, ignore_index=True) if combined_frames else pd.DataFrame()
     out: dict[str, pd.DataFrame] = {"periods": combined}
     if "summary" in frames:
         out["summary"] = frames["summary"]

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -26,7 +26,7 @@ def test_export_data(tmp_path):
     assert (tmp_path / "report_sheet1.json").exists()
     assert (tmp_path / "report_sheet2.json").exists()
 
-    read = pd.read_csv(tmp_path / "report_sheet1.csv", index_col=0)
+    read = pd.read_csv(tmp_path / "report_sheet1.csv")
     pd.testing.assert_frame_equal(read, df1)
 
 

--- a/tests/test_multi_period_export.py
+++ b/tests/test_multi_period_export.py
@@ -123,9 +123,9 @@ def test_export_multi_period_metrics(tmp_path):
     periods_path = out.with_name(f"{out.stem}_periods.csv")
     summ = out.with_name(f"{out.stem}_summary.csv")
     assert periods_path.exists() and summ.exists()
-    df_read = pd.read_csv(periods_path, index_col=0)
-    assert "Name" in df_read.columns
-    assert df_read.iloc[0, 0] == "Equal Weight"
+    df_read = pd.read_csv(periods_path)
+    assert list(df_read.columns)[0] == "Period"
+    assert df_read.iloc[0, 1] == "Equal Weight"
 
 
 def test_export_multi_period_metrics_excel(tmp_path):
@@ -155,9 +155,9 @@ def test_export_phase1_multi_metrics(tmp_path):
     assert periods_path.exists() and summary_path.exists()
     files = list(tmp_path.glob("*.csv"))
     assert {periods_path, summary_path} == set(files)
-    df_read = pd.read_csv(periods_path, index_col=0)
-    assert "Period" in df_read.columns
-    assert df_read.iloc[0, 0] == "Equal Weight"
+    df_read = pd.read_csv(periods_path)
+    assert list(df_read.columns)[0] == "Period"
+    assert df_read.iloc[0, 1] == "Equal Weight"
 
 
 def test_export_phase1_multi_metrics_json(tmp_path):
@@ -172,7 +172,7 @@ def test_export_phase1_multi_metrics_json(tmp_path):
     files = list(tmp_path.glob("*.json"))
     assert {periods_path, summary_path} == set(files)
     df_read = pd.read_json(periods_path)
-    assert "Period" in df_read.columns
+    assert list(df_read.columns)[0] == "Period"
     assert df_read.loc[0, "Name"] == "Equal Weight"
 
 


### PR DESCRIPTION
## Summary
- clarify multi-period export goal in Agents.md
- export CSV files without row index
- ensure consolidated period frame has `Period` as the first column
- update tests for the new CSV layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a1f19e7883319cc15617503d41d2