### PR TITLE
Add multi-period export test and update agents notes

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -505,3 +505,13 @@ formatting.  CSV and JSON outputs should deliver a single `<prefix>_periods.*`
 file plus `<prefix>_summary.*` to aggregate the results.  Implementation work
 begins in `export_phase1_workbook()` and `flat_frames_from_results()` to shape
 these consolidated tables.
+
+### 2025-12-15 UPDATE — PHASE-1 MULTI-PERIOD WORKBOOK GOAL
+
+The original requirement remains: metrics from each period must be exported as
+an Excel workbook with **one sheet per period** using the exact Phase‑1 summary
+formatting. A final `summary` sheet combines portfolio returns across all
+periods in the same layout. CSV and JSON outputs should consolidate all period
+tables into a single `<prefix>_periods.*` file with a matching
+`<prefix>_summary.*` file. Implementation continues in
+`export_phase1_workbook()` and `export_phase1_multi_metrics()`.

--- a/tests/test_multi_period_export.py
+++ b/tests/test_multi_period_export.py
@@ -214,3 +214,22 @@ def test_export_phase1_workbook_order(tmp_path):
     book = pd.ExcelFile(out)
     expected = [str(r["period"][3]) for r in results] + ["summary"]
     assert book.sheet_names == expected
+
+
+def test_export_phase1_multi_metrics_excel(tmp_path):
+    df = make_df()
+    cfg = make_cfg()
+    results = run_mp(cfg, df)
+    out = tmp_path / "res"
+    export_phase1_multi_metrics(results, str(out), formats=["xlsx"])
+    path = out.with_suffix(".xlsx")
+    assert path.exists()
+    first_period = str(results[0]["period"][3])
+    second_period = str(results[1]["period"][3])
+    book = pd.ExcelFile(path)
+    assert first_period in book.sheet_names
+    assert second_period in book.sheet_names
+    assert "summary" in book.sheet_names
+    df_first = pd.read_excel(path, sheet_name=first_period, skiprows=4)
+    df_summary = pd.read_excel(path, sheet_name="summary", skiprows=4)
+    assert list(df_first.columns) == list(df_summary.columns)


### PR DESCRIPTION
## Summary
- update `Agents.md` with multi‑period workbook goal
- test Excel export for `export_phase1_multi_metrics`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68718b8607c083318bc95601d1ad3529