### PR TITLE
Add coverage for GUI utilities and turnover logic

### DIFF
--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -4,6 +4,7 @@ import pytest
 from trend_analysis import rebalancing as rebalancing_module
 from trend_analysis import selector as selector_module
 from trend_analysis.plugins import rebalancer_registry, selector_registry
+from trend_analysis.gui import plugins as gui_plugins
 
 
 def test_selector_registry_discovery():
@@ -27,3 +28,18 @@ def test_rebalancer_registry_discovery():
 def test_rebalancer_unknown_name():
     with pytest.raises(ValueError, match="Unknown plugin"):
         rebalancer_registry.create("nope", {})
+
+
+def test_gui_plugin_register_deduplicates(monkeypatch):
+    """Registering the same GUI plugin twice should only keep one entry."""
+
+    monkeypatch.setattr(gui_plugins, "_PLUGIN_REGISTRY", [])
+
+    class DummyPlugin:
+        pass
+
+    gui_plugins.register_plugin(DummyPlugin)
+    gui_plugins.register_plugin(DummyPlugin)
+
+    registered = list(gui_plugins.iter_plugins())
+    assert registered == [DummyPlugin]

--- a/tests/test_policy_engine_cov.py
+++ b/tests/test_policy_engine_cov.py
@@ -108,3 +108,42 @@ def test_decide_hires_fires_diversification_and_turnover(monkeypatch):
     assert hires == [("d", "top_k")]
     assert fires == []
     assert all(h[0] != "b" for h in hires), "Bucket cap should skip second g1 fund"
+
+
+def test_decide_hires_fires_turnover_budget_prioritises(monkeypatch):
+    """Turnover limits should prioritise hires/fires based on scores."""
+
+    score_frame = pd.DataFrame({"m": [3.0, 2.0, 0.5]}, index=["a", "b", "c"])
+    policy = PolicyConfig(
+        top_k=2,
+        bottom_k=1,
+        min_track_months=0,
+        turnover_budget_max_changes=2,
+        metrics=[MetricSpec("m", 1.0)],
+    )
+    directions = {"m": 1}
+    eligible_since = {k: 12 for k in score_frame.index}
+    tenure = {"a": 5}
+
+    def fake_rank_scores(sf, metric_weights, metric_directions):
+        return pd.Series({"a": -1.0, "b": 2.0, "c": 1.5}, index=sf.index)
+
+    monkeypatch.setattr(
+        "trend_portfolio_app.policy_engine.rank_scores", fake_rank_scores
+    )
+
+    decisions = decide_hires_fires(
+        pd.Timestamp("2020-01-31"),
+        score_frame,
+        current=["a"],
+        policy=policy,
+        directions=directions,
+        cooldowns=CooldownBook(),
+        eligible_since=eligible_since,
+        tenure=tenure,
+    )
+
+    # Turnover cap of 2 should keep the top two moves (both hires) and drop the fire
+    assert len(decisions["hire"]) == 2
+    assert decisions["fire"] == []
+    assert {m for m, _ in decisions["hire"]} == {"b", "c"}

--- a/tests/test_sim_runner_cov.py
+++ b/tests/test_sim_runner_cov.py
@@ -96,6 +96,31 @@ def test_compute_score_frame_external_success(monkeypatch):
     assert list(sf.index) == ["A"] and "metric" in sf.columns
 
 
+def test_compute_score_frame_non_callable_external(monkeypatch):
+    panel = pd.DataFrame(
+        {
+            "Date": [pd.Timestamp("2020-01-31"), pd.Timestamp("2020-02-29")],
+            "A": [0.1, 0.2],
+        }
+    )
+
+    class Dummy:
+        single_period_run = None  # attribute present but not callable
+
+    monkeypatch.setattr(sim_runner, "HAS_TA", True)
+    monkeypatch.setattr(sim_runner, "ta_pipeline", Dummy())
+
+    sf = sim_runner.compute_score_frame(
+        panel,
+        pd.Timestamp("2020-01-31"),
+        pd.Timestamp("2020-02-29"),
+    )
+
+    # Should fall back to local implementation when attribute isn't callable
+    assert isinstance(sf, pd.DataFrame)
+    assert "A" in sf.index
+
+
 def test_simresult_methods():
     ev = EventLog()
     ev.append(Event(pd.Timestamp("2020-01-31"), "hire", "A", "top_k"))
