### PR TITLE
Enhance demo coverage for multi-period engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository contains experiments and utilities for analyzing volatility-adju
  `python -m venv` followed by `pip install -r requirements.txt`.  It
  creates a `.venv` directory and installs everything from
  `requirements.txt`, including `pandas`, `numpy`, `matplotlib`,
- `ipywidgets`, `PyYAML` and `xlsxwriter`.
+ `ipywidgets`, `PyYAML`, `types-PyYAML` and `xlsxwriter`.
 2. Launch Jupyter Lab or Jupyter Notebook:
    ```bash
    jupyter lab
@@ -119,7 +119,7 @@ print(score_frame)
 
 ## Testing
 
-Install the project dependencies (such as `pandas`, `numpy` and `PyYAML`) before running the test suite. This can be done using the setup script, which
+Install the project dependencies (such as `pandas`, `numpy`, `PyYAML` and `types-PyYAML`) before running the test suite. This can be done using the setup script, which
 creates a virtual environment and installs everything from `requirements.txt`
 (including `pytest`):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ xlsxwriter
 pydantic>=2
 openpyxl
 PyYAML
+types-PyYAML
 pytest-cov
 pytest
 nbformat

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -142,6 +142,7 @@ def main(out_dir: str | Path | None = None) -> Dict[str, Any]:
     print(metrics_df.head())
     print(score_frame.head())
     print("Generated periods:", len(periods))
+    print("Multi-period run count:", mp_res.get("n_periods"))
     print("Rebalanced weights:", rb_weights.to_dict())
     os.remove(cfg_file)
 

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -7,6 +7,7 @@ def test_demo_runs(tmp_path, capsys):
     captured = capsys.readouterr().out
     assert "Vol-Adj Trend Analysis" in captured
     assert "Generated periods:" in captured
+    assert "Multi-period run count:" in captured
     assert "Rebalanced weights:" in captured
     assert (tmp_path / "analysis.xlsx").exists()
     assert (tmp_path / "analysis_metrics.csv").exists()
@@ -18,7 +19,8 @@ def test_demo_runs(tmp_path, capsys):
     assert not res["metrics_df"].empty
     assert isinstance(res["score_frame"], pd.DataFrame)
     assert res["periods"]
-    assert res["mp_res"] == {}
+    assert res["mp_res"]["n_periods"] == len(res["periods"])
+    assert res["mp_res"]["periods"] == res["periods"]
     assert res["rf_col"] == "Risk-Free Rate"
     assert "Vol-Adj Trend Analysis" in res["summary_text"]
     assert "annual_return" in res["available"]

--- a/trend_analysis/config.py
+++ b/trend_analysis/config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, TYPE_CHECKING
 import os
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 
 if TYPE_CHECKING:  # pragma: no cover - mypy only

--- a/trend_analysis/multi_period/engine.py
+++ b/trend_analysis/multi_period/engine.py
@@ -5,7 +5,11 @@ Rolling multi‑period driver – to be filled by the code‑gen agent.
 from __future__ import annotations
 from typing import Dict, Mapping, Any
 
+from .scheduler import generate_periods
+
 
 def run(cfg: Mapping[str, Any]) -> Dict[str, object]:  # noqa: D401
-    """Placeholder so tests/imports don’t fail."""
-    return {}
+    """Return generated periods and metadata for the given config."""
+
+    periods = generate_periods(cfg)
+    return {"periods": periods, "n_periods": len(periods)}


### PR DESCRIPTION
## Summary
- make simple multi-period engine that returns metadata
- show multi-period results in the demo
- validate multi-period outputs in test_demo
- remove unused ignore comment for yaml import

## Testing
- `ruff check .`
- `black --check .`
- `mypy --strict trend_analysis`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874689445c0833193cfe29ea87494b3