### PR TITLE
Include core modules in coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,5 @@
 [run]
 omit =
-    src/trend_analysis/core/*
     src/trend_analysis/gui/*
     src/trend_analysis/proxy/*
     src/trend_analysis/api_server/*


### PR DESCRIPTION
## Summary
- include trend_analysis core modules in coverage tracking by removing omit rule

## Testing
- `pre-commit run --files .coveragerc`
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bcf13baec483319ee229c7ce880233