### PR TITLE
Add coverage tests for export metrics helpers

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,9 +1,16 @@
+import numpy as np
 import pandas as pd
+import pytest
+
+import trend_analysis.export as export_module
 
 from trend_analysis.export import (
     FORMATTERS_EXCEL,
+    execution_metrics_frame,
     export_data,
+    export_execution_metrics,
     export_to_excel,
+    manager_contrib_table,
     register_formatter_excel,
     reset_formatters_excel,
 )
@@ -69,3 +76,120 @@ def test_reset_formatters_excel():
     assert "foo" in FORMATTERS_EXCEL
     reset_formatters_excel()
     assert FORMATTERS_EXCEL == {}
+
+
+def test_execution_metrics_frame_builds_labels_and_nan():
+    results = [
+        {
+            "period": ("2024-01", "2024-06", "2024-07", "2024-12"),
+            "turnover": 0.15,
+            "transaction_cost": 0.002,
+        },
+        {
+            "turnover": None,
+        },
+    ]
+
+    frame = execution_metrics_frame(results)
+
+    expected = pd.DataFrame(
+        {
+            "Period": ["2024-12", "period_2"],
+            "Turnover": [0.15, np.nan],
+            "Transaction Cost": [0.002, np.nan],
+        }
+    )
+
+    pd.testing.assert_frame_equal(frame, expected)
+
+
+def test_execution_metrics_frame_empty_results():
+    frame = execution_metrics_frame([])
+    assert frame.empty
+    assert list(frame.columns) == ["Period", "Turnover", "Transaction Cost"]
+
+
+def test_export_execution_metrics_delegates(monkeypatch):
+    results_list = [
+        {
+            "period": ("2024-01", "2024-06", "2024-07", "2024-12"),
+            "turnover": 0.1,
+            "transaction_cost": 0.001,
+        }
+    ]
+    captured: dict[str, object] = {}
+
+    def fake_export_data(data, output_path, *, formats):
+        captured["data"] = data
+        captured["output_path"] = output_path
+        captured["formats"] = tuple(formats)
+
+    monkeypatch.setattr(export_module, "export_data", fake_export_data)
+
+    export_execution_metrics((res for res in results_list), "out/report", formats=("csv", "json"))
+
+    assert captured["output_path"] == "out/report"
+    assert captured["formats"] == ("csv", "json")
+    expected_df = execution_metrics_frame(results_list)
+    actual_df = captured["data"]["execution_metrics"]
+    assert isinstance(actual_df, pd.DataFrame)
+    pd.testing.assert_frame_equal(actual_df, expected_df)
+
+
+def test_manager_contrib_table_computes_participation():
+    idx1 = pd.date_range("2024-01-31", periods=2, freq="ME")
+    idx2 = pd.date_range("2024-03-31", periods=1, freq="ME")
+
+    out1 = pd.DataFrame(
+        {
+            "FundA": [0.01, 0.02],
+            "FundB": [0.005, 0.0],
+            "FundSkip": [0.03, -0.01],
+        },
+        index=idx1,
+    )
+    out2 = pd.DataFrame(
+        {
+            "FundA": [0.015],
+            "FundC": [0.04],
+            "FundB": [0.02],
+        },
+        index=idx2,
+    )
+
+    results = [
+        {"out_sample_scaled": out1, "fund_weights": {"FundA": 0.5, "FundB": 0.5, "FundSkip": 0.0}},
+        {"out_sample_scaled": out2, "fund_weights": {"FundA": 0.6, "FundC": 0.4, "FundB": 0.0}},
+    ]
+
+    table = manager_contrib_table(results)
+
+    assert list(table["Manager"]) == ["FundA", "FundC", "FundB"]
+
+    expected_years = [3 / 12, 1 / 12, 2 / 12]
+    assert table["Years"].tolist() == pytest.approx(expected_years)
+
+    def cagr(values: list[float]) -> float:
+        arr = np.array(values, dtype=float)
+        gross = float(np.prod(1.0 + arr))
+        periods = arr.size
+        return gross ** (12.0 / periods) - 1.0
+
+    expected_cagrs = [
+        cagr([0.01, 0.02, 0.015]),
+        cagr([0.04]),
+        cagr([0.005, 0.0]),
+    ]
+    assert table["OOS CAGR"].tolist() == pytest.approx(expected_cagrs)
+
+    contrib_totals = {"FundA": 0.024, "FundB": 0.0025, "FundC": 0.016}
+    total = sum(contrib_totals.values())
+    expected_shares = [contrib_totals[name] / total for name in ["FundA", "FundC", "FundB"]]
+    assert table["Contribution Share"].tolist() == pytest.approx(expected_shares)
+    assert table["Contribution Share"].sum() == pytest.approx(1.0)
+
+
+def test_manager_contrib_table_empty_results():
+    table = manager_contrib_table([{"out_sample_scaled": pd.DataFrame(), "fund_weights": {}}])
+    assert table.empty
+    assert list(table.columns) == ["Manager", "Years", "OOS CAGR", "Contribution Share"]


### PR DESCRIPTION
## Summary
- extend `tests/test_exports.py` with cases covering `execution_metrics_frame` and the generator handling in `export_execution_metrics`
- verify `manager_contrib_table` calculations and empty-result handling to close remaining gaps in the export helpers

## Testing
- pytest tests/test_exports.py


------
https://chatgpt.com/codex/tasks/task_e_68c972bb47bc83318c36aebf1c98f3a9