### PR TITLE
chore: run assignment workflow with service bot token

### DIFF
--- a/.github/workflows/assign-to-agent.yml
+++ b/.github/workflows/assign-to-agent.yml
@@ -63,7 +63,10 @@ jobs:
 
       - name: Assign or backfill
         uses: actions/github-script@v7
+        env:
+          GH_TOKEN: ${{ env.SERVICE_BOT_PAT }}
         with:
+          github-token: ${{ env.SERVICE_BOT_PAT }}
           script: |
             const { owner, repo } = context.repo;
             const number = (context.payload.issue?.number ?? context.payload.pull_request?.number);


### PR DESCRIPTION
## Summary
- ensure Assign to Agent workflow uses service bot token for API calls

## Testing
- `./scripts/run_tests.sh` *(fails: requirements.lock is out of date)*

------
https://chatgpt.com/codex/tasks/task_e_68c32e0f91b48331aca0ceb549bc89d6