### PR TITLE
Expand demo coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ It now exports each period's score frame alongside the single-period metrics
 using ``export.export_data`` so CSV, Excel, JSON **and TXT** files are produced in one call.
 The demo also exercises the ``all``, ``random`` and ``manual`` selection modes,
 and now calls ``single_period_run`` together with ``calc_portfolio_returns`` to validate
-the pipeline helpers. It verifies AdaptiveBayesWeighting state persistence and runs the CLI via both the ``-c``
+the pipeline helpers. The wrapper ``pipeline.run_analysis`` is also invoked, and
+extra calls to ``rank_select_funds`` use the ``percentile`` and ``rank`` transforms so all
+scoring options are covered. It verifies AdaptiveBayesWeighting state persistence and runs the CLI via both the ``-c``
 flag and the ``TREND_CFG`` environment variable. Finally, the script invokes the
 full test suite so every module is covered.
 

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -258,6 +258,29 @@ zscore_ids = rank_select_funds(
 if not zscore_ids:
     raise SystemExit("zscore selection produced no funds")
 
+percentile_ids = rank_select_funds(
+    window,
+    rs_cfg,
+    inclusion_approach="top_pct",
+    pct=0.3,
+    score_by="Sharpe",
+    transform="percentile",
+    rank_pct=0.5,
+)
+if not percentile_ids:
+    raise SystemExit("percentile transform produced no funds")
+
+rank_ids = rank_select_funds(
+    window,
+    rs_cfg,
+    inclusion_approach="top_n",
+    n=3,
+    score_by="Sharpe",
+    transform="rank",
+)
+if not rank_ids:
+    raise SystemExit("rank transform produced no funds")
+
 abw = AdaptiveBayesWeighting(max_w=None)
 pf_abw = _check_schedule(
     score_frames,
@@ -327,6 +350,21 @@ full_res = pipeline.run_full(cfg)
 sf = full_res.get("score_frame") if isinstance(full_res, dict) else None
 if sf is None or sf.empty:
     raise SystemExit("pipeline.run_full missing score_frame")
+
+# Exercise the convenience wrapper around ``_run_analysis``
+analysis_res = pipeline.run_analysis(
+    df_full,
+    str(split.get("in_start")),
+    str(split.get("in_end")),
+    str(split.get("out_start")),
+    str(split.get("out_end")),
+    cfg.vol_adjust.get("target_vol", 1.0),
+    cfg.run.get("monthly_cost", 0.0),
+    selection_mode="rank",
+    rank_kwargs={"n": 5, "score_by": "Sharpe", "inclusion_approach": "top_n"},
+)
+if analysis_res is None or analysis_res.get("score_frame") is None:
+    raise SystemExit("pipeline.run_analysis failed")
 
 # Export a formatted summary workbook and text summary
 split = cfg.sample_split


### PR DESCRIPTION
## Summary
- exercise additional `rank_select_funds` transform modes
- invoke `pipeline.run_analysis` within the demo
- mention new demo checks in README

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687431f05d1c83318f6923979333e06b