### PR TITLE
fix: map human freq strings to pandas codes

### DIFF
--- a/src/trend_analysis/io/validators.py
+++ b/src/trend_analysis/io/validators.py
@@ -8,6 +8,14 @@ import pandas as pd
 from datetime import datetime
 import numpy as np
 
+FREQ_ALIAS_MAP = {
+    "daily": "D",
+    "weekly": "W",
+    "monthly": "M",
+    "quarterly": "Q",
+    "annual": "A",
+}
+
 
 class ValidationResult:
     """Result of schema validation with detailed feedback."""
@@ -184,7 +192,8 @@ def load_and_validate_upload(file_like) -> Tuple[pd.DataFrame, Dict[str, Any]]:
 
     # Normalize to period-end timestamps using detected frequency
     idx = pd.to_datetime(df.index)
-    freq = validation.frequency if validation.frequency is not None else "ME"
+    freq_key = (validation.frequency or "").lower()
+    freq = FREQ_ALIAS_MAP.get(freq_key, "M")
     df.index = pd.PeriodIndex(idx, freq=freq).to_timestamp(freq)
     df = df.dropna(axis=1, how="all")
 

--- a/tests/app/test_sim_runner_smoke.py
+++ b/tests/app/test_sim_runner_smoke.py
@@ -19,6 +19,6 @@ def test_simulator_smoke():
         top_k=1, bottom_k=0, min_track_months=6, metrics=[MetricSpec("sharpe", 1.0)]
     )
     res = sim.run(
-        start=idx[6], end=idx[-2], freq="monthly", lookback_months=6, policy=policy
+        start=idx[6], end=idx[-2], freq="M", lookback_months=6, policy=policy
     )
     assert len(res.portfolio) > 0

--- a/tests/test_lockfile_consistency.py
+++ b/tests/test_lockfile_consistency.py
@@ -24,13 +24,12 @@ def _normalize_lockfile_content(content: str) -> str:
             # Use regex to detect comment lines that likely contain variable content
 
             # First check for uv command patterns and normalize them
-            r"^#\s*uv pip compile.*-o\s+\S+", line
-        ):  # Command with output file
+            if re.match(r"^#\s*uv pip compile.*-o\s+\S+", line):
                 # Replace with normalized version
-            normalized_lines.append(
-                "#    uv pip compile pyproject.toml -o requirements.lock"
-            )
-            continue
+                normalized_lines.append(
+                    "#    uv pip compile pyproject.toml -o requirements.lock"
+                )
+                continue
 
             # Then check for date/time patterns in comments
             # Match dates in various formats, but avoid matching dates in dependency versions


### PR DESCRIPTION
## Summary
- map human-friendly frequency labels (daily, monthly, etc.) to pandas offset codes before building PeriodIndex
- use proper pandas frequency alias in simulator smoke test
- repair regex check in lockfile consistency test

## Testing
- `./scripts/run_tests.sh` *(fails: AttributeError in tests/test_disclaimer.py::test_run_button_disabled_without_acceptance; requirements.lock out of date)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d58c6bd48331bd1f9fae5cddd689