### PR TITLE
Add cash weight constraint handling

### DIFF
--- a/src/trend_analysis/engine/optimizer.py
+++ b/src/trend_analysis/engine/optimizer.py
@@ -92,7 +92,7 @@ def _apply_group_caps(
         missing = set(w.index) - set(group_series.index)
         raise KeyError(f"Missing group mapping for: {sorted(missing)}")
 
-    if investable_total <= 0:
+    if investable_total <= NUMERICAL_TOLERANCE_HIGH:
         raise ConstraintViolation("Target allocation must be positive")
     scale = 1.0 / investable_total
     effective_caps: dict[str, float] = {}

--- a/src/trend_analysis/engine/optimizer.py
+++ b/src/trend_analysis/engine/optimizer.py
@@ -20,6 +20,7 @@ class ConstraintSet:
     max_weight: float | None = None
     group_caps: Mapping[str, float] | None = None
     groups: Mapping[str, str] | None = None  # asset -> group
+    cash_weight: float | None = None
 
 
 def _redistribute(w: pd.Series, mask: pd.Series, amount: float) -> pd.Series:
@@ -41,24 +42,32 @@ def _redistribute(w: pd.Series, mask: pd.Series, amount: float) -> pd.Series:
     return w
 
 
-def _apply_cap(w: pd.Series, cap: float) -> pd.Series:
+def _apply_cap(w: pd.Series, cap: float, investable_total: float = 1.0) -> pd.Series:
     """Cap individual weights at ``cap`` and redistribute the excess."""
 
     if cap is None:
         return w
+    cap = float(cap)
     if cap <= 0:
         raise ConstraintViolation("max_weight must be positive")
-    # Feasibility check
-    if cap * len(w) < 1 - NUMERICAL_TOLERANCE_HIGH:
-        raise ConstraintViolation("max_weight too small for number of assets")
+    if investable_total <= 0:
+        raise ConstraintViolation("Target allocation must be positive")
+
+    effective_cap = cap / investable_total
+    if effective_cap <= 0:
+        raise ConstraintViolation("max_weight must be positive")
+    effective_cap = min(effective_cap, 1.0)
+    # Feasibility check relative to the required investable capital
+    if effective_cap * len(w) < 1 - NUMERICAL_TOLERANCE_HIGH:
+        raise ConstraintViolation("max_weight too small for target allocation")
 
     w = w.copy()
     while True:
-        excess = (w - cap).clip(lower=0)
+        excess = (w - effective_cap).clip(lower=0)
         if excess.sum() <= NUMERICAL_TOLERANCE_HIGH:
             break
-        w = w.clip(upper=cap)
-        room_mask = w < cap - NUMERICAL_TOLERANCE_HIGH
+        w = w.clip(upper=effective_cap)
+        room_mask = w < effective_cap - NUMERICAL_TOLERANCE_HIGH
         # Ensure boolean mask is a Series aligned to w for type safety
         room_mask = (
             pd.Series(room_mask, index=w.index)
@@ -70,7 +79,10 @@ def _apply_cap(w: pd.Series, cap: float) -> pd.Series:
 
 
 def _apply_group_caps(
-    w: pd.Series, group_caps: Mapping[str, float], groups: Mapping[str, str]
+    w: pd.Series,
+    group_caps: Mapping[str, float],
+    groups: Mapping[str, str],
+    investable_total: float = 1.0,
 ) -> pd.Series:
     """Enforce group caps, redistributing excess weight."""
 
@@ -80,13 +92,25 @@ def _apply_group_caps(
         missing = set(w.index) - set(group_series.index)
         raise KeyError(f"Missing group mapping for: {sorted(missing)}")
 
+    if investable_total <= 0:
+        raise ConstraintViolation("Target allocation must be positive")
+    scale = 1.0 / investable_total
+    effective_caps: dict[str, float] = {}
+    for group, cap in group_caps.items():
+        cap = float(cap)
+        if cap < 0:
+            raise ConstraintViolation(
+                f"Group cap for '{group}' must be non-negative"
+            )
+        effective_caps[group] = min(cap * scale, 1.0)
+
     all_groups = set(group_series.loc[w.index].values)
     if all_groups.issubset(group_caps.keys()):
-        total_cap = sum(group_caps[g] for g in all_groups)
+        total_cap = sum(effective_caps[g] for g in all_groups)
         if total_cap < 1 - NUMERICAL_TOLERANCE_HIGH:
-            raise ConstraintViolation("Group caps sum to less than 100%")
+            raise ConstraintViolation("Group caps sum to less than target allocation")
 
-    for group, cap in group_caps.items():
+    for group, cap in effective_caps.items():
         members = group_series[group_series == group].index
         if members.empty:
             continue
@@ -115,6 +139,17 @@ def apply_constraints(
     if w.empty:
         return w
 
+    investable_total = 1.0
+    if constraints.cash_weight is not None:
+        cash_weight = float(constraints.cash_weight)
+        if cash_weight < 0:
+            raise ConstraintViolation("cash_weight must be non-negative")
+        if cash_weight >= 1:
+            raise ConstraintViolation("cash_weight must be less than 1")
+        investable_total = 1.0 - cash_weight
+        if investable_total <= NUMERICAL_TOLERANCE_HIGH:
+            raise ConstraintViolation("cash_weight leaves no capital for allocation")
+
     if constraints.long_only:
         w = w.clip(lower=0)
         if w.sum() == 0:
@@ -124,18 +159,23 @@ def apply_constraints(
     w /= w.sum()
 
     if constraints.max_weight is not None:
-        w = _apply_cap(w, constraints.max_weight)
+        w = _apply_cap(w, constraints.max_weight, investable_total)
 
     if constraints.group_caps:
         if not constraints.groups:
             raise ConstraintViolation("Group mapping required when group_caps set")
-        w = _apply_group_caps(w, constraints.group_caps, constraints.groups)
+        w = _apply_group_caps(
+            w, constraints.group_caps, constraints.groups, investable_total
+        )
         # max weight may have been violated again
         if constraints.max_weight is not None:
-            w = _apply_cap(w, constraints.max_weight)
+            w = _apply_cap(w, constraints.max_weight, investable_total)
 
     # Final normalisation guard
-    w /= w.sum()
+    total = float(w.sum())
+    if total <= NUMERICAL_TOLERANCE_HIGH:
+        raise ConstraintViolation("Weights sum to zero after applying constraints")
+    w *= investable_total / total
     return w
 
 

--- a/src/trend_analysis/pipeline.py
+++ b/src/trend_analysis/pipeline.py
@@ -335,6 +335,10 @@ def _run_analysis(
                 cons["group_caps"] = constraints_cfg.get("group_caps")
                 if constraints_cfg.get("groups"):
                     cons["groups"] = constraints_cfg.get("groups")
+            if "cash_weight" in constraints_cfg:
+                _cw = constraints_cfg.get("cash_weight")
+                if _cw is not None:
+                    cons["cash_weight"] = float(_cw)
             if cons:
                 w_series = apply_constraints(w_series, cons)
             user_w = (

--- a/tests/test_constraint_optimizer.py
+++ b/tests/test_constraint_optimizer.py
@@ -54,3 +54,14 @@ def test_empty_group_handling():
     assert np.isclose(out.sum(), 1.0)
     # Both assets should be in "existing" group, no constraint needed since cap is 1.0
     assert out.loc["a"] + out.loc["b"] <= 1.0 + NUMERICAL_TOLERANCE_HIGH
+
+
+def test_cash_weight_combined_with_caps():
+    w = pd.Series([0.9, 0.1], index=["a", "b"])
+    constraints = {
+        "max_weight": 0.55,
+        "cash_weight": 0.2,
+    }
+    out = apply_constraints(w, constraints)
+    assert np.isclose(out.sum(), 0.8)
+    assert out.max() <= 0.55 + NUMERICAL_TOLERANCE_HIGH

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -149,3 +149,19 @@ def test_run_analysis_custom_weights():
         custom_weights={"A": 100},
     )
     assert res["fund_weights"]["A"] == 1.0
+
+
+def test_run_analysis_cash_weight_constraint():
+    df = make_df()
+    res = pipeline.run_analysis(
+        df,
+        "2020-01",
+        "2020-03",
+        "2020-04",
+        "2020-06",
+        1.0,
+        0.0,
+        custom_weights={"A": 100},
+        constraints={"cash_weight": 0.2},
+    )
+    assert pytest.approx(res["fund_weights"]["A"]) == 0.8


### PR DESCRIPTION
## Summary
- extend the portfolio constraint engine with a `cash_weight` option and scale max/group caps by available investable capital
- plumb optional `cash_weight` through the analysis pipeline when applying user supplied constraints
- cover the new behaviour with dedicated constraint and pipeline tests

## Testing
- `pytest -q` *(fails: missing optional dependencies such as matplotlib/streamlit/fastapi)*
- `pytest tests/test_optimizer_constraints.py tests/test_constraint_optimizer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c9e6e7c6348331ad42f0e4c943ae76