### PR TITLE
Fix type checks for multi-period engine debug test

### DIFF
--- a/tests/test_multi_period_engine_debug.py
+++ b/tests/test_multi_period_engine_debug.py
@@ -26,10 +26,11 @@ class SequenceWeighting:
     sequences: Tuple[Dict[str, float], ...]
     _idx: int = 0
 
-    def update(self, scores: pd.Series, days: int) -> None:  # pragma: no cover - hook for protocol
+    def update(self, scores: pd.Series, days: int = 30) -> None:  # pragma: no cover - hook for protocol
         # The engine will call update when rank_column is present. The sequence
         # weighting used in this test is deterministic and state free, so we do
         # not need to adjust any internal state here.
+        pass
 
     def weight(self, selected: pd.DataFrame) -> pd.DataFrame:
         weights = self.sequences[self._idx]
@@ -57,13 +58,14 @@ def test_run_schedule_turnover_debug_validation(monkeypatch: pytest.MonkeyPatch)
 
     monkeypatch.setenv("DEBUG_TURNOVER_VALIDATE", "1")
 
-    portfolio = run_schedule(score_frames, selector, weighting, rank_column="Sharpe")
+    try:
+        portfolio = run_schedule(score_frames, selector, weighting, rank_column="Sharpe")
 
-    # Ensure the debug validator populated history and turnover for each period.
-    assert isinstance(portfolio, Portfolio)
-    assert set(portfolio.history) == {"2020-01-31", "2020-02-29"}
-    assert set(portfolio.turnover) == {"2020-01-31", "2020-02-29"}
-    # The second period should see turnover from introducing FundC while FundA is removed.
-    assert portfolio.turnover["2020-02-29"] > 0.0
-
-    monkeypatch.delenv("DEBUG_TURNOVER_VALIDATE")
+        # Ensure the debug validator populated history and turnover for each period.
+        assert isinstance(portfolio, Portfolio)
+        assert set(portfolio.history) == {"2020-01-31", "2020-02-29"}
+        assert set(portfolio.turnover) == {"2020-01-31", "2020-02-29"}
+        # The second period should see turnover from introducing FundC while FundA is removed.
+        assert portfolio.turnover["2020-02-29"] > 0.0
+    finally:
+        monkeypatch.delenv("DEBUG_TURNOVER_VALIDATE", raising=False)


### PR DESCRIPTION
## Summary
- update the test SequenceWeighting helper to accept an optional days argument and add a no-op body for type checking
- guard the debug environment variable cleanup with a finally block so teardown runs even on failure

## Testing
- mypy tests/test_multi_period_engine_debug.py
- pytest tests/test_multi_period_engine_debug.py

------
https://chatgpt.com/codex/tasks/task_e_68cbb4dc68048331ae76903eb1554868