### PR TITLE
Add tests for multi-period turnover helpers and proxy deps

### DIFF
--- a/tests/test_proxy_server_missing_optional.py
+++ b/tests/test_proxy_server_missing_optional.py
@@ -1,0 +1,17 @@
+import sys
+
+import pytest
+
+
+def test_assert_deps_detects_explicitly_missing_modules(monkeypatch):
+    from trend_analysis.proxy import server
+
+    with monkeypatch.context() as m:
+        for name in ["fastapi", "uvicorn", "httpx", "websockets"]:
+            m.setitem(sys.modules, name, None)
+        m.setattr(server, "_DEPS_AVAILABLE", True)
+
+        with pytest.raises(ImportError) as excinfo:
+            server._assert_deps()
+
+    assert "Required dependencies not available" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- exercise the multi-period engine helpers for preparing returns, turnover alignment, and debug validation
- ensure the proxy server dependency guard raises when core modules are explicitly unavailable

## Testing
- pytest tests/test_multi_period_engine.py tests/test_proxy_server_missing_optional.py

------
https://chatgpt.com/codex/tasks/task_e_68cc2e4f98208331b71e48cda08c828d