### PR TITLE
Add license, security policy, and run disclaimer

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Trend Model Project contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security issue, please email security@example.com.
+We will respond as soon as possible.

--- a/streamlit_app/components/__init__.py
+++ b/streamlit_app/components/__init__.py
@@ -1,0 +1,1 @@
+"""Custom Streamlit components."""

--- a/streamlit_app/components/disclaimer.py
+++ b/streamlit_app/components/disclaimer.py
@@ -1,0 +1,27 @@
+"""Disclaimer modal component for the Streamlit app."""
+
+import streamlit as st
+
+LICENSE_URL = "https://github.com/stranske/Trend_Model_Project/blob/main/LICENSE"
+SECURITY_URL = "https://github.com/stranske/Trend_Model_Project/blob/main/SECURITY.md"
+
+
+def show_disclaimer() -> bool:
+    """Render the disclaimer modal and return acceptance state.
+
+    Returns True if the user has accepted the disclaimer, False otherwise.
+    """
+    if "disclaimer_accepted" not in st.session_state:
+        st.session_state["disclaimer_accepted"] = False
+
+    if not st.session_state["disclaimer_accepted"]:
+        with st.modal("Disclaimer"):
+            st.markdown(
+                f"By continuing you agree to our [License]({LICENSE_URL}) and "
+                f"[Security Policy]({SECURITY_URL})."
+            )
+            if st.checkbox("I understand and accept", key="disclaimer_checkbox"):
+                st.session_state["disclaimer_accepted"] = True
+                st.rerun()
+
+    return st.session_state["disclaimer_accepted"]

--- a/streamlit_app/pages/3_Run.py
+++ b/streamlit_app/pages/3_Run.py
@@ -3,43 +3,54 @@ import streamlit as st
 
 from trend_analysis.api import run_simulation
 from trend_analysis.config import Config
+from streamlit_app.components.disclaimer import show_disclaimer
 
-st.title("Run")
 
-if "returns_df" not in st.session_state or "sim_config" not in st.session_state:
-    st.error("Upload data and set configuration first.")
-    st.stop()
+def main():
+    st.title("Run")
 
-df = st.session_state["returns_df"]
-cfg = st.session_state["sim_config"]
+    if "returns_df" not in st.session_state or "sim_config" not in st.session_state:
+        st.error("Upload data and set configuration first.")
+        st.stop()
 
-# Ensure 'Date' column exists for the pipeline
-returns = df.reset_index().rename(columns={df.index.name or "index": "Date"})
+    accepted = show_disclaimer()
+    run_clicked = st.button("Run simulation", disabled=not accepted)
+    if not run_clicked:
+        return
 
-progress = st.progress(0, "Running simulation...")
-lookback = cfg.get("lookback_months", 0)
-start = cfg["start"]
-end = cfg["end"]
+    df = st.session_state["returns_df"]
+    cfg = st.session_state["sim_config"]
 
-config = Config(
-    version="1",
-    data={},
-    preprocessing={},
-    vol_adjust={"target_vol": cfg.get("risk_target", 1.0)},
-    sample_split={
-        "in_start": (start - pd.DateOffset(months=lookback)).strftime("%Y-%m"),
-        "in_end": (start - pd.DateOffset(months=1)).strftime("%Y-%m"),
-        "out_start": start.strftime("%Y-%m"),
-        "out_end": end.strftime("%Y-%m"),
-    },
-    portfolio={},
-    metrics={},
-    export={},
-    run={},
-)
+    returns = df.reset_index().rename(columns={df.index.name or "index": "Date"})
 
-result = run_simulation(config, returns)
-progress.progress(100)
-st.session_state["sim_results"] = result
-st.success("Done.")
-st.write("Summary:", result.metrics)
+    progress = st.progress(0, "Running simulation...")
+    lookback = cfg.get("lookback_months", 0)
+    start = cfg["start"]
+    end = cfg["end"]
+
+    config = Config(
+        version="1",
+        data={},
+        preprocessing={},
+        vol_adjust={"target_vol": cfg.get("risk_target", 1.0)},
+        sample_split={
+            "in_start": (start - pd.DateOffset(months=lookback)).strftime("%Y-%m"),
+            "in_end": (start - pd.DateOffset(months=1)).strftime("%Y-%m"),
+            "out_start": start.strftime("%Y-%m"),
+            "out_end": end.strftime("%Y-%m"),
+        },
+        portfolio={},
+        metrics={},
+        export={},
+        run={},
+    )
+
+    result = run_simulation(config, returns)
+    progress.progress(100)
+    st.session_state["sim_results"] = result
+    st.success("Done.")
+    st.write("Summary:", result.metrics)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_disclaimer.py
+++ b/tests/test_disclaimer.py
@@ -1,0 +1,51 @@
+import importlib.util
+from types import SimpleNamespace
+
+import pandas as pd
+import streamlit as st
+
+
+def load_run_module():
+    spec = importlib.util.spec_from_file_location(
+        "run_page", "streamlit_app/pages/3_Run.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def setup_session_state(accepted: bool):
+    st.session_state.clear()
+    st.session_state["returns_df"] = pd.DataFrame({"A": [0.1]}, index=pd.to_datetime(["2020-01-31"]))
+    st.session_state["sim_config"] = {
+        "start": pd.Timestamp("2020-01-31"),
+        "end": pd.Timestamp("2020-01-31"),
+        "lookback_months": 0,
+        "risk_target": 1.0,
+    }
+    st.session_state["disclaimer_accepted"] = accepted
+
+
+def test_run_button_disabled_without_acceptance(monkeypatch):
+    module = load_run_module()
+
+    # Bypass UI in disclaimer component
+    monkeypatch.setattr(
+        module, "show_disclaimer", lambda: st.session_state.get("disclaimer_accepted", False)
+    )
+
+    disabled = SimpleNamespace(value=None)
+
+    def fake_button(label, disabled=False):
+        disabled.value = disabled
+        return False
+
+    monkeypatch.setattr(st, "button", fake_button)
+
+    setup_session_state(accepted=False)
+    module.main()
+    assert disabled.value is True
+
+    setup_session_state(accepted=True)
+    module.main()
+    assert disabled.value is False


### PR DESCRIPTION
## Summary
- Add MIT LICENSE and SECURITY policy files
- Introduce Streamlit disclaimer modal linking to policy docs
- Require disclaimer acceptance before enabling simulation run, with unit test

## Testing
- `./scripts/run_streamlit.sh --help` *(fails: Operation cancelled by user during environment bootstrap)*
- `pytest -q` *(fails: missing dependencies such as streamlit, trend_analysis, matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cef8478c8331a84c38e2a8469a6c