### PR TITLE
ci(codex): diagnostics — map tokens to steps and try both header styles (supersedes #1007)

### DIFF
--- a/.github/workflows/codex-bootstrap-diagnostic.yml
+++ b/.github/workflows/codex-bootstrap-diagnostic.yml
@@ -40,6 +40,8 @@ jobs:
         env:
           # Map the workflow token so the probe can actually see it
           GITHUB_TOKEN: ${{ github.token }}
+          # Expose PAT secret for probe visibility (safe: value not printed)
+          SERVICE_BOT_PAT: ${{ secrets.SERVICE_BOT_PAT }}
         run: |
           set -euo pipefail
           echo "Running Codex bootstrap diagnostics..."
@@ -103,6 +105,8 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run }}
           # Ensure default token is visible to the step
           GITHUB_TOKEN: ${{ github.token }}
+          # Expose PAT secret so branch create can try PAT first
+          SERVICE_BOT_PAT: ${{ secrets.SERVICE_BOT_PAT }}
         run: |
           set -euo pipefail
           echo "Testing branch create for $TARGET_BRANCH (dry_run=$DRY_RUN)"


### PR DESCRIPTION
This PR supersedes #1007 to honor the "fresh branch for every PR" policy, without pushing any further commits to the previous branch.

What’s included (same content as #1007):
- Diagnostic workflow exposes `github.token` as `GITHUB_TOKEN` and `secrets.SERVICE_BOT_PAT` to steps so probes and branch-create attempts can use them.
- Composite action previously hardened (in #1005) to try both PAT and fallback tokens with both `Bearer` and `token` Authorization styles. Diagnostics mirror this.

Why a new PR:
- The prior PR branch received an extra commit. Per your policy, this PR is a fresh branch carrying the exact intended changes.

After merge:
- Run the diagnostic with `attempt_branch_create=true` and `dry_run=false`. You should see which token and header style succeeded.
- Then trigger Codex Assign Minimal and confirm branch creation + artifacts.
