### PR TITLE
ci(tests): flaky test single rerun quarantine (Issue #1147)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,28 @@
+name: actionlint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**/*.yml'
+  push:
+    branches: [ phase-2-dev ]
+    paths:
+      - '.github/workflows/**/*.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: workflow lint (actionlint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download actionlint
+        run: |
+          curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash
+          echo "$(pwd)" >> $GITHUB_PATH
+      - name: Run actionlint
+        run: |
+          echo "Running actionlint version: $(./actionlint -version)" 
+          ./actionlint -color

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,9 @@ jobs:
         run: |
           # Default fallback ensures at least 80% coverage when CI vars are unset.
           # (Coverage gate effectively behaves as --cov-fail-under=80 by default.)
+          echo "::notice title=FlakeQuarantine::Enabling single rerun for flaky tests (Issue #1147)" || true
           pytest -m "not quarantine and not slow" \
+            --reruns 1 --reruns-delay 1 \
             --cov=src --cov-report=term-missing --cov-fail-under=${{ vars.COV_MIN || 80 }} --cov-branch
 
   gate:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           # Default fallback ensures at least 80% coverage when CI vars are unset.
           # (Coverage gate effectively behaves as --cov-fail-under=80 by default.)
-          echo "::notice title=FlakeQuarantine::Enabling single rerun for flaky tests (Issue #1147)" || true
+          echo "::notice title=FlakeQuarantine::Enabling single rerun for flaky tests (Issue #1147)"
           pytest -m "not quarantine and not slow" \
             --reruns 1 --reruns-delay 1 \
             --cov=src --cov-report=term-missing --cov-fail-under=${{ vars.COV_MIN || 80 }} --cov-branch

--- a/TESTING_SUMMARY.md
+++ b/TESTING_SUMMARY.md
@@ -57,3 +57,21 @@ COVERAGE_PROFILE=full ./scripts/run_tests.sh
 - Template section: ![Template Section](assets/screenshots/template-section.png)
 
 All acceptance criteria from issue #412 have been met and validated.
+
+## Flake Quarantine Mechanism (Issue #1147)
+
+To reduce noise from intermittent test failures, CI now enables a single automatic rerun for failing tests:
+
+- Implemented via `pytest-rerunfailures` (added to `dev` extras in `pyproject.toml`).
+- CI workflow (`ci.yml`) adds the flags `--reruns 1 --reruns-delay 1` for the core test job.
+- A GitHub Actions notice (`FlakeQuarantine`) is emitted at job start to document the policy.
+- Persistent failures (fail twice) still fail the job immediately; intermittent one-off failures are quarantined by the rerun.
+
+Future Enhancements:
+- Tag known flaky tests explicitly with `@pytest.mark.flaky(reruns=1)` and eventually remove the global flag.
+- Emit a machine-readable summary of reruns for trend analysis.
+
+Verification Steps:
+1. Intentionally introduce a transient failure (e.g., random assert) on a throwaway branch.
+2. Observe first failure followed by automatic rerun success in the CI logs.
+3. Remove the transient failure and re-run to confirm clean pass without reruns.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dev = [
     "flake8",
     "pytest",
     "pytest-cov",
+    "pytest-rerunfailures>=13.0",
     "types-PyYAML",
     "jsonschema",
     "httpx>=0.25",


### PR DESCRIPTION
ci(tests): flaky test single rerun quarantine (Issues #1147, #1142)

Implements the initial flake quarantine mechanism (Issue #1147) and now also incorporates the actionlint workflow (Issue #1142).

Changes
-------
1. Flake quarantine:
   - Add `pytest-rerunfailures` to `[project.optional-dependencies].dev` in `pyproject.toml`.
   - Update CI workflow (`ci.yml`) core-tests job with `--reruns 1 --reruns-delay 1`.
   - Emit `FlakeQuarantine` GitHub Actions notice.
   - Document mechanism in `TESTING_SUMMARY.md`.
2. Workflow linting:
   - Add new `.github/workflows/actionlint.yml` to lint all workflow YAML on PRs & pushes touching `.github/workflows/**/*.yml`.
   - Provides early detection of expression / syntax errors (Issue #1142).

Rationale
---------
- Reduce noise from intermittent test failures while preserving failure visibility.
- Prevent broken workflow YAML from reaching `phase-2-dev`.

Acceptance Alignment
--------------------
- Intermittent failures rerun once; persistent failures still fail.
- Intentional malformed workflow YAML would fail the new actionlint job.

Follow-Ups (Not in this PR)
---------------------------
- Tag specific flaky tests with `@pytest.mark.flaky(reruns=1)` and eventually remove global rerun flag.
- Collect metrics on rerun frequency and summarize in PR status output.
- Optionally add shellcheck integration via ACTIONLINT_ENABLE=sh when/if more shell usage grows.

Closes #1147
Closes #1142
