### PR TITLE
Improve demo coverage

### DIFF
--- a/config/demo.yml
+++ b/config/demo.yml
@@ -28,6 +28,9 @@ portfolio:
     params:
       top_n: 5
       rank_column: Sharpe
+  custom_weights:
+    Mgr_01: 60
+    Mgr_02: 40
   weighting:
     name: equal
     params: {}


### PR DESCRIPTION
## Summary
- test custom weights path in run_multi_demo
- include example custom weights in demo configuration

## Testing
- `./scripts/setup_env.sh` *(fails: No such file or directory)*
- `python scripts/generate_demo.py`
- `PYTHONPATH=src python scripts/run_multi_demo.py`
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687d56ea4d948331a35ed1b7dbbed083