### PR TITLE
fix rank selection ordering and add debugging protocol

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -562,3 +562,92 @@ JSON outputs must consolidate all periods into a single file.  A new helper
 sheet mapping for a multi‑period workbook, optionally including raw metrics per
 period and for the combined summary.  `export_phase1_workbook()` now builds its
 workbook from this mapping.
+
+## Fund Selection Debugging Protocol
+
+### Problem Context
+When debugging multi-period portfolio analysis where the same managers are selected every period despite changing performance rankings, follow this systematic approach.
+
+### Debugging Workflow
+
+1. **Environment Setup**
+   - Ensure virtual environment is activated: `source venv/bin/activate`
+   - Verify all dependencies installed: `pip install -r requirements.txt && pip install -e .`
+   - Confirm working on correct branch (use `chore/demo-pipeline` for debugging)
+
+2. **Data Completeness Analysis**
+   ```python
+   # Run the debug script to check data availability
+   python debug_fund_selection.py
+   ```
+
+This script will reveal:
+
+- How many managers are in the original dataset
+- Which managers get filtered out due to missing data in in-sample periods
+- Which managers get filtered out due to missing data in out-of-sample periods
+- Final available manager pool for selection
+- Actual ranking results for available managers
+
+Expected Issues to Check
+
+- Data Gap Issue: Only 8 managers have complete data across all periods
+- Ranking Bug: Selection logic not sorting by performance metrics
+- Configuration Issue: Wrong parameters passed to rank_select_funds
+- Period Definition: Incorrect date parsing or period boundaries
+
+Workflow Compliance
+
+- DO NOT make ad-hoc changes to core modules from demo branch
+- DO document findings clearly before proposing fixes
+- DO follow the phase2-dev → chore/demo-pipeline workflow for fixes
+- DO NOT merge anything with main branch
+
+Core Module Fix Process
+If debugging reveals bugs in core selection logic:
+
+- Document the Issue
+  - Specific function with the bug (e.g., rank_select_funds)
+  - Expected vs actual behavior
+  - Root cause analysis
+  - Test case demonstrating the problem
+- Implement Fix on phase2-dev
+
+Common Pitfalls to Avoid
+
+- DON'T assume the ranking algorithm is wrong without checking data completeness first
+- DON'T make changes to core modules without switching to phase2-dev
+- DON'T run analysis commands that take more than 2-3 minutes without progress updates
+- DON'T ignore the virtual environment setup - module imports will fail
+- DO trace through the actual data filtering pipeline step by step
+
+## Development Workflow
+
+### Multi-Period Analysis Debugging
+
+When debugging multi-period issues:
+
+1. **Start with data completeness check** - Most "selection not changing" issues are due to insufficient data for additional managers
+2. **Use the debug_fund_selection.py script** - Provides systematic analysis of the selection pipeline
+3. **Check both in-sample AND out-of-sample data requirements** - Both periods must have complete data for a manager to be eligible
+4. **Verify configuration parameters** - Ensure rank_select_funds is getting correct inclusion_approach, n, score_by parameters
+
+Example debug workflow:
+```bash
+# 1. Run systematic debugging
+python debug_fund_selection.py
+
+# 2. If data issue found: investigate data generation
+# 3. If logic issue found: follow core fix workflow
+# 4. If config issue found: update configuration files
+```
+
+## Code Quality Guidelines
+
+### Debugging Script Standards
+
+- Debugging scripts should be self-contained and clearly document their purpose
+- Include comprehensive output showing each step of the analysis
+- Distinguish between data issues vs. logic bugs vs. configuration problems
+- Provide clear conclusions and next steps based on findings
+- Follow the same code quality standards as production code

