### PR TITLE
Add tests to boost rank selection coverage

### DIFF
--- a/tests/test_rank_selection_additional.py
+++ b/tests/test_rank_selection_additional.py
@@ -1,7 +1,8 @@
+from types import SimpleNamespace
+
 import numpy as np
 import pandas as pd
 import pytest
-from types import SimpleNamespace
 
 from trend_analysis.core import rank_selection as rs
 

--- a/tests/test_rank_selection_additional.py
+++ b/tests/test_rank_selection_additional.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from types import SimpleNamespace
 
 from trend_analysis.core import rank_selection as rs
 
@@ -123,6 +124,151 @@ def test_register_metric_decorator_registers_callable():
     cfg = rs.RiskStatsConfig(risk_free=0.0)
     result = rs._compute_metric_series(df, "CoverageTest", cfg)
     assert isinstance(result, pd.Series)
+
+
+def test_json_default_serialises_supported_types():
+    sequence = rs._json_default(("a", "b"))
+    assert sequence == ["a", "b"]
+
+    unordered = rs._json_default({1, 2})
+    assert sorted(unordered) == [1, 2]
+
+    array = rs._json_default(np.array([3, 4]))
+    assert array == [3, 4]
+
+    scalar = rs._json_default(np.float32(5.5))
+    assert scalar == pytest.approx(5.5)
+
+    with pytest.raises(TypeError):
+        rs._json_default(object())
+
+
+def test_canonicalise_and_canonical_columns_behaviour():
+    labels = ["Alpha", "Alpha", "", "Beta"]
+    canonical = rs._canonicalise_labels(labels)
+    assert canonical == ["Alpha", "Alpha_2", "Unnamed_3", "Beta"]
+
+    empty = pd.DataFrame()
+    assert rs._ensure_canonical_columns(empty) is empty
+
+    df = pd.DataFrame([[1, 2]], columns=["X", "X"])
+    canon_df = rs._ensure_canonical_columns(df)
+    assert list(canon_df.columns) == ["X", "X_2"]
+    assert list(df.columns) == ["X", "X"]
+
+
+def test_stats_cfg_hash_accounts_for_dynamic_attributes():
+    cfg = rs.RiskStatsConfig()
+    base = rs._stats_cfg_hash(cfg)
+
+    cfg.debug_flag = 1
+    first = rs._stats_cfg_hash(cfg)
+    cfg.debug_flag = 2
+    second = rs._stats_cfg_hash(cfg)
+
+    other = rs.RiskStatsConfig()
+    other.debug_flag = 1
+
+    assert base != first != second
+    assert first == rs._stats_cfg_hash(other)
+
+
+def test_make_window_key_and_cache_helpers_round_trip():
+    cfg = rs.RiskStatsConfig()
+    universe = ["B", "A"]
+    key1 = rs.make_window_key("2021-01", "2021-06", universe, cfg)
+    key2 = rs.make_window_key("2021-01", "2021-06", reversed(universe), cfg)
+    assert key1 == key2
+
+    rs.clear_window_metric_cache()
+    df = make_simple_returns()[["Alpha One", "Alpha Two"]]
+    bundle = rs.WindowMetricBundle(
+        key=key1,
+        start="2021-01",
+        end="2021-06",
+        freq="M",
+        stats_cfg_hash=rs._stats_cfg_hash(cfg),
+        universe=tuple(df.columns),
+        in_sample_df=df,
+        _metrics=pd.DataFrame(index=df.columns, dtype=float),
+    )
+    rs.store_window_metric_bundle(key1, bundle)
+    cached = rs.get_window_metric_bundle(key1)
+    assert cached is bundle
+
+
+def test_window_metric_bundle_covariance_branch(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "Alpha": [0.01, 0.02, 0.03],
+            "Beta": [0.02, 0.01, 0.04],
+        }
+    )
+    cfg = rs.RiskStatsConfig()
+    stats_hash = rs._stats_cfg_hash(cfg)
+    bundle = rs.WindowMetricBundle(
+        key=None,
+        start="2021-01",
+        end="2021-03",
+        freq="M",
+        stats_cfg_hash=stats_hash,
+        universe=tuple(df.columns),
+        in_sample_df=df,
+        _metrics=pd.DataFrame(index=df.columns, dtype=float),
+    )
+
+    payload = SimpleNamespace(cov=np.array([[1.0, 0.5], [0.5, 1.0]]))
+    calls = {"count": 0}
+
+    def fake_cov(bundle_arg, cov_cache, *, enable_cov_cache, incremental_cov):
+        calls["count"] += 1
+        assert bundle_arg is bundle
+        assert cov_cache is None
+        assert enable_cov_cache is False
+        assert incremental_cov is False
+        return payload
+
+    monkeypatch.setattr(rs, "_compute_covariance_payload", fake_cov)
+
+    series = bundle.ensure_metric(
+        "AvgCorr",
+        cfg,
+        cov_cache=None,
+        enable_cov_cache=False,
+        incremental_cov=False,
+    )
+    assert calls["count"] == 1
+    assert bundle.cov_payload is payload
+    assert series.name == "AvgCorr"
+    assert pytest.approx(series.loc["Alpha"]) == 0.5
+    assert pytest.approx(series.loc["Beta"]) == 0.5
+
+    cached = bundle.ensure_metric("AvgCorr", cfg)
+    assert calls["count"] == 1  # second call hits cache
+    assert cached is series
+
+
+def test_apply_transform_variants_and_errors():
+    series = pd.Series([3.0, 2.0, 1.0], index=["A", "B", "C"])
+
+    raw = rs._apply_transform(series, mode="raw")
+    assert raw is series
+
+    rank = rs._apply_transform(series, mode="rank")
+    assert list(rank) == [1.0, 2.0, 3.0]
+
+    percentile = rs._apply_transform(series, mode="percentile", rank_pct=1 / 3)
+    assert percentile.notna().sum() == 1
+
+    constant = pd.Series([1.0, 1.0, 1.0], index=series.index)
+    zscored = rs._apply_transform(constant, mode="zscore", window=10)
+    assert all(value == 0.0 for value in zscored)
+
+    with pytest.raises(ValueError):
+        rs._apply_transform(series, mode="percentile")
+
+    with pytest.raises(ValueError):
+        rs._apply_transform(series, mode="unknown")
 
 
 def test_quality_filter_and_private_variant_share_logic():


### PR DESCRIPTION
## Summary
- add unit tests covering JSON serialisation helper, canonical label handling, and stats config hashing
- exercise window metric bundle covariance branch and window cache helpers for rank selection
- test metric transform modes and validation paths

## Testing
- pytest tests/test_rank_selection_additional.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cc79ca0168833198cc55481750d2a3