### PR TITLE
feat(app): add one-click demo flow with results adapter

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -1,6 +1,8 @@
 # --- Streamlit UI ---
 import streamlit as st
 
+from streamlit_app.demo import DemoRunError, run_one_click_demo
+
 st.set_page_config(
     page_title="Trend Portfolio Simulator",
     page_icon=":chart_with_upwards_trend:",
@@ -14,3 +16,23 @@ Use the sidebar to step through: Upload → Configure → Run → Results → Ex
     """
 )
 st.info("Open '1_Upload' in the sidebar to get started.")
+
+st.divider()
+st.subheader("Try the app instantly")
+st.write(
+    "Load the built-in dataset, apply the Balanced preset, and jump straight to the results and export pages."
+)
+
+if st.button("🎬 Run demo", type="primary"):
+    with st.spinner("Loading demo dataset and running the analysis..."):
+        try:
+            run_one_click_demo(st.session_state)
+        except DemoRunError as exc:
+            st.error(f"Demo run failed: {exc}")
+        else:
+            st.success("Demo complete! Opening results…")
+            if hasattr(st, "switch_page"):
+                try:
+                    st.switch_page("pages/4_Results.py")
+                except Exception:  # pragma: no cover - defensive UI fallback
+                    st.info("Use the sidebar to open the Results page.")

--- a/streamlit_app/demo.py
+++ b/streamlit_app/demo.py
@@ -1,0 +1,259 @@
+"""Utilities for the Streamlit "Run demo" workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Mapping, MutableMapping
+
+import pandas as pd
+import yaml
+
+from trend_analysis.api import run_simulation
+from trend_analysis.config import Config
+from trend_portfolio_app.data_schema import infer_benchmarks, load_and_validate_file
+from trend_portfolio_app.policy_engine import MetricSpec, PolicyConfig
+
+from .result_adapter import adapt_run_result
+
+DEFAULT_PRESET = "Balanced"
+
+_UI_METRIC_ALIASES: Dict[str, str] = {
+    "sharpe_ratio": "sharpe",
+    "sharpe": "sharpe",
+    "return_ann": "return_ann",
+    "annual_return": "return_ann",
+    "max_drawdown": "drawdown",
+    "drawdown": "drawdown",
+    "volatility": "vol",
+    "vol": "vol",
+}
+
+_PIPELINE_METRIC_ALIASES: Dict[str, str] = {
+    "sharpe_ratio": "sharpe_ratio",
+    "sharpe": "sharpe_ratio",
+    "return_ann": "annual_return",
+    "annual_return": "annual_return",
+    "max_drawdown": "max_drawdown",
+    "drawdown": "max_drawdown",
+    "volatility": "volatility",
+    "vol": "volatility",
+}
+
+
+class DemoRunError(RuntimeError):
+    """Raised when the demo workflow cannot complete."""
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _resolve_demo_dataset() -> Path:
+    root = _repo_root()
+    for name in ("demo_returns.csv", "demo_returns.xlsx"):
+        candidate = root / "demo" / name
+        if candidate.exists():
+            return candidate
+    raise DemoRunError(
+        "Demo dataset not found. Run 'python scripts/generate_demo.py' first."
+    )
+
+
+def _load_returns(path: Path) -> tuple[pd.DataFrame, Dict[str, Any]]:
+    with path.open("rb") as handle:
+        df, meta = load_and_validate_file(handle)
+    return df, dict(meta)
+
+
+def _load_preset(preset_name: str) -> Dict[str, Any]:
+    root = _repo_root()
+    path = root / "config" / "presets" / f"{preset_name.lower()}.yml"
+    if not path.exists():
+        raise DemoRunError(f"Preset '{preset_name}' not found in config/presets.")
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    if not isinstance(data, dict):
+        raise DemoRunError(f"Preset '{preset_name}' is not a mapping.")
+    return data
+
+
+def _map_metric_weights(raw: Mapping[str, Any]) -> tuple[Dict[str, float], list[str]]:
+    ui_weights: Dict[str, float] = {}
+    pipeline_metrics: list[str] = []
+    for key, value in raw.items():
+        try:
+            weight = float(value)
+        except Exception:
+            continue
+        if weight <= 0:
+            continue
+        ui_key = _UI_METRIC_ALIASES.get(key, key)
+        pipe_key = _PIPELINE_METRIC_ALIASES.get(key, key)
+        ui_weights[ui_key] = weight
+        if pipe_key not in pipeline_metrics:
+            pipeline_metrics.append(pipe_key)
+    if not ui_weights:
+        ui_weights = {"sharpe": 0.5, "return_ann": 0.5}
+        pipeline_metrics = ["sharpe_ratio", "annual_return"]
+    total = sum(ui_weights.values())
+    if total > 0:
+        ui_weights = {k: float(v) / float(total) for k, v in ui_weights.items()}
+    return ui_weights, pipeline_metrics
+
+
+def _choose_dates(df: pd.DataFrame, lookback_months: int) -> tuple[pd.Timestamp, pd.Timestamp]:
+    if df.empty:
+        raise DemoRunError("Demo dataset is empty.")
+    end = pd.Timestamp(df.index.max())
+    candidate = end - pd.DateOffset(months=11)
+    min_start = pd.Timestamp(df.index.min()) + pd.DateOffset(months=lookback_months)
+    if candidate < min_start:
+        candidate = min_start
+    start_period = pd.Period(candidate, freq="M")
+    end_period = pd.Period(end, freq="M")
+    start = start_period.to_timestamp("M")
+    end_ts = end_period.to_timestamp("M")
+    return start, end_ts
+
+
+def run_one_click_demo(
+    session_state: MutableMapping[str, Any],
+    preset_name: str = DEFAULT_PRESET,
+):
+    """Populate session state with demo data, configuration, and results."""
+
+    dataset_path = _resolve_demo_dataset()
+    returns_df, meta = _load_returns(dataset_path)
+    preset = _load_preset(preset_name)
+
+    benchmark_candidates = infer_benchmarks(list(returns_df.columns))
+    benchmark_col = benchmark_candidates[0] if benchmark_candidates else None
+    return_cols = [c for c in returns_df.columns if c != benchmark_col]
+
+    column_mapping = {
+        "date_column": "Date",
+        "return_columns": return_cols,
+        "benchmark_column": benchmark_col,
+        "risk_free_column": None,
+        "column_display_names": {},
+        "column_tickers": {},
+    }
+
+    raw_metric_cfg = preset.get("metrics", {})
+    if not isinstance(raw_metric_cfg, dict):
+        raw_metric_cfg = {}
+    ui_weights, pipeline_metrics = _map_metric_weights(raw_metric_cfg)
+
+    overrides = {
+        "lookback_months": int(preset.get("lookback_months", 36)),
+        "rebalance_frequency": str(preset.get("rebalance_frequency", "monthly")),
+        "min_track_months": int(preset.get("min_track_months", 24)),
+        "selection_count": int(preset.get("selection_count", 10)),
+        "risk_target": float(preset.get("risk_target", 0.10)),
+        "cooldown_months": int(preset.get("portfolio", {}).get("cooldown_months", 3)),
+        "selected_metrics": list(ui_weights.keys()),
+        "metric_weights": ui_weights,
+        "weighting_scheme": str(
+            preset.get("portfolio", {}).get("weighting", {}).get("name", "equal")
+        ),
+    }
+    if not overrides["selected_metrics"]:
+        overrides["selected_metrics"] = ["sharpe", "return_ann"]
+        overrides["metric_weights"] = {"sharpe": 0.5, "return_ann": 0.5}
+
+    policy = PolicyConfig(
+        top_k=overrides["selection_count"],
+        bottom_k=0,
+        cooldown_months=overrides["cooldown_months"],
+        min_track_months=overrides["min_track_months"],
+        max_active=100,
+        max_weight=float(preset.get("portfolio", {}).get("max_weight", 0.15)),
+        metrics=[
+            MetricSpec(name=name, weight=overrides["metric_weights"][name])
+            for name in overrides["selected_metrics"]
+        ],
+    )
+
+    start, end = _choose_dates(returns_df, overrides["lookback_months"])
+
+    sim_config = {
+        "start": start,
+        "end": end,
+        "freq": overrides["rebalance_frequency"],
+        "lookback_months": overrides["lookback_months"],
+        "benchmark": benchmark_col,
+        "cash_rate": 0.0,
+        "policy": policy.dict(),
+        "rebalance": {
+            "bayesian_only": True,
+            "strategies": ["drift_band"],
+            "params": {},
+        },
+        "risk_target": overrides["risk_target"],
+        "column_mapping": column_mapping,
+        "preset_name": preset_name,
+        "portfolio": {"weighting_scheme": overrides["weighting_scheme"]},
+    }
+
+    config_state = {
+        "preset_name": preset_name,
+        "preset_config": preset,
+        "column_mapping": column_mapping,
+        "custom_overrides": overrides,
+        "validation_errors": [],
+        "is_valid": True,
+    }
+
+    returns_reset = returns_df.reset_index().rename(columns={returns_df.index.name or "index": "Date"})
+
+    metrics_registry = pipeline_metrics or ["sharpe_ratio", "annual_return"]
+    rank_metric = metrics_registry[0]
+    cfg = Config(
+        version="1",
+        data={},
+        preprocessing={},
+        vol_adjust={"target_vol": overrides["risk_target"]},
+        sample_split={
+            "in_start": (start - pd.DateOffset(months=overrides["lookback_months"])).strftime("%Y-%m"),
+            "in_end": (start - pd.DateOffset(months=1)).strftime("%Y-%m"),
+            "out_start": start.strftime("%Y-%m"),
+            "out_end": end.strftime("%Y-%m"),
+        },
+        portfolio={
+            "selection_mode": "rank",
+            "rank": {
+                "inclusion_approach": "top_n",
+                "n": overrides["selection_count"],
+                "score_by": rank_metric,
+            },
+            "weighting_scheme": overrides["weighting_scheme"],
+        },
+        benchmarks={"spx": benchmark_col} if benchmark_col else {},
+        metrics={"registry": metrics_registry},
+        export={},
+        run={},
+    )
+
+    try:
+        result = run_simulation(cfg, returns_reset)
+    except Exception as exc:  # pragma: no cover - runtime safety
+        raise DemoRunError(f"Demo pipeline failed: {exc}") from exc
+    adapted = adapt_run_result(result)
+
+    session_state["returns_df"] = returns_df
+    session_state["schema_meta"] = meta
+    session_state["benchmark_candidates"] = benchmark_candidates
+    session_state["upload_status"] = "success"
+    session_state["config_state"] = config_state
+    session_state["validation_messages"] = []
+    session_state["sim_config"] = sim_config
+    session_state["sim_results"] = adapted
+    session_state["demo_metadata"] = {
+        "preset": preset_name,
+        "dataset": dataset_path.name,
+    }
+
+    return adapted
+
+
+__all__ = ["run_one_click_demo", "DemoRunError"]

--- a/streamlit_app/pages/3_Run.py
+++ b/streamlit_app/pages/3_Run.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from streamlit_app.components.disclaimer import show_disclaimer
+from streamlit_app.result_adapter import adapt_run_result
 from trend_analysis.api import run_simulation
 from trend_analysis.config import Config
 
@@ -112,11 +113,12 @@ def main():
     )
 
     result = run_simulation(config, returns)
