### PR TITLE
Improve demo coverage

### DIFF
--- a/config/demo.yml
+++ b/config/demo.yml
@@ -45,7 +45,7 @@ metrics:
     - max_drawdown
 
 export:
-  output_dir: demo/exports
+  directory: demo/exports
   formats: [csv, xlsx, json, txt]
 
 output:

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -671,6 +671,25 @@ export.export_to_excel(
 if not dummy_prefix.with_suffix(".xlsx").exists():
     raise SystemExit("Custom Excel export failed")
 
+# Exercise export_data with a formatter to cover formatting hooks
+fmt_prefix = Path("demo/exports/formatted_demo")
+df_fmt = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+
+def _double(df: pd.DataFrame) -> pd.DataFrame:
+    return df * 2
+
+export.export_data(
+    {"tbl": df_fmt},
+    str(fmt_prefix),
+    formats=["xlsx", "csv", "json", "txt"],
+    formatter=_double,
+)
+if not fmt_prefix.with_suffix(".csv").exists():
+    raise SystemExit("Formatted CSV not created")
+chk = pd.read_csv(fmt_prefix.with_suffix(".csv"))
+if chk.iloc[0, 0] != 2:
+    raise SystemExit("Formatter did not apply")
+
 _check_gui("config/demo.yml")
 _check_selection_modes(cfg)
 _check_cli_env("config/demo.yml")

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -675,8 +675,10 @@ if not dummy_prefix.with_suffix(".xlsx").exists():
 fmt_prefix = Path("demo/exports/formatted_demo")
 df_fmt = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
 
+
 def _double(df: pd.DataFrame) -> pd.DataFrame:
     return df * 2
+
 
 export.export_data(
     {"tbl": df_fmt},

--- a/src/trend_analysis/gui/app.py
+++ b/src/trend_analysis/gui/app.py
@@ -469,11 +469,11 @@ def launch() -> widgets.Widget:
         store.theme = change["new"]
         store.dirty = True
         theme_val = change["new"]
-        js: Javascript = Javascript(  # type: ignore[no-untyped-call]
+        js: Javascript = Javascript(
             f"document.documentElement.style.setProperty("
             f"' --trend-theme','{theme_val}')"
         )
-        display(js)  # type: ignore[no-untyped-call]
+        display(js)
 
     theme.observe(lambda ch, store=store: on_theme(ch, store=store), names="value")
 


### PR DESCRIPTION
## Summary
- update demo export path to match configuration
- exercise export_data formatting in the demo script

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687beaedaa6c83318ae108bc234c67dd