### PR TITLE
test: register smoke marker and fix context manager mock

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    smoke: smoke tests for app launch

--- a/tests/test_app_coverage.py
+++ b/tests/test_app_coverage.py
@@ -29,6 +29,7 @@ class TestLoadSaveState:
         """Test loading state when no file exists."""
         with patch("trend_analysis.gui.app.STATE_FILE") as mock_file:
             mock_file.exists.return_value = False
+            mock_file.open.return_value = _cm_mock()
             store = load_state()
             assert isinstance(store, ParamStore)
 


### PR DESCRIPTION
## Summary
- register custom `smoke` marker for pytest
- patch app coverage test to use context manager-aware mock

## Testing
- `pytest tests/smoke/test_app_launch.py::test_configurable_timeout -q`
- `pytest tests/test_app_coverage.py::TestLoadSaveState::test_load_state_empty -q`
- `pytest tests/test_viz_charts.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b694c07f9c83318a1dfed4d15bb9ba