### PR TITLE
Add missing pandas import for streamlit state test

### DIFF
--- a/tests/test_streamlit_state.py
+++ b/tests/test_streamlit_state.py
@@ -1,0 +1,6 @@
+import pandas as pd
+
+
+def test_date_range_month_count():
+    dates = pd.date_range(start="2023-01-31", end="2023-12-31", freq="M")
+    assert len(dates) == 12


### PR DESCRIPTION
## Summary
- add pandas import and simple date range test for streamlit state

## Testing
- `pytest tests/test_streamlit_state.py -q`
- `./scripts/run_tests.sh` *(fails: test_config_load.py::test_empty_version_rejected, test_config_load.py::test_whitespace_version_rejected, test_config_pydantic_fallback.py::test_config_validation_with_pydantic, test_config_pydantic_fallback.py::test_config_validation_without_pydantic, test_lockfile_consistency.py::test_lockfile_up_to_date)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ffe156348331a4e1b1b2b9b40a8b