### PR TITLE
Add coverage tests for data loading and simulation edge cases

### DIFF
--- a/tests/test_export_openpyxl_adapter.py
+++ b/tests/test_export_openpyxl_adapter.py
@@ -584,3 +584,23 @@ def test_export_to_excel_removes_default_and_renames(monkeypatch, tmp_path):
     assert all(ws.title != "Sheet" for ws in writer.book.worksheets)
     assert writer.book.worksheets[-1].title == "summary"
 
+
+def test_openpyxl_apply_format_skips_missing_attributes(monkeypatch):
+    utils_mod = SimpleNamespace(
+        get_column_letter=lambda idx: chr(ord("A") + idx - 1)
+    )
+    monkeypatch.setitem(sys.modules, "openpyxl", SimpleNamespace(utils=utils_mod))
+    monkeypatch.setitem(sys.modules, "openpyxl.utils", utils_mod)
+
+    class BareCell:
+        def __init__(self) -> None:
+            self.font = None  # no copy method available
+
+    ws = DummyWorksheet()
+    proxy = export._OpenpyxlWorksheetProxy(ws)
+
+    cell = BareCell()
+    proxy._apply_format(cell, {"num_format": "0.0", "font_color": object()})
+
+    assert not hasattr(cell, "number_format")
+    assert cell.font is None

--- a/tests/test_walkforward_engine.py
+++ b/tests/test_walkforward_engine.py
@@ -198,7 +198,59 @@ def test_infer_periods_per_year_branch_guards(monkeypatch):
 
     monkeypatch.setattr(np, "median", lambda arr: _PositiveMedian())
     assert walkforward._infer_periods_per_year(idx) == 1
-    monkeypatch.setattr(np, "median", real_median, raising=False)
+
+
+def test_walk_forward_handles_empty_metric_columns():
+    df = _monthly_frame(5)
+
+    result = walkforward.walk_forward(
+        df,
+        train_size=2,
+        test_size=1,
+        step_size=1,
+        metric_cols=[],
+    )
+
+    # Without metric columns the OOS aggregates should be empty but metadata retained.
+    assert result.oos.empty
+    assert list(result.oos_windows.columns.get_level_values("category")) == [
+        "window",
+        "window",
+        "window",
+        "window",
+        "window",
+        "window",
+    ]
+
+
+def test_walk_forward_no_splits_yields_empty_windows():
+    df = _monthly_frame(3)
+
+    result = walkforward.walk_forward(
+        df,
+        train_size=5,
+        test_size=3,
+        step_size=1,
+    )
+
+    assert result.splits == []
+    assert result.oos_windows.empty
+
+
+def test_walk_forward_ignores_missing_regime_labels():
+    df = _monthly_frame(6)
+    # All regimes are missing/NaN which should skip regime aggregation block
+    regimes = pd.Series([None] * len(df), index=pd.to_datetime(df["Date"]))
+
+    result = walkforward.walk_forward(
+        df,
+        train_size=3,
+        test_size=2,
+        step_size=1,
+        regimes=regimes,
+    )
+
+    assert result.by_regime.empty
 
 
 def test_walk_forward_orders_oos_window_columns():


### PR DESCRIPTION
## Summary
- add null/empty date coverage for load_csv and ensure warnings are emitted
- exercise openpyxl formatting guard and GUI step0 fallback behaviours
- extend policy engine, simulator, and walk-forward tests to cover sticky drop, missing dates, and empty metric scenarios

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cac18c854c8331ad872bc44a1dd0e4