### PR TITLE
Constraints: projection + wiring + tests (Issue #432)

### DIFF
--- a/src/trend_analysis/api.py
+++ b/src/trend_analysis/api.py
@@ -77,6 +77,7 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
         benchmarks=config.benchmarks,
         seed=seed,
         weighting_scheme=config.portfolio.get("weighting_scheme", "equal"),
+        constraints=config.portfolio.get("constraints"),
         stats_cfg=stats_cfg,
     )
     if res is None:

--- a/src/trend_analysis/engine/optimizer.py
+++ b/src/trend_analysis/engine/optimizer.py
@@ -30,7 +30,13 @@ def _redistribute(w: pd.Series, mask: pd.Series, amount: float) -> pd.Series:
     eligible = w[mask]
     if eligible.empty:
         raise ConstraintViolation("No capacity to redistribute excess weight")
-    w.loc[eligible.index] += amount * (eligible / eligible.sum())
+    total = float(eligible.sum())
+    if total <= NUMERICAL_TOLERANCE_HIGH:
+        # If eligible bucket currently has (near) zero mass, distribute uniformly
+        share = amount / len(eligible)
+        w.loc[eligible.index] += share
+    else:
+        w.loc[eligible.index] += amount * (eligible / total)
     return w
 
 

--- a/tests/test_optimizer_constraints.py
+++ b/tests/test_optimizer_constraints.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from trend_analysis.engine.optimizer import (
+    ConstraintViolation,
+    apply_constraints,
+)
+
+
+def test_long_only_projection_normalizes():
+    w = pd.Series([0.2, -0.1, 0.9], index=["a", "b", "c"], dtype=float)
+    out = apply_constraints(w, {"long_only": True})
+    assert (out >= 0).all()
+    np.testing.assert_allclose(out.sum(), 1.0)
+
+
+def test_max_weight_cap_redistributes():
+    w = pd.Series([0.6, 0.4], index=["a", "b"], dtype=float)
+    out = apply_constraints(w, {"long_only": True, "max_weight": 0.55})
+    assert out["a"] <= 0.55 + 1e-9
+    np.testing.assert_allclose(out.sum(), 1.0)
+
+
+def test_too_small_max_weight_infeasible():
+    w = pd.Series([0.5, 0.5], index=["a", "b"], dtype=float)
+    with pytest.raises(ConstraintViolation):
+        apply_constraints(w, {"max_weight": 0.3})
+
+
+def test_group_caps_enforced_and_redistributed():
+    w = pd.Series([0.5, 0.5, 0.0], index=["a", "b", "c"], dtype=float)
+    groups = {"a": "X", "b": "X", "c": "Y"}
+    out = apply_constraints(
+        w,
+        {
+            "long_only": True,
+            "group_caps": {"X": 0.6, "Y": 0.6},
+            "groups": groups,
+        },
+    )
+    assert out.loc[["a", "b"]].sum() <= 0.6 + 1e-9
+    np.testing.assert_allclose(out.sum(), 1.0)
+
+
+def test_missing_groups_raises():
+    w = pd.Series([0.5, 0.5], index=["a", "b"], dtype=float)
+    with pytest.raises(KeyError):
+        apply_constraints(w, {"group_caps": {"X": 0.6}, "groups": {"a": "X"}})


### PR DESCRIPTION
This PR implements the remaining acceptance criteria for Issue #432 and wires constraints in the single-period pipeline.\n\nHighlights:\n- Optimizer: handle redistribution when eligible bucket has ~0 mass to avoid NaNs; clearer infeasibility behavior.\n- Tests: add focused unit tests for long_only, max_weight, group_caps, and missing group mapping.\n- Pipeline/API: plumb constraints from config.portfolio into _run_analysis and apply to user-provided weights.\n- Validation: test suite passes locally; coverage >= 75%.\n\nNotes:\n- UI for providing group mappings remains out-of-scope here; API supports it via config.portfolio.constraints.groups.\n- Multi-period engine has its own constraint logic; this PR only affects single-period run.\n\nCloses #432 once merged.