### PR TITLE
feat(app): add results page with core charts

### DIFF
--- a/app/streamlit/pages/04_Results.py
+++ b/app/streamlit/pages/04_Results.py
@@ -1,0 +1,105 @@
+"""Results visualisation page for the Streamlit app."""
+
+from __future__ import annotations
+
+import io
+
+import streamlit as st
+
+from trend_analysis.viz import charts
+from trend_analysis.metrics import summary
+
+
+st.title("Results")
+
+if "sim_results" not in st.session_state:
+    st.error("Run a simulation first.")
+    st.stop()
+
+res = st.session_state["sim_results"]
+returns = res.portfolio
+benchmark = getattr(res, "benchmark", None)
+weights = getattr(res, "weights", {})
+
+# ---------------------------------------------------------------------------
+# Core charts
+# ---------------------------------------------------------------------------
+c1, c2 = st.columns(2)
+with c1:
+    st.subheader("Equity curve")
+    ec_df = charts.equity_curve(returns)
+    st.line_chart(ec_df)
+    buf = io.StringIO()
+    ec_df.to_csv(buf)
+    st.download_button(
+        "Equity curve (CSV)",
+        data=buf.getvalue(),
+        file_name="equity_curve.csv",
+        mime="text/csv",
+    )
+with c2:
+    st.subheader("Drawdown")
+    dd_df = charts.drawdown_curve(returns)
+    st.line_chart(dd_df)
+    buf = io.StringIO()
+    dd_df.to_csv(buf)
+    st.download_button(
+        "Drawdown (CSV)",
+        data=buf.getvalue(),
+        file_name="drawdown_curve.csv",
+        mime="text/csv",
+    )
+
+c3, c4 = st.columns(2)
+with c3:
+    st.subheader("Rolling info ratio")
+    ir_df = charts.rolling_information_ratio(returns, benchmark)
+    st.line_chart(ir_df)
+    buf = io.StringIO()
+    ir_df.to_csv(buf)
+    st.download_button(
+        "Rolling IR (CSV)",
+        data=buf.getvalue(),
+        file_name="rolling_ir.csv",
+        mime="text/csv",
+    )
+with c4:
+    st.subheader("Turnover")
+    to_df = charts.turnover_series(weights)
+    st.line_chart(to_df)
+    buf = io.StringIO()
+    to_df.to_csv(buf)
+    st.download_button(
+        "Turnover (CSV)",
+        data=buf.getvalue(),
+        file_name="turnover.csv",
+        mime="text/csv",
+    )
+
+st.subheader("Portfolio weights")
+w_df = charts.weights_heatmap_data(weights)
+st.dataframe(w_df.style.background_gradient(cmap="viridis"))
+buf = io.StringIO()
+w_df.to_csv(buf)
+st.download_button(
+    "Weights (CSV)",
+    data=buf.getvalue(),
+    file_name="weights.csv",
+    mime="text/csv",
+)
+
+# ---------------------------------------------------------------------------
+# Summary table
+# ---------------------------------------------------------------------------
+st.subheader("Summary")
+sum_df = summary.summary_table(returns, weights, benchmark)
+st.table(sum_df)
+buf = io.StringIO()
+sum_df.to_csv(buf)
+st.download_button(
+    "Summary (CSV)",
+    data=buf.getvalue(),
+    file_name="summary.csv",
+    mime="text/csv",
+)
+

--- a/src/trend_analysis/metrics/__init__.py
+++ b/src/trend_analysis/metrics/__init__.py
@@ -293,3 +293,6 @@ sys.modules.setdefault("tests.legacy_metrics", _legacy)
 
 setattr(_bi, "annualize_return", annualize_return)
 setattr(_bi, "annualize_volatility", annualize_volatility)
+
+# Public submodule to expose summary helpers
+from . import summary  # noqa: F401

