### PR TITLE
Improve demo coverage

### DIFF
--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,10 +1,17 @@
+import pandas as pd
 import scripts.demo as demo
 
 
 def test_demo_runs(tmp_path, capsys):
-    demo.main(out_dir=tmp_path)
+    res = demo.main(out_dir=tmp_path)
     captured = capsys.readouterr().out
     assert "Vol-Adj Trend Analysis" in captured
     assert (tmp_path / "analysis.xlsx").exists()
     assert (tmp_path / "analysis_metrics.csv").exists()
     assert (tmp_path / "analysis_metrics.json").exists()
+    assert res["cli_rc"] == 0
+    assert res["run_rc"] == 0
+    assert not res["metrics_df"].empty
+    assert isinstance(res["score_frame"], pd.DataFrame)
+    assert res["periods"]
+    assert res["mp_res"] == {}


### PR DESCRIPTION
## Summary
- upgrade demo script to return objects for verification
- check multi-period generation by forwarding `multi_period` to scheduler
- expand demo test to assert each subsystem ran

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874290b3e788331bd51e38a2b860422