### PR TITLE
ci: keep health wrapper on default port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,8 @@ jobs:
         run: docker build -t trend:ci .
       - name: Run container
         run: |
-          docker run -d --name trendci -p 8501:8501 \
+          docker run -d --name trendci -p 8501:8000 \
             -e STREAMLIT_SERVER_HEADLESS=1 \
-            -e HEALTH_PORT=8501 \
             trend:ci
       - name: Wait for health
         run: |


### PR DESCRIPTION
## Summary
- keep container health wrapper on port 8000 and map host port instead

## Testing
- `python scripts/generate_demo.py`
- `./scripts/run_tests.sh`
- `PYTHONPATH=./src python scripts/run_multi_demo.py` *(fails: ModuleNotFoundError: No module named 'trend_analysis', subsequently interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9d0697e4833181de9e2aa8f9e9d6