### PR TITLE
Extend demo to cover UI and multi-benchmark paths

### DIFF
--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -49,7 +49,7 @@ def make_config(csv: Path) -> Config:
             "selection_mode": "rank",
             "rank": {"inclusion_approach": "top_n", "n": 3, "score_by": "AnnualReturn"},
         },
-        benchmarks={"eq60": "EqualWeight_60"},
+        benchmarks={"eq60": "EqualWeight_60", "quant": "Quantum Capital"},
         metrics={},
         export={},
         run={},
@@ -134,6 +134,7 @@ def main(out_dir: str | Path | None = None) -> Dict[str, Any]:
         score_by="AnnualReturn",
         transform="zscore",
     )
+    ui_obj = rs.build_ui()
     # Demonstrate the rebalancer with a simple trigger configuration.
     rb_cfg = {"triggers": {"sigma1": {"sigma": 1, "periods": 2}}}
     rb = Rebalancer(rb_cfg)
@@ -221,6 +222,7 @@ def main(out_dir: str | Path | None = None) -> Dict[str, Any]:
     print("Multi-period final weights:", mp_weights.to_dict())
     print("Multi-period weight history:\n", mp_history_df)
     print("Multi-period selections:", mp_selected)
+    print("UI object built:", type(ui_obj).__name__)
     os.remove(cfg_file)
 
     return {
@@ -250,6 +252,7 @@ def main(out_dir: str | Path | None = None) -> Dict[str, Any]:
         "ranked_zscore": ranked_zscore,
         "loaded_version": loaded_cfg.version,
         "nb_clean": nb_clean,
+        "ui_obj": ui_obj,
     }
 
 

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from ipywidgets import Widget
 import scripts.demo as demo
 from trend_analysis.core import rank_selection as rs
 
@@ -47,6 +48,7 @@ def test_demo_runs(tmp_path, capsys):
     assert "Top fund by blended ranking:" in captured
     assert "Top fund by z-score ranking:" in captured
     assert "Multi-period selections:" in captured
+    assert "UI object built:" in captured
     assert (tmp_path / "analysis.xlsx").exists()
     assert (tmp_path / "analysis_metrics.csv").exists()
     assert (tmp_path / "analysis_metrics.json").exists()
@@ -108,6 +110,7 @@ def test_demo_runs(tmp_path, capsys):
     assert res["score_frame"].attrs["period"] == ("2012-01", "2012-06")
     assert "information_ratio" in res["metrics_df"].columns
     assert "ir_eq60" in res["metrics_df"].columns
+    assert "ir_quant" in res["metrics_df"].columns
     df_csv = pd.read_csv(tmp_path / "analysis_metrics.csv", index_col=0)
     assert df_csv.columns.tolist() == res["metrics_df"].columns.tolist()
     import openpyxl
@@ -116,7 +119,9 @@ def test_demo_runs(tmp_path, capsys):
     assert set(wb.sheetnames) == {"metrics", "summary", "history"}
     summary_headers = [c.value for c in wb["summary"][5]]
     assert "OS IR eq60" in summary_headers
+    assert "OS IR quant" in summary_headers
     assert "eq60" in res["full_res"]["benchmark_ir"]
+    assert "quant" in res["full_res"]["benchmark_ir"]
     assert "equal_weight" in res["full_res"]["benchmark_ir"]["eq60"]
 
     df_json = pd.read_json(tmp_path / "analysis_metrics.json")
@@ -127,3 +132,4 @@ def test_demo_runs(tmp_path, capsys):
     pd.testing.assert_frame_equal(
         hist_json, res["mp_history_df"].reset_index(drop=True)
     )
+    assert isinstance(res["ui_obj"], Widget)


### PR DESCRIPTION
## Summary
- demo now builds the ipywidgets UI and returns it
- support multiple benchmarks in demo config
- check for new outputs in tests

## Testing
- `ruff check .`
- `black --check scripts/demo.py tests/test_demo.py`
- `mypy trend_analysis`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687edec1861c8331aa2f5889d4fbd04b