### PR TITLE
ci: codex hardening v2 (resilient fallback + JSON summary)

### DIFF
--- a/.github/actions/codex-bootstrap/action.yml
+++ b/.github/actions/codex-bootstrap/action.yml
@@ -178,7 +178,6 @@ runs:
                   if (resp.status === 201) {
                     created = true; core.info(`Created branch ${branch} with fallback GITHUB_TOKEN.`);
                   } else {
-                    let txt; try { txt = await resp.text(); } catch {}
                     core.warning(`Fallback branch create failed http_status=${resp.status} error=Unable to create branch. See debug logs for details.`);
                   }
                 } catch (e2) {
@@ -232,6 +231,32 @@ runs:
                   prNumberExisting = newPR.number; prAuthor = newPR.user && newPR.user.login || null; reuse = false; // treat as fresh for outputs
                   const markerContent = Buffer.from(JSON.stringify({ issue: issue_number, pr: prNumberExisting, ts: new Date().toISOString(), rebootstrap: true }, null, 2)).toString('base64');
                   await github.rest.repos.createOrUpdateFileContents({ owner, repo, path: markerPath, branch, message: `chore(codex): rebootstrap marker for #${issue_number}`, content: markerContent });
+                  const human = 'stranske-automation-bot';
+                  async function assignPair(target) {
+                    try {
+                      await github.rest.issues.addAssignees({ owner, repo, issue_number: target, assignees: ['chatgpt-codex-connector', human] });
+                      return true;
+                    } catch (e) {
+                      core.warning(`Codex assignment failed on #${target}: ${e.status || '?'} ${e.message}`);
+                      return false;
+                    }
+                  }
+                  const issueAssignOk = await assignPair(issue_number);
+                  const prAssignOk = await assignPair(prNumberExisting);
+                  if (!activationSuppressed) {
+                    await github.rest.issues.createComment({ owner, repo, issue_number: prNumberExisting, body: `@chatgpt-codex-connector Please begin work on this task. Source issue #${issue_number}.` });
+                  } else {
+                    core.info('Activation comment suppressed.');
+                  }
+                  await github.rest.issues.addLabels({ owner, repo, issue_number: prNumberExisting, labels: ['agent:codex'] });
+                  let cmd = String(process.env.CODEX_COMMAND || 'codex: start').replace(/[\r\n`]/g,'').trim();
+                  const allowedCommands = ['codex: start','codex: test','codex: lint','codex: build','codex: review','codex: docs'];
+                  if (!allowedCommands.some(c => c.toLowerCase() === cmd.toLowerCase())) {
+                    core.warning('Unsafe Codex command; defaulting.');
+                    cmd = 'codex: start';
+                  }
+                  await github.rest.issues.createComment({ owner, repo, issue_number: prNumberExisting, body: `${cmd}\n\nPlease create commits on this branch, run tests, and keep the PR updated.` });
+                  await github.rest.issues.createComment({ owner, repo, issue_number, body: `Opened draft PR #${prNumberExisting} to engage Codex. Track work there.` });
                 }
               } catch (e) { core.warning(`Closed PR re-bootstrap check failed: ${e.message}`); }
             }
