### PR TITLE
Issue/PR labeler and forms mapping - follow-up adjustments

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_codex.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_codex.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Something broke. Keep it factual.
-labels: ["type:bug","codex-ready"]
+labels: ["type:bug","codex-ready","risk:low"]
 body:
   - type: input
     id: env
@@ -19,3 +19,18 @@ body:
         1.
         2.
         3.
+  - type: dropdown
+    id: labels
+    attributes:
+      label: Routing
+      description: "Pick who should handle this issue. `risk:low` is added automatically."
+      default: agent:codex
+      options:
+        - label: 🤖 Codex (default)
+          value: agent:codex
+        - label: 🤖 Copilot
+          value: agent:copilot
+        - label: 🙋 Human maintainer
+          value: agent:human
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request_codex.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_codex.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Small, single-scope feature for the Streamlit app or sim layer
-labels: ["type:feature","codex-ready"]
+labels: ["type:feature","codex-ready","risk:low"]
 body:
   - type: textarea
     id: summary
@@ -19,5 +19,20 @@ body:
         - [ ] A
         - [ ] B
         - [ ] C
+    validations:
+      required: true
+  - type: dropdown
+    id: labels
+    attributes:
+      label: Routing
+      description: "Pick who should handle this issue. `risk:low` is added automatically."
+      default: agent:codex
+      options:
+        - label: 🤖 Codex (default)
+          value: agent:codex
+        - label: 🤖 Copilot
+          value: agent:copilot
+        - label: 🙋 Human maintainer
+          value: agent:human
     validations:
       required: true

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,25 @@
+# Maps repository paths to pull request labels so automation can triage changes.
+# The labels referenced here should already exist in the repository.
+'component:app':
+  - "streamlit_app/**"
+  - "app/**"
+'component:core':
+  - "src/**"
+  - "tools/**"
+  - "scripts/**"
+'component:config':
+  - "config/**"
+  - "*.toml"
+  - "*.ini"
+'component:ci':
+  - ".github/workflows/**"
+  - ".github/*.yml"
+  - ".github/*.yaml"
+'component:docs':
+  - "docs/**"
+  - "README*.md"
+  - "**/README.md"
+'component:tests':
+  - "tests/**"
+  - "test_*.py"
+  - "**/test_*.py"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,20 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply path-based labels
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/pr-labeler.yml
+          sync-labels: false


### PR DESCRIPTION
### Summary
- ensure the issue templates default to `risk:low` and require an agent routing choice
- add a path-based pull-request labeler configuration and workflow so PRs get triaged automatically

### Testing
- not run (config-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cbb7ac0bc88331a03cd985f3d99b0b