### PR TITLE
fix: correct rebalancing import to restore tests

### DIFF
--- a/src/trend_analysis/rebalancing.py
+++ b/src/trend_analysis/rebalancing.py
@@ -15,7 +15,6 @@ from typing import Dict
 # on a non-existent top-level ``strategies`` module.
 from .rebalancing import strategies as _strategies
 from .plugins import rebalancer_registry
-from .strategies import strategies as _strategies
 
 # Re-export public classes and helpers from the strategies module
 RebalancingStrategy = _strategies.RebalancingStrategy


### PR DESCRIPTION
## Summary
- fix rebalancing shim to import strategies from the package without referencing a missing module

## Testing
- `pytest tests/test_rebalancing_strategies.py -q`
- `./scripts/run_tests.sh tests/test_rebalancing_strategies.py`

------
https://chatgpt.com/codex/tasks/task_e_68bd05abe858833183f248ba466d99ab