### PR TITLE
Enhance weight engine fallback messaging

### DIFF
--- a/streamlit_app/components/fallback_warning.py
+++ b/streamlit_app/components/fallback_warning.py
@@ -1,0 +1,29 @@
+"""Helpers for displaying weight engine fallback warnings in Streamlit."""
+
+from __future__ import annotations
+
+from typing import Mapping, Any
+
+__all__ = ["format_weight_engine_warning"]
+
+
+def format_weight_engine_warning(
+    fallback_info: Mapping[str, Any],
+    *,
+    suffix: str,
+) -> str:
+    """Return a consistent warning message for weight engine fallbacks."""
+    engine = fallback_info.get("engine") or "unknown"
+    error_type = fallback_info.get("error_type")
+    error_msg = fallback_info.get("error")
+
+    if error_type and error_msg:
+        detail = f"{error_type}: {error_msg}"
+    elif error_type:
+        detail = str(error_type)
+    elif error_msg:
+        detail = str(error_msg)
+    else:
+        detail = "unknown error"
+
+    return f"⚠️ Weight engine '{engine}' failed ({detail}). {suffix}".strip()

--- a/streamlit_app/pages/3_Run.py
+++ b/streamlit_app/pages/3_Run.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from streamlit_app.components.disclaimer import show_disclaimer
+from streamlit_app.components.fallback_warning import format_weight_engine_warning
 from trend_analysis.api import run_simulation
 from trend_analysis.config import Config
 
@@ -120,10 +121,11 @@ def main():
     except Exception:  # pragma: no cover - defensive
         fb = None
     if fb and not st.session_state.get("dismiss_weight_engine_fallback"):
-        with st.warning(
-            "⚠️ Weight engine '%s' failed (%s). Using equal weights."
-            % (fb.get("engine"), fb.get("error_type")),
-        ):
+        message = format_weight_engine_warning(
+            fb,
+            suffix="Using equal weights.",
+        )
+        with st.warning(message):
             if st.button(
                 "Dismiss",
                 key="btn_dismiss_weight_engine_fallback",

--- a/streamlit_app/pages/4_Results.py
+++ b/streamlit_app/pages/4_Results.py
@@ -7,6 +7,7 @@ import streamlit as st
 
 from trend_analysis.engine.walkforward import walk_forward
 from trend_analysis.metrics import attribution
+from streamlit_app.components.fallback_warning import format_weight_engine_warning
 
 
 def _flatten_columns(df: pd.DataFrame) -> pd.DataFrame:
@@ -42,10 +43,11 @@ try:
 except Exception:  # pragma: no cover - defensive
     fb_info = None
 if fb_info and not st.session_state.get("dismiss_weight_engine_fallback"):
-    with st.warning(
-        "⚠️ Weight engine '%s' failed (%s). Portfolio uses equal weights."
-        % (fb_info.get("engine"), fb_info.get("error_type"))
-    ):
+    message = format_weight_engine_warning(
+        fb_info,
+        suffix="Portfolio uses equal weights.",
+    )
+    with st.warning(message):
         if st.button(
             "Dismiss",
             key="btn_dismiss_weight_engine_fallback_results",

--- a/tests/test_api_run_simulation_branches.py
+++ b/tests/test_api_run_simulation_branches.py
@@ -100,7 +100,11 @@ def test_run_simulation_populates_metrics_and_fallback(monkeypatch):
                     "user_weight": 0.1,
                 }
             },
-            "weight_engine_fallback": {"engine": "TestEngine", "error": "boom"},
+            "weight_engine_fallback": {
+                "engine": "TestEngine",
+                "error": "boom",
+                "error_type": "BoomError",
+            },
         }
 
     monkeypatch.setattr(api, "_run_analysis", fake_run_analysis)
@@ -124,7 +128,11 @@ def test_run_simulation_populates_metrics_and_fallback(monkeypatch):
     assert result.metrics.loc["FundA", "ir_bench"] == 0.3
 
     # The fallback payload is surfaced directly on the RunResult.
-    assert result.fallback_info == {"engine": "TestEngine", "error": "boom"}
+    assert result.fallback_info == {
+        "engine": "TestEngine",
+        "error": "boom",
+        "error_type": "BoomError",
+    }
 
     # The details object is exactly the payload returned by ``_run_analysis``.
     assert result.details["benchmark_ir"]["bench"]["FundA"] == 0.3

--- a/tests/test_streamlit_fallback_banner.py
+++ b/tests/test_streamlit_fallback_banner.py
@@ -130,6 +130,10 @@ def test_streamlit_run_page_fallback_banner(monkeypatch):
 
     # Assertions: banner message & fallback_info present
     assert any("Weight engine" in w and "failed" in w for w in warnings)
+    assert any("ValueError" in w for w in warnings)
+    assert any("Unknown plugin" in w for w in warnings)
     sim_res = mock_st.session_state.get("sim_results")
     assert sim_res is not None
     assert getattr(sim_res, "fallback_info", None) is not None
+    details = getattr(sim_res, "details", {})
+    assert details.get("fund_weights") == details.get("ew_weights")

--- a/tests/test_weight_engine_logging.py
+++ b/tests/test_weight_engine_logging.py
@@ -71,6 +71,9 @@ def test_weight_engine_failure_logging(caplog):
     assert result.get("weight_engine_fallback") is not None
     fb = result["weight_engine_fallback"]
     assert fb["engine"] == "nonexistent_engine"
+    assert fb["error_type"] == "ValueError"
+    assert "Unknown plugin" in fb["error"]
+    assert result["fund_weights"] == result["ew_weights"]
 
     # Check that fallback message was logged
     debug_logs = [
@@ -89,6 +92,7 @@ def test_weight_engine_failure_logging(caplog):
         w for w in warn_logs if "falling back to equal weights" in w.message
     ]
     assert len(warning_fallback) == 1
+    assert "ValueError" in warning_fallback[0].message
 
 
 def test_weight_engine_import_failure_logging(caplog):


### PR DESCRIPTION
## Summary
- add a shared Streamlit helper that formats weight engine fallback warnings with error details
- update Run and Results pages to display the detailed fallback banner while keeping it dismissible
- extend regression tests to assert the warning content, equal-weight fallback, and propagated metadata

## Testing
- pytest tests/test_weight_engine_logging.py tests/test_streamlit_fallback_banner.py tests/test_api_run_simulation_branches.py

------
https://chatgpt.com/codex/tasks/task_e_68ca4ac0be908331ab1872ccee1fb92e