### PR TITLE
Improve demo validation

### DIFF
--- a/docs/DemoMaintenance.md
+++ b/docs/DemoMaintenance.md
@@ -34,6 +34,7 @@ It now verifies metric functions with DataFrame input, exercises
 DataFrame to cover the optional argument.
 It also tests ``zscore_window`` and ``ddof`` behaviour via ``_apply_transform``
 so advanced ranking options remain covered.
+It now confirms the generated demo dataset contains 10 years of monthly data across 20 managers so ``generate_demo.py`` stays reliable.
 4. **Run the test suite**
    ```bash
    ./scripts/run_tests.sh


### PR DESCRIPTION
## Summary
- extend demo to verify generated dataset shape and dates
- document the new check in demo maintenance guide

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=./src python scripts/run_multi_demo.py` *(fails: `ValueError: sharpe_ratio: DataFrame vs Series/DataFrame not supported`)*
- `PYTHONPATH=./src ./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687d0386d3388331aca3f1c379b84d97