### PR TITLE
Improve demo coverage

### DIFF
--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -49,6 +49,7 @@ def make_config(csv: Path) -> Config:
             "selection_mode": "rank",
             "rank": {"inclusion_approach": "top_n", "n": 3, "score_by": "AnnualReturn"},
         },
+        benchmarks={"eq60": "EqualWeight_60"},
         metrics={},
         export={},
         run={},

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -85,9 +85,12 @@ def test_demo_runs(tmp_path, capsys):
     assert res["score_frame"].attrs["insample_len"] == 6
     assert res["score_frame"].attrs["period"] == ("2012-01", "2012-06")
     assert "information_ratio" in res["metrics_df"].columns
+    assert "ir_eq60" in res["metrics_df"].columns
     df_csv = pd.read_csv(tmp_path / "analysis_metrics.csv", index_col=0)
     assert df_csv.columns.tolist() == res["metrics_df"].columns.tolist()
     import openpyxl
 
     wb = openpyxl.load_workbook(tmp_path / "analysis.xlsx")
     assert set(wb.sheetnames) == {"metrics", "summary", "history"}
+    assert "eq60" in res["full_res"]["benchmark_ir"]
+    assert "equal_weight" in res["full_res"]["benchmark_ir"]["eq60"]

--- a/tests/test_gui_app.py
+++ b/tests/test_gui_app.py
@@ -1,0 +1,16 @@
+import importlib
+import sys
+
+def test_gui_module(monkeypatch):
+    class Dummy:
+        def __init__(self):
+            self.titles = []
+            self.texts = []
+        def title(self, txt):
+            self.titles.append(txt)
+        def write(self, txt):
+            self.texts.append(txt)
+    dummy = Dummy()
+    monkeypatch.setitem(sys.modules, "streamlit", dummy)
+    importlib.import_module("trend_analysis.gui.app")
+    assert dummy.titles and dummy.texts

--- a/tests/test_gui_app.py
+++ b/tests/test_gui_app.py
@@ -1,15 +1,19 @@
 import importlib
 import sys
 
+
 def test_gui_module(monkeypatch):
     class Dummy:
         def __init__(self):
             self.titles = []
             self.texts = []
+
         def title(self, txt):
             self.titles.append(txt)
+
         def write(self, txt):
             self.texts.append(txt)
+
     dummy = Dummy()
     monkeypatch.setitem(sys.modules, "streamlit", dummy)
     importlib.import_module("trend_analysis.gui.app")

--- a/tests/test_metrics_edgecases.py
+++ b/tests/test_metrics_edgecases.py
@@ -31,3 +31,11 @@ def test_information_ratio_edge_cases():
     bench = pd.DataFrame({"m": [0.01, 0.01]})
     ir = metrics.information_ratio(df, bench)
     assert isinstance(ir, pd.Series) and set(ir.index) == {"a", "b"}
+
+
+def test_information_ratio_default_and_scalar():
+    df = pd.DataFrame({"a": [0.02, 0.03], "b": [0.01, 0.02]})
+    ir_none = metrics.information_ratio(df)
+    assert isinstance(ir_none, pd.Series)
+    ir_scalar = metrics.information_ratio(df, benchmark=0.0)
+    assert isinstance(ir_scalar, pd.Series)

--- a/tests/test_multi_period_stub.py
+++ b/tests/test_multi_period_stub.py
@@ -10,3 +10,7 @@ def test_scheduler_generates_periods():
     assert periods, "Scheduler returned empty list"
     first = periods[0]
     assert first.in_start < first.out_start, "Period tuple ordering incorrect"
+
+
+def test_scheduler_missing_section():
+    assert generate_periods({}) == []


### PR DESCRIPTION
## Summary
- integrate benchmark usage into demo config
- extend demo integration test to verify benchmark IR
- cover extra branches in metrics, scheduler and GUI modules

## Testing
- `pytest --cov trend_analysis --cov-branch -q`

------
https://chatgpt.com/codex/tasks/task_e_687dad83699c8331b042325204447360