### PR TITLE
Improve demo coverage

### DIFF
--- a/docs/DemoMaintenance.md
+++ b/docs/DemoMaintenance.md
@@ -14,7 +14,7 @@ This document summarises the steps required to keep the demo pipeline in sync wi
    ```bash
    python scripts/run_multi_demo.py
    ```
-   The script calls `export.export_data()` so CSV, Excel, JSON and TXT outputs are produced in one go. Extend the script and `config/demo.yml` whenever new exporter options are introduced.
+   The script calls `export.export_data()` so CSV, Excel, JSON and TXT outputs are produced in one go. Extend the script and `config/demo.yml` whenever new exporter options are introduced. It also verifies the CLI wrappers behave correctly.
 4. **Run the test suite**
    ```bash
    ./scripts/run_tests.sh

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -76,6 +76,7 @@ python scripts/run_multi_demo.py
 ```
 
 `run_multi_demo.py` calls ``export.export_data`` so CSV, Excel, JSON **and TXT** reports are produced in one go. It also runs the full test suite, ensuring multiple periods are processed and that adaptive weights evolve over time.
+The script exercises the CLI wrappers as part of these checks.
 
 ## 10. Demo pipeline (maintenance / CI)
 

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -366,6 +366,7 @@ if not dummy_prefix.with_suffix(".xlsx").exists():
 _check_gui("config/demo.yml")
 _check_selection_modes(cfg)
 _check_cli_env("config/demo.yml")
+_check_cli("config/demo.yml")
 _check_misc("config/demo.yml", cfg, results)
 
 


### PR DESCRIPTION
## Summary
- invoke `_check_cli()` in the demo script so CLI wrappers are tested
- document CLI testing in demo docs

## Testing
- `PYTHONPATH=./src .venv/bin/python scripts/run_multi_demo.py`
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68733e100ac88331ad4d820c8cb3a313