### PR TITLE
feat: add trend-model CLI entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,23 @@ For a beginner-friendly overview, see [docs/UserGuide.md](docs/UserGuide.md).
 Install the latest stable release from PyPI:
 
 ```bash
-pip install trend-analysis
+pip install trend-model
 ```
 
-This provides CLI commands:
+This provides the ``trend-model`` command with both GUI and pipeline modes:
+
 ```bash
-trend-analysis --help
-trend-multi-analysis --help
+trend-model run --help
+trend-model gui
+```
+
+### Via ``pipx``
+
+For an isolated installation without activating a virtual environment:
+
+```bash
+pipx install trend-model
+trend-model gui
 ```
 
 ### From Source
@@ -74,27 +84,16 @@ Replace `<patchfile>` with the patch you want to apply (for example `codex.patch
 
 ## Command-line usage
 
-You can also run the analysis pipeline directly from the command line. Invoke
-the entry point with an optional configuration file:
+The ``trend-model`` command wraps the pipeline and GUI. To run the analysis
+from a CSV file and YAML configuration:
 
 ```bash
-python -m trend_analysis.run_analysis -c path/to/config.yml
+trend-model run -c path/to/config.yml -i returns.csv
 ```
-This command invokes `main()` in `trend_analysis/run_analysis.py`.  That
-script loads the configuration via `trend_analysis.config.load()` and
-then runs the pipeline defined in `trend_analysis/pipeline.py`.
 
-The configuration file **must** define `data.csv_path` pointing to your CSV
-data. If ``-c`` is omitted, ``run_analysis`` loads
-`config/defaults.yml`, or the path set via the ``TREND_CFG`` environment
-variable:
-
-```bash
-TREND_CFG=custom.yml python -m trend_analysis.run_analysis
-```
-Here the environment variable ``TREND_CFG`` points the loader in
-``trend_analysis.config`` to your custom YAML file, ensuring the same
-``main()`` function from `run_analysis.py` uses your overrides.
+The configuration file **must** define `data.csv_path`, which is overridden by
+the ``-i`` option above. If ``-c`` is omitted, the defaults from
+`config/defaults.yml` or the ``TREND_CFG`` environment variable are used.
 
 
 ## Ranking-based selection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "trend-analysis"
+name = "trend-model"
 version = "0.1.0"
 description = "Volatility-adjusted trend analysis package"
 readme = "README.md"
@@ -43,6 +43,7 @@ Documentation = "https://github.com/stranske/Trend_Model_Project#readme"
 [project.scripts]
 trend-analysis = "trend_analysis.run_analysis:main"
 trend-multi-analysis = "trend_analysis.run_multi_analysis:main"
+trend-model = "trend_analysis.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -1,22 +1,92 @@
 from __future__ import annotations
 
 import argparse
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+
+from . import export, pipeline
 from .config import load
 
 
+APP_PATH = Path(__file__).resolve().parents[2] / "streamlit_app" / "app.py"
+
+
 def main(argv: list[str] | None = None) -> int:
-    """Simple command-line interface for loading configuration."""
-    parser = argparse.ArgumentParser(prog="trend-analysis")
-    parser.add_argument("-c", "--config", help="Path to YAML config")
-    parser.add_argument("--version", action="store_true", help="Print version and exit")
+    """Entry point for the ``trend-model`` command."""
+
+    parser = argparse.ArgumentParser(prog="trend-model")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("gui", help="Launch Streamlit interface")
+
+    run_p = sub.add_parser("run", help="Run analysis pipeline")
+    run_p.add_argument("-c", "--config", required=True, help="Path to YAML config")
+    run_p.add_argument("-i", "--input", required=True, help="Path to returns CSV")
+
     args = parser.parse_args(argv)
 
-    cfg = load(args.config)
-    if args.version:
-        print(cfg.version)
-    else:
-        print(cfg.model_dump_json())
-    return 0
+    if args.command == "gui":
+        result = subprocess.run(["streamlit", "run", str(APP_PATH)])
+        return result.returncode
+
+    if args.command == "run":
+        cfg = load(args.config)
+        cfg.data["csv_path"] = args.input
+
+        metrics_df = pipeline.run(cfg)
+        res = pipeline.run_full(cfg)
+        if not res:
+            print("No results")
+            return 0
+
+        split = cfg.sample_split
+        text = export.format_summary_text(
+            res,
+            str(split.get("in_start")),
+            str(split.get("in_end")),
+            str(split.get("out_start")),
+            str(split.get("out_end")),
+        )
+        print(text)
+
+        export_cfg = cfg.export
+        out_dir = export_cfg.get("directory")
+        out_formats = export_cfg.get("formats")
+        filename = export_cfg.get("filename", "analysis")
+        if not out_dir and not out_formats:
+            out_dir = "outputs"
+            out_formats = ["excel"]
+        if out_dir and out_formats:
+            data = {"metrics": metrics_df}
+            if any(f.lower() in {"excel", "xlsx"} for f in out_formats):
+                sheet_formatter = export.make_summary_formatter(
+                    res,
+                    str(split.get("in_start")),
+                    str(split.get("in_end")),
+                    str(split.get("out_start")),
+                    str(split.get("out_end")),
+                )
+                data["summary"] = pd.DataFrame()
+                export.export_to_excel(
+                    data,
+                    str(Path(out_dir) / f"{filename}.xlsx"),
+                    default_sheet_formatter=sheet_formatter,
+                )
+                other = [f for f in out_formats if f.lower() not in {"excel", "xlsx"}]
+                if other:
+                    export.export_data(
+                        data, str(Path(out_dir) / filename), formats=other
+                    )
+            else:
+                export.export_data(
+                    data, str(Path(out_dir) / filename), formats=out_formats
+                )
+        return 0
+
+    parser.print_help()
+    return 1
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation


### PR DESCRIPTION
## Summary
- expose new `trend-model` CLI with `run` and `gui` subcommands
- publish CLI through pyproject `console_scripts`
- document pipx installation and command usage

## Testing
- `./scripts/setup_env.sh`
- `python scripts/generate_demo.py`
- `python scripts/run_multi_demo.py` *(fails: ModuleNotFoundError: No module named 'trend_analysis')*
- `./scripts/run_tests.sh` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b340e5741083319a40481a3fbb72db