### PR TITLE
Handle empty portfolios in export bundle

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -20,7 +20,7 @@ executing==2.2.1
     # via stack-data
 fonttools==4.59.2
     # via matplotlib
-hypothesis==6.138.13
+hypothesis==6.138.14
     # via trend-model (pyproject.toml)
 ipython==9.5.0
     # via ipywidgets

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -14,7 +14,7 @@ set +e
 PYTHONPATH="./src" pytest --maxfail=1 --disable-warnings --cov trend_analysis --cov-branch "$@"
 status=$?
 set -e
-
+if [ "$status" -eq 5 ]; then
   echo "No tests were collected or ran. This may be due to test filters or missing/misnamed tests."
   exit 1
 fi

--- a/src/trend_analysis/export/bundle.py
+++ b/src/trend_analysis/export/bundle.py
@@ -104,18 +104,33 @@ def export_bundle(run: Any, path: Path) -> Path:
             from matplotlib import pyplot as plt  # locally scoped import
 
             eq = (1 + portfolio.fillna(0)).cumprod()
-            # Use figure/add_subplot for maximum backend compatibility
+
+            # ------------------------------------------------------------------
+            # Equity curve
+            # ------------------------------------------------------------------
             fig = plt.figure()
             ax = fig.add_subplot(1, 1, 1)
-            eq.plot(ax=ax)
+            if not eq.empty:
+                eq.plot(ax=ax)
+            else:  # pragma: no cover - visual placeholder for empty data
+                ax.set_axis_off()
             ax.set_title("Equity Curve")
             fig.savefig(charts_dir / "equity_curve.png", metadata={"run_id": run_id})
             plt.close(fig)
 
-            dd = eq / eq.cummax() - 1
+            # ------------------------------------------------------------------
+            # Drawdown chart
+            # ------------------------------------------------------------------
+            if not eq.empty:
+                dd = eq / eq.cummax() - 1
+            else:
+                dd = pd.Series(dtype=float)
             fig = plt.figure()
             ax = fig.add_subplot(1, 1, 1)
-            dd.plot(ax=ax)
+            if not dd.empty:
+                dd.plot(ax=ax)
+            else:  # pragma: no cover - visual placeholder for empty data
+                ax.set_axis_off()
             ax.set_title("Drawdown")
             fig.savefig(charts_dir / "drawdown.png", metadata={"run_id": run_id})
             plt.close(fig)

--- a/tests/test_export_bundle.py
+++ b/tests/test_export_bundle.py
@@ -85,3 +85,21 @@ def test_receipt_deterministic(tmp_path):
         r1 = z1.read("receipt.txt")
         r2 = z2.read("receipt.txt")
     assert r1 == r2
+
+
+def test_export_bundle_empty_portfolio(tmp_path):
+    """export_bundle should handle empty portfolio without crashing."""
+    input_path = _write_input(tmp_path)
+    run = DummyRun(
+        portfolio=pd.Series(dtype=float),
+        config={},
+        seed=1,
+        input_path=input_path,
+    )
+    out = tmp_path / "empty_bundle.zip"
+    export_bundle(run, out)
+    with zipfile.ZipFile(out) as z:
+        names = set(z.namelist())
+        # Placeholder charts should still be created
+        assert "charts/equity_curve.png" in names
+        assert "charts/drawdown.png" in names


### PR DESCRIPTION
## Summary
- avoid plotting errors in export bundle by handling empty portfolios and creating placeholder charts
- test that export_bundle completes and writes charts even when portfolio is empty
- update dependencies and fix test runner script so full test suite passes

## Testing
- `pre-commit run --files scripts/run_tests.sh requirements.lock`
- `python scripts/run_multi_demo.py`
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b88b62eeec8331a0c172b20bd46971