### PR TITLE
CI: Streamlit health endpoint + smoke test readiness (Issue #437)

### DIFF
--- a/src/trend_portfolio_app/app.py
+++ b/src/trend_portfolio_app/app.py
@@ -27,6 +27,21 @@ except Exception:  # pragma: no cover - optional UI nicety
     _st_sort_items = None
 
 
+# ---- health check (fast path for CI/readiness) -------------------------
+# If the query string contains health=1 (or true/yes), immediately return a tiny
+# page and stop execution. This gives CI a super-fast and deterministic endpoint
+# without rendering the full app.
+try:  # Prefer stable API when available
+    _qs = st.experimental_get_query_params()
+except Exception:  # pragma: no cover - extremely unlikely
+    _qs = {}
+
+_health_flag = str(_qs.get("health", ["0"])[0]).lower()
+if _health_flag in {"1", "true", "yes"}:  # pragma: no cover - exercised via smoke test
+    st.write("OK")
+    st.stop()
+
+
 # ---- small helpers -----------------------------------------------------
 
 


### PR DESCRIPTION
This PR implements the optional follow-up for Issue #437 to make CI smoke tests faster and more robust.\n\nChanges\n- Add a lightweight health check path in the Streamlit app: visiting  renders 'OK' and immediately stops app execution.\n- Update  to poll the health endpoint first and fall back to the root page.\n- Keep existing coverage gate  and pip/wheel caching intact.\n\nValidation\n- Ran focused smoke tests and the full suite locally: 475 passed, 6 skipped.\n- Verified pre-commit hooks pass.\n\nWhy\n- Provides a deterministic, low-latency readiness signal for CI to reduce flakes and shave startup time.\n\nAcceptance criteria alignment\n- CI will fail if the app fails to start (smoke test).\n- Coverage gates remain enforced.\n\nAfter merge\n- We can close Issue #437.\n