### PR TITLE
Expand demo coverage

### DIFF
--- a/config/demo.yml
+++ b/config/demo.yml
@@ -54,6 +54,8 @@ output:
 
 run:
   seed: 42                      # makes demo deterministic
+  jobs: 1
+  checkpoint_dir: demo/checkpoints
 
 multi_period:
   frequency: M                  # monthly periods


### PR DESCRIPTION
## Summary
- cover a helper function missing annotations in the multi demo script
- parse optional config fields `jobs` and `checkpoint_dir`
- add those keys to `config/demo.yml`

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687bf4b0121c83319dc8ab5b94d256be