### PR TITLE
Improve demo coverage

### DIFF
--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -498,6 +498,18 @@ export.export_data(
 if not summ_prefix.with_suffix(".xlsx").exists():
     raise SystemExit("summary frame Excel missing")
 
+# Export per-period metrics using all exporters to cover the helper
+metrics_prefix = Path("demo/exports/period_metrics")
+period_metrics = {
+    str(res["period"][3]): export.metrics_from_result(res) for res in results
+}
+export.export_data(period_metrics, str(metrics_prefix), formats=["xlsx", "csv", "json", "txt"])
+if not metrics_prefix.with_suffix(".xlsx").exists():
+    raise SystemExit("period metrics Excel missing")
+created = list(metrics_prefix.parent.glob(f"{metrics_prefix.stem}_*.csv"))
+if not created:
+    raise SystemExit("period metrics CSV/JSON/TXT missing")
+
 # Exercise rank_select_funds via the additional inclusion approaches
 df_full = load_csv(cfg.data["csv_path"])
 if df_full is None:

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -503,7 +503,9 @@ metrics_prefix = Path("demo/exports/period_metrics")
 period_metrics = {
     str(res["period"][3]): export.metrics_from_result(res) for res in results
 }
-export.export_data(period_metrics, str(metrics_prefix), formats=["xlsx", "csv", "json", "txt"])
+export.export_data(
+    period_metrics, str(metrics_prefix), formats=["xlsx", "csv", "json", "txt"]
+)
 if not metrics_prefix.with_suffix(".xlsx").exists():
     raise SystemExit("period metrics Excel missing")
 created = list(metrics_prefix.parent.glob(f"{metrics_prefix.stem}_*.csv"))

--- a/src/trend_analysis/gui/app.py
+++ b/src/trend_analysis/gui/app.py
@@ -469,11 +469,11 @@ def launch() -> widgets.Widget:
         store.theme = change["new"]
         store.dirty = True
         theme_val = change["new"]
-        js: Javascript = Javascript(  # type: ignore
+        js: Javascript = Javascript(
             f"document.documentElement.style.setProperty("  # noqa: W503
             f"' --trend-theme','{theme_val}')"
         )
-        display(js)  # type: ignore
+        display(js)
 
     theme.observe(lambda ch, store=store: on_theme(ch, store=store), names="value")
 


### PR DESCRIPTION
## Summary
- expand demo to export per-period metrics using all exporters
- run setup, generate demo data, demo pipeline, and test suite

## Testing
- `python scripts/generate_demo.py`
- `PYTHONPATH=./src python scripts/run_multi_demo.py`
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c2e9546688331b76d9c18832555b6