+    adapted = adapt_run_result(result)
     progress.progress(100)
-    st.session_state["sim_results"] = result
+    st.session_state["sim_results"] = adapted
     # Show fallback banner if a weight engine failed
     try:
-        fb = getattr(result, "fallback_info", None)
+        fb = getattr(adapted, "fallback_info", None)
     except Exception:  # pragma: no cover - defensive
         fb = None
     if fb and not st.session_state.get("dismiss_weight_engine_fallback"):
@@ -132,7 +134,7 @@ def main():
                 st.session_state["dismiss_weight_engine_fallback"] = True
                 st.rerun()
     st.success("Done.")
-    st.write("Summary:", result.metrics)
+    st.write("Summary:", getattr(adapted, "metrics", getattr(result, "metrics", None)))
 
 
 if __name__ == "__main__":

--- a/streamlit_app/result_adapter.py
+++ b/streamlit_app/result_adapter.py
@@ -1,0 +1,149 @@
+"""Adapters to align pipeline results with the Streamlit UI expectations."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Any, Mapping
+
+import pandas as pd
+
+
+class RunResultAdapter:
+    """Wrapper that adds Streamlit-friendly helpers to ``RunResult`` objects."""
+
+    def __init__(self, run_result: Any) -> None:
+        self._raw = run_result
+        self.metrics = getattr(run_result, "metrics", pd.DataFrame())
+        self.details = getattr(run_result, "details", {})
+        self.seed = getattr(run_result, "seed", None)
+        self.environment = getattr(run_result, "environment", {})
+        self.fallback_info = getattr(run_result, "fallback_info", None)
+        self._portfolio_returns = self._compute_portfolio_returns()
+        # ``export_bundle`` expects an attribute named ``portfolio``.
+        self.portfolio = self._portfolio_returns.copy()
+        self._weights_by_date = self._build_weights_by_date()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _out_frame(self) -> pd.DataFrame | None:
+        raw = self.details.get("out_sample_scaled")
+        if isinstance(raw, pd.DataFrame):
+            return raw.copy()
+        if raw is None:
+            return None
+        try:
+            return pd.DataFrame(raw)
+        except Exception:
+            return None
+
+    def _weight_series(self) -> pd.Series | None:
+        raw = self.details.get("fund_weights")
+        if isinstance(raw, pd.Series):
+            series = raw.astype(float)
+        elif isinstance(raw, Mapping):
+            try:
+                series = pd.Series(raw, dtype=float)
+            except Exception:
+                return None
+        else:
+            return None
+        if series.empty:
+            return None
+        return series
+
+    def _compute_portfolio_returns(self) -> pd.Series:
+        frame = self._out_frame()
+        weights = self._weight_series()
+        if frame is None or weights is None or frame.empty:
+            return pd.Series(dtype=float)
+        aligned = frame.reindex(columns=weights.index).fillna(0.0)
+        returns = aligned.mul(weights, axis=1).sum(axis=1)
+        try:
+            idx = pd.to_datetime(aligned.index)
+        except Exception:
+            idx = pd.Index(aligned.index)
+        returns = pd.Series(returns.astype(float).values, index=idx, dtype=float)
+        return returns
+
+    def _build_weights_by_date(self) -> dict[pd.Timestamp, pd.Series]:
+        frame = self._out_frame()
+        weights = self._weight_series()
+        if frame is None or weights is None or frame.empty:
+            return {}
+        mapping: "OrderedDict[pd.Timestamp, pd.Series]" = OrderedDict()
+        for label in frame.index:
+            try:
+                ts = pd.Timestamp(label)
+            except Exception:
+                continue
+            mapping[ts] = weights.copy()
+        return mapping
+
+    # ------------------------------------------------------------------
+    # Public helpers consumed by the Streamlit UI
+    # ------------------------------------------------------------------
+    def portfolio_curve(self) -> pd.Series:
+        returns = self._portfolio_returns
+        if returns.empty:
+            return pd.Series(dtype=float)
+        curve = (1.0 + returns).cumprod()
+        return curve.astype(float)
+
+    def drawdown_curve(self) -> pd.Series:
+        curve = self.portfolio_curve()
+        if curve.empty:
+            return pd.Series(dtype=float)
+        peak = curve.cummax()
+        dd = curve / peak - 1.0
+        return dd.astype(float)
+
+    def event_log_df(self) -> pd.DataFrame:
+        weights = self._weight_series()
+        if weights is None or weights.empty:
+            return pd.DataFrame(columns=["Fund", "Weight"])
+        df = pd.DataFrame({"Fund": weights.index, "Weight": weights.values})
+        df["Weight"] = df["Weight"].astype(float)
+        return df
+
+    def summary(self) -> dict[str, float]:
+        curve = self.portfolio_curve()
+        if curve.empty:
+            return {}
+        total = float(curve.iloc[-1] - 1.0)
+        drawdown = float((curve / curve.cummax() - 1.0).min())
+        periods = max(len(curve), 1)
+        try:
+            annualised = float(curve.iloc[-1] ** (12.0 / periods) - 1.0)
+        except Exception:
+            annualised = total
+        return {
+            "total_return": total,
+            "max_drawdown": drawdown,
+            "ann_return_approx": annualised,
+        }
+
+    @property
+    def weights(self) -> dict[pd.Timestamp, pd.Series]:
+        return dict(self._weights_by_date)
+
+    @property
+    def raw_result(self) -> Any:
+        return self._raw
+
+    # ------------------------------------------------------------------
+    # Fallback attribute access
+    # ------------------------------------------------------------------
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._raw, name)
+
+
+def adapt_run_result(result: Any) -> Any:
+    """Return an object that provides the interface expected by the UI."""
+
+    if hasattr(result, "portfolio_curve") and callable(result.portfolio_curve):
+        return result
+    return RunResultAdapter(result)
+
+
+__all__ = ["RunResultAdapter", "adapt_run_result"]

--- a/tests/test_streamlit_demo.py
+++ b/tests/test_streamlit_demo.py
@@ -1,0 +1,38 @@
+"""Tests for the Streamlit one-click demo workflow."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from streamlit_app.demo import DemoRunError, run_one_click_demo  # noqa: E402
+
+
+def test_run_one_click_demo_populates_state():
+    session: dict[str, object] = {}
+    result = run_one_click_demo(session)
+
+    assert "returns_df" in session
+    assert isinstance(session["returns_df"], pd.DataFrame)
+    assert "sim_results" in session
+    assert hasattr(result, "portfolio_curve")
+    curve = result.portfolio_curve()
+    assert not curve.empty
+    assert session["config_state"]["preset_name"] == "Balanced"  # type: ignore[index]
+    assert session["sim_config"]["preset_name"] == "Balanced"  # type: ignore[index]
+    assert "SPX" in session.get("benchmark_candidates", [])
+
+
+def test_run_one_click_demo_missing_dataset(monkeypatch):
+    session: dict[str, object] = {}
+    def _raise():
+        raise DemoRunError("missing")
+
+    monkeypatch.setattr("streamlit_app.demo._resolve_demo_dataset", _raise)
+    with pytest.raises(DemoRunError):
+        run_one_click_demo(session)

