### PR TITLE
Add option to skip demo Excel file

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,10 @@ pipeline features:
 
 ```bash
 ./scripts/setup_env.sh
-python scripts/generate_demo.py
+python scripts/generate_demo.py [--no-xlsx]
 python scripts/run_multi_demo.py
 ```
+Use `--no-xlsx` to skip the Excel workbook when large files are undesired.
 
 The script prints the number of generated periods and verifies that
 weights evolve across them, confirming the Phase 2 logic works end to end.
@@ -167,8 +168,9 @@ checklist of these steps.
    ```
 2. **Generate the demo dataset**
    ```bash
-   python scripts/generate_demo.py
+   python scripts/generate_demo.py [--no-xlsx]
    ```
+   Pass `--no-xlsx` to avoid creating the Excel copy.
 3. **Run the full demo pipeline and export checks**
    ```bash
    python scripts/run_multi_demo.py

--- a/docs/DemoMaintenance.md
+++ b/docs/DemoMaintenance.md
@@ -8,8 +8,9 @@ This document summarises the steps required to keep the demo pipeline in sync wi
    ```
 2. **Generate the demo dataset**
    ```bash
-   python scripts/generate_demo.py
+   python scripts/generate_demo.py [--no-xlsx]
    ```
+   Use `--no-xlsx` to skip the Excel file when binary artefacts are unwanted.
 3. **Run the full demo pipeline and export checks**
    ```bash
 python scripts/run_multi_demo.py

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -71,9 +71,11 @@ Generate the synthetic dataset and run the helper script to exercise the Phase 
 
 ```bash
 ./scripts/setup_env.sh
-python scripts/generate_demo.py
+python scripts/generate_demo.py [--no-xlsx]
 python scripts/run_multi_demo.py
 ```
+Use `--no-xlsx` to skip generating the Excel workbook if binary files should be
+avoided.
 
 `run_multi_demo.py` calls ``export.export_data`` so CSV, Excel, JSON **and TXT** reports are produced in one go. It also runs the full test suite, ensuring multiple periods are processed and that adaptive weights evolve over time.
 The script exercises the CLI wrappers as part of these checks.

--- a/docs/phase-2/Agents.md
+++ b/docs/phase-2/Agents.md
@@ -569,8 +569,9 @@ feature lands, run the sequence below and update `config/demo.yml` or
    ```
 2. **Generate the demo dataset**
    ```bash
-   python scripts/generate_demo.py
+   python scripts/generate_demo.py [--no-xlsx]
    ```
+   The optional flag skips the Excel copy when binary artefacts are not needed.
 3. **Run the full demo pipeline and export checks**
    ```bash
    python scripts/run_multi_demo.py

--- a/scripts/generate_demo.py
+++ b/scripts/generate_demo.py
@@ -3,36 +3,54 @@ Generate a 10‑year monthly return series for 20
 fake managers and dump to CSV + XLSX.
 """
 
+import argparse
+import datetime as dt
+import os
+
 import numpy as np
 import pandas as pd
-import os
-import datetime as dt
 
 OUT_DIR = "demo"
 os.makedirs(OUT_DIR, exist_ok=True)
 
-start = dt.date.today().replace(year=dt.date.today().year - 10, day=1)
-periods = 120  # 10 years * 12 months
-dates = pd.date_range(start, periods=periods, freq="M")
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate demo return series.")
+    parser.add_argument(
+        "--no-xlsx",
+        action="store_true",
+        help="Skip writing the Excel copy",
+    )
+    args = parser.parse_args()
 
-rng = np.random.default_rng(42)
-data = {}
-for i in range(1, 21):
-    base = rng.normal(loc=0.006, scale=0.04, size=periods)
-    slope = rng.normal(scale=0.0005)
-    trend = slope * np.arange(periods)
-    drift = rng.normal(scale=0.002, size=periods).cumsum()
-    data[f"Mgr_{i:02d}"] = base + trend + drift
+    start = dt.date.today().replace(year=dt.date.today().year - 10, day=1)
+    periods = 120  # 10 years * 12 months
+    dates = pd.date_range(start, periods=periods, freq="M")
 
-# Add a simple market index so benchmark logic can run
-spx = rng.normal(loc=0.005, scale=0.03, size=periods)
-data["SPX"] = spx
+    rng = np.random.default_rng(42)
+    data = {}
+    for i in range(1, 21):
+        base = rng.normal(loc=0.006, scale=0.04, size=periods)
+        slope = rng.normal(scale=0.0005)
+        trend = slope * np.arange(periods)
+        drift = rng.normal(scale=0.002, size=periods).cumsum()
+        data[f"Mgr_{i:02d}"] = base + trend + drift
 
-df = pd.DataFrame(data, index=dates)
-df.index.name = "Date"
+    # Add a simple market index so benchmark logic can run
+    spx = rng.normal(loc=0.005, scale=0.03, size=periods)
+    data["SPX"] = spx
 
-csv_path = f"{OUT_DIR}/demo_returns.csv"
-xlsx_path = f"{OUT_DIR}/demo_returns.xlsx"
-df.to_csv(csv_path)
-df.to_excel(xlsx_path)
-print(f"Wrote {csv_path} and {xlsx_path}")
+    df = pd.DataFrame(data, index=dates)
+    df.index.name = "Date"
+
+    csv_path = f"{OUT_DIR}/demo_returns.csv"
+    xlsx_path = f"{OUT_DIR}/demo_returns.xlsx"
+    df.to_csv(csv_path)
+    if not args.no_xlsx:
+        df.to_excel(xlsx_path)
+        print(f"Wrote {csv_path} and {xlsx_path}")
+    else:
+        print(f"Wrote {csv_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow `scripts/generate_demo.py` to skip writing the Excel file
- document the new `--no-xlsx` flag in the demo docs and README

## Testing
- `./scripts/setup_env.sh`
- `python scripts/generate_demo.py --no-xlsx`
- `python scripts/generate_demo.py`
- `python scripts/run_multi_demo.py`
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_687d7f33b4dc8331a5a86406c6a82632