### PR TITLE
Add coverage tests for walkforward and export pathways

### DIFF
--- a/tests/test_gui_app_extended.py
+++ b/tests/test_gui_app_extended.py
@@ -56,7 +56,8 @@ class DummyDropdown:
     def __init__(self, options, value=None, description: str = "") -> None:  # noqa: ANN001, ARG002
         self.options = list(options)
         self.description = description
-        self.value = value if value is not None else (self.options[0] if self.options else None)
+        default_value = self.options[0] if self.options else None
+        self.value = value if value is not None else default_value
         self._callbacks: list = []
         key = description or f"dropdown_{len(created_instances.get('dropdowns', []))}"
         created_instances.setdefault("dropdowns", []).append(self)

--- a/tests/test_gui_app_extended.py
+++ b/tests/test_gui_app_extended.py
@@ -81,7 +81,7 @@ class DummyCheckbox:
 
 class DummyToggleButtons(DummyCheckbox):
     def __init__(self, options, value=None, description: str = "") -> None:  # noqa: ANN001, ARG002
-        super().__init__(value=value or (options[0] if options else None), description=description)
+        super().__init__(value=value if value is not None else (options[0] if options else None), description=description)
         self.options = options
 
 


### PR DESCRIPTION
## Summary
- add a regression test that exercises walk-forward window column ordering
- extend export adapter coverage to validate openpyxl proxies, fallback sheet cleanup, and workbook helpers
- cover summary text rendering, manager contribution edge cases, and GUI exporter branch behaviour

## Testing
- pytest tests/test_walkforward_engine.py tests/test_export_openpyxl_adapter.py tests/test_export_additional_coverage.py tests/test_gui_app_extended.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ca4baf9d5c8331921585213e983ee0