### PR TITLE
chore: use service bot PAT for issue and PR labeling

### DIFF
--- a/.github/workflows/agent-watchdog.yml
+++ b/.github/workflows/agent-watchdog.yml
@@ -25,6 +25,7 @@ jobs:
         id: poll
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.SERVICE_BOT_PAT }}
           script: |
             const {owner, repo} = context.repo;
             const issue_number = context.payload.issue.number;

--- a/.github/workflows/label-agent-prs.yml
+++ b/.github/workflows/label-agent-prs.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.SERVICE_BOT_PAT }}
           script: |
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;


### PR DESCRIPTION
## Summary
- use service bot PAT in agent watchdog so comments use service account
- run PR labeling under service bot credentials

## Testing
- `python scripts/generate_demo.py`
- `PYTHONPATH=./src python scripts/run_multi_demo.py` *(fails: CLI --check failed)*
- `./scripts/run_tests.sh` *(fails: requirements.lock is out of date)*
- `gh issue list --repo cli/cli --limit 5` *(fails: authentication required)*


------
https://chatgpt.com/codex/tasks/task_e_68c336d57a348331857af46a63c25d1e