### PR TITLE
fix: adjust CI test conditions and autofix permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     name: autofix (PR only)
     if: github.event_name == 'pull_request' && github.actor != 'github-actions' && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       fix_pushed: ${{ steps.autofix_step.outputs.fix_pushed }}
     steps:
@@ -50,7 +52,7 @@ jobs:
     name: core-tests (Python ${{ matrix.py }})
     runs-on: ubuntu-latest
     needs: [autofix]
-    if: needs.autofix.result == 'skipped' || needs.autofix.outputs.fix_pushed != 'true'
+    if: needs.autofix.result == 'skipped' || needs.autofix.outputs.fix_pushed == 'false'
     strategy:
       fail-fast: false
       matrix:
@@ -75,7 +77,7 @@ jobs:
     needs: [autofix]
     # Only run docker-smoke if autofix was skipped or did not push changes.
     # This prevents testing the pre-autofix state of the code.
-    if: needs.autofix.result == 'skipped' || needs.autofix.outputs.fix_pushed != 'true'
+    if: needs.autofix.result == 'skipped' || needs.autofix.outputs.fix_pushed == 'false'
     steps:
       - uses: actions/checkout@v4
       - name: Build image


### PR DESCRIPTION
## Summary
- grant write permission to autofix job so formatting fixes can push
- skip core-tests and docker-smoke when autofix pushes changes

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bd29066e808331a048d972c0b1318e