### PR TITLE
fix: close verdict if block

### DIFF
--- a/.github/workflows/copilot-readiness.yml
+++ b/.github/workflows/copilot-readiness.yml
@@ -81,4 +81,5 @@ jobs:
               echo "::error::GitHub refused to assign @copilot here (status=${{ steps.assign.outputs.status }}). That confirms policy/enablement is blocking it."
             fi
             exit 1
+          fi
           echo "Copilot appears assignable here."


### PR DESCRIPTION
## Summary
- ensure Copilot readiness workflow closes `if` block before final success message

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bde0e28be48331a95febdf135ccf14