### PR TITLE
Add coverage tests for CI probe and config fallback

### DIFF
--- a/tests/test_ci_probe_faults.py
+++ b/tests/test_ci_probe_faults.py
@@ -1,0 +1,55 @@
+import pytest
+
+from trend_analysis import _ci_probe_faults as probe
+
+
+@pytest.mark.parametrize("a,b,expected", [(1, 2, 3), (-5, 7, 2), (0, 0, 0)])
+def test_add_numbers(a, b, expected):
+    """Ensure the simple addition helper returns the correct sum."""
+    assert probe.add_numbers(a, b) == expected
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        ({}, "Hello World"),
+        ({"name": "Codex"}, "Hello Codex"),
+        ({"name": "Codex", "excited": True}, "Hello Codex!"),
+    ],
+)
+def test_build_message_variants(kwargs, expected):
+    """The greeting builder should respect optional parameters."""
+    assert probe.build_message(**kwargs) == expected
+
+
+def test_internal_helper_aggregates_and_uses_dependencies(monkeypatch):
+    """The internal helper should sum values and invoke helper imports."""
+    captured = {}
+
+    def fake_safe_load(text):
+        captured["yaml"] = text
+        return {"numbers": [1, 2, 3]}
+
+    def fake_sqrt(value):
+        captured.setdefault("sqrt_args", []).append(value)
+        return 42
+
+    monkeypatch.setattr(probe.yaml, "safe_load", fake_safe_load)
+    monkeypatch.setattr(probe.math, "sqrt", fake_sqrt)
+
+    values = [10, 20, 30]
+    assert probe._internal_helper(values) == 60
+    assert captured["yaml"] == "numbers: [1,2,3]"
+    assert captured["sqrt_args"] == [10]
+
+
+def test_internal_helper_handles_empty_sequence(monkeypatch):
+    """Empty iterables should not break the helper and still call dependencies."""
+    calls = {}
+
+    monkeypatch.setattr(probe.yaml, "safe_load", lambda text: calls.setdefault("yaml", text))
+    monkeypatch.setattr(probe.math, "sqrt", lambda value: calls.setdefault("sqrt", value))
+
+    assert probe._internal_helper([]) == 0
+    assert calls["yaml"] == "numbers: [1,2,3]"
+    assert calls["sqrt"] == 0

--- a/tests/test_ci_probe_faults.py
+++ b/tests/test_ci_probe_faults.py
@@ -47,8 +47,8 @@ def test_internal_helper_handles_empty_sequence(monkeypatch):
     """Empty iterables should not break the helper and still call dependencies."""
     calls = {}
 
-    monkeypatch.setattr(probe.yaml, "safe_load", lambda text: calls.setdefault("yaml", text))
-    monkeypatch.setattr(probe.math, "sqrt", lambda value: calls.setdefault("sqrt", value))
+    monkeypatch.setattr(probe.yaml, "safe_load", lambda text: (calls.__setitem__("yaml", text), text)[1])
+    monkeypatch.setattr(probe.math, "sqrt", lambda value: (calls.__setitem__("sqrt", value), 0)[1])
 
     assert probe._internal_helper([]) == 0
     assert calls["yaml"] == "numbers: [1,2,3]"

--- a/tests/test_config_fallback_minimal.py
+++ b/tests/test_config_fallback_minimal.py
@@ -1,0 +1,91 @@
+import copy
+from pathlib import Path
+
+import pytest
+
+from trend_analysis.config import models as config_models
+
+
+@pytest.fixture()
+def base_config_dict():
+    return {
+        "version": "1.0",
+        "data": {},
+        "preprocessing": {},
+        "vol_adjust": {},
+        "sample_split": {},
+        "portfolio": {},
+        "metrics": {},
+        "export": {},
+        "run": {},
+    }
+
+
+def test_config_defaults_and_model_dump(base_config_dict):
+    cfg = config_models.Config(**base_config_dict)
+
+    dump = cfg.model_dump()
+    for field in config_models.Config.ALL_FIELDS:
+        assert field in dump
+
+    assert dump["version"] == "1.0"
+    assert dump["benchmarks"] == {}
+    assert dump["output"] is None
+    assert dump["multi_period"] is None
+    assert dump["seed"] == 42
+
+
+def test_config_requires_required_sections(base_config_dict):
+    bad = copy.deepcopy(base_config_dict)
+    bad["metrics"] = None
+    with pytest.raises(ValueError, match="metrics section is required"):
+        config_models.Config(**bad)
+
+
+@pytest.mark.parametrize(
+    "field, value, message",
+    [
+        ("data", [], "data must be a dictionary"),
+        ("preprocessing", 1, "preprocessing must be a dictionary"),
+    ],
+)
+def test_config_requires_dict_sections(base_config_dict, field, value, message):
+    bad = copy.deepcopy(base_config_dict)
+    bad[field] = value
+    with pytest.raises(ValueError, match=message):
+        config_models.Config(**bad)
+
+
+@pytest.mark.parametrize(
+    "value, match",
+    [
+        (123, "version must be a string"),
+        ("", "at least 1 character"),
+        ("   ", "cannot be empty"),
+    ],
+)
+def test_validate_version_value_errors(value, match):
+    with pytest.raises(ValueError, match=match):
+        config_models._validate_version_value(value)
+
+
+def test_validate_version_value_passthrough():
+    assert config_models._validate_version_value("1.2.3") == "1.2.3"
+
+
+def test_load_merges_output_into_export(base_config_dict):
+    cfg_map = copy.deepcopy(base_config_dict)
+    cfg_map["output"] = {"format": ["csv", "json"], "path": "reports/out/results.xlsx"}
+
+    cfg = config_models.load(cfg_map)
+    dump = cfg.model_dump()
+
+    assert dump["export"]["formats"] == ["csv", "json"]
+    assert dump["export"]["directory"] == str(Path("reports/out"))
+    assert dump["export"]["filename"] == "results.xlsx"
+
+
+def test_load_config_with_mapping(base_config_dict):
+    cfg = config_models.load_config(base_config_dict)
+    assert isinstance(cfg, config_models.Config)
+    assert cfg.version == "1.0"


### PR DESCRIPTION
## Summary
- add a focused test module exercising the lightweight `_ci_probe_faults` helpers
- cover the pydantic-free Config fallback path, including validation and load helpers

## Testing
- pytest tests/test_ci_probe_faults.py tests/test_config_fallback_minimal.py


------
https://chatgpt.com/codex/tasks/task_e_68c85d0fede08331bbea5fc0d0aa9b86