### PR TITLE
ci(codex): diagnostic — add bot permission check step (repo-specific)

### DIFF
--- a/.github/workflows/codex-bootstrap-diagnostic.yml
+++ b/.github/workflows/codex-bootstrap-diagnostic.yml
@@ -34,6 +34,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Bot permission on this repo
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const username = 'stranske-automation-bot';
+            try {
+              const resp = await github.request('GET /repos/{owner}/{repo}/collaborators/{username}/permission', { owner, repo, username });
+              core.info('Bot permission check:');
+              core.info(JSON.stringify(resp.data, null, 2));
+              core.summary.addHeading('Bot Permission on Repo').addCodeBlock(JSON.stringify(resp.data, null, 2), 'json').write();
+            } catch (e) {
+              core.warning(`Permission check failed: ${e.status || '?'} ${e.message}`);
+            }
+
       - name: Token / Env Probe
         id: probe
         shell: bash


### PR DESCRIPTION
This PR adds a deterministic, repo-specific permission check for `stranske-automation-bot` to the diagnostic workflow.

What it does
- Prints the bot’s effective permission on this repository via `GET /repos/{owner}/{repo}/collaborators/{username}/permission`.
- Surfaces the JSON in the job summary for quick inspection.

Why
- Your logs show PAT 403 vs GITHUB_TOKEN 201. This step makes it obvious whether the bot account is seen as `write` on THIS repo, removing all guesswork.

How to use after merge
- Manually trigger the diagnostic workflow (same as before), no inputs required for this step.
- The “Bot Permission on Repo” section will appear in the job summary.

No behavior change elsewhere; this is pure diagnostics.
