### PR TITLE
Enforce strict types for config sections

### DIFF
--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -142,9 +142,9 @@ if _HAS_PYDANTIC:
             checkpoint_dir: str | None = None
             seed: int = 42
 
-            @field_validator("version")
-            def _ensure_version_not_whitespace(cls, v: str) -> str:
                 """Reject strings that consist only of whitespace."""
+                if not isinstance(v, str):
+                    raise ValueError("Version field must be a string")
                 if not v.strip():
                     raise ValueError("Version field cannot be empty")
                 return v

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -235,7 +235,9 @@ else:  # Fallback mode for tests without pydantic
                 "export",
                 "run",
             ]:
-                value = getattr(self, section)
+                value = getattr(self, section, None)
+                if value is None:
+                    raise ValueError(f"{section} section is required")
                 if not isinstance(value, dict):
                     raise ValueError(f"{section} must be a dictionary")
 


### PR DESCRIPTION
## Summary
- validate `version` as a string with helpful errors
- require core config sections to be dictionaries in both pydantic and fallback modes

## Testing
- `pytest tests/test_config_validation.py tests/test_config_human_errors.py tests/test_config_pydantic_fallback.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xlsxwriter', and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b69b680bc4833191b093682ae60e41