### PR TITLE
Expand demo coverage

### DIFF
--- a/docs/DemoMaintenance.md
+++ b/docs/DemoMaintenance.md
@@ -40,6 +40,8 @@ It additionally verifies an Excel copy is produced and that the dates span
 exactly 120 consecutive months.
 It now ensures ``config.load(None)`` falls back to ``config/defaults.yml`` when
 no environment variable or path is provided.
+It also checks that the export helpers gracefully handle an empty results list so
+CI covers those edge cases.
 4. **Run the test suite**
    ```bash
    ./scripts/run_tests.sh


### PR DESCRIPTION
## Summary
- check that export helpers handle empty results
- exercise _run_analysis() error paths
- document the empty-results export check

## Testing
- `python scripts/generate_demo.py`
- `PYTHONPATH=./src python scripts/run_multi_demo.py`
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687e95f4b81c8331a631989aabdc23fd