--- a/src/trend_analysis/metrics/summary.py
+++ b/src/trend_analysis/metrics/summary.py
@@ -1,0 +1,50 @@
+"""Summary metrics for simulation results."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+import pandas as pd
+
+from . import (
+    annual_return,
+    volatility,
+    max_drawdown,
+    information_ratio,
+    sharpe_ratio,
+)
+from ..viz.charts import turnover_series
+
+
+def summary_table(
+    returns: pd.Series,
+    weights: Mapping[pd.Timestamp, pd.Series] | pd.DataFrame,
+    benchmark: pd.Series | float | None = None,
+    periods_per_year: int = 12,
+) -> pd.DataFrame:
+    """Return a one-column DataFrame of core performance statistics."""
+
+    bench = 0.0 if benchmark is None else benchmark
+
+    cagr = annual_return(returns, periods_per_year=periods_per_year)
+    vol = volatility(returns, periods_per_year=periods_per_year)
+    mdd = max_drawdown(returns)
+    ir = information_ratio(returns, bench, periods_per_year=periods_per_year)
+    sharpe = sharpe_ratio(returns, risk_free=0.0, periods_per_year=periods_per_year)
+    turn = float(turnover_series(weights)["turnover"].mean())
+    hit_rate = float((returns > 0).mean())
+
+    data = {
+        "CAGR": float(cagr),
+        "vol": float(vol),
+        "max_drawdown": float(mdd),
+        "information_ratio": float(ir),
+        "sharpe": float(sharpe),
+        "turnover": float(turn),
+        "hit_rate": float(hit_rate),
+    }
+    return pd.DataFrame.from_dict(data, orient="index", columns=["value"])
+
+
+__all__ = ["summary_table"]
+

--- a/src/trend_analysis/viz/__init__.py
+++ b/src/trend_analysis/viz/__init__.py
@@ -1,0 +1,24 @@
+"""Chart helpers for Trend Analysis results pages.
+
+This module exposes small utilities that transform simulation outputs into
+dataframes ready for visualisation.  The helpers are intentionally lightweight
+so they can be reused outside of Streamlit and make it easy to export the
+underlying data.
+"""
+
+from .charts import (
+    equity_curve,
+    drawdown_curve,
+    rolling_information_ratio,
+    turnover_series,
+    weights_heatmap_data,
+)
+
+__all__ = [
+    "equity_curve",
+    "drawdown_curve",
+    "rolling_information_ratio",
+    "turnover_series",
+    "weights_heatmap_data",
+]
+

--- a/src/trend_analysis/viz/charts.py
+++ b/src/trend_analysis/viz/charts.py
@@ -1,0 +1,81 @@
+"""Compute chart data for simulation outputs."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+import pandas as pd
+
+
+def _weights_to_frame(
+    weights: Mapping[pd.Timestamp, pd.Series] | pd.DataFrame,
+) -> pd.DataFrame:
+    """Return weights history as a tidy DataFrame.
+
+    The input can be a mapping of dates to weight Series or an already
+    assembled DataFrame.  Missing values are filled with ``0.0`` and the
+    index is sorted to ensure chronological order.
+    """
+
+    if isinstance(weights, pd.DataFrame):
+        return weights.sort_index().fillna(0.0)
+    return (
+        pd.DataFrame({d: s for d, s in weights.items()})
+        .T.sort_index()
+        .fillna(0.0)
+    )
+
+
+def equity_curve(returns: pd.Series) -> pd.DataFrame:
+    """Return equity curve DataFrame from periodic returns."""
+
+    curve = (1.0 + returns.fillna(0.0)).cumprod()
+    return curve.to_frame("equity")
+
+
+def drawdown_curve(returns: pd.Series) -> pd.DataFrame:
+    """Return drawdown series derived from ``returns``."""
+
+    curve = (1.0 + returns.fillna(0.0)).cumprod()
+    dd = curve / curve.cummax() - 1.0
+    return dd.to_frame("drawdown")
+
+
+def rolling_information_ratio(
+    returns: pd.Series,
+    benchmark: pd.Series | float | None = None,
+    window: int = 12,
+) -> pd.DataFrame:
+    """Rolling information ratio over ``window`` periods."""
+
+    if benchmark is None:
+        bench = pd.Series(0.0, index=returns.index)
+    elif isinstance(benchmark, pd.Series):
+        bench = benchmark.reindex_like(returns).fillna(0.0)
+    else:
+        bench = pd.Series(float(benchmark), index=returns.index)
+
+    excess = returns - bench
+    mean = excess.rolling(window).mean()
+    std = excess.rolling(window).std(ddof=0)
+    ir = mean / std.replace(0.0, pd.NA)
+    return ir.to_frame("rolling_ir")
+
+
+def turnover_series(
+    weights: Mapping[pd.Timestamp, pd.Series] | pd.DataFrame,
+) -> pd.DataFrame:
+    """Compute turnover series from weights history."""
+
+    w_df = _weights_to_frame(weights)
+    to = w_df.diff().abs().sum(axis=1)
+    return to.to_frame("turnover")
+
+
+def weights_heatmap_data(
+    weights: Mapping[pd.Timestamp, pd.Series] | pd.DataFrame,
+) -> pd.DataFrame:
+    """Return DataFrame suitable for a weights heatmap."""
+
+    return _weights_to_frame(weights)
+

--- a/tests/test_metrics_summary.py
+++ b/tests/test_metrics_summary.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import pytest
+
+from trend_analysis.metrics import summary
+
+
+def test_summary_table_snapshot() -> None:
+    returns = pd.Series(
+        [0.01, -0.02, 0.015],
+        index=pd.date_range("2020-01-31", periods=3, freq="M"),
+    )
+    weights = {
+        returns.index[0]: pd.Series({"A": 0.6, "B": 0.4}),
+        returns.index[1]: pd.Series({"A": 0.7, "B": 0.3}),
+        returns.index[2]: pd.Series({"A": 0.5, "B": 0.5}),
+    }
+    bench = pd.Series(0.0, index=returns.index)
+
+    out = summary.summary_table(returns, weights, benchmark=bench, periods_per_year=12)
+
+    assert out.loc["CAGR", "value"] == pytest.approx(0.01871797)
+    assert out.loc["vol", "value"] == pytest.approx(0.06557438)
+    assert out.loc["max_drawdown", "value"] == pytest.approx(0.02)
+    assert out.loc["information_ratio", "value"] == pytest.approx(0.30499714)
+    assert out.loc["sharpe", "value"] == pytest.approx(0.28544636)
+    assert out.loc["turnover", "value"] == pytest.approx(0.2)
+    assert out.loc["hit_rate", "value"] == pytest.approx(2 / 3)
+


### PR DESCRIPTION
## Summary
- add Streamlit results page with equity, drawdown, rolling IR, turnover, weights heatmap and summary table
- provide reusable chart utilities for equity curve, drawdown, rolling IR and turnover
- compute summary statistics including CAGR, vol, drawdown, IR, Sharpe, turnover and hit rate
- cover summary metrics with snapshot-style unit test

## Testing
- `./scripts/run_streamlit.sh --help`
- `PYTHONPATH=src pytest tests/test_metrics_summary.py -q`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b32e6ce75883319ed1bd08821b5e70