### PR TITLE
fix: resolve __init__ indentation

### DIFF
--- a/src/trend_analysis/__init__.py
+++ b/src/trend_analysis/__init__.py
@@ -18,6 +18,12 @@ _SUBMODULES = [
     "weighting",
     "run_multi_analysis",
 ]
+# Attempt to import and expose all submodules. Optional dependencies may cause
+# some imports to fail; these are skipped unless the submodule itself is
+# missing.
+for _name in _SUBMODULES:
+    try:
+        globals()[_name] = importlib.import_module(f"trend_analysis.{_name}")
     except ModuleNotFoundError as e:
         # Only suppress if the missing module is NOT the submodule itself
         if e.name == f"trend_analysis.{_name}":


### PR DESCRIPTION
## Summary
- fix mis-indented import block in `trend_analysis.__init__` to properly handle optional submodules

## Testing
- `./scripts/run_tests.sh` *(fails: ImportError: cannot import name 'create_weight_engine' from 'trend_analysis.plugins')*

------
https://chatgpt.com/codex/tasks/task_e_68b69aa96f4083319fd2e15cf1b47f2b