### PR TITLE
Expand demo output for multi-period tests

### DIFF
--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -195,6 +195,7 @@ def main(out_dir: str | Path | None = None) -> Dict[str, Any]:
         "mp_history": [w.to_dict() for w in mp_history],
         "mp_history_df": mp_history_df,
         "mp_index": mp_history_df.index.tolist(),
+        "mp_weights": mp_weights.to_dict(),
         "loaded_version": loaded_cfg.version,
         "nb_clean": nb_clean,
     }

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -46,9 +46,11 @@ def test_demo_runs(tmp_path, capsys):
     assert res["mp_history_df"].index.tolist() == res["mp_index"]
     assert res["mp_history_df"].to_dict("records") == res["mp_history"]
     assert res["mp_history_df"].columns.tolist() == res["score_frame"].columns.tolist()
+    assert res["mp_weights"] == expected_wts
     assert res["mp_res"] == {
         "periods": res["periods"],
         "n_periods": len(res["periods"]),
     }
     assert isinstance(res["analysis_res"], dict)
+    assert isinstance(res["analysis_res"].get("score_frame"), pd.DataFrame)
     assert res["analysis_res"]["selected_funds"]

--- a/tests/test_multi_period_engine.py
+++ b/tests/test_multi_period_engine.py
@@ -1,0 +1,13 @@
+import yaml
+from pathlib import Path
+from trend_analysis.multi_period.engine import run
+
+CFG = yaml.safe_load(Path("config/defaults.yml").read_text())
+
+
+def test_engine_generates_periods():
+    res = run(CFG)
+    periods = res["periods"]
+    assert res["n_periods"] == len(periods)
+    first = periods[0]
+    assert first.in_start < first.out_start


### PR DESCRIPTION
## Summary
- return `mp_weights` from demo
- check final multi-period weights in demo test
- cover multi-period engine through a new test

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687495a3376883318c07bda48f6ef3d1