### PR TITLE
ci(enable-automerge): pass pull-request-number to action

### DIFF
--- a/.github/workflows/enable-automerge.yml
+++ b/.github/workflows/enable-automerge.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           merge-method: squash
+          pull-request-number: ${{ github.event.pull_request.number }}
       - name: Summarize auto-merge enable
         if: always()
         run: |

--- a/tests/test_portfolio_app_io_utils.py
+++ b/tests/test_portfolio_app_io_utils.py
@@ -7,8 +7,6 @@ import sys
 import zipfile
 from types import ModuleType
 
-import pytest
-
 from trend_portfolio_app import io_utils
 
 
@@ -114,7 +112,8 @@ def test_cleanup_temp_files_handles_missing_files(tmp_path):
 
 
 def test_portfolio_app_main_invokes_streamlit(monkeypatch):
-    """Running ``python -m trend_portfolio_app`` should invoke streamlit CLI."""
+    """Running ``python -m trend_portfolio_app`` should invoke streamlit
+    CLI."""
 
     calls: list[list[str]] = []
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -125,7 +125,8 @@ class TestStreamlitProxy:
             importlib.import_module("trend_analysis.proxy.__main__")
 
     def test_proxy_main_entrypoint_executes(self, monkeypatch):
-        """Running ``python -m trend_analysis.proxy`` should invoke CLI main."""
+        """Running ``python -m trend_analysis.proxy`` should invoke CLI
+        main."""
 
         calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
 


### PR DESCRIPTION
Fixes failure in Enable auto-merge step when using gh CLI without a current branch by passing the PR number directly to peter-evans/enable-pull-request-automerge@v3.