### PR TITLE
Expand automerge workflow trigger

### DIFF
--- a/.github/workflows/automerge-minor.yml
+++ b/.github/workflows/automerge-minor.yml
@@ -1,16 +1,15 @@
 name: Automerge minor changes
 
 on:
-  pull_request:
-    types:
-      - labeled
+  pull_request_target:
+    types: [opened, labeled]
 
 permissions:
   pull-requests: write
 
 jobs:
   automerge:
-    if: github.event.label.name == 'minor'
+    if: contains(github.event.pull_request.labels.*.name, 'minor')
     runs-on: ubuntu-latest
     steps:
       - uses: peter-evans/enable-auto-merge@v3


### PR DESCRIPTION
## Summary
- broaden automerge trigger to run on PR open or label events
- detect `minor` label across the entire PR label set using `contains`
- run on `pull_request_target` to support forked contributions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3aa8ea8208331b3b9bfb0fe3b0a26