### PR TITLE
Codex E2E: add zscore selector + tests - Issue #1018

### DIFF
--- a/tests/test_selector_weighting.py
+++ b/tests/test_selector_weighting.py
@@ -27,6 +27,26 @@ def test_zscore_selector_edge():
     assert list(selected.index) == ["C"]
 
 
+def test_rank_selector_log_structure():
+    sf = load_fixture()
+    selector = RankSelector(top_n=2, rank_column="Sharpe")
+    _, log = selector.select(sf)
+    assert list(log.columns) == ["metric", "reason"]
+    assert log["metric"].nunique() == 1
+    assert log.loc["A", "reason"] == 1.0
+    assert log.loc["B", "reason"] == 2.0
+    assert log.loc["C", "reason"] == 3.0
+
+
+def test_zscore_selector_log_values():
+    sf = load_fixture()
+    selector = ZScoreSelector(threshold=0.0, direction=-1, column="Sharpe")
+    _, log = selector.select(sf)
+    assert log.loc["A", "metric"] == "Sharpe"
+    assert log["reason"].loc["A"] > log["reason"].loc["B"] > log["reason"].loc["C"]
+    assert log.loc["C", "reason"] < 0
+
+
 def test_equal_weighting_sum_to_one():
     sf = load_fixture().loc[["A", "B"]]
     weights = EqualWeight().weight(sf)


### PR DESCRIPTION
### Source Issue #1018: Codex E2E: add zscore selector + tests

Source: https://github.com/stranske/Trend_Model_Project/issues/1018

> We need to add a new ZScoreSelector and RankSelector plugin system plus weighting classes, wire into the multi-period engine, and export period metrics as Phase‑1 style sheets.
>
> Acceptance criteria:
> - Selector classes: RankSelector and ZScoreSelector returning selected + log
> - Weighting classes: EqualWeight, ScorePropSimple, ScorePropBayesian
> - Engine loop integrates selector + weighting
> - Export multi-period metrics with one sheet per period + summary tab
> - Tests: rank edge cases, z-score threshold negative dir, equal weights sum to one, bayesian shrinkage monotonic
>
> Please implement per Agents.md Step 5–7 and the multi-period export updates.
>
> [codex-suppress-activate]

—
(After opening the PR, comment with `@codex start`.)

### Follow-up adjustments
- Import `Path` and `pandas` in `tests/test_selector_weighting.py` so the selector and weighting regression tests run successfully.

------
https://chatgpt.com/codex/tasks/task_e_68ca1e94312c8331a69a83af64c3a29a