### PR TITLE
Expand demo coverage

### DIFF
--- a/docs/DemoMaintenance.md
+++ b/docs/DemoMaintenance.md
@@ -37,6 +37,8 @@ It also tests ``zscore_window`` and ``ddof`` behaviour via ``_apply_transform``
 so advanced ranking options remain covered.
 It now confirms the ``_Stats`` dataclass includes the ``information_ratio``
 field so metric expansions are checked end-to-end.
+It now registers a custom metric via ``rank_selection.register_metric`` so
+the metric extension hooks stay validated.
 It now confirms the generated demo dataset contains 10 years of monthly data across 20 managers so ``generate_demo.py`` stays reliable.
 It additionally verifies an Excel copy is produced and that the dates span
 exactly 120 consecutive months.

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -700,6 +700,20 @@ def _check_core_helpers() -> None:
         raise SystemExit("_compute_metric_series failed to reject unknown metric")
 
 
+def _check_rank_metric_registration() -> None:
+    """Ensure ``rank_selection.register_metric`` works end-to-end."""
+
+    @rs.register_metric("DemoAvg")  # type: ignore[misc]
+    def _demo_avg(series: pd.Series, **_: object) -> float:
+        return float(series.mean())
+
+    df = pd.DataFrame({"A": [0.1, 0.2, 0.3]})
+    scores = rs._compute_metric_series(df, "DemoAvg", RiskStatsConfig())
+    if not np.isclose(scores["A"], 0.2, atol=1e-9):
+        raise SystemExit("register_metric failed")
+    rs.METRIC_REGISTRY.pop("DemoAvg", None)
+
+
 def _check_constants() -> None:
     """Validate key constant values to catch accidental changes."""
 
@@ -1478,6 +1492,7 @@ _check_weighting_zero_sum()
 _check_equal_weight_empty()
 _check_abw_edge_cases()
 _check_core_helpers()
+_check_rank_metric_registration()
 _check_abw_halflife()
 _check_stats_dataclass()
 _check_constants()


### PR DESCRIPTION
## Summary
- extend demo to check custom metric registration
- document the new demo check in demo maintenance notes

## Testing
- `./scripts/setup_env.sh` *(fails: No such file or directory)*
- `python scripts/generate_demo.py`
- `PYTHONPATH=./src python scripts/run_multi_demo.py`
- `PYTHONPATH=./src ./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687f8726bcb4833182d983befc89ed1b