### PR TITLE
feat(codex): dual-mode entry – issues=invite, workflow=create (uses OWNER_PR_PAT when present)

### DIFF
--- a/.github/workflows/codex-issue-bridge.yml
+++ b/.github/workflows/codex-issue-bridge.yml
@@ -12,11 +12,11 @@ on:
       post_codex_comment:
         description: "Auto-post '@codex start' as the actor (true/false)"
         required: false
-        default: "false"
+        default: "true"
       pr_mode:
         description: "create | invite (invite = human opens the PR)"
         required: false
-        default: "invite"
+        default: "create"
 
 permissions:
   contents: write
@@ -77,7 +77,7 @@ jobs:
         uses: ./.github/actions/codex-bootstrap-lite
         with:
           issue: ${{ github.event.issue.number || inputs.test_issue }}
-          service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+          service_bot_pat: ${{ (inputs.pr_mode == 'create' && secrets.OWNER_PR_PAT) || secrets.SERVICE_BOT_PAT }}
           allow_fallback: true
           codex_command: '@codex start'
           base_branch: ''


### PR DESCRIPTION
This PR finalises the dual-mode wiring so both flows work without friction.\n\n- Issues (label path) → invite mode by default: branch + compare link + suggested PR body; you open the PR so you’re the author.\n- Actions → workflow_dispatch defaults to create mode: if `OWNER_PR_PAT` is configured, the PR is opened as you and `@codex start` is posted automatically.\n- If `OWNER_PR_PAT` is absent, the workflow falls back to `SERVICE_BOT_PAT` or `GITHUB_TOKEN` as before.\n\nNo CLI required: Option 1 uses the compare link; Option 2 uses the Actions UI + a repo secret only.\n\nFollow-up (optional): we can auto-switch issue events to create mode when `OWNER_PR_PAT` exists if you want label path to be fully automated when you provision the secret.\n