### PR TITLE
Extend demo coverage for rebalancer and multiperiod

### DIFF
--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -92,7 +92,9 @@ def main(out_dir: str | Path | None = None) -> Dict[str, Any]:
     )
     full_res = pipeline.run_full(cfg)
     metrics_df = pipeline.run(cfg)
-    rb = Rebalancer({})
+    # Demonstrate the rebalancer with a simple trigger configuration.
+    rb_cfg = {"triggers": {"sigma1": {"sigma": 1, "periods": 2}}}
+    rb = Rebalancer(rb_cfg)
     init_wt = pd.Series(1 / len(score_frame.columns), index=score_frame.columns)
     rb_weights = rb.apply_triggers(init_wt, score_frame)
 
@@ -139,6 +141,8 @@ def main(out_dir: str | Path | None = None) -> Dict[str, Any]:
     print("Available metrics:", available)
     print(metrics_df.head())
     print(score_frame.head())
+    print("Generated periods:", len(periods))
+    print("Rebalanced weights:", rb_weights.to_dict())
     os.remove(cfg_file)
 
     return {

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -6,6 +6,8 @@ def test_demo_runs(tmp_path, capsys):
     res = demo.main(out_dir=tmp_path)
     captured = capsys.readouterr().out
     assert "Vol-Adj Trend Analysis" in captured
+    assert "Generated periods:" in captured
+    assert "Rebalanced weights:" in captured
     assert (tmp_path / "analysis.xlsx").exists()
     assert (tmp_path / "analysis_metrics.csv").exists()
     assert (tmp_path / "analysis_metrics.json").exists()
@@ -21,5 +23,8 @@ def test_demo_runs(tmp_path, capsys):
     assert "Vol-Adj Trend Analysis" in res["summary_text"]
     assert "annual_return" in res["available"]
     assert res["loaded_version"] == "1"
-    assert set(res["rb_weights"]) == set(res["score_frame"].columns)
+    expected_wts = {
+        c: 1 / len(res["score_frame"].columns) for c in res["score_frame"].columns
+    }
+    assert res["rb_weights"] == expected_wts
     assert res["nb_clean"] is True

--- a/tests/test_rebalancer.py
+++ b/tests/test_rebalancer.py
@@ -1,0 +1,11 @@
+import pandas as pd
+from trend_analysis.multi_period.replacer import Rebalancer
+
+
+def test_rebalancer_noop():
+    cfg = {"triggers": {"sigma1": {"sigma": 1, "periods": 2}}}
+    rb = Rebalancer(cfg)
+    weights = pd.Series([0.5, 0.5], index=["A", "B"])
+    sf = pd.DataFrame({"A": [0.1], "B": [0.2]})
+    out = rb.apply_triggers(weights, sf)
+    pd.testing.assert_series_equal(out, weights)


### PR DESCRIPTION
## Summary
- enhance demo to show rebalancer usage and generated periods
- assert on these new behaviours in demo test
- add a simple unit test for the rebalancer stub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687464f5ef0083318d79358a37854c36