--- a/tests/test_streamlit_result_adapter.py
+++ b/tests/test_streamlit_result_adapter.py
@@ -1,0 +1,92 @@
+"""Tests for the RunResultAdapter used by the Streamlit UI."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+if "matplotlib" not in sys.modules:  # pragma: no cover - lightweight stub for tests
+    matplotlib_stub = types.ModuleType("matplotlib")
+    pyplot_stub = types.ModuleType("matplotlib.pyplot")
+    matplotlib_stub.pyplot = pyplot_stub
+    sys.modules["matplotlib"] = matplotlib_stub
+    sys.modules["matplotlib.pyplot"] = pyplot_stub
+
+from trend_analysis.api import run_simulation  # noqa: E402
+from trend_analysis.config import Config  # noqa: E402
+
+from streamlit_app.result_adapter import RunResultAdapter, adapt_run_result  # noqa: E402
+
+
+def _demo_returns_frame() -> pd.DataFrame:
+    dates = pd.date_range("2018-01-31", periods=72, freq="ME")
+    trend = np.linspace(0.005, 0.015, len(dates))
+    data = {
+        "Date": dates,
+        "Fund_A": 0.01 + 0.002 * np.sin(np.linspace(0, 6, len(dates))) + trend,
+        "Fund_B": 0.008 + 0.001 * np.cos(np.linspace(0, 4, len(dates))) - trend / 2,
+        "SPX": 0.006 + 0.0005 * np.sin(np.linspace(0, 3, len(dates))),
+    }
+    return pd.DataFrame(data)
+
+
+def _demo_config() -> Config:
+    return Config(
+        version="1",
+        data={},
+        preprocessing={},
+        vol_adjust={"target_vol": 0.10},
+        sample_split={
+            "in_start": "2018-01",
+            "in_end": "2020-12",
+            "out_start": "2021-01",
+            "out_end": "2022-12",
+        },
+        portfolio={"selection_mode": "rank", "rank": {"inclusion_approach": "top_n", "n": 2, "score_by": "sharpe_ratio"}},
+        benchmarks={"spx": "SPX"},
+        metrics={"registry": ["sharpe_ratio", "annual_return"]},
+        export={},
+        run={},
+    )
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_adapt_run_result_produces_curves():
+    df = _demo_returns_frame()
+    cfg = _demo_config()
+    result = run_simulation(cfg, df)
+
+    adapted = adapt_run_result(result)
+    assert isinstance(adapted, RunResultAdapter)
+
+    curve = adapted.portfolio_curve()
+    assert not curve.empty
+    dd = adapted.drawdown_curve()
+    assert len(dd) == len(curve)
+    summary = adapted.summary()
+    assert "total_return" in summary
+    assert adapted.portfolio.index.equals(curve.index)
+
+    weights = adapted.weights
+    assert isinstance(weights, dict)
+    assert weights
+
+    # Ensure fallback info and metrics are surfaced
+    assert getattr(adapted, "fallback_info", None) == getattr(result, "fallback_info", None)
+    pd.testing.assert_frame_equal(adapted.metrics, result.metrics)
+
+
+def test_adapt_run_result_passthrough():
+    class _Dummy:
+        def portfolio_curve(self):
+            return pd.Series([1, 2, 3])
+
+    dummy = _Dummy()
+    assert adapt_run_result(dummy) is dummy


### PR DESCRIPTION
## Summary
- add a "Run demo" button on the landing page that loads the bundled dataset and navigates to the results view
- implement a demo runner that loads the Balanced preset, populates Streamlit session state, and runs the pipeline
- wrap run_simulation results with an adapter so Results/Export pages can render charts and bundles and cover the flow with tests

## Testing
- pytest tests/test_streamlit_result_adapter.py tests/test_streamlit_demo.py tests/test_streamlit_fallback_banner.py

------
https://chatgpt.com/codex/tasks/task_e_68c9e4b1a9f48331acbaafcd388fa1e3