### PR TITLE
Expand Streamlit run page coverage

### DIFF
--- a/tests/test_streamlit_run_page_new.py
+++ b/tests/test_streamlit_run_page_new.py
@@ -167,7 +167,8 @@ def test_main_runs_and_surfaces_fallback(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 def test_main_handles_non_iterable_session_state() -> None:
-    """The page should fall back to attribute access when session_state misbehaves."""
+    """The page should fall back to attribute access when session_state
+    misbehaves."""
 
     class NonIterableState:
         def __init__(self, returns_df: pd.DataFrame, sim_config: dict[str, object]):
@@ -228,7 +229,8 @@ def test_main_handles_non_iterable_session_state() -> None:
 
 
 def test_main_uses_default_weighting_when_portfolio_missing() -> None:
-    """cfg_get should fall back to defaults when both get and item access fail."""
+    """cfg_get should fall back to defaults when both get and item access
+    fail."""
 
     class PortfolioFault(dict):
         def get(self, key: str, default: object | None = None) -> object | None:

--- a/tests/test_streamlit_run_page_new.py
+++ b/tests/test_streamlit_run_page_new.py
@@ -164,3 +164,144 @@ def test_main_runs_and_surfaces_fallback(monkeypatch: pytest.MonkeyPatch) -> Non
     mock_st.warning.assert_called()
     mock_st.success.assert_called_with("Done.")
     mock_st.write.assert_called_with("Summary:", result.metrics)
+
+
+def test_main_handles_non_iterable_session_state() -> None:
+    """The page should fall back to attribute access when session_state misbehaves."""
+
+    class NonIterableState:
+        def __init__(self, returns_df: pd.DataFrame, sim_config: dict[str, object]):
+            self._store: dict[str, object] = {
+                "returns_df": returns_df,
+                "sim_config": sim_config,
+            }
+
+        def __contains__(self, key: object) -> bool:
+            raise TypeError("session_state is not iterable")
+
+        def get(self, key: str, default: object | None = None) -> object | None:
+            if key in {"returns_df", "sim_config"}:
+                raise TypeError("pretend streamlit broke")
+            return self._store.get(key, default)
+
+        def __getattr__(self, name: str) -> object:
+            try:
+                return self._store[name]
+            except KeyError as exc:  # pragma: no cover - defensive
+                raise AttributeError(name) from exc
+
+        def __setitem__(self, key: str, value: object) -> None:
+            self._store[key] = value
+
+        def __getitem__(self, key: str) -> object:
+            return self._store[key]
+
+    mock_st = _make_streamlit(button_response=True)
+    module = _load_run_module(mock_st)
+
+    returns = pd.DataFrame(
+        {"A": [0.1, 0.2]}, index=pd.to_datetime(["2021-01-31", "2021-02-28"])
+    )
+    config_dict = {
+        "start": pd.Timestamp("2021-01-31"),
+        "end": pd.Timestamp("2021-02-28"),
+        "lookback_months": "2",
+        "risk_target": 0.7,
+        "portfolio": {"weighting_scheme": "equal"},
+    }
+    mock_st.session_state = NonIterableState(returns, config_dict)
+
+    module.show_disclaimer = lambda: True
+    config_instance = MagicMock()
+    module.Config = MagicMock(return_value=config_instance)
+    result = SimpleNamespace(metrics={}, fallback_info=None)
+    module.run_simulation = MagicMock(return_value=result)
+
+    with patch.dict("sys.modules", {"streamlit": mock_st}):
+        module.main()
+
+    module.Config.assert_called_once()
+    module.run_simulation.assert_called_once_with(config_instance, ANY)
+    mock_st.progress.return_value.progress.assert_called_with(100)
+    assert mock_st.session_state["sim_results"] is result
+    mock_st.error.assert_not_called()
+
+
+def test_main_uses_default_weighting_when_portfolio_missing() -> None:
+    """cfg_get should fall back to defaults when both get and item access fail."""
+
+    class PortfolioFault(dict):
+        def get(self, key: str, default: object | None = None) -> object | None:
+            if key == "portfolio":
+                raise RuntimeError("broken mapping")
+            return super().get(key, default)
+
+        def __getitem__(self, key: str) -> object:
+            if key == "portfolio":
+                raise KeyError(key)
+            return super().__getitem__(key)
+
+    mock_st = _make_streamlit(button_response=True)
+    module = _load_run_module(mock_st)
+
+    mock_cfg = PortfolioFault(
+        {
+            "start": pd.Timestamp("2022-01-31"),
+            "end": pd.Timestamp("2022-03-31"),
+            "lookback_months": 3,
+            "risk_target": 1.1,
+        }
+    )
+    mock_returns = pd.DataFrame(
+        {"A": [0.05, -0.02]}, index=pd.to_datetime(["2021-12-31", "2022-01-31"])
+    )
+    mock_st.session_state.update({"returns_df": mock_returns, "sim_config": mock_cfg})
+
+    module.show_disclaimer = lambda: True
+    config_instance = MagicMock()
+    module.Config = MagicMock(return_value=config_instance)
+    result = SimpleNamespace(metrics={}, fallback_info=None)
+    module.run_simulation = MagicMock(return_value=result)
+
+    with patch.dict("sys.modules", {"streamlit": mock_st}):
+        module.main()
+
+    _, kwargs = module.Config.call_args
+    assert kwargs["portfolio"] == {"weighting_scheme": "equal"}
+    module.run_simulation.assert_called_once_with(config_instance, ANY)
+    mock_st.success.assert_called_once_with("Done.")
+
+
+def test_main_dismisses_weight_engine_warning() -> None:
+    """Clicking the dismiss button should set state and rerun the app."""
+
+    mock_st = _make_streamlit()
+    mock_st.button.side_effect = [True, True]
+    module = _load_run_module(mock_st)
+
+    mock_cfg = {
+        "start": pd.Timestamp("2020-01-31"),
+        "end": pd.Timestamp("2020-02-29"),
+        "lookback_months": 1,
+        "risk_target": 0.4,
+        "portfolio": {"weighting_scheme": "equal"},
+    }
+    mock_returns = pd.DataFrame(
+        {"A": [0.1, -0.1]}, index=pd.to_datetime(["2020-01-31", "2020-02-29"])
+    )
+    mock_st.session_state.update({"returns_df": mock_returns, "sim_config": mock_cfg})
+
+    module.show_disclaimer = lambda: True
+    config_instance = MagicMock()
+    module.Config = MagicMock(return_value=config_instance)
+    result = SimpleNamespace(
+        metrics={},
+        fallback_info={"engine": "ERC", "error_type": "Failure"},
+    )
+    module.run_simulation = MagicMock(return_value=result)
+
+    with patch.dict("sys.modules", {"streamlit": mock_st}):
+        module.main()
+
+    assert mock_st.session_state["dismiss_weight_engine_fallback"] is True
+    mock_st.rerun.assert_called_once()


### PR DESCRIPTION
## Summary
- add regression tests for the Streamlit run page to exercise non-iterable session_state handling
- verify cfg_get fallback behaviour when portfolio settings are missing
- assert the weight-engine fallback banner can be dismissed and triggers rerun

## Testing
- ./scripts/run_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68caed4bb1c48331a2d0e56c4c4a1470