### PR TITLE
feat: integrate robustness configuration into weight engines

### DIFF
--- a/src/trend_analysis/api.py
+++ b/src/trend_analysis/api.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:  # pragma: no cover - for static type checking only
 else:  # Runtime: avoid importing typing-only names
     from typing import Any as ConfigType
 
-from .pipeline import _run_analysis
+from .pipeline import _run_analysis, _resolve_weight_engine_params
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +78,11 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
             risk_free=0.0,
         )
 
+    weighting_scheme = config.portfolio.get("weighting_scheme", "equal")
+    weight_engine_params = _resolve_weight_engine_params(
+        weighting_scheme, config.portfolio
+    )
+
     res = _run_analysis(
         returns,
         str(split.get("in_start")),
@@ -94,9 +99,10 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
         indices_list=config.portfolio.get("indices_list"),
         benchmarks=config.benchmarks,
         seed=seed,
-        weighting_scheme=config.portfolio.get("weighting_scheme", "equal"),
+        weighting_scheme=weighting_scheme,
         constraints=config.portfolio.get("constraints"),
         stats_cfg=stats_cfg,
+        weight_engine_params=weight_engine_params,
     )
     if res is None:
         logger.warning("run_simulation produced no result")

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -25,7 +25,7 @@ import pandas as pd
 from ..constants import NUMERICAL_TOLERANCE_HIGH
 from ..core.rank_selection import ASCENDING_METRICS
 from ..data import load_csv
-from ..pipeline import _run_analysis
+from ..pipeline import _run_analysis, _resolve_weight_engine_params
 from ..rebalancing import apply_rebalancing_strategies
 from ..weighting import (
     AdaptiveBayesWeighting,
@@ -282,6 +282,11 @@ def run(
         if df is None:
             raise FileNotFoundError(csv_path)
 
+    weighting_scheme = cfg.portfolio.get("weighting_scheme")
+    weight_engine_params = _resolve_weight_engine_params(
+        weighting_scheme, cfg.portfolio
+    )
+
     # If policy is not threshold-hold, use the Phase‑1 style per-period runs.
     if str(cfg.portfolio.get("policy", "").lower()) != "threshold_hold":
         periods = generate_periods(cfg.model_dump())
@@ -303,6 +308,8 @@ def run(
                 indices_list=cfg.portfolio.get("indices_list"),
                 benchmarks=cfg.benchmarks,
                 seed=getattr(cfg, "seed", 42),
+                weighting_scheme=weighting_scheme,
+                weight_engine_params=weight_engine_params,
             )
             if res is None:
                 continue
@@ -808,6 +815,8 @@ def run(
             indices_list=cfg.portfolio.get("indices_list"),
             benchmarks=cfg.benchmarks,
             seed=getattr(cfg, "seed", 42),
+            weighting_scheme=weighting_scheme,
+            weight_engine_params=weight_engine_params,
         )
         if res is None:
             continue

--- a/src/trend_analysis/weights/robust_weighting.py
+++ b/src/trend_analysis/weights/robust_weighting.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, Literal
 
 import numpy as np
 import pandas as pd

--- a/src/trend_analysis/weights/robust_weighting.py
+++ b/src/trend_analysis/weights/robust_weighting.py
@@ -418,8 +418,6 @@ class RobustRiskParity(WeightEngine):
         weights = inv_vol / np.sum(inv_vol)
 
         logger.debug("Successfully computed robust risk parity weights")
-        info.setdefault("selected_method", "risk_parity")
-        info.setdefault("reason", "condition_number_within_threshold")
         info["weights_index"] = list(cov.index)
         self.last_run_info = info
         return pd.Series(weights, index=cov.index)

--- a/src/trend_analysis/weights/robust_weighting.py
+++ b/src/trend_analysis/weights/robust_weighting.py
@@ -158,7 +158,7 @@ class RobustMeanVariance(WeightEngine):
 
     def _log_condition(self, condition_number: float) -> None:
         level = logging.INFO if self.log_condition_numbers else logging.DEBUG
-        logger.log(level, f"Covariance matrix condition number: {condition_number:.2e}")
+        logger.log(level, "Covariance matrix condition number: %.2e", condition_number)
 
     def _log_shrinkage(self, message: str) -> None:
         level = logging.INFO if self.log_shrinkage_intensity else logging.DEBUG

--- a/tests/test_api_run_simulation_branches.py
+++ b/tests/test_api_run_simulation_branches.py
@@ -117,6 +117,7 @@ def test_run_simulation_populates_metrics_and_fallback(monkeypatch):
     stats_kwargs = captured["risk_stats_calls"][0]
     assert stats_kwargs["metrics_to_run"] == [value.upper() for value in metrics_list]
     assert stats_kwargs["risk_free"] == 0.0
+    assert kwargs["weight_engine_params"] is None
 
     # Metrics are built from the stats mapping and benchmark IR data.
     assert set(result.metrics.index) == {"FundA", "FundB"}


### PR DESCRIPTION
## Summary
- derive shrinkage, condition checks, and logging options from the portfolio robustness config when instantiating robust weight engines
- enhance robust mean-variance and risk parity engines with configurable logging and structured diagnostics
- surface weight-engine diagnostics through the pipeline/API and extend tests to cover the new behavior

## Testing
- pytest tests/test_robust_weighting.py tests/test_weight_engine_logging.py tests/test_api_run_simulation_branches.py


------
https://chatgpt.com/codex/tasks/task_e_68ca295687ac83318a471e2fa0538de1