### PR TITLE
Fix Excel fallback rename and extend GUI coverage

### DIFF
--- a/src/trend_analysis/export/__init__.py
+++ b/src/trend_analysis/export/__init__.py
@@ -679,6 +679,11 @@ def export_to_excel(
                         writer.sheets.pop(removed, None)
                 formatted = _apply_format(df, df_formatter)
                 formatted.to_excel(writer, sheet_name=sheet, index=False)
+                if workbook_adapter is not None:
+                    try:
+                        workbook_adapter.rename_last_sheet(sheet)
+                    except Exception:  # pragma: no cover - defensive best effort
+                        pass
                 if proxy is not None:
                     try:
                         ws_obj = writer.book[sheet]

--- a/tests/test_gui_launch_run.py
+++ b/tests/test_gui_launch_run.py
@@ -1,0 +1,88 @@
+from types import SimpleNamespace
+
+import pandas as pd
+
+import trend_analysis.gui.app as app
+
+
+def _stub_store(output_format: str, path: str) -> app.ParamStore:
+    store = app.ParamStore()
+    store.cfg = {"output": {"format": output_format, "path": path}}
+    return store
+
+
+def test_launch_run_button_uses_exporter(monkeypatch, tmp_path):
+    store = _stub_store("csv", str(tmp_path / "report.csv"))
+
+    monkeypatch.setattr(app, "load_state", lambda: store)
+    monkeypatch.setattr(app, "discover_plugins", lambda: None)
+
+    cfg = SimpleNamespace(output=store.cfg["output"], sample_split={})
+    monkeypatch.setattr(app, "build_config_from_store", lambda s: cfg)
+
+    metrics = pd.DataFrame({"value": [1.0]})
+    monkeypatch.setattr(app.pipeline, "run", lambda cfg: metrics)
+    monkeypatch.setattr(app.pipeline, "run_full", lambda cfg: {"result": 1})
+
+    captured: dict[str, object] = {}
+
+    def fake_export(data, path, *_):  # noqa: ANN001 - signature mimics exporter
+        captured["data"] = data
+        captured["path"] = path
+
+    monkeypatch.setitem(app.export.EXPORTERS, "csv", fake_export)
+    monkeypatch.setattr(app, "save_state", lambda st: captured.setdefault("saved", st))
+
+    root = app.launch()
+    run_btn = root.children[-1]
+    run_btn.click()
+
+    assert "data" in captured
+    assert captured["data"]["metrics"].equals(metrics)
+    assert captured["path"] == store.cfg["output"]["path"]
+    assert store.dirty is False
+
+
+def test_launch_run_button_exports_excel(monkeypatch, tmp_path):
+    store = _stub_store("excel", str(tmp_path / "analysis"))
+
+    monkeypatch.setattr(app, "load_state", lambda: store)
+    monkeypatch.setattr(app, "discover_plugins", lambda: None)
+
+    sample_split = {
+        "in_start": "2020-01",
+        "in_end": "2020-06",
+        "out_start": "2020-07",
+        "out_end": "2020-12",
+    }
+    cfg = SimpleNamespace(output=store.cfg["output"], sample_split=sample_split)
+    monkeypatch.setattr(app, "build_config_from_store", lambda s: cfg)
+
+    metrics = pd.DataFrame({"value": [1.0]})
+    monkeypatch.setattr(app.pipeline, "run", lambda cfg: metrics)
+    monkeypatch.setattr(app.pipeline, "run_full", lambda cfg: {"full": "results"})
+
+    captured: dict[str, object] = {}
+
+    def fake_summary_formatter(res, *args):  # noqa: ANN001 - matches usage
+        captured["summary_args"] = (res, *args)
+        return lambda *_: None
+
+    monkeypatch.setattr(app.export, "make_summary_formatter", fake_summary_formatter)
+
+    def fake_export_to_excel(data, path, **kwargs):  # noqa: ANN001
+        captured["excel"] = (data, path, kwargs)
+
+    monkeypatch.setattr(app.export, "export_to_excel", fake_export_to_excel)
+    monkeypatch.setattr(app, "save_state", lambda st: captured.setdefault("saved", st))
+
+    root = app.launch()
+    run_btn = root.children[-1]
+    run_btn.click()
+
+    assert "excel" in captured
+    data, path, kwargs = captured["excel"]
+    assert set(data) >= {"metrics", "summary"}
+    assert path.endswith(".xlsx")
+    assert "default_sheet_formatter" in kwargs
+    assert captured["summary_args"][0] == {"full": "results"}


### PR DESCRIPTION
## Summary
- ensure the Excel exporter renames the last worksheet when the openpyxl adapter is active to keep sheet names consistent during fallback
- add GUI launch tests covering the run button behaviour for CSV and Excel outputs without requiring real widgets state persistence
- extend the simulation runner tests to cover the TypeError fallback path when the optional pipeline integration fails

## Testing
- `pytest`
- `pytest tests/test_gui_launch_run.py -q`
- `pytest tests/app/test_sim_runner_extra.py::test_compute_score_frame_type_error_fallback -q`
- `pytest tests/test_export_openpyxl_adapter.py::test_export_to_excel_uses_adapter_when_xlsxwriter_missing -q`


------
https://chatgpt.com/codex/tasks/task_e_68ca3bca9b0c8331884cfbd9990adc4f