### PR TITLE
Add bundle export feature to Streamlit app

### DIFF
--- a/app/streamlit/pages/05_Export.py
+++ b/app/streamlit/pages/05_Export.py
@@ -1,0 +1,29 @@
+"""Export bundle download page for the Streamlit app."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import streamlit as st
+
+from trend_analysis.export.bundle import export_bundle
+
+st.title("Export")
+
+if "sim_results" not in st.session_state or "sim_config" not in st.session_state:
+    st.error("Run a simulation first.")
+    st.stop()
+
+run = st.session_state["sim_results"]
+# attach config and seed if available
+setattr(run, "config", st.session_state.get("sim_config", {}))
+setattr(run, "seed", st.session_state.get("seed", None))
+
+# Create bundle on demand and offer download
+if st.button("Create bundle"):
+    tmpdir = Path(tempfile.mkdtemp())
+    zip_path = tmpdir / "analysis_bundle.zip"
+    export_bundle(run, zip_path)
+    with open(zip_path, "rb") as f:
+        st.download_button("Download bundle", f, file_name=zip_path.name)

--- a/src/trend_analysis/__init__.py
+++ b/src/trend_analysis/__init__.py
@@ -19,6 +19,7 @@ from .export import (
     export_phase1_workbook,
     export_phase1_multi_metrics,
     export_multi_period_metrics,
+    export_bundle,
 )
 
 # Expose multi-period CLI
@@ -50,5 +51,6 @@ __all__ = [
     "export_phase1_workbook",
     "export_phase1_multi_metrics",
     "export_multi_period_metrics",
+    "export_bundle",
     "run_multi_analysis",
 ]

--- a/src/trend_analysis/export/__init__.py
+++ b/src/trend_analysis/export/__init__.py
@@ -10,6 +10,8 @@ import inspect
 import pandas as pd
 import numpy as np
 
+from .bundle import export_bundle
+
 Formatter = Callable[[pd.DataFrame], pd.DataFrame]
 
 
@@ -454,7 +456,7 @@ EXPORTERS: dict[
 
 def metrics_from_result(res: Mapping[str, object]) -> pd.DataFrame:
     """Return a metrics DataFrame identical to :func:`pipeline.run` output."""
-    from .pipeline import _Stats  # lazy import to avoid cycle
+    from ..pipeline import _Stats  # lazy import to avoid cycle
 
     stats = cast(Mapping[str, _Stats], res.get("out_sample_stats", {}))
     df = pd.DataFrame({k: vars(v) for k, v in stats.items()}).T
@@ -475,7 +477,7 @@ def metrics_from_result(res: Mapping[str, object]) -> pd.DataFrame:
 def summary_frame_from_result(res: Mapping[str, object]) -> pd.DataFrame:
     """Return a DataFrame mirroring the Phase-1 summary table."""
 
-    from .pipeline import _Stats  # lazy import to avoid cycle
+    from ..pipeline import _Stats  # lazy import to avoid cycle
 
     def to_tuple(obj: Any) -> tuple[float, float, float, float, float, float]:
         if isinstance(obj, tuple):
@@ -549,7 +551,7 @@ def combined_summary_result(
 
     from collections import defaultdict
 
-    from .pipeline import _compute_stats, calc_portfolio_returns
+    from ..pipeline import _compute_stats, calc_portfolio_returns
 
     fund_in: dict[str, list[pd.Series]] = defaultdict(list)
     fund_out: dict[str, list[pd.Series]] = defaultdict(list)
@@ -1098,4 +1100,5 @@ __all__ = [
     "export_phase1_workbook",
     "export_phase1_multi_metrics",
     "export_multi_period_metrics",
+    "export_bundle",
 ]

--- a/src/trend_analysis/export/bundle.py
+++ b/src/trend_analysis/export/bundle.py
@@ -74,7 +74,7 @@ def export_bundle(run: Any, path: Path) -> Path:
     # ------------------------------------------------------------------
     # Charts PNGs
     # ------------------------------------------------------------------
-    eq = (1 + pd.Series(portfolio).fillna(0)).cumprod()
+    eq = (1 + portfolio.fillna(0)).cumprod()
     fig, ax = plt.subplots()
     eq.plot(ax=ax)
     ax.set_title("Equity Curve")

--- a/src/trend_analysis/export/bundle.py
+++ b/src/trend_analysis/export/bundle.py
@@ -59,7 +59,10 @@ def export_bundle(run: Any, path: Path) -> Path:
     # ------------------------------------------------------------------
     # Results CSVs
     # ------------------------------------------------------------------
-    portfolio = getattr(run, "portfolio")
+    try:
+        portfolio = getattr(run, "portfolio")
+    except AttributeError:
+        raise ValueError("The 'portfolio' attribute is required for bundle creation but was not found in the provided 'run' object.")
     portfolio.to_csv(results_dir / "portfolio.csv", header=["return"])
     benchmark = getattr(run, "benchmark", None)
     if benchmark is not None:

--- a/src/trend_analysis/export/bundle.py
+++ b/src/trend_analysis/export/bundle.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+import json
+import datetime as _dt
+import hashlib
+import os
+import zipfile
+import subprocess
+import sys
+
+import pandas as pd
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _git_hash() -> str:
+    try:
+        return (
+            subprocess.check_output(["git", "rev-parse", "HEAD"], encoding="utf-8")
+            .strip()
+        )
+    except Exception:
+        return ""
+
+
+def export_bundle(run: Any, path: Path) -> Path:
+    """Write a zipped analysis bundle.
+
+    Parameters
+    ----------
+    run : Any
+        Object carrying at least a ``portfolio`` Series and optional
+        ``benchmark``, ``weights``, ``config``, ``seed`` and ``input_path``
+        attributes.
+    path : Path
+        Location of the resulting ``.zip`` file.
+    """
+
+    path = Path(path)
+    bundle_dir = path.with_suffix("")
+    results_dir = bundle_dir / "results"
+    charts_dir = bundle_dir / "charts"
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    results_dir.mkdir(exist_ok=True)
+    charts_dir.mkdir(exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Results CSVs
+    # ------------------------------------------------------------------
+    portfolio = getattr(run, "portfolio")
+    portfolio.to_csv(results_dir / "portfolio.csv", header=["return"])
+    benchmark = getattr(run, "benchmark", None)
+    if benchmark is not None:
+        pd.Series(benchmark).to_csv(results_dir / "benchmark.csv", header=["return"])
+    weights = getattr(run, "weights", None)
+    if weights is not None:
+        pd.DataFrame(weights).to_csv(results_dir / "weights.csv")
+
+    # ------------------------------------------------------------------
+    # Charts PNGs
+    # ------------------------------------------------------------------
+    eq = (1 + pd.Series(portfolio).fillna(0)).cumprod()
+    fig, ax = plt.subplots()
+    eq.plot(ax=ax)
+    ax.set_title("Equity Curve")
+    fig.savefig(charts_dir / "equity_curve.png")
+    plt.close(fig)
+
+    dd = eq / eq.cummax() - 1
+    fig, ax = plt.subplots()
+    dd.plot(ax=ax)
+    ax.set_title("Drawdown")
+    fig.savefig(charts_dir / "drawdown.png")
+    plt.close(fig)
+
+    # ------------------------------------------------------------------
+    # Summary workbook
+    # ------------------------------------------------------------------
+    summary = {}
+    summ_fn = getattr(run, "summary", None)
+    if callable(summ_fn):
+        summary = summ_fn()
+    else:
+        summary = {"total_return": float(portfolio.sum())}
+    pd.DataFrame([summary]).to_excel(bundle_dir / "summary.xlsx", index=False)
+
+    # ------------------------------------------------------------------
+    # Metadata manifest
+    # ------------------------------------------------------------------
+    meta = {
+        "config": getattr(run, "config", {}),
+        "seed": getattr(run, "seed", None),
+        "versions": {
+            "python": sys.version.split()[0],
+        },
+        "git_hash": _git_hash(),
+        "receipt": {"created": _dt.datetime.utcnow().isoformat() + "Z"},
+    }
+    try:
+        import importlib.metadata as _ilmd
+
+        meta["versions"]["trend_analysis"] = _ilmd.version("trend-analysis")
+    except Exception:
+        meta["versions"]["trend_analysis"] = "0"
+
+    input_path = Path(getattr(run, "input_path", ""))
+    if input_path and input_path.exists():
+        meta["input_sha256"] = _sha256_file(input_path)
+    else:
+        meta["input_sha256"] = None
+
+    with open(bundle_dir / "run_meta.json", "w", encoding="utf-8") as f:
+        json.dump(meta, f, indent=2)
+
+    # ------------------------------------------------------------------
+    # README
+    # ------------------------------------------------------------------
+    with open(bundle_dir / "README.txt", "w", encoding="utf-8") as f:
+        f.write("Trend analysis bundle\n")
+
+    # ------------------------------------------------------------------
+    # Zip everything
+    # ------------------------------------------------------------------
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+        for root, _, files in os.walk(bundle_dir):
+            for name in files:
+                fp = Path(root) / name
+                z.write(fp, fp.relative_to(bundle_dir))
+    return path

--- a/tests/test_export_bundle.py
+++ b/tests/test_export_bundle.py
@@ -1,0 +1,53 @@
+import json
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+import pandas as pd
+
+from trend_analysis.export.bundle import export_bundle
+
+
+def _write_input(tmp_path: Path) -> Path:
+    p = tmp_path / "input.csv"
+    p.write_text("x\n1\n")
+    return p
+
+
+@dataclass
+class DummyRun:
+    portfolio: pd.Series
+    config: dict
+    seed: int
+    input_path: Path
+
+    def summary(self):
+        return {"total_return": float(self.portfolio.sum())}
+
+
+def test_export_bundle(tmp_path):
+    input_path = _write_input(tmp_path)
+    run = DummyRun(
+        portfolio=pd.Series([0.01, -0.02], index=pd.date_range("2020-01", periods=2, freq="M")),
+        config={"foo": 1},
+        seed=42,
+        input_path=input_path,
+    )
+    out = tmp_path / "bundle.zip"
+    export_bundle(run, out)
+    assert out.exists()
+
+    with zipfile.ZipFile(out) as z:
+        names = set(z.namelist())
+        assert "results/portfolio.csv" in names
+        assert "charts/equity_curve.png" in names
+        assert "summary.xlsx" in names
+        assert "run_meta.json" in names
+        assert "README.txt" in names
+        with z.open("run_meta.json") as f:
+            meta = json.load(f)
+    assert meta["config"] == {"foo": 1}
+    assert meta["seed"] == 42
+    assert "python" in meta["versions"]
+    assert len(meta.get("git_hash", "")) >= 7
+    assert meta["input_sha256"] is not None
+    assert "created" in meta["receipt"]


### PR DESCRIPTION
## Summary
- add `export_bundle` helper to package all run outputs into a ZIP with results, charts, summary workbook and metadata
- expose bundle download through new Streamlit export page
- cover bundle creation with unit test

## Testing
- `timeout 5 ./scripts/run_streamlit.sh --headless`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3368d26dc833196d6dbacfc2d663a