### PR TITLE
Codex E2E: add zscore selector + tests - Issue #1018

### DIFF
--- a/agents/codex-1018.md
+++ b/agents/codex-1018.md
@@ -1,1 +1,1 @@
-<- The “Bot Permission on Repo” section will appear in the job bootstrap for codex on issue #1018 -->
+<!-- bootstrap for codex on issue #1018 -->

--- a/tests/test_selector_weighting.py
+++ b/tests/test_selector_weighting.py
@@ -27,6 +27,25 @@ def test_zscore_selector_edge():
     assert list(selected.index) == ["C"]
 
 
+def test_rank_selector_log_structure():
+    sf = load_fixture()
+    selector = RankSelector(top_n=2, rank_column="Sharpe")
+    _, log = selector.select(sf)
+    assert list(log.columns) == ["metric", "reason"]
+    assert log["metric"].nunique() == 1
+    assert log.loc["A", "reason"] == 1.0
+    assert log.loc["B", "reason"] == 2.0
+
+
+def test_zscore_selector_log_values():
+    sf = load_fixture()
+    selector = ZScoreSelector(threshold=0.0, direction=-1, column="Sharpe")
+    _, log = selector.select(sf)
+    assert log.loc["A", "metric"] == "Sharpe"
+    assert log["reason"].loc["A"] > log["reason"].loc["B"] > log["reason"].loc["C"]
+    assert log.loc["C", "reason"] < 0
+
+
 def test_equal_weighting_sum_to_one():
     sf = load_fixture().loc[["A", "B"]]
     weights = EqualWeight().weight(sf)


### PR DESCRIPTION
### Source Issue #1018: Codex E2E: add zscore selector + tests

Source: https://github.com/stranske/Trend_Model_Project/issues/1018

> We need to add a new ZScoreSelector and RankSelector plugin system plus weighting classes, wire into the multi-period engine, and export period metrics as Phase‑1 style sheets.\n\nAcceptance criteria:\n- Selector classes: RankSelector and ZScoreSelector returning selected + log\n- Weighting classes: EqualWeight, ScorePropSimple, ScorePropBayesian\n- Engine loop integrates selector + weighting\n- Export multi-period metrics with one sheet per period + summary tab\n- Tests: rank edge cases, z-score threshold negative dir, equal weights sum to one, bayesian shrinkage monotonic\n\nPlease implement per Agents.md Step 5–7 and the multi-period export updates.\n\n[codex-suppress-activate]

—
(After opening the PR, comment with `@codex start`.)