### PR TITLE
Improve demo coverage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ openpyxl
 PyYAML
 pytest-cov
 pytest
+nbformat

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -10,7 +10,9 @@ def test_demo_runs(tmp_path, capsys):
     assert (tmp_path / "analysis_metrics.csv").exists()
     assert (tmp_path / "analysis_metrics.json").exists()
     assert res["cli_rc"] == 0
+    assert res["cli_json_rc"] == 0
     assert res["run_rc"] == 0
+    assert res["detailed_rc"] == 0
     assert not res["metrics_df"].empty
     assert isinstance(res["score_frame"], pd.DataFrame)
     assert res["periods"]
@@ -18,3 +20,6 @@ def test_demo_runs(tmp_path, capsys):
     assert res["rf_col"] == "Risk-Free Rate"
     assert "Vol-Adj Trend Analysis" in res["summary_text"]
     assert "annual_return" in res["available"]
+    assert res["loaded_version"] == "1"
+    assert set(res["rb_weights"]) == set(res["score_frame"].columns)
+    assert res["nb_clean"] is True


### PR DESCRIPTION
## Summary
- enhance demo script: load config via env var, run CLI in detailed mode
- exercise Rebalancer and strip_output utilities in the demo
- return additional metadata so the demo test validates all features
- expand demo test accordingly

## Testing
- `ruff check .`
- `black --check .`
- `mypy trend_analysis`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68745e76b27c8331aea964dcb13b3ba1