### PR TITLE
Surface CovCache statistics in CLI output

### DIFF
--- a/agents/codex-1161.md
+++ b/agents/codex-1161.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1161 -->

--- a/docs/phase-2/performance_cache.md
+++ b/docs/phase-2/performance_cache.md
@@ -56,6 +56,10 @@ All operations O(k^2) vs. O(n k^2) full recompute.
 
 `multi_period.engine` attaches an experimental `cov_diag` per result when `performance.enable_cache` is true. If `incremental_cov` is enabled and the new window is a one-step slide with identical universe and length, it applies `incremental_cov_update`; otherwise it falls back to full payload construction.
 
+## CLI Observability
+
+The `trend-model run` CLI now surfaces the cache counters at the end of a run whenever a stats payload is present.  Users will see a short block summarising the number of cache entries along with hit/miss and incremental-update totals.  Structured JSONL logging emits a dedicated `{ "event": "cache_stats", ... }` record so automation can track the same values without scraping stdout.
+
 ## Testing
 
 `tests/test_perf_cache.py` verifies:

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -24,11 +24,14 @@ LOCK_PATH = Path(__file__).resolve().parents[2] / "requirements.lock"
 def _extract_cache_stats(payload: object) -> dict[str, int] | None:
     """Return the most recent cache statistics embedded in ``payload``.
 
-    Walks nested mappings / sequences looking for dictionaries that carry the
-    four integer fields emitted by ``CovCache.stats``.  The multi-period engine
-    records a snapshot after every period, so the **last** occurrence reflects
-    the final counters that users care about.  Traversal intentionally skips
-    pandas and NumPy containers to avoid expensive recursion through frames.
+    Walks nested mappings and sequences looking for dictionaries that carry
+    four integer fields: ``entries``, ``hits``, ``misses``, and ``incremental_updates``.
+    These fields represent cache usage and performance counters during multi-period
+    trend analysis, such as the number of cache entries, cache hits, cache misses,
+    and incremental updates performed. The multi-period engine records a snapshot
+    after every period, so the **last** occurrence reflects the final counters
+    relevant to the analysis. Traversal intentionally skips pandas and NumPy
+    containers to avoid expensive recursion through frames.
     """
 
     required = ("entries", "hits", "misses", "incremental_updates")

--- a/tests/test_cli_cache_stats.py
+++ b/tests/test_cli_cache_stats.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+
+from trend_analysis.api import RunResult
+
+
+def test_cli_emits_cache_stats(monkeypatch, capsys, tmp_path):
+    from trend_analysis import cli
+
+    csv_path = tmp_path / "data.csv"
+    df = pd.DataFrame(
+        {
+            "Date": pd.date_range("2020-01-31", periods=4, freq="ME"),
+            "A": 0.01,
+            "B": 0.02,
+        }
+    )
+    df.to_csv(csv_path, index=False)
+
+    cfg = SimpleNamespace(
+        sample_split={
+            "in_start": "2020-01",
+            "in_end": "2020-02",
+            "out_start": "2020-03",
+            "out_end": "2020-04",
+        },
+        export={"directory": "ignored", "formats": []},
+        vol_adjust={},
+        portfolio={},
+        benchmarks={},
+        metrics={},
+        run={},
+        seed=7,
+    )
+
+    monkeypatch.setattr(cli, "load_config", lambda path: cfg)
+    monkeypatch.setattr(cli, "load_csv", lambda path: df.copy())
+
+    log_calls: list[tuple[str, str, str, dict[str, object]]] = []
+
+    def fake_log_step(run_id, step, message, level="INFO", **extra):
+        log_calls.append((run_id, step, message, extra))
+
+    from trend_analysis import logging as run_logging
+
+    monkeypatch.setattr(run_logging, "log_step", fake_log_step)
+    monkeypatch.setattr(run_logging, "init_run_logger", lambda run_id, path: None)
+    monkeypatch.setattr(
+        run_logging, "get_default_log_path", lambda run_id: tmp_path / "log.jsonl"
+    )
+    monkeypatch.setattr(cli.export, "format_summary_text", lambda *args, **kwargs: "summary")
+    monkeypatch.setattr(cli.export, "export_to_excel", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli.export, "export_data", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli.export, "make_summary_formatter", lambda *args, **kwargs: lambda *a, **k: None)
+
+    run_result = RunResult(
+        metrics=pd.DataFrame({"metric": [1.0]}),
+        details={
+            "something": [
+                {
+                    "cache_stats": {
+                        "entries": 2,
+                        "hits": 5,
+                        "misses": 1,
+                        "incremental_updates": 3,
+                    }
+                }
+            ]
+        },
+        seed=7,
+        environment={"python": "3.11", "numpy": "1.26", "pandas": "2.2"},
+    )
+
+    monkeypatch.setattr(cli, "run_simulation", lambda *args, **kwargs: run_result)
+
+    rc = cli.main([
+        "run",
+        "-c",
+        str(tmp_path / "cfg.yml"),
+        "-i",
+        str(csv_path),
+    ])
+
+    assert rc == 0
+
+    captured = capsys.readouterr()
+    assert "Cache statistics:" in captured.out
+    assert "Entries: 2" in captured.out
+    assert "Incremental updates: 3" in captured.out
+
+    cache_events = [call for call in log_calls if call[1] == "cache_stats"]
+    assert cache_events, "expected cache_stats log_step call"
+    event_payload = cache_events[-1][3]
+    assert event_payload["event"] == "cache_stats"
+    assert event_payload["entries"] == 2
+    assert event_payload["hits"] == 5
+    assert event_payload["misses"] == 1
+    assert event_payload["incremental_updates"] == 3


### PR DESCRIPTION
## Summary
- extract CovCache statistics from nested run results and print a cache summary at the end of `trend-model run`
- emit a structured `cache_stats` log event when structured logging is enabled
- document the new observability path and cover it with a CLI unit test that inspects stdout and structured log payloads

## Testing
- pytest tests/test_cli_cache_stats.py

------
https://chatgpt.com/codex/tasks/task_e_68cbade690708331abe9889456c809cf