### PR TITLE
Expand demo coverage

### DIFF
--- a/docs/DemoMaintenance.md
+++ b/docs/DemoMaintenance.md
@@ -20,6 +20,8 @@ via a single call to `export.export_data` to validate all exporters. Extend the
 script and `config/demo.yml` whenever new exporter options are introduced. It
 also exercises the multi-period export helpers, verifies the CLI wrappers and
 checks the Jupyter notebook utilities.
+It now validates configuration round-tripping via ``model_dump`` and
+``model_dump_json``.
 4. **Run the test suite**
    ```bash
    ./scripts/run_tests.sh

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -276,6 +276,17 @@ def _check_misc(cfg_path: str, cfg: Config, results) -> None:
         raise SystemExit("pipeline.Stats alias failed")
 
 
+def _check_config_dump(cfg: Config) -> None:
+    """Verify ``Config`` serialisation helpers."""
+    data = cfg.model_dump()
+    dumped = cfg.model_dump_json()
+    if not isinstance(dumped, str) or "version" not in dumped:
+        raise SystemExit("model_dump_json output invalid")
+    cfg2 = Config(**data)
+    if cfg2.version != cfg.version:
+        raise SystemExit("Config model_dump roundtrip failed")
+
+
 def _check_rebalancer_logic() -> None:
     """Verify Rebalancer triggers drop and add events."""
     reb = Rebalancer({})
@@ -927,6 +938,7 @@ _check_cli_env("config/demo.yml")
 _check_cli_env_multi("config/demo.yml")
 _check_cli("config/demo.yml")
 _check_misc("config/demo.yml", cfg, results)
+_check_config_dump(cfg)
 _check_rebalancer_logic()
 _check_load_csv_error()
 _check_metrics_basic()


### PR DESCRIPTION
## Summary
- improve run_multi_demo to validate config model_dump roundtrip
- mention new check in DemoMaintenance docs

## Testing
- `python scripts/generate_demo.py`
- `PYTHONPATH=./src python scripts/run_multi_demo.py`
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c6599d1a48331b585ec8ae11b6e52