### PR TITLE
test: stabilize CLI and template tests

### DIFF
--- a/tests/test_app_coverage.py
+++ b/tests/test_app_coverage.py
@@ -269,7 +269,15 @@ class TestBuildStep0:
         mock_dropdown = Mock()
         mock_widgets.FileUpload.return_value = Mock()
         mock_widgets.Dropdown.return_value = mock_dropdown
-        mock_widgets.Label.return_value = Mock()
+
+        # Label widget is used as the grid when ipydatagrid isn't available.
+        # The grid's ``hold_trait_notifications`` method is used as a context
+        # manager inside ``refresh_grid`` so we need the mock to implement the
+        # context manager protocol to avoid warnings.
+        mock_label = Mock()
+        mock_label.hold_trait_notifications.return_value = _cm_mock()
+        mock_widgets.Label.return_value = mock_label
+
         mock_widgets.Button.return_value = Mock()
         mock_widgets.VBox.return_value = Mock()
         mock_widgets.HBox.return_value = Mock()

--- a/tests/test_run_analysis_cli_default.py
+++ b/tests/test_run_analysis_cli_default.py
@@ -4,7 +4,16 @@ from pathlib import Path
 from trend_analysis import run_analysis
 
 
-def _write_cfg(path: Path, csv: Path) -> None:
+def _write_cfg(path: Path, csv: Path, out_dir: Path) -> None:
+    """Write a minimal config file for the CLI test.
+
+    The default behaviour of ``run_analysis`` is to emit output files to a
+    directory named ``outputs`` in the current working directory.  On CI this
+    can lead to permission errors when the repository root is read-only.  By
+    explicitly writing the output to a temporary directory provided by the
+    ``tmp_path`` fixture we ensure the test always has write access.
+    """
+
     path.write_text(
         "\n".join(
             [
@@ -16,7 +25,7 @@ def _write_cfg(path: Path, csv: Path) -> None:
                 "out_start: '2020-04', out_end: '2020-06'}",
                 "portfolio: {}",
                 "metrics: {}",
-                "export: {}",
+                f"export: {{directory: '{out_dir}', formats: []}}",
                 "run: {}",
             ]
         )
@@ -32,7 +41,13 @@ def test_cli_default_output(tmp_path, capsys):
     csv = tmp_path / "data.csv"
     _make_df().to_csv(csv, index=False)
     cfg = tmp_path / "cfg.yml"
-    _write_cfg(cfg, csv)
+
+    # Use a dedicated output directory within ``tmp_path`` to guarantee
+    # writable permissions and isolate test artefacts.
+    out_dir = tmp_path / "output"
+    out_dir.mkdir()
+    _write_cfg(cfg, csv, out_dir)
+
     rc = run_analysis.main(["-c", str(cfg)])
     captured = capsys.readouterr().out
     assert rc == 0


### PR DESCRIPTION
## Summary
- mock widget's `hold_trait_notifications` to support context manager in template loading test
- direct CLI test outputs to a temporary directory to avoid permission issues

## Testing
- `PYTHONPATH=src pytest tests/test_app_coverage.py tests/test_export_bundle.py tests/test_run_analysis_cli_default.py -q`
- `./scripts/run_tests.sh tests/test_app_coverage.py tests/test_export_bundle.py tests/test_run_analysis_cli_default.py`

------
https://chatgpt.com/codex/tasks/task_e_68b650a8504083319671b18621e83b50