### PR TITLE
Update demo pipeline with txt export

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ cycles through several selector and weighting combinations to cover the main
 pipeline features:
 
 ```bash
+./scripts/setup_env.sh
 python scripts/generate_demo.py
 python scripts/run_multi_demo.py
 ```
@@ -136,7 +137,7 @@ python scripts/run_multi_demo.py
 The script prints the number of generated periods and verifies that
 weights evolve across them, confirming the Phase 2 logic works end to end.
 It now also exercises the single-period pipeline functions. Results are exported
-via ``export.export_data`` so CSV, Excel and JSON reports are produced in one
+via ``export.export_data`` so CSV, Excel, JSON **and TXT** reports are produced in one
 go. The CLI entry point runs in both default and ``--detailed`` modes.
 Finally, the script invokes the full test suite to ensure all modules behave as
 expected.

--- a/config/demo.yml
+++ b/config/demo.yml
@@ -29,7 +29,7 @@ metrics:
 
 export:
   output_dir: demo/exports
-  formats: [csv, xlsx, json]
+  formats: [csv, xlsx, json, txt]
 
 run:
   seed: 42                      # makes demo deterministic

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -118,7 +118,7 @@ out_prefix = Path("demo/exports/pipeline_demo")
 export.export_data(
     {"metrics": metrics_df},
     str(out_prefix),
-    formats=["xlsx", "csv", "json"],
+    formats=["xlsx", "csv", "json", "txt"],
 )
 if not out_prefix.with_suffix(".xlsx").exists():
     raise SystemExit("Excel export failed")
@@ -126,6 +126,8 @@ if not out_prefix.with_name(f"{out_prefix.stem}_metrics.csv").exists():
     raise SystemExit("CSV export failed")
 if not out_prefix.with_name(f"{out_prefix.stem}_metrics.json").exists():
     raise SystemExit("JSON export failed")
+if not out_prefix.with_name(f"{out_prefix.stem}_metrics.txt").exists():
+    raise SystemExit("TXT export failed")
 
 full_res = pipeline.run_full(cfg)
 sf = full_res.get("score_frame") if isinstance(full_res, dict) else None

--- a/src/trend_analysis/export.py
+++ b/src/trend_analysis/export.py
@@ -329,6 +329,21 @@ def export_to_json(
         )
 
 
+def export_to_txt(
+    data: Mapping[str, pd.DataFrame],
+    output_path: str,
+    formatter: Formatter | None = None,
+) -> None:
+    """Export each dataframe to a plain text file using ``output_path`` as prefix."""
+    prefix = Path(output_path)
+    _ensure_dir(prefix)
+    for name, df in data.items():
+        formatted = _apply_format(df, formatter)
+        prefix.with_name(f"{prefix.stem}_{name}.txt").write_text(
+            formatted.to_string(index=False)
+        )
+
+
 EXPORTERS: dict[
     str, Callable[[Mapping[str, pd.DataFrame], str, Formatter | None], None]
 ] = {
@@ -337,6 +352,7 @@ EXPORTERS: dict[
     "excel": export_to_excel,
     "csv": export_to_csv,
     "json": export_to_json,
+    "txt": export_to_txt,
 }
 
 
@@ -366,5 +382,6 @@ __all__ = [
     "export_to_excel",
     "export_to_csv",
     "export_to_json",
+    "export_to_txt",
     "export_data",
 ]

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -18,13 +18,15 @@ def test_export_data(tmp_path):
     df2 = pd.DataFrame({"B": [3, 4]})
     data = {"sheet1": df1, "sheet2": df2}
     out = tmp_path / "report"
-    export_data(data, str(out), formats=["xlsx", "csv", "json"])
+    export_data(data, str(out), formats=["xlsx", "csv", "json", "txt"])
 
     assert (tmp_path / "report.xlsx").exists()
     assert (tmp_path / "report_sheet1.csv").exists()
     assert (tmp_path / "report_sheet2.csv").exists()
     assert (tmp_path / "report_sheet1.json").exists()
     assert (tmp_path / "report_sheet2.json").exists()
+    assert (tmp_path / "report_sheet1.txt").exists()
+    assert (tmp_path / "report_sheet2.txt").exists()
 
     read = pd.read_csv(tmp_path / "report_sheet1.csv", index_col=0)
     pd.testing.assert_frame_equal(read, df1)


### PR DESCRIPTION
## Summary
- add `export_to_txt` helper and wire into export dispatcher
- run demo pipeline with txt export
- record new format in demo config and README
- test txt export via new unit check

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d0ef94c08331befe36293175c78a