### PR TITLE
feat: include tests in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,13 @@ RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 RUN pip install --no-cache-dir --timeout=300 --retries=3 -r requirements.txt \
     && pip install --no-cache-dir pytest
 
-# Copy source code and essential files
-COPY src/ ./src/
-COPY config/ ./config/
-COPY scripts/ ./scripts/
-COPY README.md LICENSE ./
+# Copy the rest of the project including tests and docs
+COPY . .
 
 # Install build dependencies and the package in development mode for CLI access
 # Ensure build dependencies are available and handle editable install gracefully
 RUN pip install --no-cache-dir setuptools>=61 wheel build && \
-    (pip install --no-cache-dir -e .[app] && echo "Package installed successfully with [app] extra") || \
+    (pip install --no-cache-dir -v -e .[app] && echo "Package installed successfully with [app] extra") || \
     (echo "Warning: Editable install with [app] extra failed. Falling back to individual package install." && \
      pip install --no-cache-dir streamlit>=1.30 streamlit-sortables && \
      pip install --no-cache-dir -e . && echo "Package installed in editable mode without [app] extra")


### PR DESCRIPTION
## Summary
- copy entire repo so tests and package metadata are available during docker builds
- add verbose editable install with fallback handling for [app] extra

## Testing
- `./scripts/setup_env.sh`
- `python scripts/generate_demo.py`
- `python scripts/run_multi_demo.py`
- `./scripts/run_tests.sh` *(fails: ValueError: version must be a string)*

------
https://chatgpt.com/codex/tasks/task_e_68b6708128988331a8eb6ffdabbbe1a0