### PR TITLE
Add branch governance settings and release notes check

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,26 @@
+repository:
+  default_branch: main
+  allow_merge_commit: false
+  allow_squash_merge: true
+  allow_rebase_merge: false
+  delete_branch_on_merge: true
+
+branches:
+  - name: main
+    protection:
+      required_status_checks:
+        strict: true
+        contexts:
+          - gate / all-required-green
+          - Docker / build
+          - Release Notes / generate
+      enforce_admins: true
+      required_conversation_resolution: true
+      required_linear_history: true
+      allow_force_pushes: false
+      allow_deletions: false
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        require_code_owner_review: true
+        dismiss_stale_reviews: true
+        require_last_push_approval: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ phase-2-dev ]
+    branches: [ main, phase-2-dev ]
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [ phase-2-dev ]
+    branches: [ main, phase-2-dev ]
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/quarantine-ttl.yml
+++ b/.github/workflows/quarantine-ttl.yml
@@ -2,7 +2,7 @@ name: quarantine-ttl
 on:
   pull_request:
   push:
-    branches: [phase-2-dev]
+    branches: [main, phase-2-dev]
 permissions: read-all
 jobs:
   ttl:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,32 @@
+name: Release Notes
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Download git-cliff
+        run: |
+          curl -L https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz
+          chmod +x git-cliff
+      - name: Generate unreleased notes
+        run: ./git-cliff --unreleased --strip header --output release-notes.md
+      - name: Validate release notes output
+        run: |
+          if [ ! -s release-notes.md ]; then
+            echo "Generated release notes are empty" >&2
+            exit 1
+          fi
+      - name: Upload release notes preview
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes-preview
+          path: release-notes.md
+          retention-days: 5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to Trend Model Project
+
+Thank you for your interest in improving the Trend Model Project! This document
+explains how to work with the repository now that `main` is the default branch
+and branch protections enforce CI, Docker, and release-note quality gates.
+
+## Branching and Pull Requests
+
+- Fork or create a feature branch from `main`.
+- Keep your branch up to date with `main` by rebasing or merging regularly.
+- All pull requests **must target `main`**. Automation will reject PRs aimed at
+  other branches.
+- Each pull request requires at least one approving code-owner review and GitHub
+  auto-merge is configured for squash merges only.
+
+## Required Checks Before Merge
+
+Branch protection rules block merges until the following checks succeed:
+
+1. **CI** – `gate / all-required-green` from `.github/workflows/ci.yml`.
+2. **Docker** – `Docker / build` from `.github/workflows/docker.yml`.
+3. **Release Notes** – `Release Notes / generate`, which validates that
+   `git-cliff` can build the unreleased changelog.
+
+GitHub enforces these checks automatically, but contributors should run local
+validation before pushing to ensure quick feedback.
+
+### Local Test Matrix
+
+```bash
+# Set up environment (once)
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pip install -e ".[dev]"
+
+# Run the project test wrapper
+./scripts/run_tests.sh
+```
+
+The script executes the same pytest subset as the CI workflow. Fix any failures
+before sending your pull request.
+
+### Release Notes Dry Run
+
+The repository uses [`git-cliff`](https://git-cliff.org/) with the configuration
+stored in `cliff.toml`. Generate the unreleased changelog locally to catch
+format issues before the workflow runs:
+
+```bash
+# Ensure full git history so git-cliff can compute the changelog
+git fetch origin --tags
+
+# Build unreleased notes to release-notes.md
+git-cliff --unreleased --strip header --output release-notes.md
+```
+
+Include the resulting preview in your manual testing notes or attach it to the
+PR if reviewers request context.
+
+## Documentation Updates
+
+- Update `docs/ops/codex-bootstrap-facts.md` if operational facts change (e.g.,
+  default branch, required checks).
+- Reference `CONTRIBUTING.md` in new documentation so contributors find the
+  governance rules quickly.
+
+## Questions
+
+If you are unsure about process changes or the governance model, open a
+discussion or ping the maintainers via an issue before raising a pull request.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trend Model Project
 
-[![Codex Verification (Latest)](https://github.com/stranske/Trend_Model_Project/actions/workflows/verify-codex-bootstrap-matrix.yml/badge.svg?branch=phase-2-dev)](https://github.com/stranske/Trend_Model_Project/actions/workflows/verify-codex-bootstrap-matrix.yml) [![Codex Verification Guide](https://img.shields.io/badge/codex--verification-docs-blueviolet)](docs/codex-simulation.md)
+[![Codex Verification (Latest)](https://github.com/stranske/Trend_Model_Project/actions/workflows/verify-codex-bootstrap-matrix.yml/badge.svg?branch=main)](https://github.com/stranske/Trend_Model_Project/actions/workflows/verify-codex-bootstrap-matrix.yml) [![Codex Verification Guide](https://img.shields.io/badge/codex--verification-docs-blueviolet)](docs/codex-simulation.md)
 
 > **🚀 New User?** → **[Quick Start Guide](docs/quickstart.md)** — Get your first analysis running in under 10 minutes!
 

--- a/docs/ops/codex-bootstrap-facts.md
+++ b/docs/ops/codex-bootstrap-facts.md
@@ -5,7 +5,7 @@ This page captures the established, validated facts about the Codex bootstrap an
 Last updated: 2025‑09‑17
 
 ## Branches and Event Semantics
-- Default branch: `phase-2-dev`.
+- Default branch: `main`.
 - Issue label events execute workflows from the default branch.
 - We do not reuse existing PR branches for fixes; each run creates a fresh branch from default.
 
@@ -105,12 +105,12 @@ This catalog explains what each active workflow does, how it’s triggered, the 
 
 <a id="wf-ci"></a>
 7) [`ci.yml`](../../.github/workflows/ci.yml) — Test suite on pushes and PRs
-   - Triggers: `push` to `phase-2-dev`, `pull_request`
+   - Triggers: `push` to `main`/`phase-2-dev`, `pull_request`
    - Jobs: `core-tests` (matrix on Python 3.11/3.12), `gate` (aggregates)
 
 <a id="wf-docker"></a>
 8) [`docker.yml`](../../.github/workflows/docker.yml) — Build, test, and push container image
-   - Triggers: `push` to `phase-2-dev`, `pull_request`, `workflow_dispatch`
+   - Triggers: `push` to `main`/`phase-2-dev`, `pull_request`, `workflow_dispatch`
    - Jobs: `build`
      - Builds image, runs tests in container, health-checks a simple endpoint, pushes to GHCR
 
@@ -122,7 +122,7 @@ This catalog explains what each active workflow does, how it’s triggered, the 
 
 <a id="wf-quarantine-ttl"></a>
 10) [`quarantine-ttl.yml`](../../.github/workflows/quarantine-ttl.yml) — Enforce test quarantine expirations
-   - Triggers: `pull_request`, `push` to `phase-2-dev`
+   - Triggers: `pull_request`, `push` to `main`/`phase-2-dev`
    - Jobs: `ttl`
      - Validates `tests/quarantine.yml` entries have not expired
 


### PR DESCRIPTION
## Summary
- add `.github/settings.yml` to set `main` as the default branch and require CI, Docker, and release-note checks before merge
- create a release-notes validation workflow and extend existing automations to watch `main`
- document the governance flow in `CONTRIBUTING.md` and refresh ops/readme references

## Testing
- ./scripts/run_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68ca4d34d3688331bd35118786503592