### PR TITLE
chore(workflows): add hardened Codex diagnostic (fresh branch per policy)

### DIFF
--- a/.github/workflows/codex-bootstrap-diagnostic.yml
+++ b/.github/workflows/codex-bootstrap-diagnostic.yml
@@ -41,7 +41,7 @@ jobs:
           set -euo pipefail
           echo "Running Codex bootstrap diagnostics..."
           ISSUE_INPUT="${{ github.event.inputs.issue }}"
-          BRANCH_INPUT="${{ github.event.inputs.branch }}"
+            BRANCH_INPUT="${{ github.event.inputs.branch }}"
           DRY_RUN="${{ github.event.inputs.dry_run }}"
           ATTEMPT_BRANCH_CREATE="${{ github.event.inputs.attempt_branch_create }}"
           TS=$(date -u +%Y%m%d%H%M%S)
@@ -74,28 +74,14 @@ jobs:
           # Resolve base branch without requiring API access
           BASE_BRANCH="${{ github.ref_name }}"
           if [[ -z "$BASE_BRANCH" ]]; then
-            # Try to resolve default branch locally first
-            BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' | tr -d '\n' || true)
-            # If still empty, fall back to network request
-            if [[ -z "$BASE_BRANCH" ]]; then
-              BASE_BRANCH=$(git remote show origin | sed -n 's/.*HEAD branch: //p' | tr -d '\n' || true)
-            fi
+            BASE_BRANCH=$(git remote show origin | sed -n 's/.*HEAD branch: //p' | tr -d '\n' || true)
           fi
           if [[ -z "$BASE_BRANCH" ]]; then BASE_BRANCH="main"; fi
           echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
           echo "| base_branch | $BASE_BRANCH |" >> "$GITHUB_STEP_SUMMARY"
 
           # Resolve base SHA via git (no tokens required for local ref)
-          # Try to resolve base SHA from origin/$BASE_BRANCH first
-          BASE_SHA=$(git rev-parse "origin/$BASE_BRANCH" 2>/dev/null || echo '')
-          if [[ -z "$BASE_SHA" ]]; then
-            # Fallback: try local $BASE_BRANCH
-            BASE_SHA=$(git rev-parse "$BASE_BRANCH" 2>/dev/null || echo '')
-          fi
-          if [[ -z "$BASE_SHA" ]]; then
-            # Final fallback: unresolved
-            BASE_SHA=''
-          fi
+          BASE_SHA=$(git rev-parse "origin/$BASE_BRANCH" 2>/dev/null || git rev-parse "$BASE_BRANCH" 2>/dev/null || echo '')
           if [[ -n "$BASE_SHA" ]]; then
             echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
             echo "| base_sha | $(echo "$BASE_SHA" | cut -c1-12) |" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds the hardened diagnostic workflow via a brand-new branch per policy.\n\n- Tokenless-friendly: resolves base branch/SHA via git, not gh API.\n- Skips API branch create if no tokens present (reports in summary).\n\nRun instructions (post-merge):\nActions → Codex Bootstrap Diagnostic → Run workflow\n  - attempt_branch_create=true\n  - dry_run=false\n  - issue=<id>\n