### PR TITLE
Refactor label-agent PRs workflow for clarity

### DIFF
--- a/.github/workflows/label-agent-prs.yml
+++ b/.github/workflows/label-agent-prs.yml
@@ -20,8 +20,8 @@ jobs:
             const head = (pr.head?.ref || '').toLowerCase();
 
             const labels = [];
-            if (actor.includes('copilot') || head.startsWith('copilot/')) labels.push('from:copilot');
-            if (actor.includes('codex')   || head.startsWith('codex/'))   labels.push('from:codex');
+            if (actor.includes('copilot') || head.startsWith('copilot/')) labels.push('from:copilot', 'agent:copilot');
+            if (actor.includes('codex')   || head.startsWith('codex/'))   labels.push('from:codex', 'agent:codex');
 
             if (labels.length) {
               await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels });


### PR DESCRIPTION
## Summary
- Restore `agent:copilot`/`agent:codex` labels alongside `from:*` labels
- Retain `pull_request_target` trigger so labeling works for forked PRs

## Testing
- `pre-commit run --files .github/workflows/label-agent-prs.yml`
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bd3f5835e88331b3f6d214806d3fe7