### PR TITLE
fix: remove type ignore for fallback info

### DIFF
--- a/src/trend_analysis/api.py
+++ b/src/trend_analysis/api.py
@@ -131,12 +131,15 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
         "pandas": pd.__version__,
     }
 
-    fallback_info = res.get("weight_engine_fallback") if isinstance(res, dict) else None
+    fallback_raw = res.get("weight_engine_fallback") if isinstance(res, dict) else None
+    fallback_info: dict[str, Any] | None = (
+        fallback_raw if isinstance(fallback_raw, dict) else None
+    )
     logger.info("run_simulation end")
     return RunResult(
         metrics=metrics_df,
         details=res,
         seed=seed,
         environment=env,
-        fallback_info=fallback_info,  # type: ignore[arg-type]
+        fallback_info=fallback_info,
     )


### PR DESCRIPTION
## Summary
- ensure `fallback_info` typed without ignoring errors in `run_simulation`

## Testing
- `./scripts/setup_env.sh`
- `python scripts/generate_demo.py`
- `python scripts/run_multi_demo.py` *(fails: ModuleNotFoundError: No module named 'trend_analysis')*
- `./scripts/run_tests.sh` *(killed after long runtime)*
- `pytest tests/test_weight_engine_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbc50af97c8331bd203a50a1ca60ae