### PR TITLE
Add workflow to request Copilot fixes for failures

### DIFF
--- a/.github/workflows/copilot-autofix-on-failure.yml
+++ b/.github/workflows/copilot-autofix-on-failure.yml
@@ -1,0 +1,57 @@
+name: Ask Copilot to fix failing checks
+on:
+  check_suite:
+    types: [completed]
+permissions:
+  pull-requests: write
+  checks: read
+  contents: read
+jobs:
+  ping-copilot:
+    if: github.event.check_suite.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find open PR for this head branch
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const suite = context.payload.check_suite;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            // Find PRs with head = owner:branch
+            const prs = await github.rest.pulls.list({
+              owner, repo, state: 'open', head: `${owner}:${suite.head_branch}`
+            });
+            if (!prs.data.length) return core.setOutput('pr', '');
+            core.setOutput('pr', prs.data[0].number.toString());
+      - name: Skip if not a Copilot PR
+        if: steps.pr.outputs.pr != ''
+        id: labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr_number = Number(core.getInput('pr')) || Number('${{ steps.pr.outputs.pr }}');
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner, repo: context.repo.repo, pull_number: pr_number
+            });
+            const labels = pr.labels.map(l => l.name);
+            if (!labels.includes('from:copilot')) core.setFailed('Not a Copilot PR');
+      - name: Summarize failing checks and comment
+        if: steps.pr.outputs.pr != '' && !cancelled()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr_number = Number('${{ steps.pr.outputs.pr }}');
+            const suite = context.payload.check_suite;
+            const { data: runs } = await github.rest.checks.listForSuite({
+              owner: context.repo.owner, repo: context.repo.repo, check_suite_id: suite.id
+            });
+            const failing = runs.check_runs
+              .filter(r => r.conclusion === 'failure')
+              .map(r => `- **${r.name}**: ${r.output?.summary || r.output?.title || 'failed'}`)
+              .join('\n') || 'Some checks failed. See logs.';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: pr_number,
+              body: `@copilot please fix the failing checks by updating this PR:\n\n${failing}`
+            });

--- a/.github/workflows/copilot-autofix-on-failure.yml
+++ b/.github/workflows/copilot-autofix-on-failure.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const pr_number = Number(core.getInput('pr')) || Number('${{ steps.pr.outputs.pr }}');
+            const pr_number = Number('${{ steps.pr.outputs.pr }}');
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner, repo: context.repo.repo, pull_number: pr_number
             });

--- a/.github/workflows/copilot-autofix-on-failure.yml
+++ b/.github/workflows/copilot-autofix-on-failure.yml
@@ -19,9 +19,9 @@ jobs:
             const suite = context.payload.check_suite;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            // Find PRs with head = owner:branch
+            // Find PRs with head = branch name only
             const prs = await github.rest.pulls.list({
-              owner, repo, state: 'open', head: `${owner}:${suite.head_branch}`
+              owner, repo, state: 'open', head: suite.head_branch
             });
             if (!prs.data.length) return core.setOutput('pr', '');
             core.setOutput('pr', prs.data[0].number.toString());

--- a/.github/workflows/copilot-autofix-on-failure.yml
+++ b/.github/workflows/copilot-autofix-on-failure.yml
@@ -36,7 +36,10 @@ jobs:
               owner: context.repo.owner, repo: context.repo.repo, pull_number: pr_number
             });
             const labels = pr.labels.map(l => l.name);
-            if (!labels.includes('from:copilot')) core.setFailed('Not a Copilot PR');
+            if (!labels.includes('from:copilot')) {
+              core.info('Not a Copilot PR, skipping.');
+              return;
+            }
       - name: Summarize failing checks and comment
         if: steps.pr.outputs.pr != '' && !cancelled()
         uses: actions/github-script@v7


### PR DESCRIPTION
This workflow triggers Copilot to fix failing checks on pull requests by summarizing the failures and commenting on the PR.