### PR TITLE
ci: make agent summary comment non-fatal with PAT fallback

### DIFF
--- a/.github/workflows/assign-to-agent.yml
+++ b/.github/workflows/assign-to-agent.yml
@@ -424,9 +424,10 @@ jobs:
           name: agent-assignment-${{ github.run_id }}
           path: agent-artifacts/agent_assignment.json
 
-      - name: Post / update JSON summary comment
+      - name: Post / update JSON summary comment (non-fatal w/ fallback)
         if: always()
         uses: actions/github-script@v7
+        continue-on-error: true
         env:
           SUMMARY_EVENT: ${{ github.event_name }}
           SUMMARY_ISSUE: ${{ github.event.issue.number || '' }}
@@ -435,7 +436,10 @@ jobs:
           SUMMARY_CODEX_ISSUE: ${{ steps.assign_or_backfill.outputs.codex_issue }}
           SUMMARY_COPILOT: ${{ steps.assign_or_backfill.outputs.copilot_assigned }}
           SUMMARY_GENERIC: ${{ steps.assign_or_backfill.outputs.generic_agents }}
+          SERVICE_BOT_PAT: ${{ env.SERVICE_BOT_PAT }}
+          GH_FALLBACK_TOKEN: ${{ github.token }}
         with:
+          # Still prefer PAT so authored-by service user when permitted
           github-token: ${{ env.SERVICE_BOT_PAT != '' && env.SERVICE_BOT_PAT || github.token }}
           script: |
             const marker = '<!-- codex-agent-summary -->';
@@ -444,32 +448,57 @@ jobs:
               const n = parseInt(str, 10);
               return Number.isInteger(n) && n > 0 ? n : null;
             }
-            const issue_number =
-              getValidNumber(process.env.SUMMARY_ISSUE) ||
-              getValidNumber(process.env.SUMMARY_PR);
-            if (issue_number == null) { core.info('No issue/PR number available for summary comment'); return; }
-            const summary = {
-              event: process.env.SUMMARY_EVENT,
-              issue: process.env.SUMMARY_ISSUE || null,
-              pr: process.env.SUMMARY_PR || null,
-              needs_codex_bootstrap: process.env.SUMMARY_NEEDS === 'true',
-              codex_issue: process.env.SUMMARY_CODEX_ISSUE || null,
-              copilot_assigned: process.env.SUMMARY_COPILOT === 'true',
-              generic_agents: (process.env.SUMMARY_GENERIC || '').split(',').filter(Boolean),
-              ts: new Date().toISOString()
-            };
-            const body = `${marker}\n\n\`\`\`json\n${JSON.stringify(summary, null, 2)}\n\`\`\`\n\n_Do not edit above block; updated automatically._`;
-            const { owner, repo } = context.repo;
-            // Find existing comment
-            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number, per_page: 100 });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-              core.info('Updated existing JSON summary comment.');
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-              core.info('Created new JSON summary comment.');
+            async function upsert(octokit, issue_number, body) {
+              const { owner, repo } = context.repo;
+              const comments = await octokit.paginate(octokit.rest.issues.listComments, { owner, repo, issue_number, per_page: 100 });
+              const existing = comments.find(c => c.body && c.body.includes(marker));
+              if (existing) {
+                await octokit.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+                return 'updated';
+              } else {
+                await octokit.rest.issues.createComment({ owner, repo, issue_number, body });
+                return 'created';
+              }
             }
+            (async () => {
+              const issue_number =
+                getValidNumber(process.env.SUMMARY_ISSUE) ||
+                getValidNumber(process.env.SUMMARY_PR);
+              if (issue_number == null) { core.info('No issue/PR number available for summary comment'); return; }
+              const summary = {
+                event: process.env.SUMMARY_EVENT,
+                issue: process.env.SUMMARY_ISSUE || null,
+                pr: process.env.SUMMARY_PR || null,
+                needs_codex_bootstrap: process.env.SUMMARY_NEEDS === 'true',
+                codex_issue: process.env.SUMMARY_CODEX_ISSUE || null,
+                copilot_assigned: process.env.SUMMARY_COPILOT === 'true',
+                generic_agents: (process.env.SUMMARY_GENERIC || '').split(',').filter(Boolean),
+                ts: new Date().toISOString()
+              };
+              const body = `${marker}\n\n\`\`\`json\n${JSON.stringify(summary, null, 2)}\n\`\`\`\n\n_Do not edit above block; updated automatically._`;
+              const primaryResult = { ok: false, status: null };
+              try {
+                await upsert(github, issue_number, body);
+                primaryResult.ok = true;
+                core.info('JSON summary comment upserted with primary token.');
+              } catch (e) {
+                primaryResult.status = e.status || 'unknown';
+                core.warning(`Primary token failed to upsert summary (status=${e.status || '?'} message=${e.message}).`);
+              }
+              if (!primaryResult.ok && process.env.SERVICE_BOT_PAT && process.env.GH_FALLBACK_TOKEN) {
+                // PAT attempted and failed; retry once with fallback GITHUB_TOKEN
+                try {
+                  const { Octokit } = require('@octokit/rest');
+                  const octo = new Octokit({ auth: process.env.GH_FALLBACK_TOKEN, request: { fetch: global.fetch } });
+                  await upsert(octo, issue_number, body);
+                  core.info('JSON summary comment upserted with fallback GITHUB_TOKEN.');
+                } catch (e2) {
+                  core.warning(`Fallback token also failed to upsert summary (status=${e2.status || '?'} message=${e2.message}). Proceeding without summary comment.`);
+                }
+              }
+            })().catch(err => {
+              core.warning('Non-fatal error in JSON summary step: ' + err.message);
+            });
 
   codex_bootstrap:
     needs: assign_or_backfill


### PR DESCRIPTION
### Summary\nNon-fatalizes JSON summary step so PAT 403 no longer blocks Codex bootstrap. Adds fallback to GITHUB_TOKEN if PAT comment fails.\n\n### Changes\n- Adds continue-on-error to summary comment step\n- Adds retry with GITHUB_TOKEN if SERVICE_BOT_PAT 403s\n- Leaves outputs & subsequent Codex bootstrap trigger path intact\n\n### Motivation\nPreviously a 403 on creating/updating the summary comment aborted the assignment job, skipping the dependent `codex_bootstrap` job. This restores label→bootstrap flow when PAT lacks issue comment rights.\n\n### Testing Plan\n1. After merge, label an issue with `agent:codex` where PAT still lacks comment ability.\n2. Expect: assignment job succeeds (with warning), codex_bootstrap runs, branch + draft PR appear.\n\n### Follow-ups\n- Document fallback behavior in troubleshooting guide (if not already adjusted).\n- Optionally split telemetry into independent job post-bootstrap.