### PR TITLE
ci: manual dispatch + composite bootstrap for codex assign workflow

### DIFF
--- a/.github/workflows/codex-assign-minimal.yml
+++ b/.github/workflows/codex-assign-minimal.yml
@@ -4,6 +4,13 @@ on:
   issues:
     types: [labeled, opened, reopened]
   workflow_dispatch:
+    inputs:
+      test_issue:
+        description: "Manual test: issue number to treat as labeled"
+        required: false
+      simulate_label:
+        description: "Comma separated labels to simulate (include agent:codex to trigger)"
+        required: false
 
 permissions:
   contents: write
@@ -22,6 +29,10 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // Support both event-driven (issues.*) and manual workflow_dispatch testing.
+            const inputs = context.payload.inputs || {};
+            const manualIssue = (inputs.test_issue || '').trim();
+            const simulated = (inputs.simulate_label || '').split(',').map(s => s.trim()).filter(Boolean);
             const issue = context.payload.issue;
             let needs = 'false';
             let num = '';
@@ -29,6 +40,9 @@ jobs:
               num = String(issue.number);
               const labels = (issue.labels || []).map(l => l.name);
               if (labels.includes('agent:codex')) needs = 'true';
+            } else if (manualIssue) {
+              num = manualIssue;
+              if (simulated.map(s => s.toLowerCase()).includes('agent:codex')) needs = 'true';
             }
             core.setOutput('needs_codex_bootstrap', needs);
             core.setOutput('codex_issue', num);
@@ -49,12 +63,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Bootstrap Codex
-        uses: actions/github-script@v7
+        uses: ./.github/actions/codex-bootstrap
         with:
-          script: |
-            // TODO: Implement the bootstrap logic here, or replace with the correct action
           issue: ${{ needs.detect.outputs.codex_issue }}
-          service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+          service_bot_pat: ${{ secrets.SERVICE_BOT_PAT || '' }}
           allow_fallback: ${{ vars.CODEX_ALLOW_FALLBACK || 'true' }}
           codex_command: "codex: start"
           pr_mode: auto


### PR DESCRIPTION
Follow-up to earlier minimal workflow merge.

Adds:
- workflow_dispatch inputs: test_issue, simulate_label
- Uses composite action (codex-bootstrap) instead of placeholder github-script step
- Preserves detection job outputs exactly

Validation steps after merge:
1. Run workflow via dispatch with inputs (e.g. test_issue=981, simulate_label=agent:codex)
2. Confirm detect job sets needs_codex_bootstrap=true and codex_bootstrap runs
3. Decide on fallback policy (set CODEX_ALLOW_FALLBACK=false if enforcing PAT only)

No other files touched. YAML lint passes.