### PR TITLE
Fix unhashable dict usage in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ def pytest_collection_modifyitems(config, items):
     if not q.exists():
         return
     data = yaml.safe_load(q.read_text()) or {}
-    bad = set(data.get("tests", []))
+    bad = {t["id"] for t in data.get("tests", [])}
     for it in items:
         if it.nodeid in bad:
             it.add_marker(pytest.mark.quarantine(reason="repo quarantine list"))

--- a/tests/test_metric_vectorise_param.py
+++ b/tests/test_metric_vectorise_param.py
@@ -24,22 +24,27 @@ def _dummy_prices():
     return 100 * (1 + rets).cumprod()
 
 
-# (metric_name, data_fn, kwargs)
+# (metric_name, data_fn, kwargs_factory)
 CASES = [
-    ("volatility", _dummy_returns, {}),
-    ("sharpe_ratio", _dummy_returns, {"risk_free": 0.0}),
-    ("max_drawdown", _dummy_prices, {}),
-    ("sortino_ratio", _dummy_returns, {"target": 0.0}),
-    ("info_ratio", _dummy_returns, {"benchmark": _dummy_returns().mean(axis=1)}),
+    ("volatility", _dummy_returns, lambda: {}),
+    ("sharpe_ratio", _dummy_returns, lambda: {"risk_free": 0.0}),
+    ("max_drawdown", _dummy_prices, lambda: {}),
+    ("sortino_ratio", _dummy_returns, lambda: {"target": 0.0}),
+    (
+        "info_ratio",
+        _dummy_returns,
+        lambda: {"benchmark": _dummy_returns().mean(axis=1)},
+    ),
 ]
 
 
-@pytest.mark.parametrize("name, data_fn, kw", CASES)
-def test_vectorised_metric_matches_legacy(name, data_fn, kw):
+@pytest.mark.parametrize("name, data_fn, kw_fn", CASES)
+def test_vectorised_metric_matches_legacy(name, data_fn, kw_fn):
     data = data_fn()
     vec_fn = getattr(M, name)
     leg_fn = getattr(L, name)
 
+    kw = kw_fn()
     new_series = vec_fn(data, **kw)
     old_series = leg_fn(data, **kw)
 


### PR DESCRIPTION
## Summary
- avoid unhashable dicts in metric parameterization by using kw factories
- parse quarantine YAML entries by id to prevent set() hashing errors

## Testing
- `pre-commit run --files tests/test_metric_vectorise_param.py tests/conftest.py`
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bb8a2138c08331b0901bfb47841292