### PR TITLE
fix: import TYPE_CHECKING for config models

### DIFF
--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, cast, ClassVar
 from collections.abc import Mapping
 
 import yaml
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     # Define Config type alias for static type checking


### PR DESCRIPTION
## Summary
- import `TYPE_CHECKING` in configuration models to avoid NameError during test collection

## Testing
- `pre-commit run --files src/trend_analysis/config/models.py` *(fails: command not found)*
- `pytest -q` *(fails: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_68b72490fb6c833197de23141be85e4f