### PR TITLE
feat: min_tenure selection guard + sim tenure tracking (closes #371)

### DIFF
--- a/tests/app/test_policy_engine.py
+++ b/tests/app/test_policy_engine.py
@@ -36,3 +36,51 @@ def test_decide_hires_fires_basic():
         eligible_since=elig,
     )
     assert len(decisions["hire"]) == 1
+
+
+def test_min_tenure_blocks_bottom_fire():
+    sf = pd.DataFrame(
+        {
+            "sharpe": [2.0, 1.0, -1.0],
+            "vol": [0.10, 0.15, 0.20],
+        },
+        index=["A", "B", "C"],
+    )
+    directions = {"sharpe": +1, "vol": -1}
+    policy = PolicyConfig(
+        top_k=0,
+        bottom_k=1,
+        cooldown_months=0,
+        min_track_months=0,
+        max_active=10,
+        min_tenure_n=3,
+        metrics=[MetricSpec("sharpe", 1.0), MetricSpec("vol", 1.0)],
+    )
+    cd = CooldownBook()
+    elig = {"A": 24, "B": 24, "C": 24}
+    # Current holds C (worst), but tenure only 2 < 3, so should NOT fire yet
+    t = {"A": 0, "B": 0, "C": 2}
+    decisions = decide_hires_fires(
+        pd.Timestamp("2020-12-31"),
+        sf,
+        current=["C"],
+        policy=policy,
+        directions=directions,
+        cooldowns=cd,
+        eligible_since=elig,
+        tenure=t,
+    )
+    assert decisions["fire"] == []
+    # Once tenure reaches threshold, firing is allowed
+    t["C"] = 3
+    decisions2 = decide_hires_fires(
+        pd.Timestamp("2021-01-31"),
+        sf,
+        current=["C"],
+        policy=policy,
+        directions=directions,
+        cooldowns=cd,
+        eligible_since=elig,
+        tenure=t,
+    )
+    assert decisions2["fire"] == [("C", "bottom_k")]

--- a/tests/app/test_sim_min_tenure_integration.py
+++ b/tests/app/test_sim_min_tenure_integration.py
@@ -35,7 +35,7 @@ def test_simulator_min_tenure_integration():
         policy=policy,
     )
 
-    # Expect first hire to be A; and C (worst) should not be fired until tenure reaches threshold when it gets hired later.
+    # Expected behavior: A should be hired first due to best performance. C (worst) should not be fired until it has been held for at least min_tenure_n periods after being hired.
     # Since top_k=1 and max_active=2, initially A should be the only active.
     first_weights = res.weights[res.dates[0]]
     assert "A" in first_weights.index

--- a/tests/app/test_sim_min_tenure_integration.py
+++ b/tests/app/test_sim_min_tenure_integration.py
@@ -1,0 +1,43 @@
+import pandas as pd
+
+from trend_portfolio_app.sim_runner import Simulator
+from trend_portfolio_app.policy_engine import PolicyConfig, MetricSpec
+
+
+def test_simulator_min_tenure_integration():
+    # Build a small dataset with clear ranking: A best, B mid, C worst
+    dates = pd.period_range("2020-01", "2020-06", freq="M").to_timestamp("M")
+    data = pd.DataFrame(
+        {
+            "A": [0.05, 0.05, 0.05, 0.05, 0.05, -0.10],
+            "B": [0.02, 0.02, 0.02, 0.02, 0.02, 0.00],
+            "C": [-0.02, -0.02, -0.02, -0.02, -0.02, -0.20],
+        },
+        index=dates,
+    )
+
+    sim = Simulator(data)
+    policy = PolicyConfig(
+        top_k=1,
+        bottom_k=1,
+        cooldown_months=0,
+        min_track_months=0,
+        max_active=2,
+        min_tenure_n=2,
+        metrics=[MetricSpec("sharpe", 1.0)],
+    )
+
+    res = sim.run(
+        start=dates[0],
+        end=dates[-2],  # stop before last to focus on steady state
+        freq="m",
+        lookback_months=3,
+        policy=policy,
+    )
+
+    # Expect first hire to be A; and C (worst) should not be fired until tenure reaches threshold when it gets hired later.
+    # Since top_k=1 and max_active=2, initially A should be the only active.
+    first_weights = res.weights[res.dates[0]]
+    assert "A" in first_weights.index
+    # Ensure the simulator ran without NaNs for the period reviewed
+    assert res.portfolio.notna().any()


### PR DESCRIPTION
Implements selection guard for minimum tenure and integrates tenure tracking in the simulator.\n\nHighlights:\n- PolicyConfig.min_tenure_n (disabled when 0).\n- decide_hires_fires enforces bottom_k fires only when tenure >= n.\n- Simulator tracks per-manager tenure, resets on hire, increments when active.\n- Fixed pandas indexing for next-month returns and optional pipeline call typing.\n- Added unit test for policy and small integration test.\n\nValidation:\n- 250 tests passed locally.\n\nCloses #371.