### PR TITLE
ci(docker): buildx cache + 10m timeout (Issue #1153)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,9 +62,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: buildx-${{ hashFiles('Dockerfile', 'requirements.lock') }}
+          key: buildx-${{ hashFiles('Dockerfile', 'requirements.lock') }}-${{ github.sha }}
           restore-keys: |
-            buildx-
+            buildx-${{ hashFiles('Dockerfile', 'requirements.lock') }}
 
       - name: Note cache presence
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,7 @@ jobs:
   build:
     needs: lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: write
@@ -53,8 +54,37 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build image
-        run: docker build --pull -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Restore buildx cache
+        id: buildx-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: buildx-${{ hashFiles('Dockerfile', 'requirements.lock') }}
+          restore-keys: |
+            buildx-
+
+      - name: Note cache presence
+        run: |
+          if [ -d /tmp/.buildx-cache ]; then
+            echo "::notice title=BuildxCache::Cache restored (Issue #1153)"
+          else
+            echo "::notice title=BuildxCache::No existing cache (Issue #1153)"
+          fi
+
+      - name: Build image (cached)
+        run: |
+          docker buildx build --pull \
+            --cache-from type=local,src=/tmp/.buildx-cache \
+            --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest .
+
+      - name: Finalize cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache || true
       - name: Run test suite
         run: |
           # Use verbose output only for debug builds, quiet mode for production

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Finalize cache
         run: |
           rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache || true
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
       - name: Run test suite
         run: |
           # Use verbose output only for debug builds, quiet mode for production

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Build image (cached)
         run: |
-          docker buildx build --pull \
+          docker buildx build --pull --load \
             --cache-from type=local,src=/tmp/.buildx-cache \
             --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
             -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest .


### PR DESCRIPTION
ci(docker): buildx cache + 10m timeout (Issue #1153)

Implements Docker smoke optimization and reliability improvements.

Changes
-------
- Add `docker/setup-buildx-action@v3` to enable buildx.
- Introduce layer cache via `actions/cache@v4` keyed on `Dockerfile` + `requirements.lock`.
- Use `docker buildx build --pull` with `--cache-from/--cache-to` for incremental layer reuse.
- Add cache presence notice (`BuildxCache`).
- Add `timeout-minutes: 10` on build job.

Rationale
---------
Reduces redundant image layer rebuilds and prevents runaway build times causing CI delays.

Acceptance Criteria Alignment
-----------------------------
- Build job now enforces a 10-minute cap.
- Subsequent runs after first will show cache restoration notice and reuse layers.

Follow-Ups (Optional)
---------------------
- Add multi-platform build only if needed later (currently single arch for speed).
- Periodically prune stale cache key changes (auto-handled by key hash drift).
- Emit cache hit/miss metrics to job summary.

Closes #1153 (when merged).
