### PR TITLE
Expand demo coverage for multi-period and rebalancer

### DIFF
--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -191,8 +191,10 @@ def main(out_dir: str | Path | None = None) -> Dict[str, Any]:
         "summary_text": text_summary,
         "available": available,
         "rb_weights": rb_weights.to_dict(),
+        "rb_cfg": rb_cfg,
         "mp_history": [w.to_dict() for w in mp_history],
         "mp_history_df": mp_history_df,
+        "mp_index": mp_history_df.index.tolist(),
         "loaded_version": loaded_cfg.version,
         "nb_clean": nb_clean,
     }

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -34,10 +34,16 @@ def test_demo_runs(tmp_path, capsys):
         c: 1 / len(res["score_frame"].columns) for c in res["score_frame"].columns
     }
     assert res["rb_weights"] == expected_wts
+    assert res["rb_cfg"] == {"triggers": {"sigma1": {"sigma": 1, "periods": 2}}}
     assert len(res["mp_history"]) == len(res["periods"])
     assert res["mp_history"][-1] == expected_wts
+    assert res["mp_index"] == [f"{p.in_start[:7]}_{p.out_end[:7]}" for p in res["periods"]]
     assert res["nb_clean"] is True
     assert isinstance(res["mp_history_df"], pd.DataFrame)
     assert res["mp_history_df"].shape[0] == len(res["periods"])
+    assert res["mp_history_df"].index.tolist() == res["mp_index"]
+    assert res["mp_history_df"].to_dict("records") == res["mp_history"]
+    assert res["mp_history_df"].columns.tolist() == res["score_frame"].columns.tolist()
+    assert res["mp_res"] == {"periods": res["periods"], "n_periods": len(res["periods"])}
     assert isinstance(res["analysis_res"], dict)
     assert res["analysis_res"]["selected_funds"]


### PR DESCRIPTION
## Summary
- extend `scripts/demo.py` to expose rebalancer config and multi-period labels
- improve demo test to validate weight history and multi‑period logic

## Testing
- `pytest -q`
- `pytest tests/test_demo.py::test_demo_runs -q`


------
https://chatgpt.com/codex/tasks/task_e_68748cf496748331b0f15676e90aa42a