### PR TITLE
Fix pre-commit flake8 hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,9 +8,14 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
-    -    id: flake8
-          args: [--max-line-length=120, --extend-ignore=F401,E501,F821]
-          exclude: >
-            ( ^Old/|
-              ^notebooks/|
-              ^tests/legacy_metrics\.py )
+-   repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+    -   id: flake8
+        args:
+          - --max-line-length=120
+          - --extend-ignore=F401,E501,F821
+        exclude: >
+          ( ^Old/|
+            ^notebooks/|
+            ^tests/legacy_metrics\.py )

--- a/docs/DemoMaintenance.md
+++ b/docs/DemoMaintenance.md
@@ -22,4 +22,3 @@ This document summarises the steps required to keep the demo pipeline in sync wi
    Ensure all unit tests pass after modifying the demo pipeline.
 5. **Keep demo config current**
    - Update `config/demo.yml` and demo scripts whenever export or pipeline behaviour changes so the demo exercises every code path.
-


### PR DESCRIPTION
## Summary
- indent the flake8 hook and move it under a dedicated repo in `.pre-commit-config.yaml`
- ensure newline at end of docs/DemoMaintenance.md

## Testing
- `pre-commit run --files scripts/run_multi_demo.py docs/DemoMaintenance.md`

------
https://chatgpt.com/codex/tasks/task_e_687a4140bab48331abc177ae29450a01