### PR TITLE
Include SciPy dependency for weight engine tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "hypothesis",
     "matplotlib",
     "ipywidgets",
+    "scipy",
 ]
 
 [project.urls]

--- a/requirements.lock
+++ b/requirements.lock
@@ -44,6 +44,7 @@ numpy==2.3.2
     #   contourpy
     #   matplotlib
     #   pandas
+    #   scipy
 openpyxl==3.1.5
     # via trend-model (pyproject.toml)
 packaging==25.0
@@ -79,6 +80,8 @@ python-dateutil==2.9.0.post0
 pytz==2025.2
     # via pandas
 pyyaml==6.0.2
+    # via trend-model (pyproject.toml)
+scipy==1.16.1
     # via trend-model (pyproject.toml)
 six==1.17.0
     # via python-dateutil


### PR DESCRIPTION
## Summary
- ensure SciPy is installed by declaring it in project dependencies
- update requirements lock to include SciPy

## Testing
- `./scripts/run_tests.sh tests/test_weight_engines.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6923480588331b62a648acc444ff4