### PR TITLE
Add coverage-focused tests for config models

### DIFF
--- a/tests/test_config_models_additional.py
+++ b/tests/test_config_models_additional.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 from trend_analysis.config import models
 
@@ -27,13 +27,17 @@ def _base_config() -> dict[str, object]:
     }
 
 
-def test_column_mapping_defaults_and_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_column_mapping_defaults_and_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Exercise the ``ColumnMapping`` defaults and validation branches."""
 
     with pytest.raises(ValueError, match="Date column must be specified"):
         models.ColumnMapping(return_columns=["ret"])
 
-    with pytest.raises(ValueError, match="At least one return column must be specified"):
+    with pytest.raises(
+        ValueError, match="At least one return column must be specified"
+    ):
         models.ColumnMapping(date_column="Date")
 
     mapping = models.ColumnMapping(
@@ -65,7 +69,9 @@ def test_load_merges_output_section(tmp_path: Path) -> None:
     assert config.export["filename"] == export_target.name
 
 
-def test_load_uses_environment_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_uses_environment_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """When no path is provided, ``load`` should honour ``TREND_CFG``."""
 
     config_path = tmp_path / "custom.yml"
@@ -100,7 +106,9 @@ def test_list_available_presets_handles_missing_directory(
     assert models.list_available_presets() == []
 
 
-def test_preset_listing_and_loading(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_preset_listing_and_loading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Presets are discovered and loaded via ``_find_config_directory``."""
 
     config_dir = tmp_path / "cfg"
@@ -118,7 +126,9 @@ def test_preset_listing_and_loading(tmp_path: Path, monkeypatch: pytest.MonkeyPa
         "export": {},
         "run": {},
     }
-    (config_dir / "alpha.yml").write_text(yaml.safe_dump(preset_payload), encoding="utf-8")
+    (config_dir / "alpha.yml").write_text(
+        yaml.safe_dump(preset_payload), encoding="utf-8"
+    )
     (config_dir / "beta.yml").write_text("[]\n", encoding="utf-8")
 
     monkeypatch.setattr(models, "_find_config_directory", lambda: config_dir)