--- a/debug_fund_selection.py
+++ b/debug_fund_selection.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Debug the fund selection process - why are only Mgr_01-08 being considered?
+"""
+
+import pandas as pd
+import numpy as np
+from trend_analysis.config import load
+from trend_analysis.data import load_csv, identify_risk_free_fund
+from trend_analysis.core.rank_selection import rank_select_funds, RiskStatsConfig
+
+
+def debug_fund_selection():
+    """Debug why only first 8 managers are being selected."""
+
+    print("="*70)
+    print("DEBUGGING FUND SELECTION PROCESS")
+    print("="*70)
+
+    # Load data
+    cfg = load("config/portfolio_test.yml")
+    df = load_csv(cfg.data["csv_path"])
+
+    print(f"Original data shape: {df.shape}")
+    print(f"Columns: {list(df.columns)}")
+
+    # Simulate the first period selection process
+    # This is what _run_analysis does internally
+
+    # Define first period (same as our test showed)
+    in_start = "2008-01"
+    in_end = "2010-12"
+
+    # Convert to timestamps like _run_analysis does
+    def _parse_month(s: str) -> pd.Timestamp:
+        return pd.to_datetime(f"{s}-01") + pd.offsets.MonthEnd(0)
+
+    in_sdate = _parse_month(in_start)
+    in_edate = _parse_month(in_end)
+
+    print(f"\nAnalyzing period: {in_sdate} to {in_edate}")
+
+    # Filter data for in-sample period
+    date_col = "Date"
+    df[date_col] = pd.to_datetime(df[date_col])
+
+    in_df = df[(df[date_col] >= in_sdate) & (df[date_col] <= in_edate)].set_index(date_col)
+    print(f"In-sample data shape: {in_df.shape}")
+
+    # Identify return columns (this is the key part!)
+    ret_cols = [c for c in df.columns if c != date_col]
+    print(f"Return columns found: {len(ret_cols)}")
+    print(f"Return columns: {ret_cols}")
+
+    # Identify risk-free fund
+    rf_col = identify_risk_free_fund(df)
+    print(f"Risk-free column identified: {rf_col}")
+
+    # Get fund columns (excluding risk-free)
+    fund_cols = [c for c in ret_cols if c != rf_col]
+    print(f"Fund columns (excluding RF): {len(fund_cols)}")
+    print(f"Fund columns: {fund_cols}")
+
+    # Check for complete data (this might be the issue!)
+    print("\nChecking for complete data in in-sample period:")
+    in_ok = ~in_df[fund_cols].isna().any()
+    print("Missing data check:")
+    for col in fund_cols:
+        missing = in_df[col].isna().sum()
+        total = len(in_df)
+        pct = (missing / total) * 100 if total > 0 else 0
+        status = "OK" if in_ok[col] else "MISSING DATA"
+        print(f"  {col}: {missing}/{total} missing ({pct:.1f}%) - {status}")
+
+    # This is the critical filter that might be removing funds
+    valid_fund_cols = [c for c in fund_cols if in_ok[c]]
+    print(f"\nValid fund columns after missing data filter: {len(valid_fund_cols)}")
+    print(f"Valid funds: {valid_fund_cols}")
+
+    if len(valid_fund_cols) < len(fund_cols):
+        removed = set(fund_cols) - set(valid_fund_cols)
+        print(f"REMOVED due to missing data: {removed}")
+
+    # Check out-sample data too
+    out_start = "2011-01"
+    out_end = "2011-12"
+    out_sdate = _parse_month(out_start)
+    out_edate = _parse_month(out_end)
+
+    out_df = df[(df[date_col] >= out_sdate) & (df[date_col] <= out_edate)].set_index(date_col)
+    print(f"\nOut-sample data shape: {out_df.shape}")
+
+    out_ok = ~out_df[fund_cols].isna().any()
+    print("Out-sample missing data check:")
+    for col in fund_cols:
+        missing = out_df[col].isna().sum()
+        total = len(out_df)
+        pct = (missing / total) * 100 if total > 0 else 0
+        status = "OK" if out_ok[col] else "MISSING DATA"
+        print(f"  {col}: {missing}/{total} missing ({pct:.1f}%) - {status}")
+
+    # Final filter: both in-sample AND out-sample must be complete
+    final_fund_cols = [c for c in fund_cols if in_ok[c] and out_ok[c]]
+    print(f"\nFinal fund columns after both filters: {len(final_fund_cols)}")
+    print(f"Final funds: {final_fund_cols}")
+
+    if len(final_fund_cols) < len(fund_cols):
+        removed = set(fund_cols) - set(final_fund_cols)
+        print(f"TOTAL REMOVED: {removed}")
+        print("Removal reasons:")
+        for col in removed:
+            reasons = []
+            if not in_ok[col]:
+                in_missing = in_df[col].isna().sum()
+                reasons.append(f"in-sample missing: {in_missing}")
+            if not out_ok[col]:
+                out_missing = out_df[col].isna().sum()
+                reasons.append(f"out-sample missing: {out_missing}")
+            print(f"  {col}: {', '.join(reasons)}")
+
+    # Now test the ranking selection
+    print("\n" + "=" * 50)
+    print("TESTING RANKING SELECTION")
+    print("="*50)
+
+    if len(final_fund_cols) > 0:
+        # Create the in-sample window for ranking
+        mask = (df[date_col] >= in_sdate) & (df[date_col] <= in_edate)
+        sub = df.loc[mask, final_fund_cols]
+
+        print(f"Ranking data shape: {sub.shape}")
+        print(f"Ranking period: {sub.index.min()} to {sub.index.max()}")
+
+        # Test rank selection with our config
+        rank_kwargs = cfg.portfolio.get("rank", {})
+        print(f"Rank kwargs: {rank_kwargs}")
+
+        stats_cfg = RiskStatsConfig(risk_free=0.0)
+
+        # This is the actual selection call
+        selected = rank_select_funds(sub, stats_cfg, **rank_kwargs)
+        print(f"Selected funds: {selected}")
+        print(f"Selected count: {len(selected)}")
+
+        # Show what got ranked
+        print("\nShowing all available funds and their Sharpe ratios:")
+        for col in final_fund_cols:
+            returns = sub[col].dropna()
+            if len(returns) > 1:
+                excess_returns = returns - 0.0  # risk-free rate is 0
+                sharpe = excess_returns.mean() / excess_returns.std() * np.sqrt(12)
+                selected_status = "SELECTED" if col in selected else "not selected"
+                print(f"  {col}: {sharpe:6.2f} Sharpe - {selected_status}")
+
+    print("\n" + "=" * 70)
+    print("CONCLUSION")
+    print("=" * 70)
+
+    if len(final_fund_cols) == 8:
+        print("❌ PROBLEM IDENTIFIED: Only 8 funds have complete data!")
+        print("   The other 12 managers have missing data in some periods.")
+        print("   This explains why selection doesn't change - there are no alternatives!")
+    elif len(final_fund_cols) > 8:
+        print("✅ Data issue ruled out - multiple funds available")
+        print("   The problem is likely in the ranking/selection logic")
+    else:
+        print(f"❌ CRITICAL: Only {len(final_fund_cols)} funds available!")
+
+
+if __name__ == "__main__":
+    debug_fund_selection()

--- a/src/trend_analysis/core/rank_selection.py
+++ b/src/trend_analysis/core/rank_selection.py
@@ -30,6 +30,7 @@ def _apply_transform(
     window: int | None = None,
     rank_pct: float | None = None,
     ddof: int = 0,
+    ascending: bool = False,
 ) -> pd.Series:
     """
     Return a transformed copy of *series* without mutating the original.
