### PR TITLE
feat: Rebalancing pipeline with Bayesian-only toggle

### DIFF
--- a/src/trend_portfolio_app/sim_runner.py
+++ b/src/trend_portfolio_app/sim_runner.py
@@ -417,5 +417,5 @@ def _apply_rebalance_pipeline(
 
     rb_state["since_last_reb"] = since_last
     # Final sanity: drop tiny weights
-    work = work.where(work.abs() > 1e-9, other=0.0)
+    work = work.where(work.abs() > EPS, other=0.0)
     return work

--- a/src/trend_portfolio_app/sim_runner.py
+++ b/src/trend_portfolio_app/sim_runner.py
@@ -145,7 +145,7 @@ class Simulator:
             m: 0 for m in self.df.columns if m != self.benchmark_col
         }
 
-        portfolio_returns: List[Tuple[pd.Timestamp, float]] = []
+        portfolio_returns: List[Tuple[Any, float]] = []
         # Rebalance state: track timing and risk stats
         rb_cfg: Dict[str, Any] = dict(rebalance or {})
         rb_cfg.setdefault("bayesian_only", True)

--- a/src/trend_portfolio_app/sim_runner.py
+++ b/src/trend_portfolio_app/sim_runner.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Callable, Optional, Dict, List, Any, cast
+from typing import Callable, Optional, Dict, List, Any, cast, Tuple
 import importlib
 import pandas as pd
 import numpy as np
@@ -129,6 +129,7 @@ class Simulator:
         freq: str,
         lookback_months: int,
         policy: PolicyConfig,
+        rebalance: Optional[Dict[str, Any]] = None,
         progress_cb: Optional[Callable[[int, int], None]] = None,
     ) -> SimResult:
         review_dates = self._gen_review_dates(start, end, freq)
@@ -144,7 +145,16 @@ class Simulator:
             m: 0 for m in self.df.columns if m != self.benchmark_col
         }
 
-        portfolio_returns = []
+        portfolio_returns: List[Tuple[pd.Timestamp, float]] = []
+        # Rebalance state: track timing and risk stats
+        rb_cfg: Dict[str, Any] = dict(rebalance or {})
+        rb_cfg.setdefault("bayesian_only", True)
+        rb_state: Dict[str, Any] = {
+            "since_last_reb": 0,
+            "equity_curve": [],  # list of equity values up to current period
+        }
+
+        prev_w: pd.Series = pd.Series(dtype=float)
 
         for i, d in enumerate(review_dates):
             if progress_cb:
@@ -196,14 +206,28 @@ class Simulator:
                         Event(date=d, action="hire", manager=m, reason=reason)
                     )
 
+            # Target weights (from selection/weighting stage). For now, equal-weight.
             if active:
-                w = pd.Series(1.0 / len(active), index=active)
+                w_target = pd.Series(1.0 / len(active), index=active, dtype=float)
                 if policy.max_weight < 1.0:
-                    w = w.clip(upper=policy.max_weight)
-                    w = w / w.sum()
+                    w_target = w_target.clip(upper=policy.max_weight)
+                    w_target = w_target / max(w_target.sum(), 1e-12)
             else:
-                w = pd.Series(dtype=float)
-            weights_by_date[d] = w
+                w_target = pd.Series(dtype=float)
+
+            # Realize target via rebalancing pipeline
+            w_realized = _apply_rebalance_pipeline(
+                prev_weights=prev_w,
+                target_weights=w_target,
+                date=d,
+                rb_cfg=rb_cfg,
+                rb_state=rb_state,
+                policy=policy,
+            )
+
+            # Persist
+            weights_by_date[d] = w_realized
+            prev_w = w_realized
             # Update tenure counters after deciding holdings
             # Increment for currently active; reset for those not active
             current_set = set(active)
@@ -215,16 +239,26 @@ class Simulator:
 
             next_month = d + pd.offsets.MonthEnd(1)
             if next_month in self.df.index:
-                if len(w):
+                if len(prev_w):
                     row = self.df.loc[next_month]
-                    r_next = row.reindex(w.index).astype(float).fillna(0.0)
-                    weights_vec = w.astype(float).reindex(r_next.index).fillna(0.0)
+                    r_next = row.reindex(prev_w.index).astype(float).fillna(0.0)
+                    weights_vec = prev_w.astype(float).reindex(r_next.index).fillna(0.0)
                     port_r = float(np.dot(r_next.to_numpy(), weights_vec.to_numpy()))
                 else:
                     port_r = 0.0
             else:
                 port_r = np.nan
             portfolio_returns.append((next_month, port_r))