--- a/tests/test_config_models_additional.py
+++ b/tests/test_config_models_additional.py
@@ -1,0 +1,143 @@
+"""Additional tests for ``trend_analysis.config.models`` coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from trend_analysis.config import models
+
+
+def _base_config() -> dict[str, object]:
+    """Return a minimal configuration mapping accepted by ``models.Config``."""
+
+    return {
+        "version": "1.0",
+        "data": {},
+        "preprocessing": {},
+        "vol_adjust": {},
+        "sample_split": {},
+        "portfolio": {},
+        "benchmarks": {},
+        "metrics": {},
+        "export": {},
+        "run": {},
+    }
+
+
+def test_column_mapping_defaults_and_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise the ``ColumnMapping`` defaults and validation branches."""
+
+    with pytest.raises(ValueError, match="Date column must be specified"):
+        models.ColumnMapping(return_columns=["ret"])
+
+    with pytest.raises(ValueError, match="At least one return column must be specified"):
+        models.ColumnMapping(date_column="Date")
+
+    mapping = models.ColumnMapping(
+        date_column="Date",
+        return_columns=["ret"],
+        column_display_names=None,
+        column_tickers=None,
+    )
+
+    assert mapping.column_display_names == {}
+    assert mapping.column_tickers == {}
+
+
+def test_load_merges_output_section(tmp_path: Path) -> None:
+    """``load`` should fold ``output`` metadata into the export settings."""
+
+    export_target = tmp_path / "exports" / "report.xlsx"
+    config_dict = _base_config()
+    config_dict["export"] = {"formats": ("json",)}
+    config_dict["output"] = {
+        "format": ["CSV", "json", "csv"],
+        "path": str(export_target),
+    }
+
+    config = models.load(config_dict)
+
+    assert config.export["formats"] == ["json", "CSV"]
+    assert config.export["directory"] == str(export_target.parent)
+    assert config.export["filename"] == export_target.name
+
+
+def test_load_uses_environment_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When no path is provided, ``load`` should honour ``TREND_CFG``."""
+
+    config_path = tmp_path / "custom.yml"
+    payload = _base_config()
+    payload["version"] = "from-env"
+    config_path.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    monkeypatch.setenv("TREND_CFG", str(config_path))
+    try:
+        config = models.load()
+    finally:
+        monkeypatch.delenv("TREND_CFG", raising=False)
+
+    assert config.version == "from-env"
+
+
+def test_load_config_rejects_invalid_type() -> None:
+    """``load_config`` only accepts mappings or path-like objects."""
+
+    with pytest.raises(TypeError, match="cfg must be a mapping or path"):
+        models.load_config(123)  # type: ignore[arg-type]
+
+
+def test_list_available_presets_handles_missing_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing config directory should return an empty preset list."""
+
+    missing = tmp_path / "not_there"
+    monkeypatch.setattr(models, "_find_config_directory", lambda: missing)
+
+    assert models.list_available_presets() == []
+
+
+def test_preset_listing_and_loading(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Presets are discovered and loaded via ``_find_config_directory``."""
+
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    (config_dir / "defaults.yml").write_text("version: default\n", encoding="utf-8")
+
+    preset_payload = {
+        "description": "demo",
+        "data": {},
+        "preprocessing": {},
+        "vol_adjust": {},
+        "sample_split": {},
+        "portfolio": {},
+        "metrics": {},
+        "export": {},
+        "run": {},
+    }
+    (config_dir / "alpha.yml").write_text(yaml.safe_dump(preset_payload), encoding="utf-8")
+    (config_dir / "beta.yml").write_text("[]\n", encoding="utf-8")
+
+    monkeypatch.setattr(models, "_find_config_directory", lambda: config_dir)
+
+    assert models.list_available_presets() == ["alpha", "beta"]
+
+    preset = models.load_preset("alpha")
+    assert preset.name == "alpha"
+    assert preset.description == "demo"
+
+    with pytest.raises(TypeError, match="Preset file must contain a mapping"):
+        models.load_preset("beta")
+
+
+def test_load_raises_for_non_mapping_file(tmp_path: Path) -> None:
+    """``load`` should reject YAML files that do not contain mappings."""
+
+    cfg_file = tmp_path / "bad.yml"
+    cfg_file.write_text("- not-a-mapping\n", encoding="utf-8")
+
+    with pytest.raises(TypeError, match="Config file must contain a mapping"):
+        models.load(cfg_file)

--- a/tests/test_export_formatter.py
+++ b/tests/test_export_formatter.py
@@ -155,7 +155,9 @@ def test_make_summary_formatter_writes_manager_contrib(
         row == ["Manager Participation & Contribution"] for row in headers
     ), "Expected contribution section header"
     contrib_headers = [
-        row for row in headers if row == ["Manager", "Years", "OOS CAGR", "Contribution Share"]
+        row
+        for row in headers
+        if row == ["Manager", "Years", "OOS CAGR", "Contribution Share"]
     ]
     assert contrib_headers, "Expected contribution column headers"
 

--- a/tests/test_policy_engine_cov.py
+++ b/tests/test_policy_engine_cov.py
@@ -146,7 +146,8 @@ def test_decide_hires_fires_turnover_budget_prioritises(monkeypatch):
 
 
 def test_decide_hires_fires_turnover_budget_mixed_moves(monkeypatch):
-    """Turnover gating should compare hires and fires and keep the best move."""
+    """Turnover gating should compare hires and fires and keep the best
+    move."""
 
     score_frame = pd.DataFrame(
         {"m": [4.0, 3.0, -2.0]}, index=["hire1", "hire2", "drop"]

--- a/tests/test_portfolio_app_io_utils.py
+++ b/tests/test_portfolio_app_io_utils.py
@@ -7,8 +7,6 @@ import sys
 import zipfile
 from types import ModuleType
 
-import pytest
-
 from trend_portfolio_app import io_utils
 
 
@@ -114,7 +112,8 @@ def test_cleanup_temp_files_handles_missing_files(tmp_path):
 
 
 def test_portfolio_app_main_invokes_streamlit(monkeypatch):
-    """Running ``python -m trend_portfolio_app`` should invoke streamlit CLI."""
+    """Running ``python -m trend_portfolio_app`` should invoke streamlit
+    CLI."""
 
     calls: list[list[str]] = []
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -125,7 +125,8 @@ class TestStreamlitProxy:
             importlib.import_module("trend_analysis.proxy.__main__")
 
     def test_proxy_main_entrypoint_executes(self, monkeypatch):
-        """Running ``python -m trend_analysis.proxy`` should invoke CLI main."""
+        """Running ``python -m trend_analysis.proxy`` should invoke CLI
+        main."""
 
         calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
 


### PR DESCRIPTION
## Summary
- add configuration model regression tests covering ColumnMapping validation and defaults
- exercise load() output merging, environment overrides, preset discovery, and error paths
- ensure config coverage rises by verifying non-mapping inputs raise expected exceptions

## Testing
- ./scripts/run_tests.sh


------
https://chatgpt.com/codex/tasks/task_e_68cad94632648331afc721eed6ed90f6