@@ -169,6 +194,61 @@ def test_simulator_run_progress_and_fire(monkeypatch):
     assert calls == [(1, 2), (2, 2)]
     assert res.event_log.events[0].action == "hire"
     assert res.event_log.events[1].action == "fire"
+
+
+def test_simulator_run_max_weight_clip(monkeypatch):
+    periods = pd.period_range("2020-01", "2020-02", freq="M")
+    index = periods.to_timestamp(how="end")
+    data = pd.DataFrame({"A": [0.1, 0.0], "B": [0.2, 0.0]}, index=index)
+    sim = sim_runner.Simulator(data)
+
+    monkeypatch.setattr(
+        sim_runner,
+        "compute_score_frame",
+        lambda *a, **k: pd.DataFrame({"m": [1.0, 0.9]}, index=["A", "B"]),
+    )
+
+    call_count = {"n": 0}
+
+    def fake_decide(
+        asof, sf, current, policy, directions, cooldowns, eligible_since, tenure
+    ):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return {"hire": [("A", "top_k"), ("B", "top_k")], "fire": []}
+        return {"hire": [], "fire": []}
+
+    monkeypatch.setattr(sim_runner, "decide_hires_fires", fake_decide)
+
+    captured_targets: list[pd.Series] = []
+
+    def fake_apply(prev_weights, target_weights, date, rb_cfg, rb_state, policy):
+        captured_targets.append(target_weights.copy())
+        return target_weights
+
+    monkeypatch.setattr(sim_runner, "_apply_rebalance_pipeline", fake_apply)
+
+    original_clip = sim_runner.pd.Series.clip
+    clip_calls: list[tuple[float | None, float | None]] = []
+
+    def tracking_clip(self, lower=None, upper=None, *args, **kwargs):
+        clip_calls.append((lower, upper))
+        return original_clip(self, lower=lower, upper=upper, *args, **kwargs)
+
+    monkeypatch.setattr(sim_runner.pd.Series, "clip", tracking_clip, raising=False)
+
+    policy = PolicyConfig(top_k=2, max_weight=0.4, min_track_months=0)
+    sim.run(
+        start=index[0],
+        end=index[-1],
+        freq="M",
+        lookback_months=1,
+        policy=policy,
+    )
+
+    assert clip_calls, "Expected weight clipping to be attempted"
+    assert any(upper == policy.max_weight for _, upper in clip_calls)
+    assert captured_targets and list(captured_targets[0].index) == ["A", "B"]
 
 
 def test_simulator_handles_equity_curve_update_failure(monkeypatch, caplog):

--- a/tests/test_sim_runner_cov.py
+++ b/tests/test_sim_runner_cov.py
@@ -235,7 +235,7 @@ def test_simulator_run_max_weight_clip(monkeypatch):
         clip_calls.append((lower, upper))
         return original_clip(self, lower=lower, upper=upper, *args, **kwargs)
 
-    monkeypatch.setattr(sim_runner.pd.Series, "clip", tracking_clip, raising=False)
+    monkeypatch.setattr(sim_runner.pd.Series, "clip", tracking_clip)
 
     policy = PolicyConfig(top_k=2, max_weight=0.4, min_track_months=0)
     sim.run(


### PR DESCRIPTION
## Summary
- extend GUI step-0 DataGrid tests to cover ignored columns and missing `on` handlers
- add debounce coroutine test, GUI plugin deduplication check, and turnover budget exercise
- cover simulator fallback paths including non-callable scoring helpers and max-weight clipping

## Testing
- pytest tests/test_app_coverage.py::test_build_step0_datagrid_callbacks tests/test_app_coverage.py::test_build_step0_datagrid_missing_on
- pytest tests/test_plugin_registry.py::test_gui_plugin_register_deduplicates
- pytest tests/test_gui_utils_extra.py
- pytest tests/test_policy_engine_cov.py::test_decide_hires_fires_turnover_budget_prioritises
- pytest tests/test_sim_runner_cov.py::test_compute_score_frame_non_callable_external tests/test_sim_runner_cov.py::test_simulator_run_max_weight_clip

------
https://chatgpt.com/codex/tasks/task_e_68ca236162648331a99d25c6ca13126f