### PR TITLE
Fix mypy issues in health wrapper

### DIFF
--- a/src/trend_portfolio_app/app.py
+++ b/src/trend_portfolio_app/app.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, cast
 
 import pandas as pd
 import streamlit as st
@@ -46,7 +46,8 @@ def _read_defaults() -> Dict[str, Any]:
 
 
 def _to_yaml(d: Dict[str, Any]) -> str:
-    return yaml.safe_dump(d, sort_keys=False, allow_unicode=True)
+    dumped = yaml.safe_dump(d, sort_keys=False, allow_unicode=True)
+    return cast(str, dumped)
 
 
 def _merge_update(base: Dict[str, Any], updates: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/trend_portfolio_app/health_wrapper.py
+++ b/src/trend_portfolio_app/health_wrapper.py
@@ -10,20 +10,36 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import Any
+from types import ModuleType
+from typing import TYPE_CHECKING, Any
 
-# Optional dependency sentinels (exposed for tests to monkeypatch)
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints only
+    from fastapi import FastAPI as FastAPIType
+    from fastapi.responses import PlainTextResponse as PlainTextResponseType
+else:  # runtime fallbacks keep optional deps optional
+    FastAPIType = Any  # type: ignore[assignment]
+    PlainTextResponseType = Any  # type: ignore[assignment]
+
+FastAPI: type[FastAPIType] | None
+PlainTextResponse: type[PlainTextResponseType] | None
+
 try:  # pragma: no cover - import side effect
-    from fastapi import FastAPI  # type: ignore
-    from fastapi.responses import PlainTextResponse  # type: ignore
+    from fastapi import FastAPI as _FastAPI
+    from fastapi.responses import PlainTextResponse as _PlainTextResponse
 except (ImportError, ModuleNotFoundError):  # FastAPI missing
-    FastAPI = None  # type: ignore
-    PlainTextResponse = None  # type: ignore
+    FastAPI = None
+    PlainTextResponse = None
+else:
+    FastAPI = _FastAPI
+    PlainTextResponse = _PlainTextResponse
 
+uvicorn: ModuleType | None
 try:  # pragma: no cover - import side effect
-    import uvicorn  # type: ignore
+    import uvicorn as _uvicorn
 except (ImportError, ModuleNotFoundError):  # uvicorn missing
-    uvicorn = None  # type: ignore
+    uvicorn = None
+else:
+    uvicorn = _uvicorn
 
 
 def create_app() -> Any:


### PR DESCRIPTION
## Summary
- replace broad type ignores in the FastAPI health wrapper with typed optional imports so mypy understands optional dependencies
- ensure the Streamlit helper that writes YAML returns a concrete string instead of Any

## Testing
- PYTHONPATH=src mypy --config-file /tmp/mypy.ini -p trend_analysis -p trend_portfolio_app


------
https://chatgpt.com/codex/tasks/task_e_68cc385b35288331a342df67527f5173