### PR TITLE
Add Streamlit one-click demo run flow

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -1,6 +1,8 @@
 # --- Streamlit UI ---
 import streamlit as st
 
+from streamlit_app.demo_runner import run_one_click_demo
+
 st.set_page_config(
     page_title="Trend Portfolio Simulator",
     page_icon=":chart_with_upwards_trend:",
@@ -14,3 +16,10 @@ Use the sidebar to step through: Upload → Configure → Run → Results → Ex
     """
 )
 st.info("Open '1_Upload' in the sidebar to get started.")
+
+st.markdown("---")
+st.subheader("Quick demo")
+st.caption("Explore the app instantly without uploading data.")
+if st.button("🎯 Run demo", type="primary"):
+    run_one_click_demo()
+

--- a/streamlit_app/demo_runner.py
+++ b/streamlit_app/demo_runner.py
@@ -1,0 +1,281 @@
+"""Helpers for the Streamlit one-click demo run."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+import pandas as pd
+import streamlit as st
+import yaml
+
+from trend_portfolio_app.data_schema import infer_benchmarks, load_and_validate_file
+from trend_portfolio_app.policy_engine import MetricSpec, PolicyConfig
+from trend_portfolio_app.sim_runner import Simulator
+
+DEMO_FILENAMES: Sequence[str] = ("demo_returns.csv", "demo_returns.xlsx")
+DEFAULT_PRESET_NAME = "Balanced"
+
+METRIC_NAME_MAP: Mapping[str, str] = {
+    "sharpe_ratio": "sharpe",
+    "sharpe": "sharpe",
+    "return_ann": "return_ann",
+    "annual_return": "return_ann",
+    "max_drawdown": "drawdown",
+    "drawdown": "drawdown",
+    "volatility": "vol",
+    "vol": "vol",
+}
+
+NAV_QUEUE_KEY = "demo_nav_queue"
+NAV_READY_FLAG = "demo_nav_ready"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def load_demo_dataset() -> Tuple[pd.DataFrame, Dict[str, Any]]:
+    """Load the bundled demo dataset and validate its schema."""
+    demo_dir = _repo_root() / "demo"
+    for name in DEMO_FILENAMES:
+        path = demo_dir / name
+        if path.exists():
+            with path.open("rb") as handle:
+                df, meta = load_and_validate_file(handle)
+            return df, meta
+    raise FileNotFoundError("demo dataset not found in ./demo")
+
+
+def _preset_path(name: str) -> Path:
+    presets_dir = _repo_root() / "config" / "presets"
+    return presets_dir / f"{name.lower()}.yml"
+
+
+def load_preset_config(name: str) -> Dict[str, Any]:
+    """Load a preset configuration from ``config/presets``."""
+    path = _preset_path(name)
+    if not path.exists():
+        raise FileNotFoundError(f"preset '{name}' not found at {path}")
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):  # pragma: no cover - defensive guard
+        raise ValueError(f"preset '{name}' is not a mapping")
+    return data
+
+
+def _convert_preset_metrics(metrics: Mapping[str, Any]) -> Dict[str, float]:
+    converted: Dict[str, float] = {}
+    for raw_name, weight in metrics.items():
+        norm = METRIC_NAME_MAP.get(str(raw_name).lower())
+        if norm is None:
+            continue
+        try:
+            value = float(weight)
+        except Exception:
+            continue
+        converted[norm] = converted.get(norm, 0.0) + value
+    if not converted or sum(converted.values()) <= 0:
+        return {"sharpe": 1.0}
+    total = sum(converted.values())
+    return {k: v / total for k, v in converted.items()}
+
+
+def build_demo_configuration(
+    df: pd.DataFrame,
+    preset: Mapping[str, Any],
+    preset_name: str,
+) -> Tuple[Dict[str, Any], PolicyConfig, Dict[str, Any], Dict[str, Any], Optional[str], List[str]]:
+    """Create the configuration dictionary and policy for the demo run."""
+    lookback = int(preset.get("lookback_months", 36))
+    freq = str(preset.get("rebalance_frequency", "monthly"))
+    min_track = int(preset.get("min_track_months", 24))
+    selection_count = int(preset.get("selection_count", 10))
+    risk_target = float(preset.get("risk_target", 0.10))
+
+    metrics_map = _convert_preset_metrics(preset.get("metrics", {}))
+    metric_specs = [MetricSpec(name=k, weight=float(v)) for k, v in metrics_map.items()]
+
+    portfolio_cfg = preset.get("portfolio", {})
+    cooldown = int(portfolio_cfg.get("cooldown_months", 3))
+    max_weight = float(portfolio_cfg.get("max_weight", 0.10))
+
+    candidates = infer_benchmarks(list(df.columns))
+    benchmark = candidates[0] if candidates else None
+    return_cols = [c for c in df.columns if c != benchmark]
+
+    column_mapping = {
+        "date_column": "Date",
+        "return_columns": return_cols,
+        "benchmark_column": benchmark,
+        "risk_free_column": None,
+        "column_display_names": {c: c for c in return_cols},
+        "column_tickers": {},
+    }
+
+    overrides = {
+        "lookback_months": lookback,
+        "rebalance_frequency": freq,
+        "min_track_months": min_track,
+        "selection_count": selection_count,
+        "risk_target": risk_target,
+        "cooldown_months": cooldown,
+        "selected_metrics": list(metrics_map.keys()),
+        "metric_weights": metrics_map,
+        "weighting_scheme": "equal",
+    }
+
+    policy = PolicyConfig(
+        top_k=selection_count,
+        bottom_k=0,
+        cooldown_months=cooldown,
+        min_track_months=min_track,
+        max_active=100,
+        max_weight=max_weight,
+        metrics=metric_specs,
+    )
+
+    config_dict: Dict[str, Any] = {
+        "start": pd.Timestamp(df.index.min()),
+        "end": pd.Timestamp(df.index.max()),
+        "freq": freq,
+        "lookback_months": lookback,
+        "benchmark": benchmark,
+        "cash_rate": 0.0,
+        "policy": policy.dict(),
+        "rebalance": {
+            "bayesian_only": True,
+            "strategies": ["drift_band"],
+            "params": {},
+        },
+        "risk_target": risk_target,
+        "column_mapping": column_mapping,
+        "preset_name": preset_name,
+        "portfolio": {"weighting_scheme": overrides["weighting_scheme"]},
+    }
+
+    return config_dict, policy, column_mapping, overrides, benchmark, list(candidates)
+
+
+def _execute_demo_simulation(
+    df: pd.DataFrame,
+    config_dict: Mapping[str, Any],
+    policy: PolicyConfig,
+    benchmark: Optional[str],
+):
+    simulator = Simulator(
+        df,
+        benchmark_col=benchmark,
+        cash_rate=float(config_dict.get("cash_rate", 0.0)),
+    )
+    start = pd.Timestamp(config_dict.get("start"))
+    end = pd.Timestamp(config_dict.get("end"))
+    return simulator.run(
+        start=start,
+        end=end,
+        freq=str(config_dict.get("freq", "monthly")),
+        lookback_months=int(config_dict.get("lookback_months", 36)),
+        policy=policy,
+        rebalance=dict(config_dict.get("rebalance", {})),
+    )
+
+
+def _spinner_context(st_module, text: str):
+    spinner = getattr(st_module, "spinner", None)
+    if callable(spinner):
+        return spinner(text)
+    return nullcontext()
+
+
+def enqueue_navigation(st_module, pages: Sequence[str]) -> None:
+    st_module.session_state[NAV_QUEUE_KEY] = list(pages)
+    st_module.session_state[NAV_READY_FLAG] = False
+
+
+def safe_switch_page(st_module, page: str) -> bool:
+    switch = getattr(st_module, "switch_page", None)
+    if callable(switch):
+        try:
+            switch(page)
+        except Exception:  # pragma: no cover - defensive
+            return False
+        return True
+    return False
+
+
+def handle_demo_navigation(st_module, current_page: str) -> Optional[str]:
+    queue = st_module.session_state.get(NAV_QUEUE_KEY)
+    if not isinstance(queue, list) or not queue:
+        st_module.session_state[NAV_QUEUE_KEY] = []
+        st_module.session_state.pop(NAV_READY_FLAG, None)
+        return None
+
+    queue = list(queue)
+    if queue and queue[0] == current_page:
+        queue.pop(0)
+
+    if not queue:
+        st_module.session_state[NAV_QUEUE_KEY] = []
+        st_module.session_state.pop(NAV_READY_FLAG, None)
+        return None
+
+    if not st_module.session_state.get(NAV_READY_FLAG):
+        st_module.session_state[NAV_QUEUE_KEY] = queue
+        st_module.session_state[NAV_READY_FLAG] = True
+        return None
+
+    next_page = queue.pop(0)
+    st_module.session_state[NAV_QUEUE_KEY] = queue
+    st_module.session_state[NAV_READY_FLAG] = False
+
+    if safe_switch_page(st_module, next_page):
+        if not queue:
+            st_module.session_state.pop(NAV_READY_FLAG, None)
+        return next_page
+
+    st_module.session_state[NAV_QUEUE_KEY] = []
+    st_module.session_state.pop(NAV_READY_FLAG, None)
+    return None
+
+
+def run_one_click_demo(
+    *,
+    st_module=st,
+    preset_name: str = DEFAULT_PRESET_NAME,
+) -> None:
+    """Load demo data, execute the simulation, and queue navigation."""
+    try:
+        with _spinner_context(st_module, "Running demo analysis..."):
+            df, meta = load_demo_dataset()
+            preset = load_preset_config(preset_name)
+            config_dict, policy, mapping, overrides, benchmark, candidates = build_demo_configuration(
+                df, preset, preset_name
+            )
+
+            st_module.session_state["returns_df"] = df
+            st_module.session_state["schema_meta"] = meta
+            st_module.session_state["benchmark_candidates"] = candidates
+            st_module.session_state["sim_config"] = config_dict
+            st_module.session_state["config_state"] = {
+                "preset_name": preset_name,
+                "preset_config": preset,
+                "column_mapping": mapping,
+                "custom_overrides": overrides,
+                "validation_errors": [],
+                "is_valid": True,
+            }
+            st_module.session_state["validation_messages"] = []
+
+            result = _execute_demo_simulation(df, config_dict, policy, benchmark)
+            st_module.session_state["sim_results"] = result
+    except FileNotFoundError as err:
+        st_module.error(f"Demo data unavailable: {err}")
+        return
+    except Exception as exc:  # pragma: no cover - safety net for unexpected issues
+        st_module.error(f"Demo run failed: {exc}")
+        return
+
+    st_module.success("Demo run complete! Results and export are ready.")
+    enqueue_navigation(st_module, ["pages/4_Results.py", "pages/5_Export.py"])
+    safe_switch_page(st_module, "pages/4_Results.py")

