### PR TITLE
Enforce strict types for config sections

### DIFF
--- a/src/trend_analysis/export/__init__.py
+++ b/src/trend_analysis/export/__init__.py
@@ -373,7 +373,15 @@ def export_to_excel(
             # backward compat
             df_formatter = None
 
-    with pd.ExcelWriter(path, engine="xlsxwriter") as writer:
+    try:
+        writer = pd.ExcelWriter(path, engine="xlsxwriter")
+    except ModuleNotFoundError:
+        # ``xlsxwriter`` is an optional dependency.  Fall back to the default
+        # engine (typically ``openpyxl``) when it is unavailable so callers can
+        # still export workbooks without installing the extra package.
+        writer = pd.ExcelWriter(path)
+
+    with writer:
         # Iterate over frames and either let a registered sheet formatter
         # render the entire sheet (preferred), or fall back to writing the
         # DataFrame directly when no formatter is available.


### PR DESCRIPTION
## Summary
- validate `version` as a string with helpful errors
- require core config sections to be dictionaries in both pydantic and fallback modes
- fall back to pandas' default Excel engine when `xlsxwriter` isn't installed

## Testing
- `pytest tests/test_default_export.py tests/test_export_formatter.py tests/test_export_errors.py tests/test_exports.py tests/test_export_bundle.py -q`
- `pytest -q` *(fails: AssertionError in app and viz tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b69b680bc4833191b093682ae60e41