### PR TITLE
Fix optional imports and expose frequency map

### DIFF
--- a/src/trend_analysis/__init__.py
+++ b/src/trend_analysis/__init__.py
@@ -18,10 +18,10 @@ _SUBMODULES = [
     "weighting",
     "run_multi_analysis",
 ]
-for _name in _SUBMODULES:
-    try:
-        globals()[_name] = importlib.import_module(f".{_name}", __name__)
-    except ModuleNotFoundError:
+    except ModuleNotFoundError as e:
+        # Only suppress if the missing module is NOT the submodule itself
+        if e.name == f"trend_analysis.{_name}":
+            raise
         # Optional dependency for this submodule is missing; skip exposing it.
         pass
 

--- a/src/trend_analysis/__init__.py
+++ b/src/trend_analysis/__init__.py
@@ -1,31 +1,53 @@
 """Trend analysis package."""
 
+import importlib
 import importlib.metadata
 
-from . import api, metrics, config, data, pipeline, export, selector, weighting
-from .data import load_csv, identify_risk_free_fund
-from .export import (
-    register_formatter_excel,
-    reset_formatters_excel,
-    make_summary_formatter,
-    export_to_excel,
-    export_to_csv,
-    export_to_json,
-    export_to_txt,
-    export_data,
-    metrics_from_result,
-    combined_summary_result,
-    combined_summary_frame,
-    phase1_workbook_data,
-    flat_frames_from_results,
-    export_phase1_workbook,
-    export_phase1_multi_metrics,
-    export_multi_period_metrics,
-    export_bundle,
-)
+# Attempt to import submodules.  Some of them pull in optional heavy
+# dependencies (e.g. ``matplotlib``).  Missing extras shouldn't prevent
+# lightweight helpers such as ``io.validators`` from being imported, so we
+# ignore ``ModuleNotFoundError`` during initialisation.
+_SUBMODULES = [
+    "api",
+    "metrics",
+    "config",
+    "data",
+    "pipeline",
+    "export",
+    "selector",
+    "weighting",
+    "run_multi_analysis",
+]
+for _name in _SUBMODULES:
+    try:
+        globals()[_name] = importlib.import_module(f".{_name}", __name__)
+    except ModuleNotFoundError:
+        # Optional dependency for this submodule is missing; skip exposing it.
+        pass
 
-# Expose multi-period CLI
-from . import run_multi_analysis
+if "data" in globals():
+    from .data import load_csv, identify_risk_free_fund  # type: ignore
+
+if "export" in globals():
+    from .export import (
+        register_formatter_excel,
+        reset_formatters_excel,
+        make_summary_formatter,
+        export_to_excel,
+        export_to_csv,
+        export_to_json,
+        export_to_txt,
+        export_data,
+        metrics_from_result,
+        combined_summary_result,
+        combined_summary_frame,
+        phase1_workbook_data,
+        flat_frames_from_results,
+        export_phase1_workbook,
+        export_phase1_multi_metrics,
+        export_multi_period_metrics,
+        export_bundle,
+    )
 
 # Get version from package metadata
 try:

--- a/src/trend_analysis/__init__.py
+++ b/src/trend_analysis/__init__.py
@@ -26,7 +26,7 @@ for _name in _SUBMODULES:
         pass
 
 if "data" in globals():
-    from .data import load_csv, identify_risk_free_fund  # type: ignore
+    from .data import load_csv, identify_risk_free_fund  # type: ignore  # Conditional import: 'data' submodule may not always be present due to optional dependencies.
 
 if "export" in globals():
     from .export import (

--- a/src/trend_analysis/io/validators.py
+++ b/src/trend_analysis/io/validators.py
@@ -7,16 +7,23 @@ from typing import Tuple, List, Dict, Any, Optional
 import pandas as pd
 import numpy as np
 
-FREQ_ALIAS_MAP = {
+# Map human readable frequency labels to pandas `Period` codes.  These codes
+# can be fed directly to ``pd.PeriodIndex`` when normalising timestamps.
+#
+# The project previously used an indirection layer where monthly data mapped to
+# ``"ME"`` and was then converted to ``"M"`` for ``PeriodIndex``.  This extra
+# aliasing made it harder for downstream code (and tests) to reason about the
+# supported frequencies.  The new ``FREQUENCY_MAP`` exposes the final period
+# codes up front and is the single source of truth for frequency handling.
+FREQUENCY_MAP: Dict[str, str] = {
     "daily": "D",
     "weekly": "W",
-    "monthly": "ME",
+    # ``M`` is the canonical month‑end frequency used by ``PeriodIndex``
+    "monthly": "M",
     "quarterly": "Q",
-    "annual": "A",
+    # ``Y`` works for year‑end periods across pandas versions
+    "annual": "Y",
 }
-
-# Map modern frequency codes (e.g., 'ME' for month-end) to legacy pandas period codes ('M' for month-end)
-PANDAS_FREQ_MAP = {"ME": "M"}
 
 
 class ValidationResult:
@@ -202,11 +209,12 @@ def load_and_validate_upload(file_like: Any) -> Tuple[pd.DataFrame, Dict[str, An
     # Normalize to period-end timestamps using detected frequency
     # Use PeriodIndex.to_timestamp(how='end') to ensure end-of-period alignment
     idx = pd.to_datetime(df.index)
-    # Map human-friendly frequency labels (e.g. "monthly") to pandas codes
+    # Map human-friendly frequency labels (e.g. ``"monthly"``) to pandas
+    # ``Period`` codes using ``FREQUENCY_MAP``.  Default to monthly if detection
+    # failed so downstream code still receives a valid index.
     freq_key = (validation.frequency or "").lower()
-    freq_alias = FREQ_ALIAS_MAP.get(freq_key, "ME")
-    pandas_freq = PANDAS_FREQ_MAP.get(freq_alias, freq_alias)
-    df.index = pd.PeriodIndex(idx, freq=pandas_freq).to_timestamp(how='end')
+    pandas_freq = FREQUENCY_MAP.get(freq_key, "M")
+    df.index = pd.PeriodIndex(idx, freq=pandas_freq).to_timestamp(how="end")
     df = df.dropna(axis=1, how="all")
 
     # Convert to numeric


### PR DESCRIPTION
## Summary
- expose FREQUENCY_MAP in validators and use it for PeriodIndex normalization
- guard package `__init__` against optional dependency imports so validators can import without matplotlib

## Testing
- `pre-commit run --files src/trend_analysis/io/validators.py src/trend_analysis/__init__.py`
- `pytest tests/test_validators.py -q`
- `./scripts/run_tests.sh tests/test_validators.py` *(fails: No tests were collected or ran. This may be due to test filters or missing/misnamed tests.)*

------
https://chatgpt.com/codex/tasks/task_e_68b6950121f88331a7f8ca860588d8da