### PR TITLE
Extend demo pipeline coverage

### DIFF
--- a/docs/DemoMaintenance.md
+++ b/docs/DemoMaintenance.md
@@ -27,6 +27,8 @@ stub to ensure low-level helpers behave correctly. The demo now also selects
 funds using ``information_ratio`` so the new metric is tested end-to-end.
 It now verifies the Excel formatter registry via ``reset_formatters_excel`` and
 ``register_formatter_excel`` so custom formatting hooks remain functional.
+It additionally calls the multi-period exporters with ``include_metrics`` both
+enabled and disabled to ensure all code paths are exercised.
 4. **Run the test suite**
    ```bash
    ./scripts/run_tests.sh

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -566,9 +566,13 @@ export.export_phase1_multi_metrics(
 if not phase1_nom_prefix.with_suffix(".xlsx").exists():
     raise SystemExit("Phase1 multi metrics nometrics Excel missing")
 for ext in ("csv", "json", "txt"):
-    if not phase1_nom_prefix.with_name(f"{phase1_nom_prefix.stem}_periods.{ext}").exists():
+    if not phase1_nom_prefix.with_name(
+        f"{phase1_nom_prefix.stem}_periods.{ext}"
+    ).exists():
         raise SystemExit(f"Phase1 multi metrics nometrics {ext} missing")
-    if not phase1_nom_prefix.with_name(f"{phase1_nom_prefix.stem}_summary.{ext}").exists():
+    if not phase1_nom_prefix.with_name(
+        f"{phase1_nom_prefix.stem}_summary.{ext}"
+    ).exists():
         raise SystemExit(f"Phase1 multi metrics nometrics summary {ext} missing")
 
 mpm_nom_prefix = Path("demo/exports/multi_period_nometrics")

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -554,6 +554,37 @@ if not mpm_prefix.with_name(f"{mpm_prefix.stem}_metrics_summary.json").exists():
     raise SystemExit("Multi-period metrics metrics summary JSON missing")
 if not mpm_prefix.with_name(f"{mpm_prefix.stem}_metrics_summary.txt").exists():
     raise SystemExit("Multi-period metrics metrics summary TXT missing")
+
+# Verify exporters also handle the no-metrics case
+phase1_nom_prefix = Path("demo/exports/phase1_multi_nom")
+export.export_phase1_multi_metrics(
+    results,
+    str(phase1_nom_prefix),
+    formats=["xlsx", "csv", "json", "txt"],
+    include_metrics=False,
+)
+if not phase1_nom_prefix.with_suffix(".xlsx").exists():
+    raise SystemExit("Phase1 multi metrics nometrics Excel missing")
+for ext in ("csv", "json", "txt"):
+    if not phase1_nom_prefix.with_name(f"{phase1_nom_prefix.stem}_periods.{ext}").exists():
+        raise SystemExit(f"Phase1 multi metrics nometrics {ext} missing")
+    if not phase1_nom_prefix.with_name(f"{phase1_nom_prefix.stem}_summary.{ext}").exists():
+        raise SystemExit(f"Phase1 multi metrics nometrics summary {ext} missing")
+
+mpm_nom_prefix = Path("demo/exports/multi_period_nometrics")
+export.export_multi_period_metrics(
+    results,
+    str(mpm_nom_prefix),
+    formats=["xlsx", "csv", "json", "txt"],
+    include_metrics=False,
+)
+if not mpm_nom_prefix.with_suffix(".xlsx").exists():
+    raise SystemExit("Multi-period metrics nometrics export failed")
+for ext in ("csv", "json", "txt"):
+    if not mpm_nom_prefix.with_name(f"{mpm_nom_prefix.stem}_periods.{ext}").exists():
+        raise SystemExit(f"Multi-period metrics nometrics {ext} missing")
+    if not mpm_nom_prefix.with_name(f"{mpm_nom_prefix.stem}_summary.{ext}").exists():
+        raise SystemExit(f"Multi-period metrics nometrics summary {ext} missing")
 wb_direct = Path("demo/exports/phase1_direct.xlsx")
 export.export_phase1_workbook(results, str(wb_direct))
 if not wb_direct.exists():


### PR DESCRIPTION
## Summary
- run demo exporters with and without metrics
- document new demo coverage

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c7cf70b108331a57fdae24ea9ae2e