### PR TITLE
fix: import TYPE_CHECKING for config models

### DIFF
--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, cast, ClassVar
 from collections.abc import Mapping
 
 import yaml
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     # Define Config type alias for static type checking
@@ -309,11 +310,11 @@ else:  # Fallback mode for tests without pydantic
                 "export",
                 "run",
             ]:
-                value = getattr(self, _field, None)
+                value = getattr(self, field, None)
                 if value is None:
-                    raise ValueError(f"{_field} section is required")
+                    raise ValueError(f"{field} section is required")
                 if not isinstance(value, dict):
-                    raise ValueError(f"{_field} must be a dictionary")
+                    raise ValueError(f"{field} must be a dictionary")
 
         # Provide a similar API surface to pydantic for callers
         def model_dump(self) -> Dict[str, Any]:

--- a/src/trend_analysis/io/validators.py
+++ b/src/trend_analysis/io/validators.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 import io
-from typing import Tuple, List, Dict, Any, Optional
-import pandas as pd
-import numpy as np
+from typing import Any, Dict, List, Optional, Tuple
 
-# Map human readable frequency labels to legacy alias codes.  Earlier versions
-# of the project used indirections like ``"ME"`` (month‑end) which were then
-# converted to pandas ``PeriodIndex`` codes such as ``"M"``.  ``FREQ_ALIAS_MAP``
-# retains those aliases for backwards compatibility while ``FREQUENCY_MAP``
-# exposes the canonical pandas codes used throughout the codebase.
+import numpy as np
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Frequency mappings
+# ---------------------------------------------------------------------------
+
+# Human readable labels mapped to legacy alias codes used in older configs.
 FREQ_ALIAS_MAP: Dict[str, str] = {
     "daily": "D",
     "weekly": "W",
@@ -20,25 +21,16 @@ FREQ_ALIAS_MAP: Dict[str, str] = {
     "annual": "A",
 }
 
-# Translate legacy alias codes to the canonical pandas codes expected by
-# ``pd.PeriodIndex``.
-PANDAS_FREQ_MAP: Dict[str, str] = {"ME": "M", "QE": "Q", "A": "Y"}
+# Legacy aliases translated to canonical pandas ``PeriodIndex`` codes.
+PANDAS_FREQ_MAP: Dict[str, str] = {
+    "ME": "M",  # month-end -> monthly
+    "QE": "Q",  # quarter-end -> quarterly
+    "A": "Y",  # annual -> yearly
+}
 
-# Public mapping of human‑readable labels to canonical pandas frequency codes.
+# Public mapping of human readable labels directly to pandas codes.
 FREQUENCY_MAP: Dict[str, str] = {
     human: PANDAS_FREQ_MAP.get(alias, alias) for human, alias in FREQ_ALIAS_MAP.items()
-}
-
-# Normalize frequency aliases to pandas Period codes
-PANDAS_FREQ_MAP: Dict[str, str] = {
-    "ME": "M",  # Month-end to Month for PeriodIndex compatibility
-    "A": "Y",   # Annual to Year
-}
-
-# Final frequency map for use throughout the codebase
-FREQUENCY_MAP: Dict[str, str] = {
-    key: PANDAS_FREQ_MAP.get(alias, alias)
-    for key, alias in FREQ_ALIAS_MAP.items()
 }
 
 

--- a/tests/test_streamlit_run_page.py
+++ b/tests/test_streamlit_run_page.py
@@ -3,7 +3,7 @@
 import pytest
 import pandas as pd
 from datetime import date
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import MagicMock, Mock, patch
 import sys
 from pathlib import Path
 
@@ -13,12 +13,15 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 # Import the functions we want to test
 sys.path.insert(0, str(Path(__file__).parent.parent / "app" / "streamlit" / "pages"))
 
-# Mock external dependencies before importing our module
-sys.modules["streamlit"] = Mock()
-sys.modules["matplotlib"] = MagicMock()
-sys.modules["matplotlib.pyplot"] = MagicMock()
-
 from trend_analysis.api import RunResult  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _mock_plotting_modules(monkeypatch):
+    """Provide lightweight stand-ins for optional heavy dependencies."""
+    monkeypatch.setitem(sys.modules, "streamlit", Mock())
+    monkeypatch.setitem(sys.modules, "matplotlib", MagicMock())
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", MagicMock())
 
 
 def _ctx_mock() -> MagicMock:
@@ -39,7 +42,7 @@ def create_mock_streamlit():
     mock_st.info = MagicMock()
     mock_st.empty = MagicMock()
     mock_st.container = _ctx_mock()
-    mock_st.expander = _ctx_mock()v
+    mock_st.expander = _ctx_mock()
     mock_st.code = MagicMock()
     mock_st.rerun = MagicMock()
 
@@ -455,8 +458,12 @@ class TestAnalysisIntegration:
             with patch.object(run_page.st, "session_state", session_state):
                 # Mock streamlit UI elements
                 with patch.object(run_page.st, "container", return_value=_ctx_mock()):
-                    with patch.object(run_page.st, "progress", return_value=_ctx_mock()):
-                        with patch.object(run_page.st, "empty", return_value=_ctx_mock()):
+                    with patch.object(
+                        run_page.st, "progress", return_value=_ctx_mock()
+                    ):
+                        with patch.object(
+                            run_page.st, "empty", return_value=_ctx_mock()
+                        ):
                             result = run_page.run_analysis_with_progress()
 
                 assert result is not None
@@ -493,8 +500,12 @@ class TestAnalysisIntegration:
 
             with patch.object(run_page.st, "session_state", session_state):
                 with patch.object(run_page.st, "container", return_value=_ctx_mock()):
-                    with patch.object(run_page.st, "progress", return_value=_ctx_mock()):
-                        with patch.object(run_page.st, "empty", return_value=_ctx_mock()):
+                    with patch.object(
+                        run_page.st, "progress", return_value=_ctx_mock()
+                    ):
+                        with patch.object(
+                            run_page.st, "empty", return_value=_ctx_mock()
+                        ):
                             with patch.object(run_page.st, "error") as mock_error:
                                 with patch.object(
                                     run_page.st, "expander", return_value=_ctx_mock()


### PR DESCRIPTION
## Summary
- import `TYPE_CHECKING` in configuration models to avoid NameError during test collection
- correct field reference in fallback config validation
- remove stray character in streamlit run page test
- isolate Streamlit/Matplotlib mocks to a fixture so they don't leak into other tests
- unify frequency alias mapping so quarterly data uses canonical pandas codes

## Testing
- `pre-commit run --files tests/test_streamlit_run_page.py src/trend_analysis/io/validators.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b72490fb6c833197de23141be85e4f