### PR TITLE
Add coverage tests for export helpers and walk-forward engine

### DIFF
--- a/tests/test_export_additional_coverage.py
+++ b/tests/test_export_additional_coverage.py
@@ -1,0 +1,257 @@
+"""Additional coverage tests for export helpers."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import numpy as np
+import pandas as pd
+import pytest
+
+try:  # pragma: no cover - exercised when matplotlib is installed
+    import matplotlib  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - handled in test environment
+    matplotlib = types.ModuleType("matplotlib")
+    matplotlib.use = lambda *args, **kwargs: None
+    pyplot = types.ModuleType("matplotlib.pyplot")
+
+    class _Axis:
+        def plot(self, *args, **kwargs):
+            return None
+
+        def set_axis_off(self) -> None:
+            return None
+
+        def set_title(self, *args, **kwargs) -> None:
+            return None
+
+    class _Figure:
+        def add_subplot(self, *args, **kwargs):
+            return _Axis()
+
+        def savefig(self, *args, **kwargs) -> None:
+            return None
+
+    def _figure(*args, **kwargs):
+        return _Figure()
+
+    pyplot.figure = _figure
+    pyplot.close = lambda *args, **kwargs: None
+
+    matplotlib.pyplot = pyplot  # type: ignore[attr-defined]
+    sys.modules.setdefault("matplotlib", matplotlib)
+    sys.modules.setdefault("matplotlib.pyplot", pyplot)
+
+from trend_analysis.export import (
+    export_multi_period_metrics,
+    export_phase1_multi_metrics,
+    export_phase1_workbook,
+    flat_frames_from_results,
+    phase1_workbook_data,
+)
+from trend_analysis.pipeline import _compute_stats, calc_portfolio_returns
+
+
+def _make_period_result(
+    label: str,
+    *,
+    include_changes: bool = False,
+    period_metadata: bool = True,
+) -> dict[str, object]:
+    """Return a synthetic result dictionary exercising export helpers."""
+
+    idx_in = pd.date_range("2020-01-31", periods=3, freq="ME")
+    idx_out = pd.date_range("2020-04-30", periods=2, freq="ME")
+    in_df = pd.DataFrame(
+        {
+            "FundA": [0.01, 0.015, 0.02],
+            "FundB": [0.005, 0.0, -0.002],
+        },
+        index=idx_in,
+    )
+    out_df = pd.DataFrame(
+        {
+            "FundA": [0.012, 0.014],
+            "FundB": [0.001, -0.002],
+        },
+        index=idx_out,
+    )
+
+    funds = list(in_df.columns)
+    ew_weights = {f: 1.0 / len(funds) for f in funds}
+    fund_weights = {"FundA": 0.6, "FundB": 0.4}
+
+    rf_in = pd.Series(0.0, index=idx_in)
+    rf_out = pd.Series(0.0, index=idx_out)
+
+    # Per-fund statistics reused by summary helpers
+    fund_in_stats = _compute_stats(in_df, rf_in)
+    fund_out_stats = _compute_stats(out_df, rf_out)
+
+    def _portfolio_stats(weights: dict[str, float], frame: pd.DataFrame, rf: pd.Series) -> dict[str, object]:
+        arr = np.array([weights.get(col, 0.0) for col in frame.columns], dtype=float)
+        returns = calc_portfolio_returns(arr, frame)
+        return _compute_stats(pd.DataFrame({"p": returns}), rf)["p"]
+
+    in_ew_stats = _portfolio_stats(ew_weights, in_df, rf_in)
+    out_ew_stats = _portfolio_stats(ew_weights, out_df, rf_out)
+    in_user_stats = _portfolio_stats(fund_weights, in_df, rf_in)
+    out_user_stats = _portfolio_stats(fund_weights, out_df, rf_out)
+
+    period = (
+        (
+            str(idx_in[0].date()),
+            str(idx_in[-1].date()),
+            str(idx_out[0].date()),
+            f"Period {label}",
+        )
+        if period_metadata
+        else None
+    )
+
+    result: dict[str, object] = {
+        "period": period,
+        "in_sample_scaled": in_df,
+        "out_sample_scaled": out_df,
+        "ew_weights": ew_weights,
+        "fund_weights": fund_weights,
+        "in_ew_stats": in_ew_stats,
+        "out_ew_stats": out_ew_stats,
+        "in_user_stats": in_user_stats,
+        "out_user_stats": out_user_stats,
+        "in_sample_stats": fund_in_stats,
+        "out_sample_stats": fund_out_stats,
+        "benchmark_ir": {
+            "Bench": {
+                "FundA": 0.1 + 0.01 * int(label),
+                "FundB": 0.05,
+                "equal_weight": 0.02,
+                "user_weight": 0.03,
+            }
+        },
+    }
+
+    if include_changes:
+        result["manager_changes"] = [
+            {"action": "add", "manager": "FundA", "detail": f"{label}"},
+            {"action": "trim", "manager": "FundB"},
+        ]
+
+    return result
+
+
+def test_flat_frames_from_results_includes_contrib_and_changes():
+    result = _make_period_result("1", include_changes=True)
+    frames = flat_frames_from_results([result])
+
+    assert "manager_contrib" in frames
+    assert not frames["manager_contrib"].empty
+    assert "changes" in frames
+    # Manager change rows should include the generated period label
+    assert set(frames["changes"]["Period"]) == {"Period 1"}
+
+
+def test_phase1_workbook_data_adds_metrics_summary():
+    results = [_make_period_result("1"), _make_period_result("2")]
+    frames = phase1_workbook_data(results, include_metrics=True)
+
+    assert "summary" in frames
+    assert "metrics_Period 1" in frames
+    assert "metrics_Period 2" in frames
+    assert "metrics_summary" in frames
+
+
+def test_export_phase1_workbook_missing_period_metadata(monkeypatch, tmp_path):
+    results = [
+        _make_period_result("1", include_changes=True, period_metadata=False),
+        _make_period_result("2", period_metadata=False),
+    ]
+
+    period_calls: list[tuple[str, str, str, str, str]] = []
+    summary_call: dict[str, object] = {}
+    frames_written: dict[str, pd.DataFrame] = {}
+
+    def fake_make_period_formatter(sheet, res, in_s, in_e, out_s, out_e):
+        period_calls.append((sheet, in_s, in_e, out_s, out_e))
+        return lambda ws, wb: None
+
+    def fake_make_summary_formatter(res, in_s, in_e, out_s, out_e):
+        summary_call["args"] = (in_s, in_e, out_s, out_e)
+        summary_call["payload"] = res
+        return lambda ws, wb: None
+
+    def fake_export_to_excel(data, path):
+        frames_written.update(data)
+
+    monkeypatch.setattr("trend_analysis.export.make_period_formatter", fake_make_period_formatter)
+    monkeypatch.setattr("trend_analysis.export.make_summary_formatter", fake_make_summary_formatter)
+    monkeypatch.setattr("trend_analysis.export.export_to_excel", fake_export_to_excel)
+
+    export_phase1_workbook(results, str(tmp_path / "out.xlsx"))
+
+    # Missing period metadata should yield generated sheet names and blank ranges
+    assert {call[0] for call in period_calls} == {"period_1", "period_2"}
+    assert all(call[1:] == ("", "", "", "") for call in period_calls)
+
+    assert summary_call["args"] == ("", "", "", "")
+    payload = summary_call["payload"]
+    assert "manager_contrib" in payload
+
+    # Summary sheet should be first when exporting
+    assert list(frames_written) and list(frames_written)[0] == "summary"
+
+
+def test_export_phase1_workbook_collects_manager_changes(monkeypatch, tmp_path):
+    results = [
+        _make_period_result("1", include_changes=True),
+        _make_period_result("2", include_changes=True),
+    ]
+
+    summary_call: dict[str, object] = {}
+
+    def fake_make_summary_formatter(res, in_s, in_e, out_s, out_e):
+        summary_call["args"] = (in_s, in_e, out_s, out_e)
+        summary_call["payload"] = res
+        return lambda ws, wb: None
+
+    monkeypatch.setattr("trend_analysis.export.make_summary_formatter", fake_make_summary_formatter)
+    monkeypatch.setattr("trend_analysis.export.export_to_excel", lambda data, path: None)
+
+    export_phase1_workbook(results, str(tmp_path / "out.xlsx"))
+
+    args = summary_call["args"]
+    assert args == (
+        results[0]["period"][0],
+        results[0]["period"][1],
+        results[-1]["period"][2],
+        results[-1]["period"][3],
+    )
+
+    payload = summary_call["payload"]
+    assert "manager_changes" in payload
+    assert len(payload["manager_changes"]) == 4
+    assert "manager_contrib" in payload
+
+
+@pytest.mark.parametrize(
+    "exporter",
+    [export_phase1_multi_metrics, export_multi_period_metrics],
+)
+def test_export_multi_helpers_include_metrics(tmp_path, exporter):
+    results = [_make_period_result("1"), _make_period_result("2")]
+    out = tmp_path / "report"
+
+    exporter(results, str(out), formats=["csv"], include_metrics=True)
+
+    metrics_path = out.with_name(f"{out.stem}_metrics.csv")
+    summary_path = out.with_name(f"{out.stem}_metrics_summary.csv")
+
+    assert metrics_path.exists()
+    assert summary_path.exists()
+
+    metrics_df = pd.read_csv(metrics_path)
+    assert set(metrics_df["Period"]) == {"Period 1", "Period 2"}
+
+    summary_df = pd.read_csv(summary_path)
+    assert not summary_df.empty

--- a/tests/test_walkforward_engine.py
+++ b/tests/test_walkforward_engine.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from trend_analysis.engine.walkforward import walk_forward
 
@@ -31,3 +32,27 @@ def test_walkforward_split_counts_and_regime_aggregation():
 
     # full period mean for completeness
     assert res.full["metric"] == df["metric"].mean()
+
+
+def test_walk_forward_requires_datetime_index():
+    df = pd.DataFrame({"metric": [1, 2, 3]})
+    with pytest.raises(ValueError, match="DatetimeIndex"):
+        walk_forward(df, train_size=2, test_size=1, step_size=1)
+
+
+def test_walk_forward_empty_splits_and_regimes():
+    dates = pd.date_range("2020-01-31", periods=2, freq="ME")
+    df = pd.DataFrame({"Date": dates, "metric": [1.0, 2.0]})
+    regimes = pd.Series(["R", "R"], index=dates)
+
+    res = walk_forward(
+        df,
+        train_size=3,
+        test_size=2,
+        step_size=1,
+        regimes=regimes,
+    )
+
+    assert res.splits == []
+    assert res.oos.isna().all()
+    assert res.by_regime.empty


### PR DESCRIPTION
## Summary
- add targeted export coverage exercising manager contribution tables, summary workbooks, and metrics outputs
- cover walk-forward validation for non-datetime inputs and empty split scenarios

## Testing
- pytest tests/test_export_additional_coverage.py tests/test_walkforward_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68c9c80bfd288331929a0faefb287117