### PR TITLE
Ensure simulator scoreframes include dates

### DIFF
--- a/src/trend_portfolio_app/sim_runner.py
+++ b/src/trend_portfolio_app/sim_runner.py
@@ -26,6 +26,8 @@ def compute_score_frame_local(
     idx = panel.index
     out = {}
     for col in panel.columns:
+        if col == "Date":
+            continue
         r = panel[col].dropna()
         col_metrics = {}
         for name, spec in AVAILABLE_METRICS.items():
@@ -51,6 +53,9 @@ def compute_score_frame(
     insample_end: pd.Timestamp,
     rf_annual: float = 0.0,
 ) -> pd.DataFrame:
+    if "Date" not in panel.columns:
+        raise ValueError("DataFrame must contain a 'Date' column")
+
     if HAS_TA:
         fn = getattr(ta_pipeline, "single_period_run", None)
         if callable(fn):
@@ -77,7 +82,8 @@ def compute_score_frame(
                     e,
                 )
     return compute_score_frame_local(
-        panel.loc[insample_start:insample_end], rf_annual=rf_annual
+        panel.loc[insample_start:insample_end].drop(columns=["Date"], errors="ignore"),
+        rf_annual=rf_annual,
     )
 
 

--- a/tests/app/test_sim_diversification_guard_integration.py
+++ b/tests/app/test_sim_diversification_guard_integration.py
@@ -6,7 +6,7 @@ from trend_portfolio_app.policy_engine import PolicyConfig, MetricSpec
 
 def test_simulator_diversification_guard_integration():
     # Two funds per bucket; ensure we don't exceed cap per review
-    dates = pd.period_range("2020-01", "2020-05", freq="M").to_timestamp("M")
+    dates = pd.period_range("2020-01", "2020-05", freq="M").to_timestamp(how="end")
     data = pd.DataFrame(
         {
             "A1": [0.05, 0.05, 0.05, 0.05, 0.05],
@@ -16,6 +16,7 @@ def test_simulator_diversification_guard_integration():
         },
         index=dates,
     )
+    data["Date"] = dates
     sim = Simulator(data)
     policy = PolicyConfig(
         top_k=3,

--- a/tests/app/test_sim_min_tenure_integration.py
+++ b/tests/app/test_sim_min_tenure_integration.py
@@ -6,7 +6,7 @@ from trend_portfolio_app.policy_engine import PolicyConfig, MetricSpec
 
 def test_simulator_min_tenure_integration():
     # Build a small dataset with clear ranking: A best, B mid, C worst
-    dates = pd.period_range("2020-01", "2020-06", freq="M").to_timestamp("M")
+    dates = pd.period_range("2020-01", "2020-06", freq="M").to_timestamp(how="end")
     data = pd.DataFrame(
         {
             "A": [0.05, 0.05, 0.05, 0.05, 0.05, -0.10],
@@ -15,6 +15,7 @@ def test_simulator_min_tenure_integration():
         },
         index=dates,
     )
+    data["Date"] = dates
 
     sim = Simulator(data)
     policy = PolicyConfig(

--- a/tests/app/test_sim_runner_smoke.py
+++ b/tests/app/test_sim_runner_smoke.py
@@ -5,7 +5,9 @@ from trend_portfolio_app.policy_engine import PolicyConfig, MetricSpec
 
 
 def test_simulator_smoke():
-    idx = pd.period_range(start="2019-01", end="2020-12", freq="M").to_timestamp("M")
+    idx = pd.period_range(start="2019-01", end="2020-12", freq="M").to_timestamp(
+        how="end"
+    )
     df = pd.DataFrame(
         {
             "A": np.random.normal(0.01, 0.05, len(idx)),
@@ -14,6 +16,7 @@ def test_simulator_smoke():
         },
         index=idx,
     )
+    df["Date"] = idx
     sim = Simulator(df, benchmark_col="SPX")
     policy = PolicyConfig(
         top_k=1, bottom_k=0, min_track_months=6, metrics=[MetricSpec("sharpe", 1.0)]

--- a/tests/app/test_sim_turnover_budget_integration.py
+++ b/tests/app/test_sim_turnover_budget_integration.py
@@ -6,7 +6,7 @@ from trend_portfolio_app.policy_engine import PolicyConfig, MetricSpec
 
 def test_simulator_turnover_budget_integration():
     # Construct a simple panel where we would, without budget, fire worst and hire best two.
-    dates = pd.period_range("2020-01", "2020-05", freq="M").to_timestamp("M")
+    dates = pd.period_range("2020-01", "2020-05", freq="M").to_timestamp(how="end")
     data = pd.DataFrame(
         {
             "A": [0.05, 0.05, 0.05, 0.05, 0.05],
@@ -16,6 +16,7 @@ def test_simulator_turnover_budget_integration():
         },
         index=dates,
     )
+    data["Date"] = dates
     sim = Simulator(data)
 
     policy = PolicyConfig(


### PR DESCRIPTION
## Summary
- Require a 'Date' column for score frame computation and ignore it in the local metric path
- Build test panels with month-end `Date` columns so external scoring runs cleanly

## Testing
- `pre-commit run --files src/trend_portfolio_app/sim_runner.py tests/app/test_sim_runner_smoke.py tests/app/test_sim_min_tenure_integration.py tests/app/test_sim_turnover_budget_integration.py tests/app/test_sim_diversification_guard_integration.py`
- `PYTHONPATH=src pytest tests/app -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6953f8ce4833190584acbe1299e5e