### PR TITLE
Extend demo coverage

### DIFF
--- a/config/demo.yml
+++ b/config/demo.yml
@@ -48,6 +48,10 @@ export:
   output_dir: demo/exports
   formats: [csv, xlsx, json, txt]
 
+output:
+  format: csv
+  path: demo/exports/alias_demo.csv
+
 run:
   seed: 42                      # makes demo deterministic
 

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -63,8 +63,10 @@ def _check_gui(cfg_path: str) -> None:
         raise SystemExit("GUI state roundtrip failed")
     gui.reset_weight_state(loaded)
     gui.discover_plugins()
+
     class _DummyPlugin:
         pass
+
     gui.register_plugin(_DummyPlugin)
     if _DummyPlugin not in list(gui.iter_plugins()):
         raise SystemExit("Plugin registration failed")

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -63,8 +63,13 @@ def _check_gui(cfg_path: str) -> None:
         raise SystemExit("GUI state roundtrip failed")
     gui.reset_weight_state(loaded)
     gui.discover_plugins()
-    if not gui.list_builtin_cfgs():
-        raise SystemExit("list_builtin_cfgs returned no configs")
+    class _DummyPlugin:
+        pass
+    gui.register_plugin(_DummyPlugin)
+    if _DummyPlugin not in list(gui.iter_plugins()):
+        raise SystemExit("Plugin registration failed")
+    if "demo" not in gui.list_builtin_cfgs():
+        raise SystemExit("list_builtin_cfgs missing demo.yml")
 
 
 def _check_selection_modes(cfg: Config) -> None:
@@ -144,6 +149,8 @@ def _check_misc(cfg_path: str, cfg: Config, results) -> None:
 
 
 cfg = load("config/demo.yml")
+if cfg.export.get("filename") != "alias_demo.csv":
+    raise SystemExit("Output alias not parsed")
 results = run_mp(cfg)
 num_periods = len(results)
 periods = scheduler.generate_periods(cfg.model_dump())


### PR DESCRIPTION
## Summary
- expand demo config to exercise output alias
- register dummy GUI plugin in demo checks
- verify output alias fields in demo script

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68733178528c8331a98bf4e74df0b9b9