### PR TITLE
Add tests for GUI stub and multi-period placeholders

### DIFF
--- a/tests/test_gui_and_multi_period.py
+++ b/tests/test_gui_and_multi_period.py
@@ -1,0 +1,38 @@
+import importlib
+import sys
+import types
+
+import pandas as pd
+
+from trend_analysis.multi_period import engine, replacer
+
+
+def test_engine_run_placeholder():
+    cfg = {"foo": "bar"}
+    assert engine.run(cfg) == {}
+
+
+def test_rebalancer_apply_triggers_returns_copy():
+    prev = pd.Series({"A": 0.6, "B": 0.4})
+    scores = pd.DataFrame({"m": [1.0, 2.0]}, index=["A", "B"])
+    r = replacer.Rebalancer({})
+    out = r.apply_triggers(prev, scores)
+    assert out.equals(prev)
+    assert out is not prev
+
+
+def test_gui_app_import(monkeypatch):
+    calls = {}
+
+    def title(msg: str) -> None:
+        calls["title"] = msg
+
+    def write(msg: str) -> None:
+        calls["write"] = msg
+
+    dummy = types.SimpleNamespace(title=title, write=write)
+    monkeypatch.setitem(sys.modules, "streamlit", dummy)
+    sys.modules.pop("trend_analysis.gui.app", None)
+    importlib.import_module("trend_analysis.gui.app")
+    assert "GUI coming soon" in calls["title"]
+    assert "placeholder" in calls["write"]

--- a/tests/test_metrics_extra.py
+++ b/tests/test_metrics_extra.py
@@ -98,3 +98,17 @@ def test_max_drawdown():
     assert isinstance(metrics.max_drawdown(df), pd.Series)
     empty = pd.Series([], dtype=float)
     assert np.isnan(metrics.max_drawdown(empty))
+
+
+def test_information_ratio_dataframe_defaults_mean_benchmark():
+    df = pd.DataFrame({"a": [0.1, 0.2], "b": [0.2, 0.1]})
+    res = metrics.information_ratio(df)
+    assert isinstance(res, pd.Series)
+    assert np.allclose(res, 0.0)
+
+
+def test_information_ratio_scalar_benchmark_series():
+    s = pd.Series([0.1, 0.2])
+    ir = metrics.information_ratio(s, benchmark=0.05)
+    expected = ((s - 0.05).mean() * 12) / ((s - 0.05).std(ddof=1) * np.sqrt(12))
+    assert np.isclose(ir, expected)


### PR DESCRIPTION
## Summary
- test gui placeholder by mocking `streamlit`
- test multi-period `engine.run` and `Rebalancer.apply_triggers`
- exercise additional information_ratio branches

## Testing
- `pytest --cov=trend_analysis --cov-branch --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68c6392c8c9c8331b087447d41dcb35a