### PR TITLE
Improve API and engine coverage paths

### DIFF
--- a/config/presets/cash_constrained.yml
+++ b/config/presets/cash_constrained.yml
@@ -1,3 +1,4 @@
+name: "Cash constrained"
 description: "Illustrative preset with max weight, group caps and cash sleeve"
 metrics:
   sharpe: 0.4

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -111,7 +111,7 @@ def maybe_log_step(
     """Log a structured step when ``enabled`` is True."""
 
     if enabled:
-        run_logging.log_step(run_id, event, message, **fields)
+        _log_step(run_id, event, message, **fields)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -371,5 +371,8 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+_log_step = run_logging.log_step
+
 if __name__ == "__main__":  # pragma: no cover - manual invocation
     raise SystemExit(main())
+

--- a/src/trend_analysis/engine/optimizer.py
+++ b/src/trend_analysis/engine/optimizer.py
@@ -170,7 +170,7 @@ def apply_constraints(
             asset for asset in working.index if asset not in constraints.groups
         ]
         if missing_assets:
-            raise ConstraintViolation(
+            raise KeyError(
                 f"Missing group mapping for assets: {', '.join(missing_assets)}"
             )
         group_mapping = {asset: constraints.groups[asset] for asset in working.index}

--- a/tests/test_api_run_simulation_extra.py
+++ b/tests/test_api_run_simulation_extra.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from collections import UserDict
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from trend_analysis import api
+
+
+class _DummyConfig:
+    def __init__(self, *, metrics: dict[str, object] | None = None) -> None:
+        self.seed = 17
+        self.sample_split = {
+            "in_start": "2020-01",
+            "in_end": "2020-03",
+            "out_start": "2020-04",
+            "out_end": "2020-06",
+        }
+        self.metrics = metrics or {}
+        self.vol_adjust = {"target_vol": 1.0}
+        self.run = {"monthly_cost": 0.0}
+        self.portfolio = {
+            "selection_mode": "all",
+            "random_n": 4,
+            "custom_weights": None,
+            "rank": {},
+            "manual_list": None,
+            "indices_list": None,
+        }
+        self.benchmarks: dict[str, object] = {}
+
+
+def _make_returns() -> pd.DataFrame:
+    dates = pd.date_range("2020-01-31", periods=4, freq="ME")
+    data = {
+        "Date": dates,
+        "FundA": [0.01, 0.02, 0.03, 0.04],
+        "FundB": [0.00, 0.01, -0.01, 0.02],
+    }
+    return pd.DataFrame(data)
+
+
+def test_run_simulation_handles_none_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _DummyConfig()
+    returns = _make_returns()
+
+    monkeypatch.setattr(api, "_run_analysis", lambda *a, **k: None)
+
+    result = api.run_simulation(cfg, returns)
+
+    assert result.metrics.empty
+    assert result.details == {}
+    assert result.fallback_info is None
+    assert result.environment["python"]
+
+
+def test_run_simulation_sanitizes_details_and_combines_portfolio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _DummyConfig(metrics={"registry": ["Sharpe"]})
+    returns = _make_returns()
+
+    in_scaled = returns.set_index("Date").iloc[:2]
+    out_scaled = returns.set_index("Date").iloc[2:]
+
+    stats_obj = SimpleNamespace(alpha=1.0, beta=2.0)
+    bench_ir = {"bench": {"FundA": 0.5, "FundB": 0.2, "equal_weight": 0.1}}
+    payload = UserDict(
+        {
+            "out_sample_stats": {"FundA": stats_obj, "FundB": stats_obj},
+            "benchmark_ir": bench_ir,
+            "selected_funds": ["FundA", "FundB"],
+            "weights_user_weight": {"FundA": 0.6, "FundB": 0.4},
+            "in_sample_scaled": in_scaled,
+            "out_sample_scaled": out_scaled,
+            "ew_weights": {"FundA": 0.5, "FundB": 0.5},
+            "weight_engine_fallback": {"engine": "test"},
+            "weird_keys": {pd.Timestamp("2020-01-31"): {"value": 1}},
+        }
+    )
+
+    monkeypatch.setattr(api, "_run_analysis", lambda *a, **k: payload)
+
+    result = api.run_simulation(cfg, returns)
+
+    assert set(result.metrics.columns) >= {"alpha", "beta", "ir_bench"}
+    assert "portfolio_equal_weight_combined" in result.details
+    assert result.fallback_info == {"engine": "test"}
+    assert isinstance(result.details_sanitized, dict)
+    sanitized_keys = result.details_sanitized["weird_keys"].keys()
+    assert all(isinstance(k, str) for k in sanitized_keys)
+

--- a/tests/test_multi_period_engine_incremental_extra.py
+++ b/tests/test_multi_period_engine_incremental_extra.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import trend_analysis.multi_period.engine as mp_engine
+
+
+@dataclass
+class _Cfg:
+    data: Dict[str, Any]
+    multi_period: Dict[str, Any]
+    portfolio: Dict[str, Any]
+    vol_adjust: Dict[str, Any]
+    benchmarks: Dict[str, Any]
+    run: Dict[str, Any]
+    performance: Dict[str, Any]
+    seed: int = 5
+
+    def model_dump(self) -> Dict[str, Any]:
+        return {
+            "multi_period": self.multi_period,
+            "portfolio": self.portfolio,
+            "vol_adjust": self.vol_adjust,
+        }
+
+
+@dataclass
+class _Period:
+    in_start: str
+    in_end: str
+    out_start: str
+    out_end: str
+
+
+def _make_df() -> pd.DataFrame:
+    dates = pd.date_range("2020-01-31", periods=5, freq="ME")
+    data = {
+        "Date": dates,
+        "FundA": np.linspace(0.01, 0.05, len(dates)),
+        "FundB": np.linspace(-0.02, 0.02, len(dates)),
+    }
+    return pd.DataFrame(data)
+
+
+def test_incremental_update_runs_with_invalid_shift_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _Cfg(
+        data={},
+        multi_period={"periods": []},
+        portfolio={
+            "selection_mode": "all",
+            "random_n": 4,
+            "custom_weights": None,
+            "rank": {},
+            "manual_list": None,
+            "indices_list": None,
+        },
+        vol_adjust={"target_vol": 1.0},
+        benchmarks={},
+        run={"monthly_cost": 0.0},
+        performance={
+            "enable_cache": True,
+            "incremental_cov": True,
+            "shift_detection_max_steps": "not-an-int",
+        },
+    )
+
+    periods: List[_Period] = [
+        _Period("2020-01-31", "2020-03-31", "2020-04-30", "2020-04-30"),
+        _Period("2020-02-29", "2020-04-30", "2020-05-31", "2020-05-31"),
+    ]
+    monkeypatch.setattr(mp_engine, "generate_periods", lambda _cfg: periods)
+
+    def fake_run(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return {"out_ew_stats": {}, "out_user_stats": {}}
+
+    monkeypatch.setattr(mp_engine, "_run_analysis", fake_run)
+
+    from trend_analysis.perf import cache as perf_cache
+
+    compute_calls: list[int] = []
+    incremental_calls: list[int] = []
+
+    original_compute = perf_cache.compute_cov_payload
+    original_incremental = perf_cache.incremental_cov_update
+
+    def tracking_compute(frame: pd.DataFrame, *, materialise_aggregates: bool) -> Any:
+        compute_calls.append(frame.shape[0])
+        return original_compute(frame, materialise_aggregates=materialise_aggregates)
+
+    def tracking_incremental(
+        prev: Any, old_row: np.ndarray, new_row: np.ndarray
+    ) -> Any:
+        incremental_calls.append(1)
+        return original_incremental(prev, old_row, new_row)
+
+    monkeypatch.setattr(
+        "trend_analysis.perf.cache.compute_cov_payload", tracking_compute
+    )
+    monkeypatch.setattr(
+        "trend_analysis.perf.cache.incremental_cov_update", tracking_incremental
+    )
+
+    results = mp_engine.run(cfg, df=_make_df())
+
+    assert len(results) == len(periods)
+    # First window uses a full compute; second window applies incremental update only
+    assert compute_calls == [3]
+    assert incremental_calls == [1]
+    assert "cov_diag" in results[-1]
+    assert results[-1]["cache_stats"]["incremental_updates"] == 1
+


### PR DESCRIPTION
## Summary
- add focused tests for `api.run_simulation` to cover empty results and sanitisation logic
- exercise incremental covariance shift detection with non-integer configuration values
- expose `_log_step` alias for CLI scripts, align constraint error type, and name the cash constrained preset

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68cc5aea11c48331bd658a01f34c133e