### PR TITLE
docs: second auto-merge smoke test (docs-only)

### DIFF
--- a/docs/ops/smoke-automerge-2.md
+++ b/docs/ops/smoke-automerge-2.md
@@ -1,0 +1,8 @@
+# Auto-merge Smoke Test 2
+
+This second smoke test file is used to validate that labeler → auto-approve → enable-automerge still function after recent fixes.
+
+Expectations:
+- Branch naming (agents/codex-*) triggers from:codex + agent:codex + automerge + risk:low labels.
+- Auto-approve approves this docs-only PR.
+- Enable auto-merge enables squash merging and merges once checks pass.


### PR DESCRIPTION
Second iteration to validate stable labeler → auto-approve → enable-automerge chain after workflow/test fixes.\n\n- Branch prefix triggers codex labels automatically\n- docs/** only change\n- Expect auto-approve + auto-merge to complete once checks are green.