### PR TITLE
refactor: add fallback git hash

### DIFF
--- a/src/trend_analysis/export/bundle.py
+++ b/src/trend_analysis/export/bundle.py
@@ -31,8 +31,11 @@ def _git_hash() -> str:
             ["git", "rev-parse", "HEAD"], encoding="utf-8", shell=False
         ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
-        # Handle cases where git command fails or is not found
-        return ""
+        # Ensure a non-empty fallback so callers always receive at least a
+        # short hash.  This prevents downstream checks from failing when the
+        # repository metadata isn't available (e.g. in a zipped release
+        # environment where the ``.git`` directory is absent).
+        return "unknown"
 
 
 def export_bundle(run: Any, path: Path) -> Path:


### PR DESCRIPTION
## Summary
- ensure export bundle writes a non-empty `git_hash` even when git metadata is missing

## Testing
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b65467dcdc8331ab0457920748d2c4