### PR TITLE
test: add edge case coverage

### DIFF
--- a/tests/test_block_bootstrap_engine.py
+++ b/tests/test_block_bootstrap_engine.py
@@ -2,10 +2,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from trend_portfolio_app.monte_carlo.engine import (
-    BlockBootstrapModel,
-    ReturnModelConfig,
-)
+from trend_portfolio_app.monte_carlo.engine import (BlockBootstrapModel,
+                                                    ReturnModelConfig)
 
 
 def make_panel():

--- a/tests/test_block_bootstrap_engine.py
+++ b/tests/test_block_bootstrap_engine.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from trend_portfolio_app.monte_carlo.engine import (
+    BlockBootstrapModel,
+    ReturnModelConfig,
+)
+
+
+def make_panel():
+    data = np.arange(60).reshape(20, 3) + 1
+    dates = pd.date_range("2020-01-31", periods=20, freq="M")
+    return pd.DataFrame(data, index=dates, columns=["A", "B", "C"])
+
+
+def test_sample_before_fit_raises():
+    model = BlockBootstrapModel(ReturnModelConfig(block=3, seed=0))
+    with pytest.raises(RuntimeError):
+        model.sample(5, 1)
+
+
+def test_output_shape_and_reproducibility():
+    panel = make_panel()
+    cfg = ReturnModelConfig(block=4, seed=42)
+    model1 = BlockBootstrapModel(cfg)
+    model1.fit(panel)
+    out1 = model1.sample(8, 2)
+    assert out1.shape == (2, 8, panel.shape[1])
+
+    model2 = BlockBootstrapModel(cfg)
+    model2.fit(panel)
+    out2 = model2.sample(8, 2)
+    np.testing.assert_array_equal(out1, out2)
+
+    cfg_diff = ReturnModelConfig(block=4, seed=43)
+    model3 = BlockBootstrapModel(cfg_diff)
+    model3.fit(panel)
+    out3 = model3.sample(8, 2)
+    assert not np.array_equal(out1, out3)
+
+
+def test_stitching_with_non_divisible_periods():
+    panel = make_panel()
+    cfg = ReturnModelConfig(block=6, seed=1)
+    model = BlockBootstrapModel(cfg)
+    model.fit(panel)
+    out = model.sample(10, 1)
+    assert out.shape == (1, 10, panel.shape[1])
+    assert (out != 0).all()

--- a/tests/test_optimizer_constraints.py
+++ b/tests/test_optimizer_constraints.py
@@ -45,3 +45,9 @@ def test_missing_groups_raises():
     w = pd.Series([0.5, 0.5], index=["a", "b"], dtype=float)
     with pytest.raises(KeyError):
         apply_constraints(w, {"group_caps": {"X": 0.6}, "groups": {"a": "X"}})
+
+
+def test_redistribute_failure_raises():
+    w = pd.Series([0.5, 0.5], index=["a", "b"], dtype=float)
+    with pytest.raises(ConstraintViolation):
+        apply_constraints(w, {"long_only": True, "max_weight": 0.4})

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,7 +1,6 @@
 """Tests for trend_analysis.io.validators module."""
 
 import io
-import os
 import tempfile
 from pathlib import Path
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -207,15 +207,12 @@ class TestLoadAndValidateUpload:
             assert "File contains no data" in str(exc_info.value)
 
     def test_garbled_content_error(self):
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv") as tmp:
             tmp.write('"unclosed,quote')
-            tmp_path = tmp.name
-        try:
+            tmp.flush()
             with pytest.raises(ValueError) as exc_info:
-                load_and_validate_upload(tmp_path)
+                load_and_validate_upload(tmp.name)
             assert "Failed to parse file" in str(exc_info.value)
-        finally:
-            os.remove(tmp_path)
 
     def test_excel_pointer_reset(self):
         df = pd.DataFrame({"Date": ["2023-01-31"], "Fund1": [0.01]})


### PR DESCRIPTION
## Summary
- add frequency detection tests for single and irregular timestamps
- cover schema validation, load errors, and frequency fallback in upload validator
- test block bootstrap engine, constraint redistribution failure, and health wrapper imports

## Testing
- `PYTHONPATH=./src pytest tests/test_block_bootstrap_engine.py tests/test_optimizer_constraints.py::test_redistribute_failure_raises tests/test_validators.py::TestDetectFrequency::test_single_timestamp_returns_unknown tests/test_validators.py::TestDetectFrequency::test_irregular_spacing_returns_irregular tests/test_validators.py::TestValidateReturnsSchema::test_non_numeric_strings_fail_validation tests/test_validators.py::TestValidateReturnsSchema::test_small_sample_emits_warning tests/test_validators.py::TestLoadAndValidateUpload::test_nonexistent_file_raises tests/test_validators.py::TestLoadAndValidateUpload::test_permission_error_raises tests/test_validators.py::TestLoadAndValidateUpload::test_directory_path_error tests/test_validators.py::TestLoadAndValidateUpload::test_empty_file_error tests/test_validators.py::TestLoadAndValidateUpload::test_garbled_content_error tests/test_validators.py::TestLoadAndValidateUpload::test_excel_pointer_reset tests/test_validators.py::TestLoadAndValidateUpload::test_frequency_detection_fallback tests/test_health_wrapper.py::test_create_app_missing_fastapi tests/test_health_wrapper.py::test_main_missing_uvicorn -q`

------
https://chatgpt.com/codex/tasks/task_e_68bcfda203bc8331a9f88b8e3801b546