### PR TITLE
Config: optional Pydantic fallback + stable Config identity

### DIFF
--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -163,7 +163,7 @@ if _HAS_PYDANTIC:
                 "run",
                 mode="before",
             )
-            def _ensure_dict(cls, v: Any, info: Any) -> dict[str, Any]:
+            def _ensure_dict(cls, v: Any, info: _ValidationInfo) -> dict[str, Any]:
                 if not isinstance(v, dict):
                     raise TypeError(f"{info.field_name} must be a dictionary")
                 return v

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -25,7 +25,7 @@ try:  # pragma: no cover - exercised via tests toggling availability
     _field_validator = _pyd.field_validator
 
     _HAS_PYDANTIC = True
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover
     _BaseModel = object
 
     def _Field(*_args: Any, **_kwargs: Any) -> None:  # noqa: D401 - simple fallback

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -104,7 +104,7 @@ def _validate_version_value(v: Any) -> str:
 
 if _HAS_PYDANTIC:
     # Cache class identity across re-imports to keep isinstance checks stable
-    import builtins as _bi  # type: ignore
+    import builtins as _bi
 
     _cached = getattr(_bi, "_TREND_CONFIG_CLASS", None)
 


### PR DESCRIPTION
Adds Pydantic-v2-backed Config with fallback SimpleBaseModel; exports Config consistently across re-imports to satisfy isinstance in tests; exposes _HAS_PYDANTIC flag; cleans up validators and defaults.