### PR TITLE
feat: add constrained optimizer

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -80,6 +80,10 @@ portfolio:
     name: score_prop_bayes
     params:
       shrink_tau: 0.25
+  constraints:
+    long_only: true
+    max_weight: 0.25
+    group_caps: {}
 # ----------------------------------------------------------------------
 # BENCHMARKS
 # ----------------------------------------------------------------------

--- a/src/trend_analysis/engine/optimizer.py
+++ b/src/trend_analysis/engine/optimizer.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Any
+
+import pandas as pd
+
+
+class ConstraintViolation(Exception):
+    """Raised when a set of constraints is infeasible."""
+
+
+@dataclass
+class ConstraintSet:
+    """Configuration for portfolio constraints."""
+
+    long_only: bool = True
+    max_weight: float | None = None
+    group_caps: Mapping[str, float] | None = None
+    groups: Mapping[str, str] | None = None  # asset -> group
+
+
+def _redistribute(w: pd.Series, mask: pd.Series, amount: float) -> pd.Series:
+    """Redistribute ``amount`` to weights where ``mask`` is True proportionally."""
+
+    if amount <= 0:
+        return w
+    eligible = w[mask]
+    if eligible.empty:
+        raise ConstraintViolation("No capacity to redistribute excess weight")
+    w.loc[eligible.index] += amount * (eligible / eligible.sum())
+    return w
+
+
+def _apply_cap(w: pd.Series, cap: float) -> pd.Series:
+    """Cap individual weights at ``cap`` and redistribute the excess."""
+
+    if cap is None:
+        return w
+    if cap <= 0:
+        raise ConstraintViolation("max_weight must be positive")
+    # Feasibility check
+    if cap * len(w) < 1 - 1e-12:
+        raise ConstraintViolation("max_weight too small for number of assets")
+
+    w = w.copy()
+    while True:
+        excess = (w - cap).clip(lower=0)
+        if excess.sum() <= 1e-12:
+            break
+        w = w.clip(upper=cap)
+        room_mask = w < cap - 1e-12
+        w = _redistribute(w, room_mask, excess.sum())
+    return w
+
+
+def _apply_group_caps(
+    w: pd.Series, group_caps: Mapping[str, float], groups: Mapping[str, str]
+) -> pd.Series:
+    """Enforce group caps, redistributing excess weight."""
+
+    w = w.copy()
+    group_series = pd.Series(groups)
+    if not set(w.index).issubset(group_series.index):
+        missing = set(w.index) - set(group_series.index)
+        raise KeyError(f"Missing group mapping for: {sorted(missing)}")
+
+    all_groups = set(group_series.loc[w.index].values)
+    if all_groups.issubset(group_caps.keys()):
+        total_cap = sum(group_caps[g] for g in all_groups)
+        if total_cap < 1 - 1e-12:
+            raise ConstraintViolation("Group caps sum to less than 100%")
+
+    for group, cap in group_caps.items():
+        members = group_series[group_series == group].index.intersection(w.index)
+        if not members.any():
+            continue
+        grp_weight = w.loc[members].sum()
+        if grp_weight <= cap + 1e-12:
+            continue
+        excess = grp_weight - cap
+        scale = cap / grp_weight
+        w.loc[members] *= scale
+        others_mask = ~w.index.isin(members)
+        w = _redistribute(w, others_mask, excess)
+    return w
+
+
+def apply_constraints(
+    weights: pd.Series, constraints: ConstraintSet | Mapping[str, Any]
+) -> pd.Series:
+    """Project ``weights`` onto the feasible region defined by ``constraints``."""
+
+    if isinstance(constraints, Mapping) and not isinstance(constraints, ConstraintSet):
+        constraints = ConstraintSet(**constraints)
+
+    w = weights.astype(float).copy()
+    if w.empty:
+        return w
+
+    if constraints.long_only:
+        w = w.clip(lower=0)
+        if w.sum() == 0:
+            raise ConstraintViolation(
+                "All weights non-positive under long-only constraint"
+            )
+    w /= w.sum()
+
+    if constraints.max_weight is not None:
+        w = _apply_cap(w, constraints.max_weight)
+
+    if constraints.group_caps:
+        if not constraints.groups:
+            raise ConstraintViolation("Group mapping required when group_caps set")
+        w = _apply_group_caps(w, constraints.group_caps, constraints.groups)
+        # max weight may have been violated again
+        if constraints.max_weight is not None:
+            w = _apply_cap(w, constraints.max_weight)
+
+    # Final normalisation guard
+    w /= w.sum()
+    return w
+
+
+__all__ = ["ConstraintSet", "ConstraintViolation", "apply_constraints"]

--- a/src/trend_analysis/engine/optimizer.py
+++ b/src/trend_analysis/engine/optimizer.py
@@ -72,8 +72,7 @@ def _apply_group_caps(
             raise ConstraintViolation("Group caps sum to less than 100%")
 
     for group, cap in group_caps.items():
-        members = group_series[group_series == group].index.intersection(w.index)
-        if not members.any():
+        if members.empty:
             continue
         grp_weight = w.loc[members].sum()
         if grp_weight <= cap + 1e-12:


### PR DESCRIPTION
## Summary
- add `apply_constraints` with long-only, cap, and group-limit support
- expose portfolio constraint options in default config
- cover constraint projection and edge cases with tests

## Testing
- `pre-commit run --files src/trend_analysis/engine/optimizer.py tests/test_constraint_optimizer.py config/defaults.yml`
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b6688e57148331b2430f1ec4c3e505