@@ -240,14 +265,14 @@ runs:
             const prAuthorFinal = prAuthor;
             try {
               const fs = require('fs'); fs.mkdirSync('codex-artifacts', { recursive: true });
-              fs.writeFileSync('codex-artifacts/codex_bootstrap_result.json', JSON.stringify({
+              fs.writeFileSync('codex-artifacts/codex_bootstrap_summary.json', JSON.stringify({
                 reused: reuse, issue: issue_number, pr: prNumberExisting || null, branch, base: baseBranch,
                 suppression: activationSuppressed, token_source: tokenSource, pr_author: prAuthorFinal, ts: new Date().toISOString(), rebootstrap_attempt: !reuse
               }, null, 2));
               if (decoded) fs.writeFileSync('codex-artifacts/marker_snapshot.json', decoded);
               fs.writeFileSync('codex-artifacts/README.txt', 'Codex bootstrap artifacts.');
-            } catch (e) { core.warning('Failed to write codex_bootstrap_result.json: ' + e.message); }
-            console.log('CODEX_BOOTSTRAP_RESULT:' + JSON.stringify({ reused: reuse, issue: issue_number, pr: prNumberExisting || null, branch, base: baseBranch, suppression: activationSuppressed, token_source: tokenSource, pr_author: prAuthorFinal }));
+            } catch (e) { core.warning('Failed to write codex_bootstrap_summary.json: ' + e.message); }
+            console.log('CODEX_BOOTSTRAP_SUMMARY:' + JSON.stringify({ reused: reuse, issue: issue_number, pr: prNumberExisting || null, branch, base: baseBranch, suppression: activationSuppressed, token_source: tokenSource, pr_author: prAuthorFinal }));
             return;
           }
           // Create marker seed file to ensure branch has a change (issue markdown stub)
@@ -266,8 +291,8 @@ runs:
             await github.rest.issues.createComment({ owner, repo, issue_number, body: `Branch **${branch}** created. Manual mode is enabled (CODEX_PR_MODE=manual). Open a draft PR from this branch targeting **${baseBranch}** then label with \`agent:codex\`.` });
             core.summary.addHeading('Codex Bootstrap (Manual Mode)').addTable([[{data:'Issue',header:true},{data:'Branch',header:true},{data:'PR Created',header:true},{data:'Mode',header:true},{data:'TokenSource',header:true}], [String(issue_number), branch, 'false', 'manual', tokenSource]]).write();
             const fs = require('fs'); fs.mkdirSync('codex-artifacts', { recursive: true });
-            fs.writeFileSync('codex-artifacts/codex_bootstrap_result.json', JSON.stringify({ reused:false, issue:issue_number, pr:null, branch, base:baseBranch, manual:true, token_source: tokenSource, pr_author: null, ts:new Date().toISOString() }, null, 2));
-            console.log('CODEX_BOOTSTRAP_RESULT:' + JSON.stringify({ reused:false, issue:issue_number, pr:null, branch, base:baseBranch, manual:true, token_source: tokenSource, pr_author: null }));
+            fs.writeFileSync('codex-artifacts/codex_bootstrap_summary.json', JSON.stringify({ reused:false, issue:issue_number, pr:null, branch, base:baseBranch, manual:true, token_source: tokenSource, pr_author: null, ts:new Date().toISOString() }, null, 2));
+            console.log('CODEX_BOOTSTRAP_SUMMARY:' + JSON.stringify({ reused:false, issue:issue_number, pr:null, branch, base:baseBranch, manual:true, token_source: tokenSource, pr_author: null }));
             core.setOutput('codex_pr', ''); core.setOutput('codex_reused', 'false');
             return;
           }
@@ -310,8 +335,8 @@ runs:
           core.summary.addHeading('Codex Bootstrap').addTable([[{data:'Issue',header:true},{data:'PR',header:true},{data:'Branch',header:true},{data:'Reused',header:true},{data:'Suppressed',header:true},{data:'TokenSource',header:true},{data:'Author',header:true}], [String(issue_number), String(prNumber), branch, 'false', String(activationSuppressed), tokenSource, prAuthorLogin || '(unknown)']]).write();
           core.setOutput('codex_pr', String(prNumber));
           core.setOutput('codex_reused', 'false');
