### PR TITLE
fix: correct validator imports, add frequency map, and validate config sections

### DIFF
--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -220,7 +220,7 @@ else:  # Fallback mode for tests without pydantic
             if not self.version.strip():
                 raise ValueError("Version field cannot be empty")
 
-            for _field in [
+            for field in [
                 "data",
                 "preprocessing",
                 "vol_adjust",

--- a/src/trend_analysis/io/validators.py
+++ b/src/trend_analysis/io/validators.py
@@ -20,6 +20,24 @@ FREQ_ALIAS_MAP: Dict[str, str] = {
     "annual": "A",  # mapped to ``Y``
 }
 
+# Map the aliases above to canonical pandas ``Period`` frequency codes.  This
+# allows us to expose a stable public mapping while retaining backwards
+# compatible aliases internally.
+PANDAS_FREQ_MAP: Dict[str, str] = {
+    "D": "D",
+    "W": "W",
+    "ME": "M",  # month-end alias normalised to monthly
+    "Q": "Q",
+    "A": "Y",  # annual alias normalised to yearly
+}
+
+# Public mapping from human-readable frequency labels to pandas ``Period``
+# codes used throughout the codebase and tests.
+FREQUENCY_MAP: Dict[str, str] = {
+    human: PANDAS_FREQ_MAP[alias] for human, alias in FREQ_ALIAS_MAP.items()
+}
+
+
 class ValidationResult:
     """Result of schema validation with detailed feedback."""
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3,7 +3,7 @@
 import pytest
 import pandas as pd
 import io
-from src.trend_analysis.io.validators import (
+from trend_analysis.io.validators import (
     ValidationResult,
     validate_returns_schema,
     detect_frequency,


### PR DESCRIPTION
## Summary
- expose canonical FREQUENCY_MAP in validators for human-readable time frequency detection
- fix tests to import validators from installed trend_analysis package
- fix fallback Config validation to check required sections with correct variable

## Testing
- `pre-commit run --files src/trend_analysis/config/models.py`
- `pytest tests/test_config_pydantic_fallback.py`
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b719bcdec08331b0c0be8545516c1b