### PR TITLE
Transaction costs and turnover controls (first‑class) - Source Issue #730: 

### DIFF
--- a/agents/codex-730.md
+++ b/agents/codex-730.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #730 -->

--- a/tests/test_export_additional_coverage.py
+++ b/tests/test_export_additional_coverage.py
@@ -152,6 +152,7 @@ def test_flat_frames_from_results_includes_contrib_and_changes():
 
     assert "manager_contrib" in frames
     assert not frames["manager_contrib"].empty
+    assert "execution_metrics" in frames
     assert "changes" in frames
     # Manager change rows should include the generated period label
     assert set(frames["changes"]["Period"]) == {"Period 1"}

--- a/tests/test_export_openpyxl_adapter.py
+++ b/tests/test_export_openpyxl_adapter.py
@@ -261,6 +261,7 @@ def test_flat_frames_from_results_collects_changes(monkeypatch):
 
     out = export.flat_frames_from_results(results)
     assert "periods" in out and "summary" in out
+    assert "execution_metrics" in out
     assert "manager_contrib" in out
     assert "changes" in out and out["changes"].iloc[0]["Period"] == "2020-12"
 


### PR DESCRIPTION
### Source Issue #730: Transaction costs and turnover controls (first‑class)

Source: https://github.com/stranske/Trend_Model_Project/issues/730

> Milestone: M2 Depth & Robustness
> Tasks
> 
> Add transaction_cost_bps and max_turnover to config.
> 
> Compute realized turnover; apply cost drag; enforce cap.
> Acceptance criteria
> 
> Results table and chart show turnover and cost impact; CSVs exported.
> Code pointers
> 
> src/trend_analysis/engine/execution.py, src/trend_analysis/metrics/turnover.py.
> Test notes
> 
> Unit test with simple trades and known results.

—
(After opening the PR, comment with `@codex start`.)