### PR TITLE
Add selector metric bundle cache for rank selection

### DIFF
--- a/src/trend_analysis/core/rank_selection.py
+++ b/src/trend_analysis/core/rank_selection.py
@@ -11,11 +11,13 @@ by metrics registered in `METRIC_REGISTRY`. Metrics listed in
 # =============================================================================
 from __future__ import annotations
 
+import hashlib
 import io
+import json
 import re
 from contextvars import ContextVar
-from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Iterable, List, cast, TYPE_CHECKING
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, cast
 
 import ipywidgets as widgets
 import numpy as np
@@ -99,6 +101,9 @@ def rank_select_funds(
     zscore_ddof: int = 1,
     rank_pct: float = 0.5,
     limit_one_per_firm: bool = True,
+    window_key: WindowKey | None = None,
+    bundle: WindowMetricBundle | None = None,
+    enable_cache: bool = True,
 ) -> list[str]:
     """Select funds based on ranking by a specified metric."""
 
@@ -107,6 +112,8 @@ def rank_select_funds(
         transform = transform_mode
 
     metric_name = _METRIC_ALIASES.get(score_by, score_by)
+
+    active_bundle = _resolve_bundle(window_key, bundle, enable_cache)
 
     # Normalise column labels early so downstream logic never sees blank names.
     # ``rank_select_funds`` historically received DataFrames with accidental
@@ -138,11 +145,16 @@ def rank_select_funds(
     if metric_name == "blended":
         if blended_weights is None:
             raise ValueError("blended score requires blended_weights parameter")
-        scores = blended_score(df, blended_weights, cfg)
+        scores = blended_score(
+            df, blended_weights, cfg, bundle=active_bundle
+        )
     else:
-        scores = _compute_metric_series(df, metric_name, cfg)
+        scores = _get_metric_series_cached(
+            metric_name, df, cfg, active_bundle
+        )
 
     # Apply transform
+    scores = scores.copy()
     scores = _apply_transform(
         scores,
         mode=transform,
@@ -307,6 +319,102 @@ METRIC_REGISTRY: Dict[str, Callable[..., float | pd.Series | np.floating]] = {}
 _METRIC_CONTEXT: ContextVar[dict[str, Any] | None] = ContextVar(
     "_TREND_METRIC_CONTEXT", default=None
 )
+
+WindowKey = tuple[str, str, int, int]
+
+
+@dataclass
+class WindowMetricBundle:
+    """Cached metric series and covariance payload for a window."""
+
+    key: WindowKey
+    metrics: Dict[str, pd.Series] = field(default_factory=dict)
+    cov_payload: "CovPayload | None" = None
+
+    def as_frame(self) -> pd.DataFrame:
+        """Materialise cached metrics as a DataFrame."""
+
+        if not self.metrics:
+            return pd.DataFrame()
+        return pd.DataFrame(self.metrics)
+
+    def available_metrics(self) -> list[str]:
+        """Return the metric names stored in this bundle."""
+
+        return list(self.metrics.keys())
+
+
+selector_cache_hits = 0
+selector_cache_misses = 0
+_WINDOW_METRIC_CACHE: Dict[WindowKey, WindowMetricBundle] = {}
+
+
+def _stats_cfg_hash(stats_cfg: RiskStatsConfig) -> int:
+    """Stable hash for a :class:`RiskStatsConfig` instance."""
+
+    payload = json.dumps(asdict(stats_cfg), sort_keys=True)
+    digest = hashlib.sha256(payload.encode("utf-8")).digest()[:8]
+    return int.from_bytes(digest, "big", signed=False)
+
+
+def make_window_key(
+    start: str, end: str, assets: Iterable[str], stats_cfg: RiskStatsConfig
+) -> WindowKey:
+    """Construct the canonical cache key for a selector window."""
+
+    from ..perf.cache import CovCache  # local import to avoid circular deps
+
+    cov_key = CovCache.make_key(start, end, assets)
+    return (start, end, cov_key[2], _stats_cfg_hash(stats_cfg))
+
+
+def get_window_metric_bundle(window_key: WindowKey) -> WindowMetricBundle | None:
+    """Return the cached bundle for ``window_key`` if available."""
+
+    return _WINDOW_METRIC_CACHE.get(window_key)
+
+
+def reset_selector_cache() -> None:
+    """Clear selector metric caches and reset instrumentation counters."""
+
+    global selector_cache_hits, selector_cache_misses
+    _WINDOW_METRIC_CACHE.clear()
+    selector_cache_hits = 0
+    selector_cache_misses = 0
+
+
+def _resolve_bundle(
+    window_key: WindowKey | None,
+    bundle: WindowMetricBundle | None,
+    enable_cache: bool,
+) -> WindowMetricBundle | None:
+    """Return the active bundle taking into account cache settings."""
+
+    if not enable_cache:
+        return None
+
+    key = window_key
+    if bundle is not None and key is None:
+        key = bundle.key
+
+    if bundle is not None:
+        if key is not None:
+            bundle.key = key
+            cached = _WINDOW_METRIC_CACHE.get(key)
+            if cached is not bundle:
+                _WINDOW_METRIC_CACHE[key] = bundle
+        return bundle
+
+    if key is None:
+        return None
+
+    cached = _WINDOW_METRIC_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    new_bundle = WindowMetricBundle(key=key)
+    _WINDOW_METRIC_CACHE[key] = new_bundle
+    return new_bundle
 
 # Map snake_case config names to the canonical registry keys.
 _METRIC_ALIASES: dict[str, str] = {
@@ -523,6 +631,73 @@ def _compute_metric_series(
         _METRIC_CONTEXT.reset(token)
 
 
+def _ensure_cov_payload(
+    in_sample_df: pd.DataFrame, bundle: WindowMetricBundle | None
+) -> "CovPayload":
+    """Return a covariance payload, populating the bundle if provided."""
+
+    if bundle is not None and bundle.cov_payload is not None:
+        return bundle.cov_payload
+
+    from ..perf.cache import compute_cov_payload
+
+    payload = compute_cov_payload(in_sample_df)
+    if bundle is not None:
+        bundle.cov_payload = payload
+    return payload
+
+
+def _metric_from_cov_payload(
+    metric_name: str, in_sample_df: pd.DataFrame, payload: "CovPayload"
+) -> pd.Series:
+    """Compute covariance-derived metric series from ``payload``."""
+
+    if metric_name == "__COV_VAR__":
+        return pd.Series(
+            payload.cov.diagonal(), index=in_sample_df.columns, name="CovVar"
+        )
+
+    diag = np.sqrt(np.clip(np.diag(payload.cov), 0, None))
+    if diag.size <= 1:
+        return pd.Series(0.0, index=in_sample_df.columns, name="AvgCorr")
+    with np.errstate(divide="ignore", invalid="ignore"):
+        denom = np.outer(diag, diag)
+        corr = np.divide(
+            payload.cov, denom, out=np.zeros_like(payload.cov), where=denom != 0
+        )
+    sums = corr.sum(axis=1) - 1.0
+    avg = sums / (corr.shape[0] - 1)
+    return pd.Series(avg, index=in_sample_df.columns, name="AvgCorr")
+
+
+def _get_metric_series_cached(
+    metric_name: str,
+    in_sample_df: pd.DataFrame,
+    stats_cfg: RiskStatsConfig,
+    bundle: WindowMetricBundle | None,
+) -> pd.Series:
+    """Return metric series, reusing cached computations when possible."""
+
+    if bundle is not None:
+        cached = bundle.metrics.get(metric_name)
+        if cached is not None:
+            global selector_cache_hits
+            selector_cache_hits += 1
+            return cached
+
+    if metric_name in {"AvgCorr", "__COV_VAR__"}:
+        payload = _ensure_cov_payload(in_sample_df, bundle)
+        series = _metric_from_cov_payload(metric_name, in_sample_df, payload)
+    else:
+        series = _compute_metric_series(in_sample_df, metric_name, stats_cfg)
+
+    if bundle is not None:
+        global selector_cache_misses
+        selector_cache_misses += 1
+        bundle.metrics[metric_name] = series
+    return series
+
+
 def compute_metric_series_with_cache(
     in_sample_df: pd.DataFrame,
     metric_name: str,
@@ -657,7 +832,11 @@ def _zscore(series: pd.Series) -> pd.Series:
 
 
 def blended_score(
-    in_sample_df: pd.DataFrame, weights: dict[str, float], stats_cfg: RiskStatsConfig
+    in_sample_df: pd.DataFrame,
+    weights: dict[str, float],
+    stats_cfg: RiskStatsConfig,
+    *,
+    bundle: WindowMetricBundle | None = None,
 ) -> pd.Series:
     """Z‑score each contributing metric, then weighted linear combo."""
     if not weights:
@@ -677,7 +856,7 @@ def blended_score(
 
     combo = pd.Series(0.0, index=in_sample_df.columns)
     for metric, w in w_norm.items():
-        raw = _compute_metric_series(in_sample_df, metric, stats_cfg)
+        raw = _get_metric_series_cached(metric, in_sample_df, stats_cfg, bundle)
         z = _zscore(raw)
         # If metric is "smaller‑is‑better", *invert* before z‑score
         if metric in ASCENDING_METRICS:
@@ -821,10 +1000,19 @@ def select_funds_extended(
             pd.Period(in_sdate, "M").to_timestamp("M"),
             pd.Period(in_edate, "M").to_timestamp("M"),
         )
+        stats_cfg = RiskStatsConfig(risk_free=0.0)
+        window_df = pd.DataFrame(df.loc[mask, eligible])
+        rank_args = dict(rank_kwargs)
+        if "window_key" not in rank_args:
+            rank_args["window_key"] = make_window_key(
+                in_sdate, in_edate, eligible, stats_cfg
+            )
+        if "bundle" not in rank_args:
+            rank_args["bundle"] = get_window_metric_bundle(rank_args["window_key"])
         return rank_select_funds(
-            pd.DataFrame(df.loc[mask, eligible]),
-            RiskStatsConfig(risk_free=0.0),
-            **rank_kwargs,
+            window_df,
+            stats_cfg,
+            **rank_args,
         )
 
     raise ValueError(f"Unsupported selection_mode '{selection_mode}'")
@@ -1239,6 +1427,12 @@ __all__ = [
     "RiskStatsConfig",
     "register_metric",
     "METRIC_REGISTRY",
+    "WindowMetricBundle",
+    "make_window_key",
+    "get_window_metric_bundle",
+    "reset_selector_cache",
+    "selector_cache_hits",
+    "selector_cache_misses",
     "blended_score",
     "compute_metric_series_with_cache",
     "rank_select_funds",

--- a/src/trend_analysis/core/rank_selection.py
+++ b/src/trend_analysis/core/rank_selection.py
@@ -154,7 +154,6 @@ def rank_select_funds(
         )
 
     # Apply transform
-    scores = scores.copy()
     scores = _apply_transform(
         scores,
         mode=transform,

--- a/tests/test_selector_window_cache.py
+++ b/tests/test_selector_window_cache.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pandas as pd
+
+import trend_analysis.core.rank_selection as rs
+
+
+def _sample_window() -> pd.DataFrame:
+    dates = pd.date_range("2020-01-31", periods=6, freq="ME")
+    data = {
+        "Date": dates,
+        "FundA": np.linspace(0.01, 0.06, len(dates)),
+        "FundB": np.linspace(0.015, 0.05, len(dates)),
+        "FundC": np.linspace(0.02, 0.07, len(dates)),
+    }
+    df = pd.DataFrame(data)
+    return df.set_index("Date")[["FundA", "FundB", "FundC"]]
+
+
+def test_rank_selector_reuses_metric_bundle() -> None:
+    rs.reset_selector_cache()
+    window = _sample_window()
+    stats_cfg = rs.RiskStatsConfig()
+    window_key = rs.make_window_key("2020-01", "2020-06", window.columns, stats_cfg)
+
+    rs.rank_select_funds(
+        window,
+        stats_cfg,
+        inclusion_approach="top_n",
+        n=2,
+        score_by="Sharpe",
+        window_key=window_key,
+    )
+    assert rs.selector_cache_hits == 0
+
+    rs.rank_select_funds(
+        window,
+        stats_cfg,
+        inclusion_approach="top_n",
+        n=1,
+        score_by="Sharpe",
+        window_key=window_key,
+    )
+    assert rs.selector_cache_hits >= 1
+
+    bundle = rs.get_window_metric_bundle(window_key)
+    assert bundle is not None
+    frame = bundle.as_frame()
+    assert "Sharpe" in frame.columns
+
+    rs.rank_select_funds(
+        window,
+        stats_cfg,
+        inclusion_approach="top_n",
+        n=2,
+        score_by="AvgCorr",
+        window_key=window_key,
+        bundle=bundle,
+    )
+    assert bundle.cov_payload is not None
+
+    hits_before = rs.selector_cache_hits
+    rs.rank_select_funds(
+        window,
+        stats_cfg,
+        inclusion_approach="top_n",
+        n=2,
+        score_by="AvgCorr",
+        window_key=window_key,
+        bundle=bundle,
+    )
+    assert rs.selector_cache_hits > hits_before


### PR DESCRIPTION
## Summary
- add a selector window metric bundle cache with instrumentation helpers
- update rank_select_funds/select_funds_extended to reuse cached metrics and covariance payloads
- cover the new API with a regression test exercising cache hits

## Testing
- pytest tests/test_selector_window_cache.py tests/test_cov_cache_integration.py tests/test_avg_corr_metric.py tests/test_cache_disable.py

------
https://chatgpt.com/codex/tasks/task_e_68cbbd692ec083318b1591b6c5250681