-          try { const fs = require('fs'); fs.mkdirSync('codex-artifacts', { recursive: true }); fs.writeFileSync('codex-artifacts/codex_bootstrap_result.json', JSON.stringify({ reused:false, issue:issue_number, pr:prNumber, branch, base:baseBranch, assigned_issue:issueAssignOk, assigned_pr:prAssignOk, suppression:activationSuppressed, token_source: tokenSource, pr_author: prAuthorLogin, ts:new Date().toISOString() }, null, 2)); fs.writeFileSync('codex-artifacts/README.txt', 'Codex bootstrap artifacts.'); } catch(e){ core.warning('Failed to write artifact: '+e.message); }
-          console.log('CODEX_BOOTSTRAP_RESULT:' + JSON.stringify({ reused:false, issue:issue_number, pr:prNumber, branch, base:baseBranch, assigned_issue:issueAssignOk, assigned_pr:prAssignOk, suppression:activationSuppressed, token_source: tokenSource, pr_author: prAuthorLogin }));
+          try { const fs = require('fs'); fs.mkdirSync('codex-artifacts', { recursive: true }); fs.writeFileSync('codex-artifacts/codex_bootstrap_summary.json', JSON.stringify({ reused:false, issue:issue_number, pr:prNumber, branch, base:baseBranch, assigned_issue:issueAssignOk, assigned_pr:prAssignOk, suppression:activationSuppressed, token_source: tokenSource, pr_author: prAuthorLogin, ts:new Date().toISOString() }, null, 2)); fs.writeFileSync('codex-artifacts/README.txt', 'Codex bootstrap artifacts.'); } catch(e){ core.warning('Failed to write artifact: '+e.message); }
+          console.log('CODEX_BOOTSTRAP_SUMMARY:' + JSON.stringify({ reused:false, issue:issue_number, pr:prNumber, branch, base:baseBranch, assigned_issue:issueAssignOk, assigned_pr:prAssignOk, suppression:activationSuppressed, token_source: tokenSource, pr_author: prAuthorLogin }));
           const mismatch = usingPAT && prAuthorLogin === 'github-actions[bot]';
           if (mismatch) {
             const msg = `:warning: Token mismatch – SERVICE_BOT_PAT present but PR author is github-actions[bot].`;

--- a/.github/actions/codex-bootstrap/action.yml
+++ b/.github/actions/codex-bootstrap/action.yml
@@ -179,7 +179,7 @@ runs:
                     created = true; core.info(`Created branch ${branch} with fallback GITHUB_TOKEN.`);
                   } else {
                     let txt; try { txt = await resp.text(); } catch {}
-                    core.warning(`Fallback branch create failed http_status=${resp.status} body=${(txt||'').slice(0,500)}`);
+                    core.warning(`Fallback branch create failed http_status=${resp.status} error=Unable to create branch. See debug logs for details.`);
                   }
                 } catch (e2) {
                   const detail2 = e2 && e2.response && e2.response.data ? JSON.stringify(e2.response.data) : '';

--- a/.github/actions/codex-bootstrap/action.yml
+++ b/.github/actions/codex-bootstrap/action.yml
@@ -23,7 +23,7 @@ inputs:
   allow_fallback:
     description: "Permit fallback to GITHUB_TOKEN when PAT absent (true|false)"
     required: false
-    default: "false"
+    default: "true"
   fail_on_token_mismatch:
     description: "If set (non-empty), fail when PAT present but PR author is github-actions[bot]"
     required: false
@@ -42,6 +42,10 @@ inputs:
     default: "false"
   fail_on_dual_branch_failure:
     description: "Fail the action if both primary and fallback branch creation attempts fail (true|false)"
+    required: false
+    default: "true"
+  rebootstrap_closed_pr:
+    description: "If true and referenced PR is closed, create a fresh draft PR and update marker"
     required: false
     default: "true"
 outputs:
@@ -213,19 +217,36 @@ runs:
             const suppressFromEnv   = !!process.env.CODEX_SUPPRESS_ACTIVATE;
             const activationSuppressed = suppressFromEnv || suppressFromInput || suppressFromToken;
             let parsed = {}; try { parsed = JSON.parse(decoded||'{}'); } catch {}
-            if (parsed.pr) core.setOutput('codex_pr', String(parsed.pr));
-            core.setOutput('codex_reused', 'true');
-            const prAuthor = parsed.pr_author || null;
+            let reuse = true; let prNumberExisting = parsed.pr || null; let prAuthor = parsed.pr_author || null;
+            // Optional re-bootstrap if existing PR is closed
+            if (prNumberExisting && '${{ inputs.rebootstrap_closed_pr }}' === 'true') {
+              try {
+                const { data: existingPR } = await github.rest.pulls.get({ owner, repo, pull_number: prNumberExisting });
+                if (existingPR.state === 'closed') {
+                  core.info(`Existing PR #${prNumberExisting} is closed; initiating re-bootstrap.`);
+                  // create new draft PR referencing same branch
+                  const replicatedHeader = `### Source Issue #${issue_number}: ${existingPR.title || ''}`;
+                  const newBody = `${replicatedHeader}\n\nRe-bootstrap due to closed original PR #${prNumberExisting}.`;
+                  const { data: newPR } = await github.rest.pulls.create({ owner, repo, head: branch, base: baseBranch, draft: true, title: `Codex re-bootstrap for #${issue_number}`, body: newBody });
+                  prNumberExisting = newPR.number; prAuthor = newPR.user && newPR.user.login || null; reuse = false; // treat as fresh for outputs
+                  const markerContent = Buffer.from(JSON.stringify({ issue: issue_number, pr: prNumberExisting, ts: new Date().toISOString(), rebootstrap: true }, null, 2)).toString('base64');
+                  await github.rest.repos.createOrUpdateFileContents({ owner, repo, path: markerPath, branch, message: `chore(codex): rebootstrap marker for #${issue_number}`, content: markerContent });
+                }
+              } catch (e) { core.warning(`Closed PR re-bootstrap check failed: ${e.message}`); }
+            }
+            if (prNumberExisting) core.setOutput('codex_pr', String(prNumberExisting));
+            core.setOutput('codex_reused', reuse ? 'true' : 'false');
+            const prAuthorFinal = prAuthor;
             try {
               const fs = require('fs'); fs.mkdirSync('codex-artifacts', { recursive: true });
               fs.writeFileSync('codex-artifacts/codex_bootstrap_result.json', JSON.stringify({
-                reused: true, issue: issue_number, pr: parsed.pr || null, branch, base: baseBranch,
-                suppression: activationSuppressed, token_source: tokenSource, pr_author: prAuthor, ts: new Date().toISOString()
+                reused: reuse, issue: issue_number, pr: prNumberExisting || null, branch, base: baseBranch,
+                suppression: activationSuppressed, token_source: tokenSource, pr_author: prAuthorFinal, ts: new Date().toISOString(), rebootstrap_attempt: !reuse
               }, null, 2));
               if (decoded) fs.writeFileSync('codex-artifacts/marker_snapshot.json', decoded);
               fs.writeFileSync('codex-artifacts/README.txt', 'Codex bootstrap artifacts.');
             } catch (e) { core.warning('Failed to write codex_bootstrap_result.json: ' + e.message); }
-            console.log('CODEX_BOOTSTRAP_RESULT:' + JSON.stringify({ reused: true, issue: issue_number, pr: parsed.pr || null, branch, base: baseBranch, suppression: activationSuppressed, token_source: tokenSource, pr_author: prAuthor }));
+            console.log('CODEX_BOOTSTRAP_RESULT:' + JSON.stringify({ reused: reuse, issue: issue_number, pr: prNumberExisting || null, branch, base: baseBranch, suppression: activationSuppressed, token_source: tokenSource, pr_author: prAuthorFinal }));
             return;
           }
           // Create marker seed file to ensure branch has a change (issue markdown stub)

