### PR TITLE
Update CODEOWNERS patterns and document review ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,10 @@
 /notebooks/**                       @stranske
 /*.ipynb                            @stranske
 
-# CI/CD and container files
-/.github/workflows/**               @stranske
+# Automation, infrastructure, and agents
+/.github/**                         @stranske
+/agents/**                          @stranske
+
+# Container tooling
 /Dockerfile                         @stranske
 /docker-compose.yml                 @stranske

--- a/docs/OWNERSHIP.md
+++ b/docs/OWNERSHIP.md
@@ -1,0 +1,32 @@
+# Code Ownership and Review Expectations
+
+This repository uses a single CODEOWNERS routing profile to keep reviews fast
+and predictable. The current mappings are intentionally coarse grained so that
+any change touching the critical execution paths automatically notifies the core
+maintainer.
+
+## Ownership Map
+
+| Path Pattern        | Owners      | Notes |
+|---------------------|-------------|-------|
+| `/src/**`           | `@stranske` | Core engine and model code. |
+| `/tests/**`         | `@stranske` | Unit and integration coverage for the engine. |
+| `/.github/**`       | `@stranske` | Automation, workflows, and policy configuration. |
+| `/agents/**`        | `@stranske` | Agent bootstrap files and task playbooks. |
+| `*` (fallback)      | `@stranske` | Any file not captured by the patterns above. |
+
+## Review and Auto-Merge Workflow
+
+- **Pull Request reviews** – Whenever a PR touches one of the paths above the
+  listed owner is automatically requested as a reviewer. This keeps code reviews
+  aligned with the areas of expertise documented here.
+- **Low-risk lanes** – Once the CODEOWNER has approved, low-risk changes that
+  satisfy repository checks are eligible for auto-merge. No additional manual
+  steps are required.
+- **Shared context** – Contributors should reference this document when opening
+  PRs so they know which maintainer will be looped in and what areas are
+  considered high-priority for review.
+
+If ownership ever needs to expand beyond a single maintainer, update both this
+file and `.github/CODEOWNERS` in the same commit so the documentation and routing
+logic stay synchronized.


### PR DESCRIPTION
## Summary
- expand CODEOWNERS coverage to include .github automation and agent playbooks
- add repository ownership guide explaining review routing and auto-merge expectations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc2ecb53c4833181b658c07d9dac6b