### PR TITLE
feat: add plugin interface for strategies

### DIFF
--- a/src/trend_analysis/plugins/__init__.py
+++ b/src/trend_analysis/plugins/__init__.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict, Generic, List, Type, TypeVar
+
+import pandas as pd
+
+T = TypeVar("T", bound="Plugin")
+
+
+class Plugin(ABC):
+    """Base class for all plugins."""
+
+
+class PluginRegistry(Generic[T]):
+    """Simple in-memory registry mapping names to plugin classes."""
+
+    def __init__(self) -> None:
+        self._plugins: Dict[str, Type[T]] = {}
+
+    def register(self, name: str) -> Callable[[Type[T]], Type[T]]:
+        """Register ``cls`` under ``name`` using a decorator."""
+
+        def decorator(cls: Type[T]) -> Type[T]:
+            self._plugins[name] = cls
+            return cls
+
+        return decorator
+
+    def create(self, name: str, *args, **kwargs) -> T:
+        """Instantiate the plugin registered under ``name``."""
+        try:
+            cls = self._plugins[name]
+        except KeyError as exc:
+            raise ValueError(
+                f"Unknown plugin: {name}. Available: {list(self._plugins.keys())}"
+            ) from exc
+        return cls(*args, **kwargs)
+
+    def available(self) -> List[str]:
+        """Return a list of registered plugin names."""
+        return list(self._plugins.keys())
+
+
+class Selector(Plugin):
+    """Base class for selector plugins."""
+
+    @abstractmethod
+    def select(self, score_frame: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Select assets from ``score_frame`` returning (selected, log)."""
+
+
+class Rebalancer(Plugin):
+    """Base class for rebalancing strategy plugins."""
+
+    def __init__(self, params: Dict[str, Any] | None = None) -> None:
+        self.params = params or {}
+
+    @abstractmethod
+    def apply(
+        self, current_weights: pd.Series, target_weights: pd.Series, **kwargs
+    ) -> tuple[pd.Series, float]:
+        """Return new weights and total cost for the rebalance."""
+
+
+selector_registry: PluginRegistry[Selector] = PluginRegistry()
+rebalancer_registry: PluginRegistry[Rebalancer] = PluginRegistry()
+
+
+def create_selector(name: str, **params: Any) -> Selector:
+    """Instantiate a selector plugin by ``name``."""
+    return selector_registry.create(name, **params)
+
+
+def create_rebalancer(name: str, params: Dict[str, Any] | None = None) -> Rebalancer:
+    """Instantiate a rebalancer plugin by ``name``."""
+    return rebalancer_registry.create(name, params or {})

--- a/src/trend_analysis/selector.py
+++ b/src/trend_analysis/selector.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import pandas as pd
 
 from .core.rank_selection import ASCENDING_METRICS
+from .plugins import Selector, selector_registry, create_selector
 
 
-class RankSelector:
+@selector_registry.register("rank")
+class RankSelector(Selector):
     """Select top N funds based on a metric column."""
 
     def __init__(self, top_n: int, rank_column: str) -> None:
@@ -30,7 +32,8 @@ class RankSelector:
         return selected, log
 
 
-class ZScoreSelector:
+@selector_registry.register("zscore")
+class ZScoreSelector(Selector):
     """Filter by z-score threshold."""
 
     def __init__(
@@ -53,3 +56,16 @@ class ZScoreSelector:
             {"candidate": score_frame.index, "metric": self.column, "reason": z}
         ).set_index("candidate")
         return selected, log
+
+
+def create_selector_by_name(name: str, **params) -> Selector:
+    """Factory helper for creating selectors via the plugin registry."""
+    return create_selector(name, **params)
+
+
+__all__ = [
+    "RankSelector",
+    "ZScoreSelector",
+    "create_selector_by_name",
+    "selector_registry",
+]

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,0 +1,32 @@
+import pytest
+
+# Import modules to trigger plugin registration
+from trend_analysis import selector as selector_module
+from trend_analysis import rebalancing as rebalancing_module
+from trend_analysis.plugins import (
+    selector_registry,
+    rebalancer_registry,
+)
+
+
+def test_selector_registry_discovery():
+    assert "rank" in selector_registry.available()
+    assert "zscore" in selector_registry.available()
+    sel = selector_registry.create("rank", top_n=1, rank_column="Sharpe")
+    assert isinstance(sel, selector_module.RankSelector)
+
+
+def test_selector_unknown_name():
+    with pytest.raises(ValueError, match="Unknown plugin"):
+        selector_registry.create("nope")
+
+
+def test_rebalancer_registry_discovery():
+    assert "turnover_cap" in rebalancer_registry.available()
+    rb = rebalancer_registry.create("turnover_cap", {"max_turnover": 0.1})
+    assert isinstance(rb, rebalancing_module.TurnoverCapStrategy)
+
+
+def test_rebalancer_unknown_name():
+    with pytest.raises(ValueError, match="Unknown plugin"):
+        rebalancer_registry.create("nope", {})


### PR DESCRIPTION
## Summary
- introduce generic plugin registry with base Selector and Rebalancer classes
- register existing selectors and rebalancing strategies via plugin interface
- add tests for plugin discovery and unknown-name errors

## Testing
- `./scripts/setup_env.sh`
- `python scripts/generate_demo.py`
- `python scripts/run_multi_demo.py` (warning: Demo dataset date range mismatch)
- `./scripts/run_streamlit.sh` (timed run)
- `./scripts/run_tests.sh` (fails: SyntaxError in tests/test_lockfile_consistency.py)
- `pytest -q` (fails: SyntaxError in tests/test_lockfile_consistency.py)
- `pytest tests/test_plugin_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d4abcaa08331bc6b4eb81cb84a9f