### PR TITLE
ci: trigger autofix on more workflows

### DIFF
--- a/.github/workflows/autofix-on-failure.yml
+++ b/.github/workflows/autofix-on-failure.yml
@@ -2,7 +2,7 @@ name: autofix on failures
 
 on:
   workflow_run:
-    workflows: ["CI", "Docker"]
+    workflows: ["CI", "Docker", "Lint", "Tests"]
     types: [completed]
 
 permissions:


### PR DESCRIPTION
## Summary
- trigger autofix workflow when Lint or Tests workflows fail, in addition to CI and Docker

## Testing
- `./scripts/setup_env.sh`
- `python scripts/generate_demo.py`
- `python scripts/run_multi_demo.py` *(fails: ModuleNotFoundError: No module named 'trend_analysis')*
- `./scripts/run_tests.sh` *(fails: requirements.lock is out of date)*

------
https://chatgpt.com/codex/tasks/task_e_68c32e38d51c8331acbb684513831234