### PR TITLE
Include Streamlit app in coverage

### DIFF
--- a/src/trend_portfolio_app/health_wrapper.py
+++ b/src/trend_portfolio_app/health_wrapper.py
@@ -81,5 +81,5 @@ def main() -> None:
     )
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/tests/test_data_schema.py
+++ b/tests/test_data_schema.py
@@ -1,0 +1,80 @@
+import io
+
+import pandas as pd
+import pytest
+
+from trend_portfolio_app.data_schema import (
+    DATE_COL,
+    _validate_df,
+    infer_benchmarks,
+    load_and_validate_csv,
+    load_and_validate_file,
+)
+
+
+def test_validate_df_basic():
+    csv = "Date,A,B\n2020-02-01,3,4\n2020-01-01,1,2\n"
+    df, meta = load_and_validate_csv(io.StringIO(csv))
+    # index should be month-end timestamps
+    expected = [
+        pd.Timestamp("2020-01-31").to_period("M").to_timestamp("M", how="end"),
+        pd.Timestamp("2020-02-29").to_period("M").to_timestamp("M", how="end"),
+    ]
+    assert list(df.index) == expected
+    assert meta["original_columns"] == ["A", "B"]
+    assert meta["n_rows"] == 2
+
+
+def test_validate_df_errors():
+    # missing Date column
+    with pytest.raises(ValueError):
+        _validate_df(pd.DataFrame({"A": [1]}))
+
+    # duplicate columns
+    df = pd.DataFrame({"Date": ["2020-01-01"], "A": [1], "B": [2]})
+    df.columns = ["Date", "A", "A"]
+    with pytest.raises(ValueError):
+        _validate_df(df)
+
+    # all NA returns
+    df = pd.DataFrame({"Date": ["2020-01-01"], "A": [float("nan")]})
+    with pytest.raises(ValueError):
+        _validate_df(df)
+
+
+def test_load_and_validate_file_excel(tmp_path):
+    df = pd.DataFrame({"Date": ["2020-01-01"], "A": [1]})
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False)
+    buf.seek(0)
+    buf.name = "test.xlsx"
+    df2, meta = load_and_validate_file(buf)
+    assert DATE_COL not in df2.columns
+    assert meta["n_rows"] == 1
+
+
+def test_load_and_validate_file_seek_error():
+    class NoSeek(io.StringIO):
+        def seek(self, *args, **kwargs):
+            raise RuntimeError("no seek")
+
+    buf = NoSeek("Date,A\n2020-01-01,1\n")
+    buf.name = "data.csv"
+    df, meta = load_and_validate_file(buf)
+    assert meta["n_rows"] == 1
+
+
+def test_load_and_validate_file_read_error():
+    class BadFile:
+        name = "bad.csv"
+
+        def read(self, *args, **kwargs):  # pragma: no cover - via pandas
+            raise ValueError("bad read")
+
+    with pytest.raises(ValueError):
+        load_and_validate_file(BadFile())
+
+
+def test_infer_benchmarks():
+    cols = ["SPX", "fund1", "MyIndex"]
+    assert infer_benchmarks(cols) == ["SPX", "MyIndex"]

--- a/tests/test_data_schema.py
+++ b/tests/test_data_schema.py
@@ -3,13 +3,10 @@ import io
 import pandas as pd
 import pytest
 
-from trend_portfolio_app.data_schema import (
-    DATE_COL,
-    _validate_df,
-    infer_benchmarks,
-    load_and_validate_csv,
-    load_and_validate_file,
-)
+from trend_portfolio_app.data_schema import (DATE_COL, _validate_df,
+                                             infer_benchmarks,
+                                             load_and_validate_csv,
+                                             load_and_validate_file)
 
 
 def test_validate_df_basic():

--- a/tests/test_health_wrapper.py
+++ b/tests/test_health_wrapper.py
@@ -75,7 +75,7 @@ def test_import_without_dependencies(monkeypatch):
 
     def fake_import(name, *args, **kwargs):
         if name.startswith("fastapi") or name == "uvicorn":
-            raise ImportError(f'No module named {name}')
+            raise ImportError(f"No module named {name}")
         return original_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)

