### PR TITLE
Fix CI dependency installation and health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Install test deps
         run: |
           python -m pip install -U pip
+          pip install -r requirements.txt
           pip install -e ".[dev]" pytest pytest-cov
       - name: Run core subset
         run: |
@@ -47,6 +48,7 @@ jobs:
       - name: Install test deps
         run: |
           python -m pip install -U pip
+          pip install -r requirements.txt
           pip install -e ".[dev]" pytest pytest-rerunfailures pytest-timeout pyyaml
       - name: Run quarantined/slow with retries
         run: |
@@ -66,11 +68,11 @@ jobs:
             trend:ci
       - name: Wait for health
         run: |
-          for i in {1..20}; do
+          for i in {1..10}; do
             if curl -fsS http://localhost:8501/health | grep -qi "ok"; then
               echo "App healthy"; exit 0
             fi
-            sleep 2
+            sleep 1
           done
           echo "Health check failed"; docker logs trendci; exit 1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ scipy
 fastapi>=0.104.0
 uvicorn[standard]
 httpx>=0.25
+requests
 
 # Optional proxy dependencies (for WebSocket-capable Streamlit proxy)
 # Install with: pip install fastapi uvicorn httpx websockets
@@ -29,8 +30,3 @@ ruff
 mypy
 pytest-cov
 jsonschema
-
-# FastAPI health wrapper dependencies
-fastapi
-uvicorn[standard]
-httpx


### PR DESCRIPTION
## Summary
- install app dependencies via requirements.txt in CI
- add missing `requests` requirement
- reduce docker health check wait and use `/health` endpoint

## Testing
- `./scripts/setup_env.sh`
- `python scripts/generate_demo.py`
- `.venv/bin/python scripts/run_multi_demo.py`
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bbd588c830833195665780b28dcb4f