### PR TITLE
Extend demo coverage for exporters and CLI

### DIFF
--- a/docs/DemoMaintenance.md
+++ b/docs/DemoMaintenance.md
@@ -14,7 +14,7 @@ This document summarises the steps required to keep the demo pipeline in sync wi
    ```bash
    python scripts/run_multi_demo.py
    ```
-   The script calls `export.export_data()` so CSV, Excel, JSON and TXT outputs are produced in one go. Extend the script and `config/demo.yml` whenever new exporter options are introduced. It also verifies the CLI wrappers behave correctly.
+   The script calls `export.export_data()` so CSV, Excel, JSON and TXT outputs are produced in one go. Extend the script and `config/demo.yml` whenever new exporter options are introduced. It now also exercises the multi-period export helpers and verifies the CLI wrappers behave correctly.
 4. **Run the test suite**
    ```bash
    ./scripts/run_tests.sh


### PR DESCRIPTION
## Summary
- enhance demo checks for multi-period exporter outputs
- verify period frame helpers and direct workbook export
- run CLI with default config and include --detailed mode
- exercise indices_list branch in pipeline
- document updated demo behaviour

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6879b81c5d9c8331a676d6b38c22a7d6