### PR TITLE
Extend demo coverage

### DIFF
--- a/docs/DemoMaintenance.md
+++ b/docs/DemoMaintenance.md
@@ -22,6 +22,8 @@ also exercises the multi-period export helpers, verifies the CLI wrappers and
 checks the Jupyter notebook utilities.
 It now validates configuration round-tripping via ``model_dump`` and
 ``model_dump_json``.
+It further exercises core utilities like ``_zscore`` and the base weighting
+stub to ensure low-level helpers behave correctly.
 4. **Run the test suite**
    ```bash
    ./scripts/run_tests.sh

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -38,6 +38,7 @@ from trend_analysis.core.rank_selection import rank_select_funds, RiskStatsConfi
 from trend_analysis.core import rank_selection as rs
 from trend_analysis.weighting import (
     AdaptiveBayesWeighting,
+    BaseWeighting,
     EqualWeight,
     ScorePropSimple,
     ScorePropBayesian,

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -383,6 +383,35 @@ def _check_weighting_errors() -> None:
         raise SystemExit(f"{cls.__name__} missing-column check failed")
 
 
+def _check_core_helpers() -> None:
+    """Exercise low-level helpers not hit elsewhere."""
+
+    const = pd.Series([0.0, 0.0, 0.0])
+    z = rs._zscore(const)
+    if not np.allclose(z, 0.0):
+        raise SystemExit("_zscore constant input failed")
+
+    try:
+        BaseWeighting().weight(pd.DataFrame())
+    except NotImplementedError:
+        pass
+    else:  # pragma: no cover - should not happen
+        raise SystemExit("BaseWeighting.weight did not raise")
+
+    alias_cfg = {
+        "multi_period": {
+            "frequency": "QE",
+            "in_sample_len": 4,
+            "out_sample_len": 1,
+            "start": "2019-01",
+            "end": "2020-12",
+        }
+    }
+    periods = scheduler.generate_periods(alias_cfg)
+    if not periods or not periods[0].in_start.startswith("2019"):
+        raise SystemExit("generate_periods alias handling failed")
+
+
 def _check_notebook_utils() -> None:
     """Exercise notebook helper scripts."""
     src = Path("Vol_Adj_Trend_Analysis1.5.TrEx.ipynb")
@@ -945,6 +974,7 @@ _check_metrics_basic()
 _check_builtin_metric_aliases()
 _check_selector_errors()
 _check_weighting_errors()
+_check_core_helpers()
 _check_notebook_utils()
 
 # ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- call new `_check_core_helpers` in `run_multi_demo.py`
- verify `_zscore`, `BaseWeighting` and scheduler aliases
- mention core helper coverage in demo maintenance docs

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c67f2fab083319560d836c271a290