### PR TITLE
Docs & examples: strategy doc + demo export fix

### DIFF
--- a/docs/turnover_cap_strategy.md
+++ b/docs/turnover_cap_strategy.md
@@ -161,7 +161,7 @@ PYTHONPATH=./src python demo_turnover_cap.py
 
 The Turnover Cap Rebalancing Strategy is **production-ready** and fully integrated with the Trend Model Project infrastructure:
 
-- ✅ **Complete Implementation** in `src/trend_analysis/rebalancing.py`
+- ✅ **Complete Implementation** in `src/trend_analysis/rebalancing/strategies.py`
 - ✅ **Multi-Period Integration** in `src/trend_analysis/multi_period/engine.py`
 - ✅ **Comprehensive Testing** with 15 dedicated tests
 - ✅ **Full Documentation** with working examples

--- a/scripts/demo_export_fix.py
+++ b/scripts/demo_export_fix.py
@@ -1,20 +1,16 @@
 #!/usr/bin/env python3
+# ruff: noqa=E402
 """
 Demo script showing the before/after behavior of the export bundle fix.
 
 Run this to see the improvements in temporary file handling.
 """
 
-import sys
 import os
-import tempfile
-import time
-
-# Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
-
-from trend_portfolio_app.io_utils import export_bundle, _TEMP_FILES_TO_CLEANUP
 from unittest import mock
+
+# Add src to path then import (ignore E402 due to path setup for demo script)
+from trend_portfolio_app.io_utils import export_bundle, _TEMP_FILES_TO_CLEANUP
 
 
 def create_mock_results():


### PR DESCRIPTION
Adds turnover cap strategy documentation and a demo export fix script.