### PR TITLE
Expand demo coverage

### DIFF
--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -105,6 +105,15 @@ def main(out_dir: str | Path | None = None) -> Dict[str, Any]:
     periods = generate_periods(cfg_dict)
     mp_res = run_multi(cfg_dict)
 
+    mp_history = []
+    mp_weights = init_wt.copy()
+    for p in periods:
+        mp_sf = pipeline.single_period_run(
+            df, p.in_start[:7], p.in_end[:7]
+        )
+        mp_weights = rb.apply_triggers(mp_weights, mp_sf)
+        mp_history.append(mp_weights.copy())
+
     out_dir_path = Path(out_dir) if out_dir else root / "demo_outputs"
     out_dir_path.mkdir(exist_ok=True)
 
@@ -144,6 +153,7 @@ def main(out_dir: str | Path | None = None) -> Dict[str, Any]:
     print("Generated periods:", len(periods))
     print("Multi-period run count:", mp_res.get("n_periods"))
     print("Rebalanced weights:", rb_weights.to_dict())
+    print("Multi-period final weights:", mp_weights.to_dict())
     os.remove(cfg_file)
 
     return {
@@ -161,6 +171,7 @@ def main(out_dir: str | Path | None = None) -> Dict[str, Any]:
         "summary_text": text_summary,
         "available": available,
         "rb_weights": rb_weights.to_dict(),
+        "mp_history": [w.to_dict() for w in mp_history],
         "loaded_version": loaded_cfg.version,
         "nb_clean": nb_clean,
     }

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -9,6 +9,7 @@ def test_demo_runs(tmp_path, capsys):
     assert "Generated periods:" in captured
     assert "Multi-period run count:" in captured
     assert "Rebalanced weights:" in captured
+    assert "Multi-period final weights:" in captured
     assert (tmp_path / "analysis.xlsx").exists()
     assert (tmp_path / "analysis_metrics.csv").exists()
     assert (tmp_path / "analysis_metrics.json").exists()
@@ -29,4 +30,6 @@ def test_demo_runs(tmp_path, capsys):
         c: 1 / len(res["score_frame"].columns) for c in res["score_frame"].columns
     }
     assert res["rb_weights"] == expected_wts
+    assert len(res["mp_history"]) == len(res["periods"])
+    assert res["mp_history"][-1] == expected_wts
     assert res["nb_clean"] is True


### PR DESCRIPTION
## Summary
- enhance demo to apply the rebalancer across multi-period runs
- verify extra output in `test_demo`

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6874766f3e748331a156038c71a8217a