### PR TITLE
types: MyPy cleanup, metrics stabilization, export tidy-ups

### DIFF
--- a/app/streamlit/pages/04_Results.py
+++ b/app/streamlit/pages/04_Results.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import pandas as pd  # Required for type annotations used as strings
 
 import streamlit as st
 

--- a/src/trend_analysis/gui/app.py
+++ b/src/trend_analysis/gui/app.py
@@ -507,7 +507,7 @@ def launch() -> widgets.Widget:
         store.dirty = True
         theme_val = change["new"]
         js = cast(Any, Javascript)(
-            f"document.documentElement.style.setProperty("  # noqa: W503
+            f"document.documentElement.style.setProperty("
             f"' --trend-theme','{theme_val}')"
         )
         cast(Any, display)(js)

--- a/tests/test_cli_api_golden_master.py
+++ b/tests/test_cli_api_golden_master.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 from trend_analysis.config import Config
 from trend_analysis import api
-from trend_analysis.data import load_csv
 
 
 def make_test_data():
@@ -73,48 +72,48 @@ def test_cli_api_golden_master():
         _write_config(config_file, cfg)
 
         # Test API output
-        api_result = api.run_simulation(cfg, df)
+    api_result = api.run_simulation(cfg, df)
 
-        # Test CLI output (detailed mode to get metrics DataFrame)
-        result = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "trend_analysis.run_analysis",
-                "-c",
-                str(config_file),
-                "--detailed",
-            ],
-            cwd=Path(__file__).parent.parent,
-            env={
-                **dict(os.environ),
-                "PYTHONPATH": str(Path(__file__).parent.parent / "src"),
-            },
-            capture_output=True,
-            text=True,
-        )
+    # Test CLI output (detailed mode to get metrics DataFrame)
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "trend_analysis.run_analysis",
+            "-c",
+            str(config_file),
+            "--detailed",
+        ],
+        cwd=Path(__file__).parent.parent,
+        env={
+            **dict(os.environ),
+            "PYTHONPATH": str(Path(__file__).parent.parent / "src"),
+        },
+        capture_output=True,
+        text=True,
+    )
 
-        # For this test, we'll compare API results with expected structure
-        # The CLI comparison is complex due to output formatting
-        assert isinstance(api_result.metrics, pd.DataFrame)
-        assert not api_result.metrics.empty
-        assert "cagr" in api_result.metrics.columns
-        assert "sharpe" in api_result.metrics.columns
-        assert "ir_spx" in api_result.metrics.columns
+    # For this test, we'll compare API results with expected structure
+    # The CLI comparison is complex due to output formatting
+    assert isinstance(api_result.metrics, pd.DataFrame)
+    assert not api_result.metrics.empty
+    assert "cagr" in api_result.metrics.columns
+    assert "sharpe" in api_result.metrics.columns
+    assert "ir_spx" in api_result.metrics.columns
 
-        # Validate RunResult structure
-        assert hasattr(api_result, "details")
-        assert hasattr(api_result, "seed")
-        assert hasattr(api_result, "environment")
+    # Validate RunResult structure
+    assert hasattr(api_result, "details")
+    assert hasattr(api_result, "seed")
+    assert hasattr(api_result, "environment")
 
-        # Validate details structure
-        assert "out_sample_stats" in api_result.details
-        assert "benchmark_ir" in api_result.details
+    # Validate details structure
+    assert "out_sample_stats" in api_result.details
+    assert "benchmark_ir" in api_result.details
 
-        # Validate environment info
-        assert "python" in api_result.environment
-        assert "numpy" in api_result.environment
-        assert "pandas" in api_result.environment
+    # Validate environment info
+    assert "python" in api_result.environment
+    assert "numpy" in api_result.environment
+    assert "pandas" in api_result.environment
 
 
 def test_api_deterministic_behavior():

--- a/tests/test_cli_installed.py
+++ b/tests/test_cli_installed.py
@@ -1,10 +1,7 @@
 """Smoke tests for installed CLI entry points - validates console_scripts work in CI Ubuntu."""
 
 import subprocess
-import sys
 import shutil
-import os
-from pathlib import Path
 import pytest
 
 

--- a/tests/test_no_hardcoded_sleeps.py
+++ b/tests/test_no_hardcoded_sleeps.py
@@ -7,8 +7,6 @@ are not present in Streamlit smoke tests, which could cause flaky tests.
 import re
 from pathlib import Path
 
-import pytest
-
 
 def test_no_hardcoded_sleeps_in_smoke_tests():
     """Verify that smoke tests don't contain hardcoded sleep statements."""

--- a/tests/test_unified_api_integration.py
+++ b/tests/test_unified_api_integration.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from trend_analysis.config import Config
 from trend_analysis import api
 from trend_analysis.data import load_csv
-from trend_analysis.run_analysis import main as cli_main
 
 
 def test_comprehensive_api_integration():


### PR DESCRIPTION
Summary\n- Remove unused type: ignore; add precise casts and control-flow narrowing in metrics/export.\n- Stabilize annual_return on non-positive compounded growth (return -1.0), DataFrame-safe handling.\n- Normalize export formatters (records conversion, safe() using math.isnan), minor indentation fixes.\n\nValidation\n- Black/Flake8: PASS\n- MyPy: PASS (0 issues)\n- Unit tests: PASS (460 passed, 1 skipped). Coverage gate in script is at 70% vs ~64% overall, so CI coverage job may fail even though tests pass.\n\nFollow-ups\n- Lift coverage or adjust threshold as needed for merge.