### PR TITLE
Ensure strict config field types

### DIFF
--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -158,7 +158,7 @@ if _HAS_PYDANTIC:
             )
             def _ensure_dict(cls, v: Any, info: _ValidationInfo) -> dict[str, Any]:
                 if not isinstance(v, dict):
-                    raise ValueError(f"{info.field_name} must be a dictionary")
+                    raise TypeError(f"{info.field_name} must be a dictionary")
                 return v
 
         setattr(_bi, "_TREND_CONFIG_CLASS", Config)

--- a/streamlit_app/pages/3_Run.py
+++ b/streamlit_app/pages/3_Run.py
@@ -1,12 +1,15 @@
 import pandas as pd
-import streamlit as st
-
 from trend_analysis.api import run_simulation
 from trend_analysis.config import Config
 from streamlit_app.components.disclaimer import show_disclaimer
 
 
 def main():
+    # Re-import streamlit within the function to ensure any test-time monkeypatches
+    # (e.g. replacing ``st.button``) are respected even if the module was previously
+    # imported elsewhere.
+    import streamlit as st  # noqa: WPS433 - local import for testability
+
     st.title("Run")
     # Always render disclaimer + button first so tests can capture state
     accepted = show_disclaimer()


### PR DESCRIPTION
## Summary
- enforce string type for `version` in Config
- normalize Data column before scoring in simulator and slice using normalized index
- reload streamlit in run page to respect patched buttons

## Testing
- `pre-commit run --files src/trend_portfolio_app/sim_runner.py src/trend_analysis/config/models.py streamlit_app/pages/3_Run.py`
- `pytest tests/test_config_human_errors.py::TestHumanErrors::test_version_as_number tests/test_config_human_errors.py::TestHumanErrors::test_version_as_bool tests/test_config_human_errors.py::TestHumanErrors::test_data_as_string tests/test_config_human_errors.py::TestHumanErrors::test_preprocessing_as_list tests/test_config_human_errors.py::TestHumanErrors::test_vol_adjust_as_number tests/test_config_human_errors.py::TestHumanErrors::test_portfolio_as_string tests/test_config_human_errors.py::TestHumanErrors::test_section_as_null tests/test_config_validation.py::test_sections_require_mappings tests/test_config_validation.py::test_version_must_be_string -q`
- `pytest tests/app/test_sim_min_tenure_integration.py::test_simulator_min_tenure_integration -q`
- `./scripts/run_tests.sh` *(fails: tests/test_disclaimer.py::test_run_button_disabled_without_acceptance)*

------
https://chatgpt.com/codex/tasks/task_e_68b69ca4f22883319215d3bff8e32d28