### PR TITLE
fix: expose weight engine modules

### DIFF
--- a/src/trend_analysis/plugins/__init__.py
+++ b/src/trend_analysis/plugins/__init__.py
@@ -123,4 +123,7 @@ __all__ = [
     "create_selector",
     "create_rebalancer",
     "create_weight_engine",
+    "_equal_risk_contribution",
+    "_hierarchical_risk_parity",
+    "_risk_parity",
 ]


### PR DESCRIPTION
## Summary
- include weight engine imports in `plugins.__all__` so linters recognize intentional side-effect imports

## Testing
- `pytest tests/test_weight_engine_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9cdcbd0f08331aba8277170f43ea7