### PR TITLE
Implement summary formatter usage for multi-period export

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -519,3 +519,12 @@ tables into a single `<prefix>_periods.*` file with a matching
 ### 2025-12-22 UPDATE — PHASE-1 EXPORT ROADMAP
 
 Implementation is ongoing to deliver a multi-period Excel workbook with one sheet per period and a final `summary` sheet of combined portfolio returns. Each sheet must use the exact Phase‑1 formatting. CSV and JSON exports shall output a single `<prefix>_periods.*` file and a companion `<prefix>_summary.*` file. Work continues in `export_phase1_workbook()` and `export_phase1_multi_metrics()`.
+
+### 2026-01-05 UPDATE — MULTI-PERIOD OUTPUT OBJECTIVE
+
+The project still needs a full Phase‑1 workbook for rolling runs.  Every period
+should populate its own tab with identical formatting, and a final `summary`
+tab must aggregate portfolio returns in the very same layout.  CSV and JSON
+exports must bundle the per-period tables into one `<prefix>_periods.*` file
+with a matching `<prefix>_summary.*` companion file.  Implementation will finish
+linking these helpers into the public CLI.

--- a/src/trend_analysis/export.py
+++ b/src/trend_analysis/export.py
@@ -638,8 +638,7 @@ def export_phase1_workbook(
         first = results_list[0].get("period")
         last = results_list[-1].get("period")
         if isinstance(first, (list, tuple)) and isinstance(last, (list, tuple)):
-            make_period_formatter(
-                "summary",
+            make_summary_formatter(
                 summary,
                 str(first[0]),
                 str(first[1]),
@@ -647,7 +646,7 @@ def export_phase1_workbook(
                 str(last[3]),
             )
         else:
-            make_period_formatter("summary", summary, "", "", "", "")
+            make_summary_formatter(summary, "", "", "", "")
 
     if include_metrics:
         frames.update(metrics_frames)
@@ -774,8 +773,7 @@ def export_multi_period_metrics(
             first = results_list[0].get("period")
             last = results_list[-1].get("period")
             if isinstance(first, (list, tuple)) and isinstance(last, (list, tuple)):
-                make_period_formatter(
-                    "summary",
+                make_summary_formatter(
                     summary,
                     str(first[0]),
                     str(first[1]),
@@ -783,7 +781,7 @@ def export_multi_period_metrics(
                     str(last[3]),
                 )
             else:
-                make_period_formatter("summary", summary, "", "", "", "")
+                make_summary_formatter(summary, "", "", "", "")
             if include_metrics:
                 excel_data["metrics_summary"] = metrics_from_result(summary)
 


### PR DESCRIPTION
## Summary
- document the remaining multi-period output goal
- use `make_summary_formatter` for summary tabs
- keep formatting helpers consistent with root instructions

## Testing
- `ruff check .`
- `black --check .`
- `mypy src/trend_analysis`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871c4d318c483319ce95c665cb03eed