### PR TITLE
feat: unify CLI execution with API run_simulation

### DIFF
--- a/src/trend_analysis/api.py
+++ b/src/trend_analysis/api.py
@@ -159,6 +159,7 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
                 str(split.get("out_end")),
             )
         except Exception:  # pragma: no cover - defensive guard
+            logger.exception("Error generating summary text in run_simulation")
             summary_text = None
     logger.info("run_simulation end")
     return RunResult(


### PR DESCRIPTION
## Summary
- add summary text plumbing to `trend_analysis.api.RunResult` and delegate attribute access to pipeline details
- update the CLI to always route through `run_simulation` and reuse the generated summary output
- refresh the CLI/API conformance test to compare the printed summary against the API result

## Testing
- pytest tests/test_cli.py tests/test_cli_api_golden_master.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ca4d4c687c8331ac805a0d2bde7b45