### PR TITLE
Update demo to export multi-period results

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ python scripts/run_multi_demo.py
 
 The script prints the number of generated periods and verifies that
 weights evolve across them, confirming the Phase 2 logic works end to end.
-It now also exercises the single-period pipeline functions. Results are exported
-via ``export.export_data`` so CSV, Excel, JSON **and TXT** reports are produced in one
-go. The CLI entry point runs in both default and ``--detailed`` modes.
+It now exports each period's score frame alongside the single-period metrics
+using ``export.export_data`` so CSV, Excel, JSON **and TXT** files are produced in one
+call. The CLI entry point runs in both default and ``--detailed`` modes.
 Finally, the script invokes the full test suite to ensure all modules behave as
 expected.
 

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -69,6 +69,13 @@ if result_periods != sched_tuples:
 
 score_frames = {r["period"][3]: r["score_frame"] for r in results}
 
+# export all score frames in one go so Excel, CSV, JSON and TXT versions are
+# produced for CI. Each period becomes a separate sheet/file.
+mp_prefix = Path("demo/exports/multi_period_scores")
+export.export_data(score_frames, str(mp_prefix), formats=["xlsx", "csv", "json", "txt"])
+if not mp_prefix.with_suffix(".xlsx").exists():
+    raise SystemExit("Multi-period score frame export failed")
+
 # ensure metadata lines up with the generated periods
 for r in results:
     sf = r["score_frame"]


### PR DESCRIPTION
## Summary
- export score frames for all periods in `run_multi_demo.py`
- document the new export step in the README

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6872e52a66848331959183c9501671fb