### PR TITLE
test: improve weighting branch coverage

### DIFF
--- a/tests/test_robust_weighting.py
+++ b/tests/test_robust_weighting.py
@@ -345,7 +345,9 @@ class TestRobustWeightingBranchCoverage:
             engine.weight(cov)
 
     def test_risk_parity_zero_variance_fallback(self):
-        cov = pd.DataFrame(np.zeros((3, 3)), index=["a", "b", "c"], columns=["a", "b", "c"])
+        cov = pd.DataFrame(
+            np.zeros((3, 3)), index=["a", "b", "c"], columns=["a", "b", "c"]
+        )
         engine = rw.RobustRiskParity()
         weights = engine.weight(cov)
         assert pytest.approx(weights.sum()) == 1.0

--- a/tests/test_robust_weighting.py
+++ b/tests/test_robust_weighting.py
@@ -5,8 +5,10 @@ import logging
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from trend_analysis.plugins import create_weight_engine
+from trend_analysis.weights import robust_weighting as rw
 
 
 def create_well_conditioned_cov():
@@ -286,6 +288,80 @@ class TestShrinkageFunctions:
 
         # Diagonal elements should be larger
         assert (np.diag(loaded_cov) >= np.diag(cov)).all()
+
+
+class TestRobustWeightingBranchCoverage:
+    def test_ledoit_wolf_zero_trace_intensity(self):
+        cov = np.zeros((2, 2))
+        shrunk, intensity = rw.ledoit_wolf_shrinkage(cov)
+        assert intensity == pytest.approx(1.0)
+        assert np.allclose(shrunk, np.zeros_like(cov))
+
+    def test_oas_zero_trace_intensity(self):
+        cov = np.zeros((3, 3))
+        shrunk, intensity = rw.oas_shrinkage(cov)
+        assert intensity == pytest.approx(1.0)
+        assert np.allclose(shrunk, np.zeros_like(cov))
+
+    def test_robust_mv_unknown_shrinkage(self):
+        cov = pd.DataFrame(np.eye(2), index=["a", "b"], columns=["a", "b"])
+        engine = rw.RobustMeanVariance(shrinkage_method="mystery")
+        with pytest.raises(ValueError, match="Unknown shrinkage method"):
+            engine.weight(cov)
+
+    def test_robust_mv_unknown_safe_mode(self):
+        cov = create_ill_conditioned_cov()
+        engine = rw.RobustMeanVariance(
+            safe_mode="mystery", condition_threshold=1.0, shrinkage_method="none"
+        )
+        with pytest.raises(ValueError, match="Unknown safe mode"):
+            engine.weight(cov)
+
+    def test_robust_mv_non_square_matrix(self):
+        cov = pd.DataFrame(
+            [[0.1, 0.02], [0.02, 0.1]], index=["a", "b"], columns=["a", "c"]
+        )
+        engine = rw.RobustMeanVariance()
+        with pytest.raises(ValueError, match="Covariance matrix must be square"):
+            engine.weight(cov)
+
+    def test_robust_mv_singular_fallback_to_equal_weights(self):
+        cov = create_singular_cov()
+        engine = rw.RobustMeanVariance(
+            shrinkage_method="none",
+            condition_threshold=float("inf"),
+            min_weight=0.0,
+        )
+        weights = engine.weight(cov)
+        assert pytest.approx(weights.sum()) == 1.0
+        assert np.allclose(weights.values, np.repeat(1 / len(cov), len(cov)))
+
+    def test_risk_parity_non_square_matrix(self):
+        cov = pd.DataFrame(
+            [[0.05, 0.01], [0.01, 0.04]], index=["a", "b"], columns=["a", "c"]
+        )
+        engine = rw.RobustRiskParity()
+        with pytest.raises(ValueError, match="Covariance matrix must be square"):
+            engine.weight(cov)
+
+    def test_risk_parity_zero_variance_fallback(self):
+        cov = pd.DataFrame(np.zeros((3, 3)), index=["a", "b", "c"], columns=["a", "b", "c"])
+        engine = rw.RobustRiskParity()
+        weights = engine.weight(cov)
+        assert pytest.approx(weights.sum()) == 1.0
+        assert np.allclose(weights.values, np.repeat(1 / len(cov), len(cov)))
+
+    def test_risk_parity_invalid_inverse_sum(self, monkeypatch):
+        cov = create_well_conditioned_cov()
+        engine = rw.RobustRiskParity()
+
+        def fake_reciprocal(values):
+            return np.full(values.shape, np.nan)
+
+        monkeypatch.setattr(rw.np, "reciprocal", fake_reciprocal)
+        weights = engine.weight(cov)
+        assert pytest.approx(weights.sum()) == 1.0
+        assert np.allclose(weights.values, np.repeat(1 / len(cov), len(cov)))
 
 
 class TestSyntheticNearSingularCases:

