### PR TITLE
chore: install build tools before app dependency setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,11 @@ WORKDIR /app
 # Copy requirements first for better Docker layer caching
 COPY requirements.txt pyproject.toml ./
 
+# Ensure build tools are available
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+
 # Install Python dependencies with retry logic for network issues
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir --timeout=300 --retries=3 -r requirements.txt \
+RUN pip install --no-cache-dir --timeout=300 --retries=3 -r requirements.txt \
     && pip install --no-cache-dir pytest
 
 # Copy source code and essential files


### PR DESCRIPTION
## Summary
- install pip, setuptools, and wheel before installing project deps in Dockerfile
- ensures editable install of `[app]` extras works during image build

## Testing
- ⚠️ `./scripts/run_streamlit.sh --help` (bootstrap cancelled)
- ❌ `pytest -q` (6 failed, 444 passed)


------
https://chatgpt.com/codex/tasks/task_e_68b66d27c8808331bbd77fd94ae61a7b