### PR TITLE
Add Streamlit smoke test and coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,16 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-      - name: Install dependencies
+      - name: Build wheel cache
         run: |
           python -m pip install -U pip
-          pip install -r requirements.txt
+          pip wheel -r requirements.txt -w ~/.cache/pip/wheels
+      - name: Install dependencies
+        run: |
+          pip install --no-index --find-links=~/.cache/pip/wheels -r requirements.txt
           pip install -e ".[app]"
           pip install pre-commit
       - name: Run linters
         run: pre-commit run --show-diff-on-failure --color=always --all-files
       - name: Test
-        run: ./scripts/run_tests.sh
+        run: ./scripts/run_tests.sh --cov-fail-under=70

--- a/tests/smoke/test_app_launch.py
+++ b/tests/smoke/test_app_launch.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+APP_PATH = (
+    Path(__file__).resolve().parents[2] / "src" / "trend_portfolio_app" / "app.py"
+)
+
+
+def test_app_starts_headlessly():
+    env = os.environ.copy()
+    env["STREAMLIT_SERVER_HEADLESS"] = "true"
+    cmd = [
+        sys.executable,
+        "-m",
+        "streamlit",
+        "run",
+        str(APP_PATH),
+        "--server.headless=true",
+        "--server.port=8765",
+    ]
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+    try:
+        time.sleep(5)
+        assert proc.poll() is None, "Streamlit app terminated early"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()

--- a/tests/smoke/test_app_launch.py
+++ b/tests/smoke/test_app_launch.py
@@ -8,11 +8,17 @@ import pytest
 
 pytestmark = pytest.mark.smoke
 
-APP_PATH = (
-    Path(__file__).resolve().parents[2] / "src" / "trend_portfolio_app" / "app.py"
-)
+def find_project_root(start_path: Path, marker_files=("pyproject.toml", "setup.py", ".git")) -> Path:
+    """Search upwards from start_path for a directory containing one of the marker files."""
+    current = start_path.resolve()
+    for parent in [current] + list(current.parents):
+        for marker in marker_files:
+            if (parent / marker).exists():
+                return parent
+    raise FileNotFoundError(f"Could not find project root with markers {marker_files}")
 
-
+PROJECT_ROOT = find_project_root(Path(__file__))
+APP_PATH = PROJECT_ROOT / "src" / "trend_portfolio_app" / "app.py"
 def test_app_starts_headlessly():
     env = os.environ.copy()
     env["STREAMLIT_SERVER_HEADLESS"] = "true"


### PR DESCRIPTION
## Summary
- add Streamlit app smoke test that runs headlessly
- cache pip wheels and enforce coverage threshold in CI

## Testing
- `pre-commit run --files tests/smoke/test_app_launch.py .github/workflows/ci.yml`
- `./scripts/run_tests.sh tests/smoke/test_app_launch.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6728725d88331a9d7bb97ba45ceea