--- a/tests/test_health_wrapper.py
+++ b/tests/test_health_wrapper.py
@@ -1,7 +1,7 @@
 """Test for health wrapper module to ensure proper module qualification."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -66,8 +66,8 @@ def test_main_missing_uvicorn(monkeypatch, capsys):
 
 
 def test_import_without_dependencies(monkeypatch):
-    import importlib
     import builtins
+    import importlib
 
     from trend_portfolio_app import health_wrapper as hw
 

--- a/tests/test_health_wrapper.py
+++ b/tests/test_health_wrapper.py
@@ -75,7 +75,7 @@ def test_import_without_dependencies(monkeypatch):
 
     def fake_import(name, *args, **kwargs):
         if name.startswith("fastapi") or name == "uvicorn":
-            raise ImportError
+            raise ImportError(f'No module named {name}')
         return original_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)

--- a/tests/test_health_wrapper.py
+++ b/tests/test_health_wrapper.py
@@ -1,9 +1,11 @@
 """Test for health wrapper module to ensure proper module qualification."""
 
-import sys
 from pathlib import Path
+import sys
+from types import SimpleNamespace
 
 import pytest
+from fastapi.testclient import TestClient
 
 # Add src to path
 repo_root = Path(__file__).parent.parent
@@ -61,6 +63,69 @@ def test_main_missing_uvicorn(monkeypatch, capsys):
     assert exc_info.value.code == 1
     captured = capsys.readouterr()
     assert "uvicorn is required" in captured.err
+
+
+def test_import_without_dependencies(monkeypatch):
+    import importlib
+    import builtins
+
+    from trend_portfolio_app import health_wrapper as hw
+
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("fastapi") or name == "uvicorn":
+            raise ImportError
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    reloaded = importlib.reload(hw)
+    assert reloaded.FastAPI is None
+    assert reloaded.app is None
+
+    # Reload again with real imports to restore module state
+    monkeypatch.setattr(builtins, "__import__", original_import)
+    importlib.reload(reloaded)
+
+
+def test_create_app_endpoints():
+    """Ensure the FastAPI app exposes expected health endpoints."""
+    from trend_portfolio_app import health_wrapper
+
+    app = health_wrapper.create_app()
+    client = TestClient(app)
+    assert client.get("/health").text == "OK"
+    assert client.get("/").text == "OK"
+
+
+def test_main_runs_uvicorn(monkeypatch):
+    from trend_portfolio_app import health_wrapper
+
+    calls = {}
+
+    def fake_run(app_path, host, port, reload, access_log):
+        calls["app_path"] = app_path
+        calls["host"] = host
+        calls["port"] = port
+        calls["reload"] = reload
+        calls["access_log"] = access_log
+
+    monkeypatch.setattr(
+        health_wrapper,
+        "uvicorn",
+        SimpleNamespace(run=fake_run),
+    )
+    monkeypatch.setenv("HEALTH_HOST", "127.0.0.1")
+    monkeypatch.setenv("HEALTH_PORT", "1234")
+
+    health_wrapper.main()
+
+    assert calls["app_path"] == "trend_portfolio_app.health_wrapper:app"
+    assert calls["host"] == "127.0.0.1"
+    assert calls["port"] == 1234
+    assert calls["reload"] is False
+    assert calls["access_log"] is False
 
 
 if __name__ == "__main__":

--- a/tests/test_streamlit_disclaimer_component.py
+++ b/tests/test_streamlit_disclaimer_component.py
@@ -1,0 +1,17 @@
+import sys
+from unittest.mock import MagicMock
+import importlib
+
+
+def test_show_disclaimer(monkeypatch):
+    st = MagicMock()
+    st.session_state = {}
+    st.checkbox.side_effect = [False, True]
+    st.modal.return_value.__enter__.return_value = None
+    st.modal.return_value.__exit__.return_value = None
+    st.rerun.return_value = None
+
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+    disclaimer = importlib.reload(importlib.import_module("streamlit_app.components.disclaimer"))
+    assert disclaimer.show_disclaimer() is False
+    assert disclaimer.show_disclaimer() is True

--- a/tests/test_streamlit_disclaimer_component.py
+++ b/tests/test_streamlit_disclaimer_component.py
@@ -1,6 +1,6 @@
+import importlib
 import sys
 from unittest.mock import MagicMock
-import importlib
 
 
 def test_show_disclaimer(monkeypatch):
@@ -12,6 +12,8 @@ def test_show_disclaimer(monkeypatch):
     st.rerun.return_value = None
 
     monkeypatch.setitem(sys.modules, "streamlit", st)
-    disclaimer = importlib.reload(importlib.import_module("streamlit_app.components.disclaimer"))
+    disclaimer = importlib.reload(
+        importlib.import_module("streamlit_app.components.disclaimer")
+    )
     assert disclaimer.show_disclaimer() is False
     assert disclaimer.show_disclaimer() is True


### PR DESCRIPTION
## Summary
- remove Streamlit folders from coverage exclusions
- add test exercising disclaimer component for coverage

## Testing
- `./scripts/run_tests.sh`
- `pytest -q` *(fails: tests/smoke/test_app_launch.py::test_app_starts_headlessly - Failed: Health wrapper terminated early with exit code 1)*
- `timeout 5 ./scripts/run_streamlit.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bd32656dd4833192305798c5cbf632