--- a/.github/actions/codex-bootstrap/action.yml
+++ b/.github/actions/codex-bootstrap/action.yml
@@ -257,7 +257,8 @@ runs:
                   await github.rest.issues.addLabels({ owner, repo, issue_number: prNumberExisting, labels: ['agent:codex'] });
                   let cmd = String(process.env.CODEX_COMMAND || 'codex: start').replace(/[\r\n`]/g,'').trim();
                   const allowedCommands = ['codex: start','codex: test','codex: lint','codex: build','codex: review','codex: docs'];
-                  if (!allowedCommands.some(c => c.toLowerCase() === cmd.toLowerCase())) {
+                  const allowedCommandsLower = allowedCommands.map(c => c.toLowerCase());
+                  if (!allowedCommandsLower.includes(cmd.toLowerCase())) {
                     core.warning('Unsafe Codex command; defaulting.');
                     cmd = 'codex: start';
                   }

--- a/.github/actions/codex-bootstrap/action.yml
+++ b/.github/actions/codex-bootstrap/action.yml
@@ -165,7 +165,8 @@ runs:
               if (tokenSource === 'SERVICE_BOT_PAT' && allowFallback && process.env.GITHUB_TOKEN) {
                 core.info('Attempting branch create retry with GITHUB_TOKEN fallback (fetch API).');
                 try {
-                  const resp = await fetch(`https://api.github.com/repos/${owner}/${repo}/git/refs`, {
+                  const apiBaseUrl = process.env.GITHUB_API_URL || 'https://api.github.com';
+                  const resp = await fetch(`${apiBaseUrl}/repos/${owner}/${repo}/git/refs`, {
                     method: 'POST',
                     headers: {
                       'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`,

--- a/.github/workflows/codex-assign-minimal.yml
+++ b/.github/workflows/codex-assign-minimal.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Checkout repository (required for local action)
         uses: actions/checkout@v4
       - name: Bootstrap Codex
+        id: bootstrap
         uses: ./.github/actions/codex-bootstrap
         with:
           issue: ${{ needs.detect.outputs.codex_issue }}
@@ -95,3 +96,35 @@ jobs:
           name: codex-bootstrap-${{ needs.detect.outputs.codex_issue || 'unknown' }}
           path: codex-artifacts
           if-no-files-found: ignore
+      - name: Bootstrap outputs summary
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = core.getInput('codex_pr') || process.env.CODex_PR || '';
+            core.summary
+              .addHeading('Codex Bootstrap Outputs')
+              .addTable([
+                [{data:'Output',header:true},{data:'Value',header:true}],
+                ['codex_pr', '${{ steps.bootstrap.outputs.codex_pr || '' }}'],
+                ['codex_reused', '${{ steps.bootstrap.outputs.codex_reused || '' }}'],
+                ['branch_created', '${{ steps.bootstrap.outputs.branch_created || '' }}']
+              ])
+              .write();
+      - name: Structured JSON summary
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            fs.mkdirSync('codex-artifacts', { recursive: true });
+            const summary = {
+              issue: '${{ needs.detect.outputs.codex_issue }}',
+              detection_reason: '${{ needs.detect.outputs.detection_reason }}',
+              codex_pr: '${{ steps.bootstrap.outputs.codex_pr || '' }}',
+              codex_reused: '${{ steps.bootstrap.outputs.codex_reused || '' }}',
+              branch_created: '${{ steps.bootstrap.outputs.branch_created || '' }}',
+              ts: new Date().toISOString()
+            };
+            fs.writeFileSync('codex-artifacts/codex_bootstrap_summary.json', JSON.stringify(summary, null, 2));
+            core.info('Wrote codex-artifacts/codex_bootstrap_summary.json');

--- a/.github/workflows/codex-assign-minimal.yml
+++ b/.github/workflows/codex-assign-minimal.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const pr = core.getInput('codex_pr') || process.env.CODex_PR || '';
+            const pr = core.getInput('codex_pr') || process.env.CODEX_PR || '';
             core.summary
               .addHeading('Codex Bootstrap Outputs')
               .addTable([

--- a/docs/agent-automation.md
+++ b/docs/agent-automation.md
@@ -53,7 +53,7 @@ Responsibilities:
 - Creates or reuses branch `agents/codex-issue-<n>` and marker file `agents/.codex-bootstrap-<n>.json`.
 - Auto (default) mode: opens or reuses draft PR with replicated issue content.
 - Manual mode: only branch + marker + instructions comment (user opens draft PR).
-- Writes structured artifact `codex_bootstrap_result.json` (always) for downstream inspection.
+- Writes structured artifact `codex_bootstrap_summary.json` (always) for downstream inspection.
 - Idempotent: re-run when marker exists emits summary without duplicating PR.
 
 Composite inputs (selected):

--- a/docs/codex_bootstrap_verification.md
+++ b/docs/codex_bootstrap_verification.md
@@ -54,7 +54,7 @@
 ## 4. Operational Notes
 - Always test create (T01) and idempotent reuse (T02) after any action.yml change.
 - Run dual failure (T11) before relaxing protections to ensure fail path clarity.
-- Keep artifact JSON (`codex_bootstrap_result.json`) as source of truth for outputs vs console logs.
+- Keep artifact JSON (`codex_bootstrap_summary.json`) as source of truth for outputs vs console logs.
 
 ## 5. Suggested Future Enhancements
 - (DONE) Structured JSON summary artifact (`codex_bootstrap_summary.json`).

--- a/docs/codex_bootstrap_verification.md
+++ b/docs/codex_bootstrap_verification.md
@@ -54,7 +54,7 @@
 ## 4. Operational Notes
 - Always test create (T01) and idempotent reuse (T02) after any action.yml change.
 - Run dual failure (T11) before relaxing protections to ensure fail path clarity.
-- Keep artifact JSON (`codex_bootstrap_summary.json`) as source of truth for outputs vs console logs.
+- Use artifact JSON (`codex_bootstrap_summary.json`) as the source of truth for outputs; console logs are informational only.
 
 ## 5. Suggested Future Enhancements
 - (DONE) Structured JSON summary artifact (`codex_bootstrap_summary.json`).

--- a/docs/codex_bootstrap_verification.md
+++ b/docs/codex_bootstrap_verification.md
@@ -1,0 +1,65 @@
+# Codex Bootstrap Workflow – Failure Points & Verification Matrix
+
+## 1. Failure Point Enumeration
+
+| ID | Scenario | Trigger Condition | Expected Current Behaviour | Mitigation / Handling | Recommended Test |
+|----|----------|------------------|-----------------------------|-----------------------|------------------|
+| FP1 | No codex label | Issue event without `agent:codex` | detect sets needs=false; no bootstrap job | Clear reason output: issue-without-label | Remove label, re-run |
+| FP2 | Manual dispatch missing simulated label | Dispatch with simulate_label not containing `agent:codex` | needs=false; reason=manual-dispatch-missing-simulated-label | Explicit reason for transparency | Dispatch test |
+| FP3 | Invalid manual issue id | Non-numeric test_issue | needs=false; reason=invalid-manual-issue | Guard warns & skips | Dispatch test with `ABC` |
+| FP4 | Missing PAT & fallback disabled | PAT empty, allow_fallback=false | Token gate exits (code 86) fail | Early explicit failure prevents wasted API calls | Run with CODEX_ALLOW_FALLBACK=false |
+| FP5 | Primary branch create 403 | PAT attempt fails 403 | Fallback fetch attempt (if allowed) else failure | Fallback uses GITHUB_TOKEN; dual failure setFailed | Simulate restricted PAT |
+| FP6 | Fallback branch create HTTP error | GITHUB_TOKEN restricted or ruleset blocks | setFailed (if fail_on_dual_branch_failure=true) | Clear guidance comment added | Temporarily restrict token perms |
+| FP7 | Marker present (idempotent) | Branch+marker exist | Reuse path; codex_reused=true | Avoids duplicate PR churn | Relabel same issue |
+| FP8 | Marker present but PR closed & rebootstrap enabled | Existing PR closed | New draft PR created; reused=false | Automated re-engagement | Close PR then relabel |
+| FP9 | Marker present PR closed & rebootstrap disabled | Input sets rebootstrap_closed_pr=false | Reuse path still; will not create new PR | Conservative mode | Configure input override |
+| FP10 | Manual mode | pr_mode=manual | Branch + marker only; no PR | Allows staged manual PR creation | Input test |
+| FP11 | Activation suppression token | Issue body contains [codex-suppress-activate] | Activation comment skipped | Respect suppression directive | Add token to issue body |
+| FP12 | Command validation | Unsupported codex_command | Falls back to safe default | Prevents unsafe commands | Pass invalid command |
+| FP13 | Network rate-limit transient | Preflight curl fails until attempts exhausted | Retry then exit 75 | Prevents partial bootstrap w/o API budget | Temporarily lower rate limit |
+| FP14 | Closed PR rebootstrap error | New PR creation fails | Warning, action continues (branch already exists) | Surface error, idempotent marker unaffected | Simulate with restricted PR creation |
+| FP15 | JSON marker parse error | Corrupt marker file | Warnings; bootstrap continues using defaults | Defensive try/catch | Manually corrupt marker |
+
+## 2. Verification Matrix
+
+| Test Name | Inputs / Pre-state | Assertions |
+|-----------|--------------------|------------|
+| T01 Basic Create | New issue + label | branch_created=true; codex_reused=false; codex_pr != '' |
+| T02 Idempotent Reuse | Relabel same issue | branch_created=false; codex_reused=true; codex_pr same as first |
+| T03 Closed PR Rebootstrap | Close PR then relabel | new codex_pr != old; codex_reused=false; marker rebootstrap:true |
+| T04 Missing Label | Issue without label | detect.reason=issue-without-label; no bootstrap job |
+| T05 Manual Dispatch Simulated | dispatch test_issue=N simulate_label=agent:codex | branch_created=true; codex_pr set |
+| T06 Manual Dispatch Missing Sim | dispatch test_issue=N simulate_label=foo | reason=manual-dispatch-missing-simulated-label |
+| T07 Invalid Manual Issue | dispatch test_issue=ABC simulate_label=agent:codex | reason=invalid-manual-issue |
+| T08 PAT Missing Fallback Allowed | Remove PAT; allow_fallback=true | branch_created=true (or failure surfaced); token_source=GITHUB_TOKEN in artifact |
+| T09 PAT Missing Fallback Disabled | Remove PAT; allow_fallback=false | Job fails token gate (exit 86) |
+| T10 Primary 403 + Fallback Success | Restrict PAT; fallback allowed | Primary fail log + fallback success log |
+| T11 Dual Failure | Restrict both PAT & GITHUB_TOKEN branch perms | Job fails; fail_on_dual_branch_failure true |
+| T12 Manual Mode | pr_mode=manual | codex_pr empty; marker mode:manual |
+| T13 Suppressed Activation | Add suppression token to issue body | No activation comment on PR |
+| T14 Invalid Command | codex_command=codex: unknown | Warning + default command used |
+| T15 Corrupt Marker | Manually edit marker invalid JSON then relabel | Warning about parse; reuse logic still sets outputs |
+
+## 3. Inputs Reference
+
+| Input | Purpose | Typical Values |
+|-------|---------|----------------|
+| allow_fallback | Permit GITHUB_TOKEN fallback (default now true for resilience) | true / false |
+| pr_mode | Manual vs auto PR creation | auto / manual |
+| rebootstrap_closed_pr | Recreate PR if closed | true / false |
+| fail_on_dual_branch_failure | Fail job if both branch attempts fail | true / false |
+| codex_command | Initial Codex command (validated) | codex: start, codex: test |
+| debug_mode | Verbose logging | true / false |
+
+## 4. Operational Notes
+- Always test create (T01) and idempotent reuse (T02) after any action.yml change.
+- Run dual failure (T11) before relaxing protections to ensure fail path clarity.
+- Keep artifact JSON (`codex_bootstrap_result.json`) as source of truth for outputs vs console logs.
+
+## 5. Suggested Future Enhancements
+- (DONE) Structured JSON summary artifact (`codex_bootstrap_summary.json`).
+- Add optional reviewer assignment list input.
+- Implement stale PR detection (time-based rebootstrap) separate from closed state.
+
+---
+Generated as part of Codex bootstrap verification tasks.


### PR DESCRIPTION
## Summary
- document correct codex bootstrap artifact name
- sanitize fallback branch logging and allow custom API base URL
- label and assign re-bootstrapped PRs

## Testing
- `./scripts/run_tests.sh` *(fails: requirements.lock is out of date)*

------
https://chatgpt.com/codex/tasks/task_e_68c60cc1e4c48331b734ed4ffed417c6