@@ -40,18 +41,19 @@ def _apply_transform(
     window    : trailing periods for z‑score (ignored otherwise)
     rank_pct  : top‑X% mask when mode == 'percentile'
     ddof      : degrees of freedom for std in z‑score
+    ascending : whether smaller values are better
     """
     if mode == "raw":
         return series
 
     if mode == "rank":
-        return series.rank(ascending=False, pct=False)
+        return series.rank(ascending=ascending, pct=False)
 
     if mode == "percentile":
         if rank_pct is None:
             raise ValueError("rank_pct must be set for percentile transform")
         k = max(int(round(len(series) * rank_pct)), 1)
-        mask = series.rank(ascending=False, pct=False) <= k
+        mask = series.rank(ascending=ascending, pct=False) <= k
         return series.where(mask, np.nan)
 
     if mode == "zscore":
@@ -84,18 +86,25 @@ def rank_select_funds(
     """
     if score_by == "blended":
         scores = blended_score(in_sample_df, blended_weights or {}, stats_cfg)
+        metric_name = None
+        ascending = False
     else:
-        scores = _compute_metric_series(in_sample_df, score_by, stats_cfg)
+        metric_name = _METRIC_ALIASES.get(score_by, score_by)
+        scores = _compute_metric_series(in_sample_df, metric_name, stats_cfg)
+        ascending = metric_name in ASCENDING_METRICS
 
-    scores = _apply_transform(
-        scores,
-        mode=transform,
-        window=zscore_window,
-        rank_pct=rank_pct,
-    )
-
-    ascending = score_by in ASCENDING_METRICS
-    scores = scores.sort_values(ascending=ascending)
+    if transform == "rank":
+        scores = scores.rank(ascending=ascending, pct=False)
+        # lower ranks are better regardless of metric direction
+        scores = scores.sort_values()
+    else:
+        scores = _apply_transform(
+            scores,
+            mode=transform,
+            window=zscore_window,
+            rank_pct=rank_pct,
+            ascending=ascending,
+        ).sort_values(ascending=ascending)
 
     if inclusion_approach == "top_n":
         if n is None:
@@ -304,7 +313,10 @@ def blended_score(
     """
     if not weights:
         raise ValueError("blended_score requires non‑empty weights dict")
-    w_norm = {k: v / sum(weights.values()) for k, v in weights.items()}
+    w_norm = {
+        _METRIC_ALIASES.get(k, k): v / sum(weights.values())
+        for k, v in weights.items()
+    }
 
     combo = pd.Series(0.0, index=in_sample_df.columns)
     for metric, w in w_norm.items():

--- a/tests/test_rank_selection.py
+++ b/tests/test_rank_selection.py
@@ -25,6 +25,35 @@ def test_rank_select_funds_top_n():
     assert selected == ["A"]
 
 
+def test_rank_transform_sorts_best_first():
+    df = make_df()
+    in_df = df.loc[df.index[:3], ["A", "B"]]
+    cfg = rs.RiskStatsConfig(risk_free=0.0)
+    selected = rs.rank_select_funds(
+        in_df,
+        cfg,
+        inclusion_approach="top_n",
+        n=1,
+        score_by="AnnualReturn",
+        transform="rank",
+    )
+    assert selected == ["A"]
+
+
+def test_metric_alias_handled():
+    df = make_df()
+    in_df = df.loc[df.index[:3], ["A", "B"]]
+    cfg = rs.RiskStatsConfig(risk_free=0.0)
+    selected = rs.rank_select_funds(
+        in_df,
+        cfg,
+        inclusion_approach="top_n",
+        n=1,
+        score_by="annual_return",
+    )
+    assert selected == ["A"]
+
+
 def test_run_analysis_rank_mode():
     df = make_df()
     res = run_analysis(


### PR DESCRIPTION
## Summary
- document a multi-period fund selection debugging workflow
- fix rank selection to honor metric direction, support metric aliases, and ensure rank transforms pick the highest-scoring funds first
- add debug_fund_selection.py for systematic data checks

## Testing
- `ruff check src/trend_analysis/core/rank_selection.py tests/test_rank_selection.py debug_fund_selection.py --fix`
- `pre-commit run --files src/trend_analysis/core/rank_selection.py tests/test_rank_selection.py debug_fund_selection.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893f228dd408331ba17fcf751535098