### PR TITLE
Expand demo multi-period testing

### DIFF
--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -26,6 +26,7 @@ def test_demo_runs(tmp_path, capsys):
     assert "Rebalanced weights:" in captured
     assert "Multi-period final weights:" in captured
     assert "Multi-period weight history:" in captured
+    assert "Multi-period score frame count:" in captured
     assert "Analysis selected:" in captured
     assert "Top fund by ranking:" in captured
     assert "Multi-period selections:" in captured
@@ -79,6 +80,8 @@ def test_demo_runs(tmp_path, capsys):
     assert res["analysis_res"]["selected_funds"]
     assert res["ranked"]
     assert res["mp_selected"]
+    assert len(res["mp_results"]) == len(res["periods"])
+    assert len(res["mp_score_frames"]) == len(res["periods"])
     assert len(res["mp_selected"]) == len(res["periods"])
     assert all(res["mp_selected"])
     assert res["ranked"] == expected_rank


### PR DESCRIPTION
## Summary
- reset Excel formatters in demo
- collect score frames and analysis results for multi-period loop
- print multi-period score frame count
- verify new outputs in `test_demo`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a46af2388331a035540c2b5c0a1c