### PR TITLE
Fix period scheduling test and add sim runner coverage

### DIFF
--- a/tests/test_multi_period_engine.py
+++ b/tests/test_multi_period_engine.py
@@ -176,7 +176,10 @@ def test_generate_periods_respects_boundaries():
     }
     periods = generate_periods(cfg)
     # The number of periods depends on the date range and window sizes
-    expected_periods = len(pd.period_range(start, end, freq="M")) - 2 + 1
+    total = len(pd.period_range(start, end, freq="M"))
+    in_len = cfg["multi_period"]["in_sample_len"]
+    out_len = cfg["multi_period"]["out_sample_len"]
+    expected_periods = ((total - (in_len + out_len)) // out_len) + 1
     assert len(periods) == expected_periods
     prev_start = None
     for pt in periods:

--- a/tests/test_sim_runner_cov.py
+++ b/tests/test_sim_runner_cov.py
@@ -25,6 +25,23 @@ def test_compute_score_frame_local_handles_failure(monkeypatch):
     assert np.isnan(df.loc["A", "boom"])
 
 
+def test_compute_score_frame_local_skips_date_column(monkeypatch):
+    panel = pd.DataFrame(
+        {
+            "Date": [pd.Timestamp("2020-01-31"), pd.Timestamp("2020-02-29")],
+            "A": [0.1, 0.2],
+        }
+    )
+
+    monkeypatch.setitem(
+        sim_runner.AVAILABLE_METRICS, "dummy", {"fn": lambda r, idx: 1.0}
+    )
+
+    df = sim_runner.compute_score_frame_local(panel)
+    assert "Date" not in df.index
+    assert df.loc["A", "dummy"] == 1.0
+
+
 def test_compute_score_frame_validations_and_fallback(monkeypatch):
     df = pd.DataFrame({"A": [0.1, 0.2]})
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- Correct period count calculation in `test_generate_periods_respects_boundaries`
- Add unit test ensuring `compute_score_frame_local` skips the `Date` column

## Testing
- `./scripts/run_tests.sh tests/test_sim_runner_cov.py tests/test_multi_period_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_68bd0c6bde0083318d6af44384ad2589