--- a/tests/test_weighting_edges.py
+++ b/tests/test_weighting_edges.py
@@ -2,8 +2,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from trend_analysis.weighting import (AdaptiveBayesWeighting, EqualWeight,
-                                      ScorePropBayesian, ScorePropSimple)
+from trend_analysis.weighting import (AdaptiveBayesWeighting, BaseWeighting,
+                                      EqualWeight, ScorePropBayesian,
+                                      ScorePropSimple)
 
 
 def make_df() -> pd.DataFrame:
@@ -14,6 +15,15 @@ def test_equal_weight_empty():
     df = pd.DataFrame(columns=["Sharpe"])
     out = EqualWeight().weight(df)
     assert out.empty
+
+
+def test_base_weighting_is_abstract():
+    class Dummy(BaseWeighting):
+        pass
+
+    dummy = Dummy()
+    with pytest.raises(NotImplementedError):
+        dummy.weight(pd.DataFrame())
 
 
 def test_scoreprop_simple_missing_column():
@@ -66,6 +76,34 @@ def test_adaptive_bayes_weight_caps_and_state_roundtrip():
     # Round-trip state serialization keeps the most recent posterior.
     new_state = weighting.get_state()
     assert new_state["mean"]["A"] == pytest.approx(state["mean"]["A"])
+
+
+def test_adaptive_bayes_cap_renormalise_when_no_room():
+    weighting = AdaptiveBayesWeighting(max_w=0.3)
+    weighting.set_state(
+        {
+            "mean": {"A": 2.0, "B": 2.0, "C": 2.0},
+            "tau": {"A": 1.0, "B": 1.0, "C": 1.0},
+        }
+    )
+    df = pd.DataFrame(index=["A", "B", "C"])
+    out = weighting.weight(df)
+    assert pytest.approx(out["weight"].sum(), rel=1e-6) == 1.0
+    # With every asset at the cap, the implementation renormalises weights so
+    # the portfolio still sums to one.
+    assert out["weight"].max() > 0.3
+    assert pytest.approx(out["weight"].max(), rel=1e-6) == pytest.approx(1 / 3)
+
+
+def test_adaptive_bayes_adds_new_assets():
+    weighting = AdaptiveBayesWeighting(max_w=None)
+    weighting.update(pd.Series({"A": 1.0, "B": 0.5}), days=30)
+    # Introduce a new asset "C" not seen during the update
+    df = pd.DataFrame(index=["A", "B", "C"])
+    out = weighting.weight(df)
+    assert "C" in out.index
+    # Newly added asset receives a finite non-negative weight
+    assert out.loc["C", "weight"] >= 0.0
 
 
 def test_adaptive_bayes_update_without_half_life_decay():


### PR DESCRIPTION
## Summary
- add unit tests for BaseWeighting and AdaptiveBayesWeighting edge conditions
- exercise robust mean-variance and risk parity error handling and fallback paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb9b5833948331a8e2504d665d0847