### PR TITLE
Add config model validation tests

### DIFF
--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -1,0 +1,75 @@
+import importlib
+from typing import Any
+
+import pytest
+
+
+# Import the module directly via its source path
+models = importlib.import_module("trend_analysis.config.models")
+
+
+# Helper to produce a minimal valid configuration mapping
+# Required keys are version, data, preprocessing, vol_adjust, sample_split,
+# portfolio, metrics, export, and run
+
+
+def _sample_config() -> dict[str, Any]:
+    return {
+        "version": "1",
+        "data": {},
+        "preprocessing": {},
+        "vol_adjust": {},
+        "sample_split": {},
+        "portfolio": {},
+        "metrics": {},
+        "export": {},
+        "run": {},
+    }
+
+
+def test_load_config_returns_struct():
+    cfg = models.load_config(_sample_config())
+    assert isinstance(cfg, models.Config)
+    dumped = cfg.model_dump()
+    assert dumped["version"] == "1"
+    # Ensure required dictionary sections round trip via model_dump
+    for key in [
+        "data",
+        "preprocessing",
+        "vol_adjust",
+        "sample_split",
+        "portfolio",
+        "metrics",
+        "export",
+        "run",
+    ]:
+        assert key in dumped
+        assert isinstance(dumped[key], dict)
+
+
+def test_missing_required_key_raises():
+    cfg_dict = _sample_config()
+    cfg_dict.pop("version")
+    try:
+        from pydantic import ValidationError  # type: ignore[import-not-found]
+
+        err_type = (ValueError, ValidationError)
+    except Exception:
+        err_type = (ValueError,)
+
+    with pytest.raises(err_type):
+        models.Config(**cfg_dict)
+
+
+def test_invalid_version_type_raises():
+    cfg_dict = _sample_config()
+    cfg_dict["version"] = 123  # type: ignore[assignment]
+    try:
+        from pydantic import ValidationError  # type: ignore[import-not-found]
+
+        err_type = (ValueError, ValidationError)
+    except Exception:
+        err_type = (ValueError,)
+
+    with pytest.raises(err_type):
+        models.Config(**cfg_dict)


### PR DESCRIPTION
## Summary
- add regression tests for config models to verify sample loading and validation

## Testing
- `pre-commit run --files tests/test_config_models.py`
- `./scripts/run_tests.sh tests/test_config_models.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcf13df5a08331bee7a6ff13919ca6