### PR TITLE
Fix config fallback and Streamlit test mocks

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     smoke: smoke tests for app launch
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -220,7 +220,7 @@ else:  # Fallback mode for tests without pydantic
             if not self.version.strip():
                 raise ValueError("Version field cannot be empty")
 
-            for _field in [
+            for field in [
                 "data",
                 "preprocessing",
                 "vol_adjust",


### PR DESCRIPTION
## Summary
- register `slow` marker in pytest config
- correct Config fallback validation logic
- patch Streamlit tests with context-aware mocks and stub `matplotlib`
- isolate Streamlit test mocks to avoid leaking into other modules

## Testing
- `./scripts/run_tests.sh tests/test_streamlit_run_page.py`
- `./scripts/run_tests.sh tests/test_config_pydantic_fallback.py::test_config_import_without_pydantic tests/test_config_pydantic_fallback.py::test_load_function_works_without_pydantic tests/test_viz_charts.py`

------
https://chatgpt.com/codex/tasks/task_e_68b71d1cb73083319f5f34e22afc2bd1