### PR TITLE
Ensure deterministic seeds are applied by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl --fail http://localhost:8000/health || exit 1
 
 # Default command runs the health wrapper (which starts Streamlit internally)
+ENV PYTHONHASHSEED=0
+ENV TREND_PIPELINE_SEED=42
 ENV PYTHONPATH="/app/src"
 ENV STREAMLIT_APP_PATH="/app/src/trend_portfolio_app/app.py"
 ENV HEALTH_PORT="8000"

--- a/scripts/trend-model
+++ b/scripts/trend-model
@@ -2,6 +2,16 @@
 # Development wrapper for trend-model CLI
 # Makes 'trend-model' command available without requiring package installation
 
+# Ensure deterministic hashes unless caller explicitly set one
+if [ -z "${PYTHONHASHSEED+x}" ]; then
+    export PYTHONHASHSEED=0
+fi
+
+# Provide a default pipeline seed while allowing overrides
+if [ -z "${TREND_PIPELINE_SEED+x}" ]; then
+    export TREND_PIPELINE_SEED=42
+fi
+
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"

--- a/src/trend_analysis/export/bundle.py
+++ b/src/trend_analysis/export/bundle.py
@@ -53,6 +53,12 @@ def export_bundle(run: Any, path: Path) -> Path:
         # Pre-compute hashes and run identifier --------------------------------
         config = getattr(run, "config", {})
         seed = getattr(run, "seed", None)
+        python_hash_seed = getattr(run, "python_hash_seed", None)
+        if isinstance(python_hash_seed, str):
+            try:
+                python_hash_seed = int(python_hash_seed)
+            except ValueError:
+                python_hash_seed = None
 
         # input_path may be missing or explicitly None; handle safely
         _inp = getattr(run, "input_path", None)
@@ -197,6 +203,7 @@ def export_bundle(run: Any, path: Path) -> Path:
             "config": config,
             "config_sha256": config_sha256,
             "seed": seed,
+            "python_hash_seed": python_hash_seed,
             "environment": env,
             "git_hash": _git_hash(),
             "receipt": {"created": _dt.datetime.utcnow().isoformat() + "Z"},
@@ -215,6 +222,8 @@ def export_bundle(run: Any, path: Path) -> Path:
         ]
         if seed is not None:
             receipt_lines.append(f"seed: {seed}")
+        if python_hash_seed is not None:
+            receipt_lines.append(f"python_hash_seed: {python_hash_seed}")
         receipt_lines.append(f"git_hash: {meta['git_hash']}")
         receipt_path = bundle_dir / "receipt.txt"
         receipt_path.write_text("\n".join(receipt_lines) + "\n", encoding="utf-8")

--- a/tests/test_api_run_simulation_branches.py
+++ b/tests/test_api_run_simulation_branches.py
@@ -48,7 +48,7 @@ def test_run_simulation_handles_missing_result(monkeypatch):
     assert result.fallback_info is None
     # The helper falls back to a deterministic default seed when absent.
     assert result.seed == 42
-    assert set(result.environment) == {"python", "numpy", "pandas"}
+    assert set(result.environment) == {"python", "numpy", "pandas", "python_hash_seed"}
 
 
 def test_run_simulation_populates_metrics_and_fallback(monkeypatch):

--- a/tests/test_export_bundle.py
+++ b/tests/test_export_bundle.py
@@ -241,10 +241,10 @@ def test_export_data_all_formats_content(tmp_path):
     assert txt_path.exists()
 
     pd.testing.assert_frame_equal(pd.read_csv(csv_path), df, check_dtype=False)
-    excel_reader = pd.ExcelFile(xlsx_path)
-    first_sheet = excel_reader.sheet_names[0]
+    # Use engine="openpyxl" for explicit Excel reading, and access the expected sheet by name.
+    excel_reader = pd.ExcelFile(xlsx_path, engine="openpyxl")
     pd.testing.assert_frame_equal(
-        excel_reader.parse(first_sheet), df, check_dtype=False
+        excel_reader.parse("sheet"), df, check_dtype=False
     )
     with open(json_path) as f:
         json_data = json.load(f)

--- a/tests/test_export_manifest_schema.py
+++ b/tests/test_export_manifest_schema.py
@@ -29,6 +29,7 @@ class DummyRun:
     config: dict
     seed: int
     input_path: Path
+    python_hash_seed: int | None = None
 
     def summary(self) -> dict:
         return {"total_return": float(self.portfolio.sum())}
@@ -50,6 +51,7 @@ def _schema() -> dict:
             "config",
             "config_sha256",
             "seed",
+            "python_hash_seed",
             "environment",
             "git_hash",
             "receipt",
@@ -70,6 +72,7 @@ def _schema() -> dict:
             "config_sha256": {"type": "string"},
             "seed": {"type": ["integer", "null"]},
             "environment": {"type": "object"},
+            "python_hash_seed": {"type": ["integer", "null"]},
             "git_hash": {"type": ["string", "null"]},
             "receipt": {
                 "type": "object",
@@ -96,6 +99,7 @@ def _build_meta(tmp_path: Path) -> dict:
         config=config,
         seed=42,
         input_path=input_path,
+        python_hash_seed=0,
     )
 
     out = tmp_path / "bundle.zip"


### PR DESCRIPTION
## Summary
- export PYTHONHASHSEED and TREND_PIPELINE_SEED defaults from the CLI wrapper and Docker image so runs start deterministically
- honour TREND_PIPELINE_SEED inside the API, capture the active PYTHONHASHSEED, and surface both values through run results and export bundles
- extend manifest schema/tests to cover the new metadata and make the Excel exporter smoke test resilient to engine differences

## Testing
- pytest tests/test_export_bundle.py tests/test_export_manifest_schema.py tests/test_api_run_simulation.py tests/test_api_run_simulation_branches.py

------
https://chatgpt.com/codex/tasks/task_e_68ca24d98be88331a97f5194719c06d8