### PR TITLE
Docker smoke: buildx cache + 10‑minute timeout - Source Issue #1153

### DIFF
--- a/agents/codex-1153.md
+++ b/agents/codex-1153.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1153 -->


### PR DESCRIPTION
### Source Issue #1153: Docker smoke: buildx cache + 10‑minute timeout

Source: https://github.com/stranske/Trend_Model_Project/issues/1153

> Docker smoke: buildx cache + 10‑minute timeout
> 
> Labels: agent:codex
> Why: Reduce flaky, slow image pulls.
> Tasks
> 
> Use buildx with a cache keyed on Dockerfile + requirements.lock.
> 
> Add --pull and a 10‑minute timeout-minutes on the smoke job.
> Acceptance criteria
> 
> Smoke job completes consistently under timeout; cache hits visible in logs.

—
(After opening the PR, comment with `@codex start`.)