### PR TITLE
fix: correct quarantine variable usage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,9 +38,9 @@ def pytest_collection_modifyitems(config, items):
     qfile = pathlib.Path(__file__).with_name("quarantine.yml")
     if not qfile.exists() or yaml is None:
         return
-    data = yaml.safe_load(q.read_text()) or {}
+    data = yaml.safe_load(qfile.read_text()) or {}
     bad = {t["id"] for t in data.get("tests", [])}
     for it in items:
-        if it.nodeid in q:
+        if it.nodeid in bad:
             it.add_marker(pytest.mark.quarantine(reason="repo quarantine list"))
             it.add_marker(pytest.mark.xfail(reason="quarantined", strict=False))


### PR DESCRIPTION
## Summary
- fix NameError in pytest quarantine hook

## Testing
- `pre-commit run --files tests/conftest.py`
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bb9387ad6883318d4103c3a53eebba