### PR TITLE
Codex bootstrap for #1018

### DIFF
--- a/agents/codex-1018.md
+++ b/agents/codex-1018.md
@@ -1,0 +1,1 @@
+<- The “Bot Permission on Repo” section will appear in the job bootstrap for codex on issue #1018 -->

--- a/src/trend_analysis/selector.py
+++ b/src/trend_analysis/selector.py
@@ -47,9 +47,10 @@ class ZScoreSelector(Selector):
         if self.column not in score_frame.columns:
             raise KeyError(self.column)
         scores = score_frame[self.column].astype(float)
-        mu = scores.mean()
-        sigma = scores.std(ddof=0)
-        z = (scores - mu) / (sigma if sigma else 1.0)
+        mu = float(scores.mean())
+        sigma = float(scores.std(ddof=0))
+        denom = sigma if pd.notna(sigma) and sigma != 0 else 1.0
+        z = (scores - mu) / denom
         mask = z * self.direction > self.threshold
         selected = score_frame.loc[mask].copy()
         log = pd.DataFrame(

--- a/src/trend_analysis/weighting.py
+++ b/src/trend_analysis/weighting.py
@@ -21,8 +21,12 @@ class EqualWeight(BaseWeighting):
         if selected.empty:
             return pd.DataFrame(columns=["weight"])
         n = len(selected)
-        w = np.repeat(1.0 / n, n)
-        w = (w * 10000).round() / 10000
+        w = np.full(n, 1.0 / n, dtype=float)
+        # Numerical stability: guard against accumulated floating error by
+        # re-normalising to exactly sum to one.
+        total = float(w.sum())
+        if total != 0:
+            w /= total
         return pd.DataFrame({"weight": w}, index=selected.index)
 
 


### PR DESCRIPTION
### Source Issue #1018: Codex E2E: add zscore selector + tests

---
We need to add a new ZScoreSelector and RankSelector plugin system plus weighting classes, wire into the multi-period engine, and export period metrics as Phase‑1 style sheets.\n\nAcceptance criteria:\n- Selector classes: RankSelector and ZScoreSelector returning selected + log\n- Weighting classes: EqualWeight, ScorePropSimple, ScorePropBayesian\n- Engine loop integrates selector + weighting\n- Export multi-period metrics with one sheet per period + summary tab\n- Tests: rank edge cases, z-score threshold negative dir, equal weights sum to one, bayesian shrinkage monotonic\n\nPlease implement per Agents.md Step 5–7 and the multi-period export updates.\n\n[codex-suppress-activate]

---

This draft PR was auto-created to engage Codex on the task above. All edits should occur on this branch.