### PR TITLE
chore: pin build dependencies for docker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ exclude: |
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         files: '\\.(py|pyi|toml|ya?ml)$'

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ WORKDIR /app
 # Copy requirements first for better Docker layer caching
 COPY requirements.txt pyproject.toml ./
 
-# Ensure build tools are available
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+# Ensure build tools are available and pinned for reproducibility
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir setuptools==69.5.1 wheel==0.43.0
 
 # Install Python dependencies with retry logic for network issues
 RUN pip install --no-cache-dir --timeout=300 --retries=3 -r requirements.txt \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["setuptools>=61", "wheel"]
+# Pin build dependencies to ensure reproducible installs during Docker builds
+requires = ["setuptools==69.5.1", "wheel==0.43.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/src/trend_analysis/engine/optimizer.py
+++ b/src/trend_analysis/engine/optimizer.py
@@ -72,6 +72,7 @@ def _apply_group_caps(
             raise ConstraintViolation("Group caps sum to less than 100%")
 
     for group, cap in group_caps.items():
+        members = group_series[group_series == group].index
         if members.empty:
             continue
         grp_weight = w.loc[members].sum()

--- a/tests/test_config_pydantic_fallback.py
+++ b/tests/test_config_pydantic_fallback.py
@@ -52,10 +52,17 @@ def test_config_import_without_pydantic():
 
 def test_config_validation_with_pydantic():
     """Test that validation works when pydantic is available."""
+    # Reload config module to ensure _HAS_PYDANTIC reflects current environment
+    for module in [
+        "trend_analysis.config.models",
+        "trend_analysis.config",
+    ]:
+        if module in sys.modules:
+            del sys.modules[module]
+
     from trend_analysis.config.models import Config
     from pydantic import ValidationError
 
-    # Test validation error with pydantic
     with pytest.raises(ValidationError, match="version must be a string"):
         Config(version=123)
 


### PR DESCRIPTION
## Summary
- pin setuptools and wheel versions for reliable Docker builds
- document build dependency pinning in pyproject
- refresh pre-commit hooks and stabilize config tests
- fix group-cap constraint to avoid NameError

## Testing
- `./scripts/setup_env.sh`
- `python scripts/generate_demo.py`
- `python scripts/run_multi_demo.py`
- `./scripts/run_streamlit.sh` *(terminated after launch)*
- `./scripts/run_tests.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b66f0286c88331ac3214f013eb6956