### PR TITLE
Expand demo coverage

### DIFF
--- a/config/demo.yml
+++ b/config/demo.yml
@@ -57,6 +57,9 @@ run:
   jobs: 1
   checkpoint_dir: demo/checkpoints
 
+jobs: 1
+checkpoint_dir: demo/checkpoints
+
 multi_period:
   frequency: M                  # monthly periods
   in_sample_len: 36             # 3 years in-sample

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -381,6 +381,11 @@ results_prefix = Path("demo/exports/workbook_frames")
 export.export_data(frames, str(results_prefix), formats=["xlsx", "csv", "json", "txt"])
 if not results_prefix.with_suffix(".xlsx").exists():
     raise SystemExit("Workbook frame export failed")
+csv_files = list(results_prefix.parent.glob(f"{results_prefix.stem}_*.csv"))
+json_files = list(results_prefix.parent.glob(f"{results_prefix.stem}_*.json"))
+txt_files = list(results_prefix.parent.glob(f"{results_prefix.stem}_*.txt"))
+if not csv_files or not json_files or not txt_files:
+    raise SystemExit("Workbook frame CSV/JSON/TXT missing")
 phase1_prefix = Path("demo/exports/phase1_multi")
 export.export_phase1_multi_metrics(
     results,
@@ -425,14 +430,20 @@ if not mpm_prefix.with_name(f"{mpm_prefix.stem}_summary.csv").exists():
     raise SystemExit("Multi-period metrics summary CSV missing")
 if not mpm_prefix.with_name(f"{mpm_prefix.stem}_summary.json").exists():
     raise SystemExit("Multi-period metrics summary JSON missing")
+if not mpm_prefix.with_name(f"{mpm_prefix.stem}_summary.txt").exists():
+    raise SystemExit("Multi-period metrics summary TXT missing")
 if not mpm_prefix.with_name(f"{mpm_prefix.stem}_metrics.csv").exists():
     raise SystemExit("Multi-period metrics metrics CSV missing")
 if not mpm_prefix.with_name(f"{mpm_prefix.stem}_metrics.json").exists():
     raise SystemExit("Multi-period metrics metrics JSON missing")
+if not mpm_prefix.with_name(f"{mpm_prefix.stem}_metrics.txt").exists():
+    raise SystemExit("Multi-period metrics metrics TXT missing")
 if not mpm_prefix.with_name(f"{mpm_prefix.stem}_metrics_summary.csv").exists():
     raise SystemExit("Multi-period metrics metrics summary CSV missing")
 if not mpm_prefix.with_name(f"{mpm_prefix.stem}_metrics_summary.json").exists():
     raise SystemExit("Multi-period metrics metrics summary JSON missing")
+if not mpm_prefix.with_name(f"{mpm_prefix.stem}_metrics_summary.txt").exists():
+    raise SystemExit("Multi-period metrics metrics summary TXT missing")
 wb_direct = Path("demo/exports/phase1_direct.xlsx")
 export.export_phase1_workbook(results, str(wb_direct))
 if not wb_direct.exists():
@@ -590,6 +601,9 @@ export.export_data(
 )
 if not abw_prefix.with_suffix(".xlsx").exists():
     raise SystemExit("ABW weight export failed")
+for ext in ("csv", "json", "txt"):
+    if not abw_prefix.with_name(f"{abw_prefix.stem}_weights.{ext}").exists():
+        raise SystemExit(f"ABW weight {ext} missing")
 state = abw.get_state()
 abw2 = AdaptiveBayesWeighting(max_w=None)
 abw2.set_state(state)

--- a/src/trend_analysis/gui/app.py
+++ b/src/trend_analysis/gui/app.py
@@ -469,11 +469,11 @@ def launch() -> widgets.Widget:
         store.theme = change["new"]
         store.dirty = True
         theme_val = change["new"]
-        js: Javascript = Javascript(
-            f"document.documentElement.style.setProperty("
+        js: Javascript = Javascript(  # type: ignore
+            f"document.documentElement.style.setProperty("  # noqa: W503
             f"' --trend-theme','{theme_val}')"
         )
-        display(js)
+        display(js)  # type: ignore
 
     theme.observe(lambda ch, store=store: on_theme(ch, store=store), names="value")
 


### PR DESCRIPTION
## Summary
- ensure workbook helpers export CSV/JSON/TXT files
- check all exported files from multi-period metrics
- verify AdaptiveBayesWeighting exports in all formats
- add root-level `jobs` and `checkpoint_dir` in demo config
- silence mypy on GUI theme helper

## Testing
- `python scripts/run_multi_demo.py`
- `./scripts/run_tests.sh`
- `ruff check .`
- `black --check src scripts config tests`
- `mypy src`


------
https://chatgpt.com/codex/tasks/task_e_687c1b1877ac8331b8a8d1ed1dd048ee