### PR TITLE
Update demo to exercise misc modules

### DIFF
--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -104,6 +104,45 @@ def _check_cli(cfg_path: str) -> None:
         raise SystemExit("CLI default run failed")
 
 
+def _check_misc(cfg_path: str, cfg: Config, results) -> None:
+    """Exercise smaller utility modules."""
+    from trend_analysis import metrics
+    import asyncio
+
+    if "annual_return" not in metrics.available_metrics():
+        raise SystemExit("Metrics registry incomplete")
+
+    # scheduler.generate_periods should agree with the results length
+    periods = scheduler.generate_periods(cfg.model_dump())
+    if len(periods) != len(results):
+        raise SystemExit("Scheduler period count mismatch")
+
+    store = gui.ParamStore.from_yaml(Path(cfg_path))
+    if gui.build_config_from_store(store).version != cfg.version:
+        raise SystemExit("Config build roundtrip failed")
+
+    called: list[int] = []
+
+    @gui.debounce(50)
+    async def ping(val: int) -> None:
+        called.append(val)
+
+    async def drive() -> None:
+        await ping(1)
+        await ping(2)
+        await asyncio.sleep(0.1)
+
+    asyncio.run(drive())
+    if called != [2]:
+        raise SystemExit("debounce failed")
+
+    os.environ["TREND_CFG"] = cfg_path
+    cfg_env = load(None)
+    os.environ.pop("TREND_CFG", None)
+    if cfg_env.version != cfg.version:
+        raise SystemExit("TREND_CFG not honoured")
+
+
 
 cfg = load("config/demo.yml")
 results = run_mp(cfg)
@@ -298,6 +337,7 @@ if not dummy_prefix.with_suffix(".xlsx").exists():
 _check_gui("config/demo.yml")
 _check_selection_modes(cfg)
 _check_cli_env("config/demo.yml")
+_check_misc("config/demo.yml", cfg, results)
 
 
 print("Multi-period demo checks passed")


### PR DESCRIPTION
## Summary
- expand demo to test config, scheduler and metrics helpers
- run debounce and env-var load checks

## Testing
- `./scripts/setup_env.sh`
- `python scripts/generate_demo.py`
- `PYTHONPATH=./src python scripts/run_multi_demo.py`
- `PYTHONPATH=./src ./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68732b71936c83318381b5380ca9a78e