### PR TITLE
Handle axes sequences in attribution plotting

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -20,7 +20,7 @@ executing==2.2.1
     # via stack-data
 fonttools==4.59.2
     # via matplotlib
-hypothesis==6.138.13
+hypothesis==6.138.14
     # via trend-model (pyproject.toml)
 ipython==9.5.0
     # via ipywidgets

--- a/src/trend_analysis/metrics/attribution.py
+++ b/src/trend_analysis/metrics/attribution.py
@@ -93,7 +93,7 @@ if (
 def plot_contributions(
     contrib: pd.DataFrame,
     *,
-    ax: "_Axes | None" = None,
+    ax: "_Axes | Iterable[_Axes] | None" = None,
     labels: Iterable[str] | None = None,
 ) -> "_Axes":
     """Plot cumulative contributions over time.
@@ -118,6 +118,15 @@ def plot_contributions(
 
     if ax is None:
         _, ax = plt.subplots()
+    else:
+        # ``plt.subplots`` returns either a single ``Axes`` instance or a
+        # sequence of them.  Some callers may accidentally pass the entire
+        # sequence which is often a tuple (immutable).  Converting to a list
+        # allows safe indexing and we pick the first axis for plotting.
+        if isinstance(ax, tuple):
+            ax = list(ax)
+        if isinstance(ax, (list, np.ndarray)):
+            ax = ax[0]
 
     if labels is None:
         labels = [c for c in contrib.columns if c != "total"]

--- a/src/trend_analysis/metrics/attribution.py
+++ b/src/trend_analysis/metrics/attribution.py
@@ -123,9 +123,8 @@ def plot_contributions(
         # sequence of them.  Some callers may accidentally pass the entire
         # sequence which is often a tuple (immutable).  Converting to a list
         # allows safe indexing and we pick the first axis for plotting.
-        if isinstance(ax, tuple):
-            ax = list(ax)
-        if isinstance(ax, (list, np.ndarray)):
+        # If ax is any iterable (except string), extract the first element.
+        if isinstance(ax, Iterable) and not isinstance(ax, str):
             ax = ax[0]
 
     if labels is None:

--- a/tests/test_viz_charts.py
+++ b/tests/test_viz_charts.py
@@ -202,6 +202,8 @@ def test_basic_functionality_integration():
         from typing import cast
 
         to_result = charts.turnover_series(cast(dict, weights))
+        if isinstance(to_result, tuple):
+            _, to_result = to_result
         assert to_result.shape == (4, 1)
         assert list(to_result.columns) == ["turnover"]
     except Exception:


### PR DESCRIPTION
## Summary
- make `plot_contributions` resilient to receiving a sequence of axes by normalising to the first axis
- adjust visualization tests to unpack results from `turnover_series`
- refresh `requirements.lock` to align with latest dependency versions

## Testing
- `pytest tests/test_export_bundle.py::test_export_bundle tests/test_metrics_attribution.py tests/test_viz_charts.py -q`
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b880846f108331bc353d42c146dcbb