### PR TITLE
Fix weighting edge tests imports

### DIFF
--- a/tests/test_weighting_edges.py
+++ b/tests/test_weighting_edges.py
@@ -2,7 +2,13 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from trend_analysis.weighting import EqualWeight, ScorePropBayesian, ScorePropSimple
+from trend_analysis.weighting import (
+    AdaptiveBayesWeighting,
+    BaseWeighting,
+    EqualWeight,
+    ScorePropBayesian,
+    ScorePropSimple,
+)
 
 
 def make_df() -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- import BaseWeighting and AdaptiveBayesWeighting in the weighting edge tests

## Testing
- pytest tests/test_weighting_edges.py

------
https://chatgpt.com/codex/tasks/task_e_68cbaed193488331acefacec8df9a6b0