### PR TITLE
fix: annotate blended score weights

### DIFF
--- a/src/trend_analysis/core/rank_selection.py
+++ b/src/trend_analysis/core/rank_selection.py
@@ -322,9 +322,9 @@ def blended_score(
     if not weights:
         raise ValueError("blended_score requires non‑empty weights dict")
     # Normalize metric names using _METRIC_ALIASES
-    canonical_weights = {}
+    canonical_weights: dict[str, float] = {}
     for k, v in weights.items():
-        canonical = _metrics._METRIC_ALIASES.get(k, k)
+        canonical = _METRIC_ALIASES.get(k, k)
         if canonical in canonical_weights:
             canonical_weights[canonical] += v
         else:


### PR DESCRIPTION
## Summary
- fix blended_score type annotation
- use local metric alias mapping

## Testing
- `pre-commit run --files src/trend_analysis/core/rank_selection.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68940d7a17e483318720f60f8b9b3586