### PR TITLE
feat: add typed config loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "xlsxwriter",
     "openpyxl",
     "pydantic>=2",
+    "hypothesis",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ PyYAML
 types-PyYAML
 pytest-cov
 pytest
+hypothesis
 nbformat
 streamlit>=1.30
 streamlit-sortables

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pandas as pd
 
 from . import export, pipeline
-from .config.models import load
+from .config import load_config
 
 
 APP_PATH = Path(__file__).resolve().parents[2] / "streamlit_app" / "app.py"
@@ -32,7 +32,7 @@ def main(argv: list[str] | None = None) -> int:
         return result.returncode
 
     if args.command == "run":
-        cfg = load(args.config)
+        cfg = load_config(args.config)
         cfg.data["csv_path"] = args.input
 
         metrics_df = pipeline.run(cfg)

--- a/src/trend_analysis/config/__init__.py
+++ b/src/trend_analysis/config/__init__.py
@@ -7,6 +7,11 @@ from .models import (
     ConfigurationState,
     load_preset,
     list_available_presets,
+    Config,
+    load_config,
+    load,
+    DEFAULTS,
+    _find_config_directory,
 )
 
 __all__ = [
@@ -15,4 +20,9 @@ __all__ = [
     "ConfigurationState",
     "load_preset",
     "list_available_presets",
+    "Config",
+    "load_config",
+    "load",
+    "DEFAULTS",
+    "_find_config_directory",
 ]

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 from pathlib import Path
-from typing import Dict, List, Any, Optional, Union
+from typing import Dict, List, Any
 import os
 import yaml
+
+from pydantic import BaseModel, Field, ConfigDict, StrictStr
 
 
 # Simple BaseModel that works without pydantic
@@ -30,8 +32,10 @@ class SimpleBaseModel:
         """Validate the configuration."""
         pass
 
+
 class PresetConfig(SimpleBaseModel):
     """Configuration preset with validation."""
+
     def _get_defaults(self) -> Dict[str, Any]:
         return {
             "data": {},
@@ -43,6 +47,7 @@ class PresetConfig(SimpleBaseModel):
             "export": {},
             "run": {},
         }
+
     name: str
     description: str
     data: Dict[str, Any]
@@ -53,7 +58,6 @@ class PresetConfig(SimpleBaseModel):
     metrics: Dict[str, Any]
     export: Dict[str, Any]
     run: Dict[str, Any]
-
 
     def _validate(self) -> None:
         """Validate preset configuration."""
@@ -72,7 +76,7 @@ class ColumnMapping(SimpleBaseModel):
         risk_free_column: str | None = None,
         column_display_names: Dict[str, str] = None,
         column_tickers: Dict[str, str] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         if return_columns is None:
             return_columns = []
@@ -87,7 +91,7 @@ class ColumnMapping(SimpleBaseModel):
             risk_free_column=risk_free_column,
             column_display_names=column_display_names,
             column_tickers=column_tickers,
-            **kwargs
+            **kwargs,
         )
 
     def _get_defaults(self) -> Dict[str, Any]:
@@ -165,89 +169,53 @@ def list_available_presets() -> List[str]:
     return sorted(presets)
 
 
-# Add TYPE_CHECKING and BaseModel compatibility for pydantic-free environments
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
-
-if TYPE_CHECKING:  # pragma: no cover - mypy only
-
-    class BaseModel:
-        """Minimal subset of :class:`pydantic.BaseModel` for type checking."""
-        pass
-
-else:  # pragma: no cover - fallback when pydantic isn't installed during CI
-    try:  # pragma: no cover - runtime import
-        from pydantic import BaseModel as BaseModel
-    except Exception:  # pragma: no cover - simplified stub
-
-        class BaseModel:
-            """Runtime stub used when ``pydantic`` is unavailable."""
-            pass
-
-
 class Config(BaseModel):
     """Typed access to the YAML configuration."""
 
-    version: str
-    data: dict[str, Any]
-    preprocessing: dict[str, Any]
-    vol_adjust: dict[str, Any]
-    sample_split: dict[str, Any]
-    portfolio: dict[str, Any]
-    benchmarks: dict[str, str] = {}
-    metrics: dict[str, Any]
-    export: dict[str, Any]
-    output: dict[str, Any] | None = None
-    run: dict[str, Any]
+    model_config = ConfigDict(extra="forbid")
+
+    version: StrictStr
+    data: dict[str, Any] = Field(default_factory=dict)
+    preprocessing: dict[str, Any] = Field(default_factory=dict)
+    vol_adjust: dict[str, Any] = Field(default_factory=dict)
+    sample_split: dict[str, Any] = Field(default_factory=dict)
+    portfolio: dict[str, Any] = Field(default_factory=dict)
+    benchmarks: dict[str, str] = Field(default_factory=dict)
+    metrics: dict[str, Any] = Field(default_factory=dict)
+    export: dict[str, Any] = Field(default_factory=dict)
+    run: dict[str, Any] = Field(default_factory=dict)
     multi_period: dict[str, Any] | None = None
     jobs: int | None = None
     checkpoint_dir: str | None = None
     random_seed: int | None = None
 
-    def __init__(self, **data: Any) -> None:  # pragma: no cover - simple assign
-        """Populate attributes from ``data`` regardless of ``BaseModel``."""
-        super().__init__(**data)
-        for key, value in data.items():
-            setattr(self, key, value)
-
-    def model_dump_json(self) -> str:  # pragma: no cover - trivial
-        import json
-
-        return json.dumps(self.__dict__)
-
-    # Provide a lightweight ``dict`` representation for tests.
-    def model_dump(self) -> dict[str, Any]:  # pragma: no cover - trivial
-        return dict(self.__dict__)
-
 
 def _find_config_directory() -> Path:
     """Find config directory by searching up from current file.
-    
+
     This provides a more robust alternative to hardcoded parent navigation.
     Searches for a 'config' directory starting from the current file location
     and working up the directory tree, but skips the config package directory itself.
-    
+
     Returns:
         Path to the config directory
-        
+
     Raises:
         FileNotFoundError: If config directory cannot be found
     """
     current = Path(__file__).resolve()
     current_config_package = current.parent  # Skip the config package directory itself
