### PR TITLE
Update demo maintenance docs and pipeline

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -24,8 +24,8 @@ YOU ARE CODEX.  EXTEND THE VOL_ADJ_TREND_ANALYSIS PROJECT AS FOLLOWS
    ```
 
    The script must invoke `export.export_data()` with the demo results so CSV,
-   Excel and JSON outputs are generated in one call.  Update it whenever new
-   exporter functionality is added.
+   Excel, JSON **and TXT** outputs are generated in one call.  Update it
+   whenever new exporter functionality is added.
 
    When exporter features evolve (e.g. additional formats or option flags),
    extend both `run_multi_demo.py` and `config/demo.yml` so the demo pipeline

--- a/docs/phase-2/Agents.md
+++ b/docs/phase-2/Agents.md
@@ -574,9 +574,9 @@ feature lands, run the sequence below and update `config/demo.yml` or
    ```bash
    python scripts/run_multi_demo.py
    ```
-   The script must call `export.export_data()` so CSV, Excel and JSON outputs are
-   produced in one go. Extend the script and config whenever new exporter options
-   are introduced.
+   The script must call `export.export_data()` so CSV, Excel, JSON **and TXT**
+   outputs are produced in one go. Extend the script and config whenever new
+   exporter options are introduced.
 4. **Run the test suite**
    ```bash
    ./scripts/run_tests.sh

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -91,9 +91,7 @@ for r in results:
 df_full = load_csv(cfg.data["csv_path"])
 if df_full is None:
     raise SystemExit("Failed to load demo CSV")
-mask = df_full["Date"].between(
-    cfg.sample_split["in_start"], cfg.sample_split["in_end"]
-)
+mask = df_full["Date"].between(cfg.sample_split["in_start"], cfg.sample_split["in_end"])
 window = df_full.loc[mask].drop(columns=["Date"])
 rs_cfg = RiskStatsConfig()
 top_pct_ids = rank_select_funds(

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -91,8 +91,10 @@ for r in results:
 df_full = load_csv(cfg.data["csv_path"])
 if df_full is None:
     raise SystemExit("Failed to load demo CSV")
-mask = df_full["Date"].between(cfg.sample_split["in_start"], cfg.sample_split["in_end"])
-window = df_full.loc[mask]
+mask = df_full["Date"].between(
+    cfg.sample_split["in_start"], cfg.sample_split["in_end"]
+)
+window = df_full.loc[mask].drop(columns=["Date"])
 rs_cfg = RiskStatsConfig()
 top_pct_ids = rank_select_funds(
     window,


### PR DESCRIPTION
## Summary
- document TXT output in demo maintenance instructions
- drop the Date column when exercising `rank_select_funds`

## Testing
- `./scripts/setup_env.sh`
- `python scripts/generate_demo.py`
- `PYTHONPATH=./src python scripts/run_multi_demo.py`
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6872ffa3497c8331a205e05247ed3059