### PR TITLE
Exclude old code from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
 [run]
 omit =
     trend_analysis/core/*
+    Old/*
+    tests/*


### PR DESCRIPTION
## Summary
- Exclude deprecated `Old/` code and tests from coverage metrics

## Testing
- `pytest -q --cov=. --cov-report=term`

------
https://chatgpt.com/codex/tasks/task_e_68c63ea4ccac8331bb13f852023771fd