### PR TITLE
Codex bootstrap for #1160

### DIFF
--- a/agents/codex-1160.md
+++ b/agents/codex-1160.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1160 -->


### PR DESCRIPTION
### Source Issue #1160: Export: populate real IS/OS AvgCorr values

Source: https://github.com/stranske/Trend_Model_Project/issues/1160

> ### Context\nSummary export optionally adds IS/OS AvgCorr columns but they are placeholders (NA). Need actual average pairwise correlation per fund (or portfolio-level depending on design).\n\n### Goal\nCompute and surface AvgCorr values in exports when metric computed during run, without breaking default column ordering when absent.\n\n### Tasks\n- Decide granularity: current design implies per-fund; confirm/implement.\n- Extend stats capture to store AvgCorr (IS/OS).\n- Update summary_frame_from_result to insert numeric values instead of NA.\n- Golden test with expected AvgCorr values for synthetic data.\n- Backwards compatibility test (no columns when not computed).\n\n### Acceptance Criteria\n- AvgCorr appears only when user requested via extra_metrics or config flag.\n- Values match manual correlation computation (tolerance 1e-12).\n- No regression in existing summary tests.\n\n### Out of Scope\nRolling window meta-averages beyond existing period definition.\n\n### Follow-Up\nOptionally expose portfolio-level average correlation row.

—
PR created automatically to engage Codex.