+
+            # Update equity curve for drawdown/vol in rb_state
+            try:
+                if not np.isnan(port_r):
+                    ec = rb_state.get("equity_curve", [])
+                    last = ec[-1] if ec else 1.0
+                    ec.append(last * (1.0 + float(port_r)))
+                    rb_state["equity_curve"] = ec
+            except Exception:
+                pass
 
             cooldowns.tick()
 
@@ -241,3 +275,161 @@ class Simulator:
 
 # Small epsilon to avoid divide-by-zero in IR calculations
 EPS = 1e-12
+
+
+def _apply_rebalance_pipeline(
+    *,
+    prev_weights: pd.Series,
+    target_weights: pd.Series,
+    date: pd.Timestamp,
+    rb_cfg: Dict[str, Any],
+    rb_state: Dict[str, Any],
+    policy: PolicyConfig,
+) -> pd.Series:
+    """Apply rebalancing strategies in order to realize target weights.
+
+    Contract:
+    - Inputs: prev_weights (current holdings), target_weights (desired), date, rb_cfg (dict), rb_state (mutable), policy.
+    - Output: realized weights Series, index is union of prev/target; NaNs treated as 0.
+    - Side effects: updates rb_state keys such as since_last_reb and risk stats.
+    """
+    # Normalize inputs
+    pw = prev_weights.astype(float).copy()
+    tw = target_weights.astype(float).copy()
+    pw = pw[pw != 0.0]
+    tw = tw[tw != 0.0]
+    all_idx = list(dict.fromkeys(list(pw.index) + list(tw.index)))
+    pw = pw.reindex(all_idx).fillna(0.0)
+    tw = tw.reindex(all_idx).fillna(0.0)
+
+    # If bayesian_only toggle: pass-through target
+    if bool(rb_cfg.get("bayesian_only", True)):
+        rb_state["since_last_reb"] = 0
+        return tw
+    # If no previous holdings, adopt target immediately
+    if pw.empty:
+        rb_state["since_last_reb"] = 0
+        return tw
+
+    # Strategy order and params
+    strategies: List[str] = list(rb_cfg.get("strategies", ["drift_band"]))
+    params: Dict[str, Any] = dict(rb_cfg.get("params", {}))
+
+    work = pw.copy()
+
+    # Helper to cap weights and normalise
+    def _cap_and_norm(s: pd.Series, gross: Optional[float] = None) -> pd.Series:
+        out = s.clip(lower=0.0)
+        if policy.max_weight < 1.0 and policy.max_weight > 0.0:
+            out = out.clip(upper=float(policy.max_weight))
+        total = float(out.sum())
+        target_sum = float(gross if gross is not None else (1.0 if len(out) else 0.0))
+        if total > EPS and target_sum > 0.0:
+            out = out * (target_sum / total)
+        return out
+
+    # Track gross to preserve unless a full rebalance happens
+    gross_prev = float(max(pw.sum(), 0.0))
+    since_last = int(rb_state.get("since_last_reb", 0))
+    full_rebalanced = False
+
+    for name in strategies:
+        if name == "periodic_rebalance":
+            cfg = params.get("periodic_rebalance", {})
+            interval = int(cfg.get("interval", 1))
+            if interval <= 1 or since_last + 1 >= interval:
+                work = tw.copy()
+                since_last = 0
+                full_rebalanced = True
+            else:
+                # Skip rebalancing this period
+                since_last += 1
+        elif name == "drift_band":
+            cfg = params.get("drift_band", {})
+            band = float(cfg.get("band_pct", 0.03))
+            min_trade = float(cfg.get("min_trade", 0.005))
+            mode = str(cfg.get("mode", "partial"))
+            delta = tw - work
+            adjust = pd.Series(0.0, index=delta.index)
+            for k, dv in delta.items():
+                if abs(dv) <= band:
+                    continue
+                if mode == "partial":
+                    # Move halfway back into band boundary
+                    step = np.sign(dv) * max(abs(dv) - band, 0.0)
+                else:  # full
+                    step = dv
+                if abs(step) >= min_trade:
+                    adjust[k] = step
+            work = _cap_and_norm(work + adjust, gross=gross_prev)
+        elif name == "turnover_cap":
+            cfg = params.get("turnover_cap", {})
+            max_to = float(cfg.get("max_turnover", 0.20))
+            priority = str(cfg.get("priority", "largest_gap"))
+            candidate = tw.copy() if full_rebalanced else work.copy()
+            gap = (candidate - work).abs().sort_values(ascending=False)
+            if gap.sum() <= max_to + 1e-9:
+                work = candidate
+            else:
+                # Allocate turnover budget starting with largest gaps
+                remaining = max_to
+                alloc = work.copy()
+                order = gap.index.tolist()
+                if priority == "largest_gap":
+                    pass  # already sorted
+                for k in order:
+                    cand_v = float(candidate.get(k, 0.0))
+                    alloc_v = float(alloc.get(k, 0.0))
+                    need = float(cand_v - alloc_v)
+                    step = float(np.sign(need) * min(abs(need), remaining))
+                    if remaining <= 1e-12:
+                        break
+                    alloc[k] = float(alloc_v + step)
+                    remaining -= abs(step)
+                work = _cap_and_norm(alloc, gross=gross_prev)
+        elif name == "vol_target_rebalance":
+            cfg = params.get("vol_target_rebalance", {})
+            target_vol = float(cfg.get("target", 0.10))
+            lev_min = float(cfg.get("lev_min", 0.5))
+            lev_max = float(cfg.get("lev_max", 1.5))
+            window = int(cfg.get("window", 6))
+            # Estimate realized vol from rb_state equity_curve
+            ec: List[float] = list(rb_state.get("equity_curve", []))
+            if len(ec) >= window + 1:
+                # Compute past window simple returns from equity
+                rets = pd.Series(np.diff(ec[-(window + 1) :]) / ec[-(window + 1) : -1])
+                vol = float(rets.std(ddof=0)) * np.sqrt(12)
+                if vol > 0:
+                    lev = float(np.clip(target_vol / vol, lev_min, lev_max))
+                    work = work * lev
+        elif name == "drawdown_guard":
+            cfg = params.get("drawdown_guard", {})
+            dd_win = int(cfg.get("dd_window", 12))
+            dd_th = float(cfg.get("dd_threshold", 0.10))
+            guard_mult = float(cfg.get("guard_multiplier", 0.5))
+            recover = float(cfg.get("recover_threshold", 0.05))
+            ec: List[float] = list(rb_state.get("equity_curve", []))
+            guard_on = bool(rb_state.get("guard_on", False))
+            dd = 0.0
+            if len(ec) >= 1:
+                # Use trailing window if available
+                sub = ec[-dd_win:] if len(ec) >= dd_win else ec
+                peak = max(sub)
+                cur = sub[-1]
+                if peak > 0:
+                    dd = (cur / peak) - 1.0
+            if (not guard_on and dd <= -dd_th) or (guard_on and dd <= -recover):
+                guard_on = True
+            elif guard_on and dd >= -recover:
+                guard_on = False
+            rb_state["guard_on"] = guard_on
+            if guard_on:
+                work = work * guard_mult
+        else:
+            # Unknown strategy: skip (forward-compat)
+            continue
+
+    rb_state["since_last_reb"] = since_last
+    # Final sanity: drop tiny weights
+    work = work.where(work.abs() > 1e-9, other=0.0)
+    return work

