### PR TITLE
Handle codex assignment on opened issues

### DIFF
--- a/.github/workflows/assign-codex.yml
+++ b/.github/workflows/assign-codex.yml
@@ -2,15 +2,17 @@ name: Assign codex to labeled issues
 
 on:
   issues:
-    types:
-      - labeled
+    types: [opened, labeled]
 
 permissions:
   issues: write
 
 jobs:
   assign:
-    if: github.event.label.name == 'agent:codex'
+    if: >
+      (github.event.action == 'labeled' && github.event.label.name == 'agent:codex') ||
+      (github.event.action == 'opened' &&
+       contains(github.event.issue.labels.*.name, 'agent:codex'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6


### PR DESCRIPTION
## Summary
- Trigger codex assignment when issues are opened or labeled
- Only assign when the `agent:codex` label is present

## Testing
- `pytest --cov trend_analysis --cov-branch`


------
https://chatgpt.com/codex/tasks/task_e_68c3aa777c6883318386687a4ff13310