### PR TITLE
fix: expose config field constants

### DIFF
--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -155,35 +155,21 @@ if _HAS_PYDANTIC:
     class _PydanticConfigImpl(PydanticConfigBase):  # type: ignore[misc, valid-type]
         """Typed access to the YAML configuration (Pydantic mode)."""
 
-        # Field lists as class constants to prevent maintenance burden
-        REQUIRED_DICT_FIELDS: ClassVar[List[str]] = [
-            "data",
-            "preprocessing",
-            "vol_adjust",
-            "sample_split",
-            "portfolio",
-            "metrics",
-            "export",
-            "run",
-        ]
+        # Field lists generated dynamically from model fields to prevent maintenance burden
+        @classmethod
+        def _dict_field_names(cls) -> List[str]:
+            """Return names of fields whose type is dict[str, Any] (or compatible)."""
+            # Only include fields whose annotation is a dict (ignoring optionality)
+            result = []
+            for name, field in cls.__fields__.items():
+                # Check if the outer type is dict (for Pydantic v1/v2 compatibility)
+                typ = field.outer_type_
+                if getattr(typ, "__origin__", None) is dict:
+                    result.append(name)
+            return result
 
-        ALL_FIELDS: ClassVar[List[str]] = [
-            "version",
-            "data",
-            "preprocessing",
-            "vol_adjust",
-            "sample_split",
-            "portfolio",
-            "benchmarks",
-            "metrics",
-            "export",
-            "output",
-            "run",
-            "multi_period",
-            "jobs",
-            "checkpoint_dir",
-            "seed",
-        ]
+        REQUIRED_DICT_FIELDS: ClassVar[List[str]] = _dict_field_names.__func__(None)
+        ALL_FIELDS: ClassVar[List[str]] = list(__fields__.keys())
 
         # Use a plain dict for model_config to avoid type-checker issues when
         # Pydantic is not installed (tests toggle availability).

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -155,6 +155,36 @@ if _HAS_PYDANTIC:
     class _PydanticConfigImpl(PydanticConfigBase):  # type: ignore[misc, valid-type]
         """Typed access to the YAML configuration (Pydantic mode)."""
 
+        # Field lists as class constants to prevent maintenance burden
+        REQUIRED_DICT_FIELDS: ClassVar[List[str]] = [
+            "data",
+            "preprocessing",
+            "vol_adjust",
+            "sample_split",
+            "portfolio",
+            "metrics",
+            "export",
+            "run",
+        ]
+
+        ALL_FIELDS: ClassVar[List[str]] = [
+            "version",
+            "data",
+            "preprocessing",
+            "vol_adjust",
+            "sample_split",
+            "portfolio",
+            "benchmarks",
+            "metrics",
+            "export",
+            "output",
+            "run",
+            "multi_period",
+            "jobs",
+            "checkpoint_dir",
+            "seed",
+        ]
+
         # Use a plain dict for model_config to avoid type-checker issues when
         # Pydantic is not installed (tests toggle availability).
         model_config = {"extra": "ignore"}

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -8,6 +8,8 @@ sys.path.insert(0, str(ROOT / "src"))  # noqa: E402
 
 from trend_analysis import config  # noqa: E402
 
+Config = config.models.Config
+
 # Try to import ValidationError, fallback to ValueError for environments without pydantic
 try:
     from pydantic import ValidationError
@@ -17,7 +19,7 @@ except ImportError:
     ValidationException = ValueError
 
 # Use constants from the Config class to avoid hardcoded duplication
-_DICT_SECTIONS = config.models.Config.REQUIRED_DICT_FIELDS
+_DICT_SECTIONS = Config.REQUIRED_DICT_FIELDS
 
 invalid_values = st.one_of(
     st.integers(), st.floats(), st.booleans(), st.lists(st.integers())


### PR DESCRIPTION
## Summary
- ensure Config exposes REQUIRED_DICT_FIELDS and ALL_FIELDS in pydantic mode
- use Config alias for required field constant in tests

## Testing
- `./scripts/run_tests.sh` *(fails: no tests were run; only dependency installation output)*
- `PYTHONPATH=./src pytest tests/test_config_validation.py::test_config_field_constants_synchronized -q`


------
https://chatgpt.com/codex/tasks/task_e_68b763cd076c8331b383eee4ce6b0d82