--- a/streamlit_app/pages/4_Results.py
+++ b/streamlit_app/pages/4_Results.py
@@ -5,6 +5,8 @@ import numpy as np
 import pandas as pd
 import streamlit as st
 
+from streamlit_app.demo_runner import handle_demo_navigation
+
 from trend_analysis.engine.walkforward import walk_forward
 from trend_analysis.metrics import attribution
 
@@ -270,3 +272,5 @@ with col3:
         file_name="summary.json",
         mime="application/json",
     )
+
+handle_demo_navigation(st, "pages/4_Results.py")

--- a/streamlit_app/pages/5_Export.py
+++ b/streamlit_app/pages/5_Export.py
@@ -3,6 +3,8 @@ import os
 
 import streamlit as st
 
+from streamlit_app.demo_runner import handle_demo_navigation
+
 from trend_analysis.io import export_bundle
 
 st.title("Export")
@@ -83,3 +85,5 @@ except Exception as e:
     st.error(f"Failed to create export bundle: {e}")
 
     # The temporary files will be cleaned up automatically on process exit
+
+handle_demo_navigation(st, "pages/5_Export.py")

--- a/tests/test_streamlit_demo_run.py
+++ b/tests/test_streamlit_demo_run.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, List
+
+
+class _ImportSpinner:
+    def __call__(self, *_args, **_kwargs):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _ImportStub(SimpleNamespace):
+    def __init__(self):
+        super().__init__()
+        self.session_state = {}
+        self.spinner = _ImportSpinner()
+
+    def success(self, *_args, **_kwargs):
+        return None
+
+    def error(self, *_args, **_kwargs):
+        return None
+
+
+sys.modules.setdefault("streamlit", _ImportStub())
+
+import pandas as pd
+import pytest
+
+import streamlit_app.demo_runner as demo_runner
+
+
+class DummySpinner:
+    """Minimal spinner context manager."""
+
+    def __call__(self, _text: str):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummyStreamlit:
+    """Lightweight stand-in for the Streamlit module."""
+
+    def __init__(self) -> None:
+        self.session_state: dict[str, Any] = {}
+        self.spinner = DummySpinner()
+        self.success_messages: List[str] = []
+        self.error_messages: List[str] = []
+        self._switched_pages: List[str] = []
+
+    # UI helpers ---------------------------------------------------------
+    def success(self, msg: str) -> None:
+        self.success_messages.append(msg)
+
+    def error(self, msg: str) -> None:
+        self.error_messages.append(msg)
+
+    def switch_page(self, page: str) -> None:
+        self._switched_pages.append(page)
+
+
+@dataclass
+class DummySimResult:
+    """Simple object exposing the interface expected by the results view."""
+
+    portfolio: pd.Series
+    weights: dict[pd.Timestamp, pd.Series]
+
+    def __post_init__(self) -> None:
+        self.fallback_info = None
+        self.signal_pnls = None
+        self.rebalancing_pnl = None
+
+    def portfolio_curve(self) -> pd.Series:
+        return (1 + self.portfolio.fillna(0.0)).cumprod()
+
+    def drawdown_curve(self) -> pd.Series:
+        curve = self.portfolio_curve()
+        return curve / curve.cummax() - 1.0
+
+    def event_log_df(self) -> pd.DataFrame:
+        return pd.DataFrame({"event": ["demo"], "detail": ["ok"]})
+
+    def summary(self) -> dict[str, Any]:
+        return {"total_return": float(self.portfolio_curve().iloc[-1] - 1.0)}
+
+
+def test_load_demo_dataset_smoke():
+    """The bundled demo dataset should load with basic structure."""
+    df, meta = demo_runner.load_demo_dataset()
+    assert not df.empty
+    assert "Mgr_01" in df.columns
+    assert meta["n_rows"] == len(df)
+
+
+def test_build_demo_configuration_maps_metrics():
+    """Preset metrics should map onto the Streamlit metric registry."""
+    df, _ = demo_runner.load_demo_dataset()
+    preset = {
+        "lookback_months": 12,
+        "rebalance_frequency": "monthly",
+        "min_track_months": 6,
+        "selection_count": 5,
+        "risk_target": 0.1,
+        "metrics": {"sharpe_ratio": 0.6, "max_drawdown": 0.4},
+        "portfolio": {"cooldown_months": 2, "max_weight": 0.2},
+    }
+    cfg, policy, mapping, overrides, benchmark, _cands = demo_runner.build_demo_configuration(
+        df, preset, "Test"
+    )
+    assert cfg["lookback_months"] == 12
+    metric_names = {m.name for m in policy.metrics}
+    assert metric_names == {"sharpe", "drawdown"}
+    assert overrides["selected_metrics"] == ["sharpe", "drawdown"]
+    assert mapping["benchmark_column"] == benchmark
+
+
+def test_run_one_click_demo_sets_state(monkeypatch):
+    """Running the demo should populate session state and queue navigation."""
+    df, _ = demo_runner.load_demo_dataset()
+    dates = df.index[:3]
+    dummy_result = DummySimResult(
+        portfolio=pd.Series([0.01, -0.005, 0.007], index=dates),
+        weights={dates[0]: pd.Series([0.5, 0.5], index=df.columns[:2])},
+    )
+
+    monkeypatch.setattr(
+        demo_runner,
+        "_execute_demo_simulation",
+        lambda *_args, **_kwargs: dummy_result,
+    )
+
+    st_mod = DummyStreamlit()
+    demo_runner.run_one_click_demo(st_module=st_mod, preset_name="Balanced")
+
+    assert "returns_df" in st_mod.session_state
+    assert "sim_config" in st_mod.session_state
+    assert st_mod.session_state[demo_runner.NAV_QUEUE_KEY] == [
+        "pages/4_Results.py",
+        "pages/5_Export.py",
+    ]
+    assert st_mod._switched_pages == ["pages/4_Results.py"]
+    assert st_mod.success_messages
+    assert st_mod.session_state["sim_results"] is dummy_result
+
+
+def test_handle_demo_navigation_advances_queue():
+    """Navigation helper should advance through queued pages."""
+    st_mod = DummyStreamlit()
+    st_mod.session_state[demo_runner.NAV_QUEUE_KEY] = [
+        "pages/4_Results.py",
+        "pages/5_Export.py",
+    ]
+    # First call primes the redirect without switching
+    assert (
+        demo_runner.handle_demo_navigation(st_mod, "pages/4_Results.py")
+        is None
+    )
+    assert st_mod._switched_pages == []
+    assert st_mod.session_state[demo_runner.NAV_READY_FLAG] is True
+    # Second call performs the switch
+    assert (
+        demo_runner.handle_demo_navigation(st_mod, "pages/4_Results.py")
+        == "pages/5_Export.py"
+    )
+    assert st_mod._switched_pages == ["pages/5_Export.py"]
+    assert st_mod.session_state[demo_runner.NAV_QUEUE_KEY] == []
+    assert (
+        demo_runner.handle_demo_navigation(st_mod, "pages/4_Results.py")
+        is None
+    )
+
+
+def test_handle_demo_navigation_without_switch():
+    """Gracefully handle missing switch_page attribute."""
+    st_mod = DummyStreamlit()
+    st_mod.switch_page = None
+    st_mod.session_state[demo_runner.NAV_QUEUE_KEY] = ["pages/4_Results.py"]
+    # Should not raise even though switch_page is unavailable
+    assert (
+        demo_runner.handle_demo_navigation(st_mod, "pages/4_Results.py")
+        is None
+    )
+    assert st_mod.session_state[demo_runner.NAV_QUEUE_KEY] == []


### PR DESCRIPTION
## Summary
- add a reusable demo runner that loads bundled data, builds a preset configuration, executes the simulator and queues navigation to results and export
- expose a "Run demo" button on the landing page and wire results/export pages to honour the queued navigation helper
- cover the demo runner with unit tests that exercise config building, session-state mutation and navigation helpers

## Testing
- pytest tests/test_streamlit_demo_run.py
- pytest -q *(fails: missing optional deps such as matplotlib/streamlit/fastapi/hypothesis in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e4c749888331bf7e79dec526530f