### PR TITLE
Fix CLI test cache fixtures

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,33 @@ from trend_analysis.constants import (DEFAULT_OUTPUT_DIRECTORY,
                                       DEFAULT_OUTPUT_FORMATS)
 
 
+cache_first = {
+    "entries": 1,
+    "hits": 2,
+    "misses": 3,
+    "incremental_updates": 4,
+}
+
+cache_second = {
+    "entries": 5.0,
+    "hits": 6.0,
+    "misses": 7.0,
+    "incremental_updates": 8.0,
+}
+
+
+# Helper class for tests
+class TruthySeries:
+    def __init__(self, series: pd.Series):
+        self.series = series
+
+    def __bool__(self) -> bool:
+        return True
+
+    def __getattr__(self, name: str):
+        return getattr(self.series, name)
+
+
 def _write_cfg(path: Path, version: str) -> None:
     path.write_text(
         "\n".join(
@@ -390,30 +417,6 @@ def test_cli_run_uses_env_seed_and_populates_run_result(tmp_path, capsys, monkey
         [0.05], index=pd.Index(["2020-01"], name="month"), name="bench"
     )
     weights_df = pd.DataFrame({"A": [0.6], "B": [0.4]})
-
-    cache_first = {
-        "entries": 1,
-        "hits": 2,
-        "misses": 3,
-        "incremental_updates": 4,
-    }
-    cache_second = {
-        "entries": 5.0,
-        "hits": 6.0,
-        "misses": 7.0,
-        "incremental_updates": 8.0,
-    }
-# Helper class for tests
-class TruthySeries:
-    def __init__(self, series: pd.Series):
-        self.series = series
-
-    def __bool__(self) -> bool:
-        return True
-
-    def __getattr__(self, name: str):
-        return getattr(self.series, name)
-
     details = {
         "cache": cache_first,
         "nested": [cache_second],
@@ -490,6 +493,7 @@ class TruthySeries:
         lambda run_id, path: log_calls.append(("init", run_id)),
     )
     monkeypatch.setattr("trend_analysis.logging.log_step", fake_log_step)
+    monkeypatch.setattr(cli, "_log_step", fake_log_step)
 
     monkeypatch.setattr(
         "uuid.uuid4",


### PR DESCRIPTION
## Summary
- define reusable cache fixtures and TruthySeries helper at module scope for CLI tests
- ensure CLI test patches the CLI log_step alias so cache statistics assertions observe log events

## Testing
- pytest tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cc3f3c6d448331bab45c9b6ccbd30d