### PR TITLE
Extend demo coverage

### DIFF
--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -15,3 +15,6 @@ def test_demo_runs(tmp_path, capsys):
     assert isinstance(res["score_frame"], pd.DataFrame)
     assert res["periods"]
     assert res["mp_res"] == {}
+    assert res["rf_col"] == "Risk-Free Rate"
+    assert "Vol-Adj Trend Analysis" in res["summary_text"]
+    assert "annual_return" in res["available"]


### PR DESCRIPTION
## Summary
- expand demo to use data helpers and metrics registry
- print text summary and other debug info
- test demo output covers new features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687459c989cc8331aab1ec4b7378eed0