### PR TITLE
feat: add turnover cost metrics and config

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -59,6 +59,8 @@ portfolio:
   weighting_scheme: "equal" # equal | vol_inverse | custom
   rebalance_freq: "M" # M | Q | A | None
   leverage_cap: 2.0 # max gross exposure
+  transaction_cost_bps: 0       # linear cost per unit turnover
+  max_turnover: 1.0             # optional turnover cap (1.0 = no cap)
   rank:
     inclusion_approach: top_n     # top_n | top_pct | threshold
     n: 10                         # for top_n

--- a/config/demo.yml
+++ b/config/demo.yml
@@ -34,6 +34,8 @@ portfolio:
   weighting:
     name: equal
     params: {}
+  transaction_cost_bps: 25
+  max_turnover: 0.2
 
 benchmarks:
   spx: SPX

--- a/src/trend_analysis/metrics/__init__.py
+++ b/src/trend_analysis/metrics/__init__.py
@@ -303,3 +303,4 @@ setattr(_bi, "annualize_volatility", annualize_volatility)
 # Public submodule to expose summary helpers
 from . import summary  # noqa: E402,F401
 from . import rolling  # noqa: E402,F401
+from . import turnover  # noqa: E402,F401

--- a/src/trend_analysis/metrics/turnover.py
+++ b/src/trend_analysis/metrics/turnover.py
@@ -1,0 +1,55 @@
+"""Turnover and transaction cost utilities.
+
+This module provides helper functions for computing realized turnover and
+associated transaction costs from a weight history.  The implementation is
+vectorised and free of plotting dependencies so it can be used from the metrics
+package without requiring the ``viz`` helpers.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+import pandas as pd
+
+
+def _weights_to_frame(
+    weights: Mapping[pd.Timestamp, pd.Series] | pd.DataFrame,
+) -> pd.DataFrame:
+    """Return weights history as a tidy DataFrame.
+
+    The input can be a mapping of dates to weight Series or an already
+    assembled DataFrame.  Missing values are filled with ``0.0`` and the
+    index is sorted to ensure chronological order.
+    """
+    if isinstance(weights, pd.DataFrame):
+        return weights.sort_index().fillna(0.0)
+    return pd.DataFrame({d: s for d, s in weights.items()}).T.sort_index().fillna(0.0)
+
+
+def realized_turnover(
+    weights: Mapping[pd.Timestamp, pd.Series] | pd.DataFrame,
+) -> pd.DataFrame:
+    """Return a DataFrame of realized turnover per period."""
+    w_df = _weights_to_frame(weights)
+    to = w_df.diff().abs().sum(axis=1).to_frame("turnover")
+    return to
+
+
+def turnover_cost(
+    weights: Mapping[pd.Timestamp, pd.Series] | pd.DataFrame,
+    cost_bps: float,
+) -> pd.Series:
+    """Return a Series of transaction cost deductions per period.
+
+    Parameters
+    ----------
+    weights : Mapping or DataFrame
+        Weight history used to compute turnover.
+    cost_bps : float
+        Linear transaction cost in basis points applied to turnover.
+    """
+    turn_df = realized_turnover(weights)
+    return turn_df["turnover"] * (cost_bps / 10000.0)
+
+
+__all__ = ["realized_turnover", "turnover_cost"]

--- a/tests/test_app_coverage.py
+++ b/tests/test_app_coverage.py
@@ -292,11 +292,18 @@ class TestBuildStep0:
 
         with (
             patch("trend_analysis.gui.app.reset_weight_state"),
-            patch.object(mock_dropdown, 'observe') as mock_observe
+            patch.object(mock_dropdown, "observe") as mock_observe,
         ):
             # Set up the mock to use our safe callback
+            def safe_template_callback(change, store=None):
+                if store is not None and "new" in change:
+                    store.cfg["loaded_template"] = change["new"]
+                    store.dirty = True
+
+                return None
+
             mock_observe.side_effect = lambda callback, names=None: setattr(
-                mock_observe, '_callback', safe_template_callback
+                mock_observe, "_callback", safe_template_callback
             )
 
             _build_step0(store)
@@ -311,7 +318,7 @@ class TestBuildStep0:
             # Verify the callback worked correctly
             assert store.cfg["loaded_template"] == "demo"
             assert store.dirty is True
-            
+
             # This demonstrates that template loading logic works without filesystem access
             success = True
             assert success, "Template loading should handle errors gracefully"

--- a/tests/test_metrics_summary.py
+++ b/tests/test_metrics_summary.py
@@ -16,12 +16,19 @@ def test_summary_table_snapshot() -> None:
     }
     bench = pd.Series(0.0, index=returns.index)
 
-    out = summary.summary_table(returns, weights, benchmark=bench, periods_per_year=12)
+    out = summary.summary_table(
+        returns,
+        weights,
+        benchmark=bench,
+        periods_per_year=12,
+        transaction_cost_bps=25,
+    )
 
-    assert out.loc["CAGR", "value"] == pytest.approx(0.01871797)
-    assert out.loc["vol", "value"] == pytest.approx(0.06557438)
-    assert out.loc["max_drawdown", "value"] == pytest.approx(0.02)
-    assert out.loc["information_ratio", "value"] == pytest.approx(0.30499714)
-    assert out.loc["sharpe", "value"] == pytest.approx(0.28544636)
+    assert out.loc["CAGR", "value"] == pytest.approx(0.012639995599)
+    assert out.loc["vol", "value"] == pytest.approx(0.065368187982)
+    assert out.loc["max_drawdown", "value"] == pytest.approx(0.0205)
+    assert out.loc["information_ratio", "value"] == pytest.approx(0.214171456060)
+    assert out.loc["sharpe", "value"] == pytest.approx(0.193366161568)
     assert out.loc["turnover", "value"] == pytest.approx(0.2)
+    assert out.loc["cost_impact", "value"] == pytest.approx(0.0005)
     assert out.loc["hit_rate", "value"] == pytest.approx(2 / 3)


### PR DESCRIPTION
## Summary
- track per-period turnover and costs in the multi-period engine
- expose transaction cost and turnover cap in config and summary metrics
- add turnover utility helpers and cost-aware summary calculations

## Testing
- `./scripts/setup_env.sh`
- `python scripts/generate_demo.py`
- `python scripts/run_multi_demo.py`
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b65c0be7cc8331bc3a6311516d23df