### PR TITLE
fix: respect cash residual when enforcing max_weight

### DIFF
--- a/src/trend_analysis/engine/optimizer.py
+++ b/src/trend_analysis/engine/optimizer.py
@@ -166,8 +166,9 @@ def apply_constraints(
     if constraints.group_caps:
         if not constraints.groups:
             raise ConstraintViolation("Group mapping required when group_caps set")
+        group_mapping = {asset: constraints.groups[asset] for asset in working.index}
         working = _apply_group_caps(
-            working, constraints.group_caps, constraints.groups, total=total_allocation
+            working, constraints.group_caps, group_mapping, total=total_allocation
         )
         # max weight may have been violated again
         if constraints.max_weight is not None:


### PR DESCRIPTION
## Summary
- adjust `_apply_cap` and `_apply_group_caps` to consider a provided total allocation when validating feasibility
- rework `apply_constraints` cash-weight flow so non-cash assets are projected before cap enforcement and cash order is preserved
- update constraint tests for revised messaging and add coverage for cash/max_weight compatibility
- filter group mappings passed to `_apply_group_caps` so cash-only entries do not trigger missing-key errors after cash removal

## Testing
- pytest tests/test_optimizer_constraints.py

------
https://chatgpt.com/codex/tasks/task_e_68cc4da0d3108331a13c4546f7245380