--- a/src/trend_portfolio_app/sim_runner.py
+++ b/src/trend_portfolio_app/sim_runner.py
@@ -211,7 +211,7 @@ class Simulator:
                 w_target = pd.Series(1.0 / len(active), index=active, dtype=float)
                 if policy.max_weight < 1.0:
                     w_target = w_target.clip(upper=policy.max_weight)
-                    w_target = w_target / max(w_target.sum(), 1e-12)
+                    w_target = w_target / max(w_target.sum(), EPS)
             else:
                 w_target = pd.Series(dtype=float)
 

--- a/src/trend_portfolio_app/sim_runner.py
+++ b/src/trend_portfolio_app/sim_runner.py
@@ -324,7 +324,7 @@ def _apply_rebalance_pipeline(
             out = out.clip(upper=float(policy.max_weight))
         total = float(out.sum())
         target_sum = float(gross if gross is not None else (1.0 if len(out) else 0.0))
-        if total > EPS and target_sum > 0.0:
+        if total > EPS and target_sum > EPS:
             out = out * (target_sum / total)
         return out
 

--- a/streamlit_app/pages/2_Configure.py
+++ b/streamlit_app/pages/2_Configure.py
@@ -71,6 +71,8 @@ st.session_state["sim_config"] = {
     "benchmark": None if benchmark == "<none>" else benchmark,
     "cash_rate": float(cash_rate),
     "policy": policy.dict(),
+    # Minimal rebalance config; UI for detailed strategies lives in the main app
+    "rebalance": {"bayesian_only": True, "strategies": ["drift_band"], "params": {}},
 }
 
 st.success("Configuration saved. Proceed to Run.")

--- a/streamlit_app/pages/3_Run.py
+++ b/streamlit_app/pages/3_Run.py
@@ -24,7 +24,7 @@ results = sim.run(
     rebalance=cfg.get("rebalance", {}),
     progress_cb=lambda i, n: (
         progress.progress(int(100 * i / n), text=f"Running period {i}/{n}") and None
-    ),
+    progress_cb=lambda i, n: progress.progress(int(100 * i / n), text=f"Running period {i}/{n}"),
 )
 
 st.session_state["sim_results"] = results

--- a/streamlit_app/pages/3_Run.py
+++ b/streamlit_app/pages/3_Run.py
@@ -21,8 +21,9 @@ results = sim.run(
     freq=cfg["freq"],
     lookback_months=cfg["lookback_months"],
     policy=policy,
-    progress_cb=lambda i, n: progress.progress(
-        int(100 * i / n), text=f"Running period {i}/{n}"
+    rebalance=cfg.get("rebalance", {}),
+    progress_cb=lambda i, n: (
+        progress.progress(int(100 * i / n), text=f"Running period {i}/{n}") and None
     ),
 )
 

--- a/tests/app/test_rebalance_pipeline.py
+++ b/tests/app/test_rebalance_pipeline.py
@@ -77,3 +77,91 @@ def test_drift_band_partial_adjusts():
     )
     assert out["A"] > prev["A"] and out["A"] < target["A"]
     assert pytest.approx(out.sum(), rel=0, abs=1e-9) == 1.0
+
+
+def test_turnover_cap_limits_moves():
+    prev = pd.Series({"A": 0.50, "B": 0.50}, dtype=float)
+    target = pd.Series({"A": 0.80, "B": 0.20}, dtype=float)
+    rb_cfg = {
+        "bayesian_only": False,
+        "strategies": ["turnover_cap"],
+        "params": {"turnover_cap": {"max_turnover": 0.10, "priority": "largest_gap"}},
+    }
+    rb_state = {}
+    out = _apply_rebalance_pipeline(
+        prev_weights=prev,
+        target_weights=target,
+        date=pd.Timestamp("2020-01-31"),
+        rb_cfg=rb_cfg,
+        rb_state=rb_state,
+        policy=_pc(),
+    )
+    # Sum of absolute trades should be close to 0.10
+    trn = float((out - prev).abs().sum())
+    assert trn == pytest.approx(0.10, abs=1e-6)
+    # Move should be in the correct direction
+    assert out["A"] > prev["A"]
+    assert out["B"] < prev["B"]
+
+
+def test_vol_target_scales_within_bounds():
+    prev = pd.Series({"A": 0.50, "B": 0.50}, dtype=float)
+    target = pd.Series({"A": 0.50, "B": 0.50}, dtype=float)
+    rb_cfg = {
+        "bayesian_only": False,
+        "strategies": ["vol_target_rebalance"],
+        "params": {
+            "vol_target_rebalance": {
+                "target": 0.10,
+                "window": 6,
+                "lev_min": 0.8,
+                "lev_max": 1.2,
+            }
+        },
+    }
+    # Craft an equity curve with high realized vol so lev factor clamps to lev_min
+    ec = [1.0]
+    for r in [0.05, -0.04, 0.06, -0.05, 0.04, -0.03, 0.05]:
+        ec.append(ec[-1] * (1.0 + r))
+    rb_state = {"equity_curve": ec}
+    out = _apply_rebalance_pipeline(
+        prev_weights=prev,
+        target_weights=target,
+        date=pd.Timestamp("2020-07-31"),
+        rb_cfg=rb_cfg,
+        rb_state=rb_state,
+        policy=_pc(),
+    )
+    # Gross should be within lev bounds [0.8, 1.2]
+    gross = float(out.sum())
+    assert 0.8 - 1e-6 <= gross <= 1.2 + 1e-6
+
+
+def test_drawdown_guard_reduces_exposure_on_dd():
+    prev = pd.Series({"A": 0.60, "B": 0.40}, dtype=float)
+    target = pd.Series({"A": 0.60, "B": 0.40}, dtype=float)
+    rb_cfg = {
+        "bayesian_only": False,
+        "strategies": ["drawdown_guard"],
+        "params": {
+            "drawdown_guard": {
+                "dd_window": 5,
+                "dd_threshold": 0.10,
+                "guard_multiplier": 0.5,
+                "recover_threshold": 0.05,
+            }
+        },
+    }
+    # Equity curve experiencing a ~-15% drawdown
+    ec = [1.0, 1.02, 0.98, 0.95, 0.90, 0.88]
+    rb_state = {"equity_curve": ec}
+    out = _apply_rebalance_pipeline(
+        prev_weights=prev,
+        target_weights=target,
+        date=pd.Timestamp("2020-06-30"),
+        rb_cfg=rb_cfg,
+        rb_state=rb_state,
+        policy=_pc(),
+    )
+    # Exposure should be reduced by guard_multiplier (approx half gross)
+    assert float(out.sum()) == pytest.approx(0.5, abs=1e-6)

--- a/tests/app/test_rebalance_pipeline.py
+++ b/tests/app/test_rebalance_pipeline.py
@@ -1,0 +1,79 @@
+import pytest
+import pandas as pd
+from trend_portfolio_app.sim_runner import _apply_rebalance_pipeline
+from trend_portfolio_app.policy_engine import PolicyConfig
+
+
+def _pc() -> PolicyConfig:
+    return PolicyConfig(max_weight=1.0)
+
+
+def test_bayesian_only_passthrough():
+    prev = pd.Series({"A": 0.6, "B": 0.4}, dtype=float)
+    target = pd.Series({"A": 0.2, "B": 0.8}, dtype=float)
+    rb_cfg = {"bayesian_only": True}
+    rb_state = {}
+    out = _apply_rebalance_pipeline(
+        prev_weights=prev,
+        target_weights=target,
+        date=pd.Timestamp("2020-01-31"),
+        rb_cfg=rb_cfg,
+        rb_state=rb_state,
+        policy=_pc(),
+    )
+    # Should equal target
+    pd.testing.assert_series_equal(out.sort_index(), target.sort_index())
+
+
+def test_periodic_rebalance_every_two():
+    prev = pd.Series({"A": 0.5, "B": 0.5}, dtype=float)
+    target = pd.Series({"A": 0.0, "B": 1.0}, dtype=float)
+    rb_cfg = {
+        "bayesian_only": False,
+        "strategies": ["periodic_rebalance"],
+        "params": {"periodic_rebalance": {"interval": 2}},
+    }
+    rb_state = {"since_last_reb": 0}
+    # First call: interval condition not met yet, so no rebalance
+    out1 = _apply_rebalance_pipeline(
+        prev_weights=prev,
+        target_weights=target,
+        date=pd.Timestamp("2020-01-31"),
+        rb_cfg=rb_cfg,
+        rb_state=rb_state,
+        policy=_pc(),
+    )
+    pd.testing.assert_series_equal(out1.sort_index(), prev.sort_index())
+    # Second call: should now rebalance to target
+    out2 = _apply_rebalance_pipeline(
+        prev_weights=out1,
+        target_weights=target,
+        date=pd.Timestamp("2020-02-29"),
+        rb_cfg=rb_cfg,
+        rb_state=rb_state,
+        policy=_pc(),
+    )
+    pd.testing.assert_series_equal(out2.sort_index(), target.sort_index())
+
+
+def test_drift_band_partial_adjusts():
+    prev = pd.Series({"A": 0.50, "B": 0.50}, dtype=float)
+    target = pd.Series({"A": 0.60, "B": 0.40}, dtype=float)
+    rb_cfg = {
+        "bayesian_only": False,
+        "strategies": ["drift_band"],
+        "params": {
+            "drift_band": {"band_pct": 0.03, "min_trade": 0.001, "mode": "partial"}
+        },
+    }
+    rb_state = {}
+    out = _apply_rebalance_pipeline(
+        prev_weights=prev,
+        target_weights=target,
+        date=pd.Timestamp("2020-01-31"),
+        rb_cfg=rb_cfg,
+        rb_state=rb_state,
+        policy=_pc(),
+    )
+    assert out["A"] > prev["A"] and out["A"] < target["A"]
+    assert pytest.approx(out.sum(), rel=0, abs=1e-9) == 1.0


### PR DESCRIPTION
Implements #375.\n\n- Adds bayesian_only toggle and ordered non-Bayesian strategies: periodic_rebalance, drift_band, turnover_cap, vol_target_rebalance, drawdown_guard.\n- Integrates pipeline into Simulator.run with rb_state for last-rebalance and risk stats.\n- Wires Streamlit Configure/Run pages to pass rebalance config.\n- Adds unit tests for pipeline behavior.\n\nCloses #375