### PR TITLE
Ensure _is_zero_everywhere handles NumPy scalars

### DIFF
--- a/src/trend_analysis/metrics/__init__.py
+++ b/src/trend_analysis/metrics/__init__.py
@@ -85,8 +85,11 @@ def _is_zero_everywhere(
         )
         return bool(result)
 
-    # For scalar values, check if close to zero to handle floating-point precision
-    return abs(value) <= tol
+    # For scalar values, check if close to zero to handle floating-point precision.
+    # ``abs(value) <= tol`` may return a ``numpy.bool_`` when ``value`` is a NumPy
+    # scalar.  Cast to ``bool`` so callers can rely on a plain Python ``bool`` and
+    # identity checks like ``is True`` behave as expected.
+    return bool(abs(value) <= tol)
 
 
 # ------------------------------------------------------------------------

--- a/tests/test_is_zero_everywhere_helper.py
+++ b/tests/test_is_zero_everywhere_helper.py
@@ -28,6 +28,12 @@ class TestIsZeroEverywhere:
         # The tolerance can be overridden for scalar comparisons
         assert _is_zero_everywhere(1e-13, tol=1e-12) is True
 
+        # Works with NumPy scalar types and still returns a Python ``bool``
+        np_value = np.float64(1e-13)
+        result = _is_zero_everywhere(np_value, tol=1e-12)
+        assert result is True
+        assert isinstance(result, bool)
+
     def test_pandas_series(self):
         """Test _is_zero_everywhere with pandas Series."""
         # Test all-zero series


### PR DESCRIPTION
## Summary
- cast scalar comparison result to `bool` so `_is_zero_everywhere` works with NumPy scalar types
- expand `_is_zero_everywhere` tests to cover NumPy floats and ensure boolean return

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8b9bfcb448331b7cf790c9f0bdfb7