### PR TITLE
Expose risk-based weight engines via configuration UI

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -58,10 +58,21 @@ Manual mode displays a table of candidates so you can override fund inclusion an
 
 Several weighting strategies are built in:
 
+**Score-based weights** (configured under `portfolio.weighting.name`):
+
 - **EqualWeight** – simple 1/N allocation.
 - **ScorePropSimple** – weights proportional to positive scores.
 - **ScorePropBayesian** – shrinks scores toward the mean before weighting.
 - **AdaptiveBayesWeighting** – updates weights over multiple periods and persists its state between runs.
+
+**Covariance-driven engines** (pick via `portfolio.weighting_scheme` or the Streamlit dropdown):
+
+- **Risk Parity (`risk_parity`)** – inverse-volatility weights with safety checks for tiny variances (alias: `vol_inverse`).
+- **Hierarchical Risk Parity (`hrp`)** – tree-clustered allocation that decorrelates highly related assets.
+- **Equal Risk Contribution (`erc`)** – iteratively scales positions until each contributes the same marginal risk.
+- **Robust Mean-Variance / Risk Parity** – defensive variants that add diagonal loading when the covariance matrix is ill conditioned.
+
+All engines operate on the in-sample covariance matrix and normalise the output to 100 % long-only weights. If numerical issues occur the pipeline emits a warning and falls back to equal weighting so runs remain reproducible.
 
 When the GUI is used, the state of AdaptiveBayesWeighting is saved alongside the main config so that repeated runs refine the posterior.
 

--- a/docs/plugin-interface.md
+++ b/docs/plugin-interface.md
@@ -50,5 +50,16 @@ print(weight_engine_registry.available())
 ## Config usage
 Strategies can be specified by name in config and constructed via the factories. Unknown names raise a clear `ValueError` listing available plugins.
 
+Example (Weight Engine):
+
+```python
+from trend_analysis.plugins import create_weight_engine
+
+engine = create_weight_engine("risk_parity")
+weights = engine.weight(cov_matrix)
+```
+
+Built-in names include `risk_parity`, `hrp`, `erc`, `robust_mv`, and `robust_risk_parity`. Aliases such as `vol_inverse` map to their canonical counterparts.
+
 ## Tests
 - Registry behavior and error handling are covered by tests (e.g., `tests/test_weight_engines.py`, `tests/test_rebalancing_*`, `tests/test_selector_weighting.py`).

--- a/tests/test_weight_engines.py
+++ b/tests/test_weight_engines.py
@@ -39,3 +39,10 @@ def test_hierarchical_risk_parity_expected_weights():
     assert np.allclose(w.values, expected.values, atol=1e-6)
     assert np.isclose(w.sum(), 1.0)
     assert (w >= 0).all()
+
+
+def test_risk_parity_alias_maps_to_same_engine():
+    cov = pd.DataFrame([[0.25, 0.05], [0.05, 0.16]], index=["x", "y"], columns=["x", "y"])
+    canonical = create_weight_engine("risk_parity").weight(cov)
+    alias = create_weight_engine("vol_inverse").weight(cov)
+    assert np.allclose(canonical.values, alias.values)


### PR DESCRIPTION
## Summary
- add dynamic discovery of registered weight engines to the Streamlit configuration page with friendly labels and preset support
- document covariance-driven engines alongside existing score-based weighting options and extend the plugin guide with a weight-engine example
- cover the `vol_inverse` alias in weight-engine unit tests to guarantee parity with the canonical risk-parity implementation

## Testing
- pytest tests/test_weight_engines.py


------
https://chatgpt.com/codex/tasks/task_e_68ca52fd4ab4833194eeb3e440908dc1