-    
+
     # Search up the directory tree for a config directory
     for parent in current.parents:
         # Skip the config package directory itself
         if parent == current_config_package:
             continue
-            
+
         config_dir = parent / "config"
         if config_dir.is_dir() and (config_dir / "defaults.yml").exists():
             return config_dir
-    
+
     # Fallback: search all parent directories for a "config" directory with "defaults.yml"
     for parent in current.parents:
         config_dir = parent / "config"
@@ -262,21 +230,42 @@ def _find_config_directory() -> Path:
 DEFAULTS = _find_config_directory() / "defaults.yml"
 
 
-def load(path: str | Path | None = None) -> Config:
-    """Load configuration from ``path`` or ``DEFAULTS``.
-
-    If ``path`` is ``None``, the ``TREND_CFG`` environment variable is
-    consulted before falling back to ``DEFAULTS``.
-    """
-    if path is None:
-        env = os.environ.get("TREND_CFG")
-        cfg_path = Path(env) if env else DEFAULTS
-    else:
-        cfg_path = Path(path)
-    with cfg_path.open("r", encoding="utf-8") as fh:
+def _read_yaml(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
         data = yaml.safe_load(fh)
-        if not isinstance(data, dict):
-            raise TypeError("Config file must contain a mapping")
+    if not isinstance(data, dict):
+        raise TypeError("Config file must contain a mapping")
+    return data
+
+
+def _deep_update(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            base[key] = _deep_update(dict(base[key]), value)
+        else:
+            base[key] = value
+    return base
+
+
+def load_config(src: str | Path | dict[str, Any] | None = None) -> Config:
+    """Load configuration from ``src`` applying defaults and validation.
+
+    ``src`` may be a path to a YAML file, a pre-parsed dictionary or ``None`` to
+    load the default configuration.  Environment variable ``TREND_CFG`` is
+    honoured when ``src`` is ``None``.
+    """
+
+    if src is None:
+        env = os.environ.get("TREND_CFG")
+        data = _read_yaml(Path(env) if env else DEFAULTS)
+    else:
+        if isinstance(src, (str, Path)):
+            user_data = _read_yaml(Path(src))
+        elif isinstance(src, dict):
+            user_data = src
+        else:  # pragma: no cover - defensive
+            raise TypeError("src must be path or mapping")
+        data = _deep_update(_read_yaml(DEFAULTS), user_data)
 
     out_cfg = data.pop("output", None)
     if isinstance(out_cfg, dict):
@@ -287,19 +276,24 @@ def load(path: str | Path | None = None) -> Config:
         path_val = out_cfg.get("path")
         if path_val:
             p = Path(path_val)
-            export_cfg.setdefault("directory", str(p.parent) if p.parent else ".")
-            export_cfg.setdefault("filename", p.name)
+            export_cfg["directory"] = str(p.parent) if p.parent else "."
+            export_cfg["filename"] = p.name
 
-    return Config(**data)
+    return Config.model_validate(data)
+
+
+# Backwards compatible name
+load = load_config
 
 
 __all__ = [
     "PresetConfig",
     "ColumnMapping",
-    "ConfigurationState", 
+    "ConfigurationState",
     "load_preset",
     "list_available_presets",
     "Config",
+    "load_config",
     "load",
     "DEFAULTS",
 ]

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -276,8 +276,8 @@ def load_config(src: str | Path | dict[str, Any] | None = None) -> Config:
         path_val = out_cfg.get("path")
         if path_val:
             p = Path(path_val)
-            export_cfg["directory"] = str(p.parent) if p.parent else "."
-            export_cfg["filename"] = p.name
+            export_cfg.setdefault("directory", str(p.parent) if p.parent else ".")
+            export_cfg.setdefault("filename", p.name)
 
     return Config.model_validate(data)
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,37 @@
+import sys
+import pathlib
+import pytest
+from hypothesis import given, strategies as st
+from pydantic import ValidationError
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))  # noqa: E402
+
+from trend_analysis import config  # noqa: E402
+
+_DICT_SECTIONS = [
+    "data",
+    "preprocessing",
+    "vol_adjust",
+    "sample_split",
+    "portfolio",
+    "metrics",
+    "export",
+    "run",
+]
+
+invalid_values = st.one_of(
+    st.integers(), st.floats(), st.booleans(), st.lists(st.integers())
+)
+
+
+@given(field=st.sampled_from(_DICT_SECTIONS), val=invalid_values)
+def test_sections_require_mappings(field, val):
+    with pytest.raises(ValidationError):
+        config.load_config({field: val})
+
+
+@given(val=invalid_values)
+def test_version_must_be_string(val):
+    with pytest.raises(ValidationError):
+        config.load_config({"version": val})


### PR DESCRIPTION
## Summary
- define Pydantic Config model and load_config helper
- expose new config loader across package and CLI
- add property-based tests for invalid configuration

## Testing
- `./scripts/setup_env.sh`
- `python scripts/generate_demo.py`
- `PYTHONPATH=./src python scripts/run_multi_demo.py` *(fails: KeyError: ['Mgr_18'] not in index)*
- `./scripts/run_tests.sh` *(fails: 5 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b35b5643308331b634f6cbbade6993