### PR TITLE
Add deterministic assertions for turnover execution metrics

### DIFF
--- a/tests/test_portfolio_app_io_utils.py
+++ b/tests/test_portfolio_app_io_utils.py
@@ -7,8 +7,6 @@ import sys
 import zipfile
 from types import ModuleType
 
-import pytest
-
 from trend_portfolio_app import io_utils
 
 
@@ -114,7 +112,8 @@ def test_cleanup_temp_files_handles_missing_files(tmp_path):
 
 
 def test_portfolio_app_main_invokes_streamlit(monkeypatch):
-    """Running ``python -m trend_portfolio_app`` should invoke streamlit CLI."""
+    """Running ``python -m trend_portfolio_app`` should invoke streamlit
+    CLI."""
 
     calls: list[list[str]] = []
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -125,7 +125,8 @@ class TestStreamlitProxy:
             importlib.import_module("trend_analysis.proxy.__main__")
 
     def test_proxy_main_entrypoint_executes(self, monkeypatch):
-        """Running ``python -m trend_analysis.proxy`` should invoke CLI main."""
+        """Running ``python -m trend_analysis.proxy`` should invoke CLI
+        main."""
 
         calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
 

--- a/tests/test_transaction_costs_and_turnover.py
+++ b/tests/test_transaction_costs_and_turnover.py
@@ -1,10 +1,12 @@
 from pathlib import Path
 
 import pandas as pd
+import pytest
 import yaml  # type: ignore[import-untyped]
 
 from trend_analysis.config import Config
 from trend_analysis.export import (combined_summary_result,
+                                   execution_metrics_frame,
                                    summary_frame_from_result)
 from trend_analysis.multi_period import run as run_mp
 
@@ -36,12 +38,22 @@ def test_period_results_include_turnover_and_cost():
     cfg = make_cfg()
     results = run_mp(cfg, df)
     assert results, "no results returned"
-    # Each period result should carry execution metrics
-    for res in results:
+    # Each period result should carry execution metrics with correct values
+    expected_turnover = [0.5, 0.0, 0.0, 0.0]
+    expected_cost = [0.0005, 0.0, 0.0, 0.0]
+    for res, to_exp, cost_exp in zip(results, expected_turnover, expected_cost):
         assert "turnover" in res
         assert "transaction_cost" in res
         assert isinstance(res["turnover"], float)
         assert isinstance(res["transaction_cost"], float)
+        assert res["turnover"] == pytest.approx(to_exp)
+        assert res["transaction_cost"] == pytest.approx(cost_exp)
+
+    # Export frame should reflect the same execution metrics
+    frame = execution_metrics_frame(results)
+    assert frame.shape[0] == len(results)
+    assert frame["Turnover"].tolist() == pytest.approx(expected_turnover)
+    assert frame["Transaction Cost"].tolist() == pytest.approx(expected_cost)
 
 
 def test_export_summary_schema_unchanged_and_metrics_available_elsewhere():

--- a/tests/test_transaction_costs_and_turnover.py
+++ b/tests/test_transaction_costs_and_turnover.py
@@ -39,7 +39,11 @@ def test_period_results_include_turnover_and_cost():
     results = run_mp(cfg, df)
     assert results, "no results returned"
     # Each period result should carry execution metrics with correct values
+    # Turnover is 0.5 in the first period because the portfolio is fully reallocated (max_turnover=0.5),
+    # and 0.0 in subsequent periods due to the threshold-hold policy (no further rebalancing).
     expected_turnover = [0.5, 0.0, 0.0, 0.0]
+    # Transaction cost is calculated as turnover * transaction_cost_rate (10 bps = 0.0010),
+    # so 0.5 * 0.0010 = 0.0005 in the first period, and 0.0 thereafter.
     expected_cost = [0.0005, 0.0, 0.0, 0.0]
     for res, to_exp, cost_exp in zip(results, expected_turnover, expected_cost):
         assert "turnover" in res


### PR DESCRIPTION
## Summary
- import pathlib Path and pytest utilities for turnover regression test
- assert exact turnover and transaction cost values for each period
- verify execution metrics export frame mirrors the expected series

## Testing
- PYTHONPATH=src pytest tests/test_transaction_costs_and_turnover.py

------
https://chatgpt.com/codex/tasks/task_e_68cad8a81fd883319b0377748bcef2cc