### PR TITLE
feat: add docker compose setup

### DIFF
--- a/DOCKER_QUICKSTART.md
+++ b/DOCKER_QUICKSTART.md
@@ -35,6 +35,17 @@ Get a shell inside the container for development:
 docker run -it --rm ghcr.io/stranske/trend-model:latest bash
 ```
 
+### Option 4: Docker Compose (App + API)
+
+Bring up the Streamlit app and a minimal API server with one command:
+
+```bash
+docker compose up app
+```
+
+This uses the included `docker-compose.yml` which also mounts `./data` into the
+container at `/app/data` for local files.
+
 ## Working with Your Data
 
 To analyze your own data, mount a local directory containing your CSV files:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+services:
+  app:
+    image: ghcr.io/stranske/trend-model:latest
+    ports:
+      - "8501:8501"
+    volumes:
+      - ./data:/app/data
+  api:
+    image: ghcr.io/stranske/trend-model:latest
+    command: python -m trend_analysis.api_server
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./data:/app/data

--- a/src/trend_analysis/api_server/__init__.py
+++ b/src/trend_analysis/api_server/__init__.py
@@ -1,0 +1,26 @@
+"""Minimal HTTP API server for demo purposes.
+
+Exposes a simple health check endpoint at ``/health``.
+"""
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class RequestHandler(BaseHTTPRequestHandler):
+    """Handle basic GET requests."""
+
+    def do_GET(self):  # noqa: N802 (Http server interface)
+        if self.path == "/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"status":"ok"}')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+def run(host: str = "0.0.0.0", port: int = 8000) -> None:
+    """Start the minimal HTTP server."""
+    server = HTTPServer((host, port), RequestHandler)
+    server.serve_forever()

--- a/src/trend_analysis/api_server/__init__.py
+++ b/src/trend_analysis/api_server/__init__.py
@@ -20,7 +20,10 @@ class RequestHandler(BaseHTTPRequestHandler):
             self.end_headers()
 
 
-def run(host: str = "0.0.0.0", port: int = 8000) -> None:
-    """Start the minimal HTTP server."""
-    server = HTTPServer((host, port), RequestHandler)
-    server.serve_forever()
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/src/trend_analysis/api_server/__main__.py
+++ b/src/trend_analysis/api_server/__main__.py
@@ -1,0 +1,4 @@
+from . import run
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add docker-compose with Streamlit app and optional API server
- document docker compose usage in quickstart guide
- stub minimal HTTP API server with health endpoint

## Testing
- `pre-commit run --files docker-compose.yml src/trend_analysis/api_server/__init__.py src_trend_analysis/api_server/__main__.py DOCKER_QUICKSTART.md`
- `./scripts/setup_env.sh` *(fails: Operation cancelled by user)*
- `python scripts/generate_demo.py`
- `python scripts/run_multi_demo.py` *(fails: ModuleNotFoundError: No module named 'trend_analysis')*
- `./scripts/run_streamlit.sh` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'trend_analysis')*
- `./scripts/run_tests.sh` *(fails: Operation cancelled by user)*
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b66ff4261083319582db875ab7c388