### PR TITLE
chore: remove stray rebalancing alias

### DIFF
--- a/src/trend_analysis/rebalancing.py
+++ b/src/trend_analysis/rebalancing.py
@@ -13,20 +13,17 @@ from typing import Dict
 # Import canonical implementations from the package so this shim
 # can re-export them without triggering circular imports or relying
 # on a non-existent top-level ``strategies`` module.
-from .rebalancing import strategies as _strategies
+from .rebalancing.strategies import (
+    DrawdownGuardStrategy,
+    DriftBandStrategy,
+    PeriodicRebalanceStrategy,
+    RebalancingStrategy,
+    TurnoverCapStrategy,
+    VolTargetRebalanceStrategy,
+    apply_rebalancing_strategies,
+    create_rebalancing_strategy,
+)
 from .plugins import rebalancer_registry
-from .strategies import strategies as _strategies
-
-# Re-export public classes and helpers from the strategies module
-RebalancingStrategy = _strategies.RebalancingStrategy
-TurnoverCapStrategy = _strategies.TurnoverCapStrategy
-PeriodicRebalanceStrategy = _strategies.PeriodicRebalanceStrategy
-DriftBandStrategy = _strategies.DriftBandStrategy
-VolTargetRebalanceStrategy = _strategies.VolTargetRebalanceStrategy
-DrawdownGuardStrategy = _strategies.DrawdownGuardStrategy
-create_rebalancing_strategy = _strategies.create_rebalancing_strategy
-apply_rebalancing_strategies = _strategies.apply_rebalancing_strategies
-TURNOVER_EPSILON = _strategies.TURNOVER_EPSILON
 
 
 def get_rebalancing_strategies() -> Dict[str, type]:

--- a/src/trend_analysis/rebalancing.py
+++ b/src/trend_analysis/rebalancing.py
@@ -14,17 +14,12 @@ from .plugins import rebalancer_registry
 # Import canonical implementations from the package so this shim
 # can re-export them without triggering circular imports or relying
 # on a non-existent top-level ``strategies`` module.
-from .rebalancing.strategies import (
-    DrawdownGuardStrategy,
-    DriftBandStrategy,
-    PeriodicRebalanceStrategy,
-    RebalancingStrategy,
-    TurnoverCapStrategy,
-    VolTargetRebalanceStrategy,
-    apply_rebalancing_strategies,
-    create_rebalancing_strategy,
-)
-from .plugins import rebalancer_registry
+from .rebalancing.strategies import (DrawdownGuardStrategy, DriftBandStrategy,
+                                     PeriodicRebalanceStrategy,
+                                     RebalancingStrategy, TurnoverCapStrategy,
+                                     VolTargetRebalanceStrategy,
+                                     apply_rebalancing_strategies,
+                                     create_rebalancing_strategy)
 
 
 def get_rebalancing_strategies() -> Dict[str, type]:

--- a/tests/test_multi_period_engine.py
+++ b/tests/test_multi_period_engine.py
@@ -7,8 +7,8 @@ from trend_analysis.config import Config
 from trend_analysis.multi_period import Portfolio
 from trend_analysis.multi_period import run as run_mp
 from trend_analysis.multi_period import run_schedule
-from trend_analysis.multi_period.scheduler import generate_periods
 from trend_analysis.multi_period.replacer import Rebalancer
+from trend_analysis.multi_period.scheduler import generate_periods
 from trend_analysis.selector import RankSelector
 from trend_analysis.weighting import AdaptiveBayesWeighting, EqualWeight
 
@@ -201,7 +201,7 @@ def test_run_schedule_with_rebalancer_replaces_funds():
     sf1 = pd.DataFrame({"zscore": [2.0, 1.5, -0.5]}, index=["A", "B", "C"])
     sf2 = pd.DataFrame({"zscore": [-1.5, 0.5, 2.0]}, index=["A", "B", "C"])
     # Use a fixed reference date for deterministic tests
-    end_of_month = pd.Timestamp('2023-01-31')
+    end_of_month = pd.Timestamp("2023-01-31")
     prev_month_end = end_of_month - pd.offsets.MonthEnd(1)
     frames = {prev_month_end: sf1, end_of_month: sf2}
     selector = RankSelector(top_n=2, rank_column="zscore")


### PR DESCRIPTION
## Summary
- refactor rebalancing compatibility shim to import and re-export canonical strategy classes directly from the package

## Testing
- `pre-commit run --files src/trend_analysis/rebalancing.py`
- `python scripts/generate_demo.py`
- `PYTHONPATH=src python scripts/run_multi_demo.py` *(fails: AttributeError: 'Workbook' object has no attribute 'add_worksheet')*
- `PYTHONPATH=src pytest tests/test_rebalancing_imports.py::test_apply_rebalancing_strategies_import -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd056eba808331a194ecd62b403df4