### PR TITLE
Ensure _is_zero_everywhere handles NumPy scalars

### DIFF
--- a/tests/test_is_zero_everywhere_helper.py
+++ b/tests/test_is_zero_everywhere_helper.py
@@ -28,6 +28,23 @@ class TestIsZeroEverywhere:
         # The tolerance can be overridden for scalar comparisons
         assert _is_zero_everywhere(1e-13, tol=1e-12) is True
 
+        # Works with NumPy scalar types and still returns a Python ``bool``
+        np_value = np.float64(1e-13)
+        result = _is_zero_everywhere(np_value, tol=1e-12)
+        assert result is True
+        assert isinstance(result, bool)
+
+    def test_numpy_array(self):
+        """Test _is_zero_everywhere with NumPy array inputs."""
+        zeros = np.array([0.0, 0.0])
+        assert _is_zero_everywhere(zeros) is True
+
+        mixed = np.array([0.0, 1e-13])
+        assert _is_zero_everywhere(mixed) is False
+        array_result = _is_zero_everywhere(mixed, tol=1e-12)
+        assert array_result is True
+        assert isinstance(array_result, bool)
+
     def test_pandas_series(self):
         """Test _is_zero_everywhere with pandas Series."""
         # Test all-zero series


### PR DESCRIPTION
## Summary
- cast scalar comparison result to `bool` so `_is_zero_everywhere` works with NumPy scalar types
- expand `_is_zero_everywhere` to support array-like inputs and tighten tests

## Testing
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b8b9bfcb448331b7cf790c9f0bdfb7