### PR TITLE
Fix frequency map mapping and register slow tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     smoke: smoke tests for app launch
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any, Dict, List, cast, ClassVar
+from typing import Any, Dict, List, cast, ClassVar, TYPE_CHECKING
 from collections.abc import Mapping
 
 import yaml

--- a/src/trend_analysis/io/validators.py
+++ b/src/trend_analysis/io/validators.py
@@ -26,19 +26,7 @@ PANDAS_FREQ_MAP: Dict[str, str] = {"ME": "M", "QE": "Q", "A": "Y"}
 
 # Public mapping of human‑readable labels to canonical pandas frequency codes.
 FREQUENCY_MAP: Dict[str, str] = {
-    human: PANDAS_FREQ_MAP.get(alias, alias) for human, alias in FREQ_ALIAS_MAP.items()
-}
-
-# Normalize frequency aliases to pandas Period codes
-PANDAS_FREQ_MAP: Dict[str, str] = {
-    "ME": "M",  # Month-end to Month for PeriodIndex compatibility
-    "A": "Y",   # Annual to Year
-}
-
-# Final frequency map for use throughout the codebase
-FREQUENCY_MAP: Dict[str, str] = {
-    key: PANDAS_FREQ_MAP.get(alias, alias)
-    for key, alias in FREQ_ALIAS_MAP.items()
+    key: PANDAS_FREQ_MAP.get(alias, alias) for key, alias in FREQ_ALIAS_MAP.items()
 }
 
 

--- a/tests/test_app_coverage.py
+++ b/tests/test_app_coverage.py
@@ -122,9 +122,10 @@ class TestBuildStep0:
         mock_widgets.HBox.return_value = Mock()
 
         # Mock DataGrid availability
-        mock_datagrid_instance = Mock()
-        mock_datagrid_instance.on = Mock()  # Add the missing 'on' method
-        mock_datagrid_class = Mock(return_value=mock_datagrid_instance)
+        mock_datagrid_instance = MagicMock()
+        mock_datagrid_instance.on = MagicMock()  # Add the missing 'on' method
+        mock_datagrid_instance.hold_trait_notifications.return_value = _cm_mock()
+        mock_datagrid_class = MagicMock(return_value=mock_datagrid_instance)
 
         with patch("trend_analysis.gui.app.DataGrid", mock_datagrid_class):
             store = ParamStore()
@@ -509,9 +510,10 @@ class TestErrorHandling:
         mock_widgets.HBox.return_value = Mock()
 
         # Mock DataGrid availability
-        mock_datagrid_instance = Mock()
-        mock_datagrid_instance.on = Mock()  # Add the missing 'on' method
-        mock_datagrid_class = Mock(return_value=mock_datagrid_instance)
+        mock_datagrid_instance = MagicMock()
+        mock_datagrid_instance.on = MagicMock()  # Add the missing 'on' method
+        mock_datagrid_instance.hold_trait_notifications.return_value = _cm_mock()
+        mock_datagrid_class = MagicMock(return_value=mock_datagrid_instance)
 
         with patch("trend_analysis.gui.app.DataGrid", mock_datagrid_class):
             store = ParamStore()


### PR DESCRIPTION
## Summary
- remove duplicate frequency map definitions to ensure quarterly mapping resolves to `Q`
- import `TYPE_CHECKING` in config models to avoid NameError during imports
- use `MagicMock` for DataGrid tests so context managers work
- register a `slow` pytest mark in `pytest.ini`

## Testing
- `./scripts/run_tests.sh`
- `pytest tests/test_validators.py::TestFrequencyMap::test_frequency_map_mappings -q`


------
https://chatgpt.com/codex/tasks/task_e_68b722fe5bdc833199105cc6282d97c3