### PR TITLE
fix: refine agent readiness workflow

### DIFF
--- a/.github/workflows/agent-readiness.yml
+++ b/.github/workflows/agent-readiness.yml
@@ -131,17 +131,19 @@ jobs:
 
             core.info("Report: " + JSON.stringify(report, null, 2));
             core.setOutput('report', JSON.stringify(report));
-            if (Object.values(report).some(v => v && v.ok === false) && requireAll) {
+            if (Object.values(report).some(v => v && typeof v === 'object' && v.ok === false) && requireAll) {
               core.setFailed("One or more requested agents are not assignable here. See report above.");
             }
 
       - name: Close temporary issue
         if: always()
+        env:
+          ISSUE_NUM: ${{ steps.tmp.outputs.num }}
         uses: actions/github-script@v7
         with:
           script: |
             const { owner, repo } = context.repo;
-            const num = Number(process.env.ISSUE_NUM || '${{ steps.tmp.outputs.num || 0 }}');
+            const num = Number(process.env.ISSUE_NUM || '0');
             if (num) {
               await github.rest.issues.update({ owner, repo, issue_number: num, state: 'closed' });
               core.info(`Temp issue #${num} closed`);

--- a/requirements.lock
+++ b/requirements.lock
@@ -20,7 +20,7 @@ executing==2.2.1
     # via stack-data
 fonttools==4.59.2
     # via matplotlib
-hypothesis==6.138.14
+hypothesis==6.138.15
     # via trend-model (pyproject.toml)
 ipython==9.5.0
     # via ipywidgets
@@ -38,7 +38,7 @@ matplotlib==3.10.6
     # via trend-model (pyproject.toml)
 matplotlib-inline==0.1.7
     # via ipython
-numpy==2.3.2
+numpy==2.3.3
     # via
     #   trend-model (pyproject.toml)
     #   contourpy


### PR DESCRIPTION
## Summary
- ensure report failure check validates object shape
- rely on env for issue number when closing temp issue
- refresh requirements.lock to satisfy lockfile check

## Testing
- `pre-commit run --files .github/workflows/agent-readiness.yml requirements.lock`
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c0d5435a4c8331ada073c9ca41901f