### PR TITLE
fix: correct __init__ import loop

### DIFF
--- a/src/trend_analysis/__init__.py
+++ b/src/trend_analysis/__init__.py
@@ -18,6 +18,9 @@ _SUBMODULES = [
     "weighting",
     "run_multi_analysis",
 ]
+for _name in _SUBMODULES:
+    try:
+        globals()[_name] = importlib.import_module(f"trend_analysis.{_name}")
     except ModuleNotFoundError as e:
         # Only suppress if the missing module is NOT the submodule itself
         if e.name == f"trend_analysis.{_name}":


### PR DESCRIPTION
## Summary
- fix unexpected indent in trend_analysis module initialization by restoring for loop and try/except

## Testing
- `pre-commit run --files src/trend_analysis/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'trend_portfolio_app')*
- `./scripts/run_streamlit.sh` *(fails: Operation cancelled; bootstrapping environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b69842c0108331905c528f59b77226