### PR TITLE
Expand demo coverage for ranking helpers

### DIFF
--- a/docs/DemoMaintenance.md
+++ b/docs/DemoMaintenance.md
@@ -32,6 +32,8 @@ enabled and disabled to ensure all code paths are exercised.
 It now verifies metric functions with DataFrame input, exercises
 ``ParamStore.to_dict`` and runs the multi-period engine using a pre-loaded
 DataFrame to cover the optional argument.
+It also tests ``zscore_window`` and ``ddof`` behaviour via ``_apply_transform``
+so advanced ranking options remain covered.
 4. **Run the test suite**
    ```bash
    ./scripts/run_tests.sh

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -464,6 +464,12 @@ def _check_core_helpers() -> None:
     else:  # pragma: no cover - should not happen
         raise SystemExit("_apply_transform invalid mode")
 
+    # verify ddof and window handling
+    series = pd.Series([1.0, 2.0, 3.0])
+    transformed = rs._apply_transform(series, mode="zscore", window=2, ddof=1)
+    if not np.isclose(transformed.iloc[-1], 0.70710678, atol=1e-6):
+        raise SystemExit("_apply_transform ddof/window failed")
+
     try:
         rs._compute_metric_series(df, "NoSuch", RiskStatsConfig())
     except ValueError:
@@ -752,6 +758,18 @@ zscore_ids = rank_select_funds(
 )
 if not zscore_ids:
     raise SystemExit("zscore selection produced no funds")
+
+zwin_ids = rank_select_funds(
+    window,
+    rs_cfg,
+    inclusion_approach="top_n",
+    n=2,
+    score_by="Sharpe",
+    transform="zscore",
+    zscore_window=5,
+)
+if not zwin_ids:
+    raise SystemExit("zscore window selection produced no funds")
 
 percentile_ids = rank_select_funds(
     window,


### PR DESCRIPTION
## Summary
- exercise `zscore_window` via `rank_select_funds`
- verify `_apply_transform` window and `ddof`
- document new checks in DemoMaintenance

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687cfdbd886883318fe44adfe9c42de6