### PR TITLE
test(observability,#1161): add disabled cache stats negative test

### DIFF
--- a/docs/phase-2/performance_cache.md
+++ b/docs/phase-2/performance_cache.md
@@ -60,6 +60,8 @@ All operations O(k^2) vs. O(n k^2) full recompute.
 
 The `trend-model run` CLI now surfaces the cache counters at the end of a run whenever a stats payload is present.  Users will see a short block summarising the number of cache entries along with hit/miss and incremental-update totals.  Structured JSONL logging emits a dedicated `{ "event": "cache_stats", ... }` record so automation can track the same values without scraping stdout.
 
+When caching is disabled (e.g. `performance.enable_cache: false`) or no cache snapshot exists in the result payload, the CLI produces **no cache statistics block** and emits **no** `cache_stats` structured event—ensuring true zero overhead in the disabled path.
+
 ## Testing
 
 `tests/test_perf_cache.py` verifies:

--- a/tests/test_cli_cache_stats_disabled.py
+++ b/tests/test_cli_cache_stats_disabled.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import pandas as pd
+from types import SimpleNamespace
+
+from trend_analysis import cli
+from trend_analysis.api import RunResult
+
+
+def test_cli_suppresses_cache_stats_when_absent(monkeypatch, capsys, tmp_path):
+    # Prepare tiny dataset
+    csv_path = tmp_path / "data.csv"
+    df = pd.DataFrame(
+        {
+            "Date": pd.date_range("2020-01-31", periods=3, freq="ME"),
+            "A": [0.01, 0.02, 0.03],
+            "B": [0.02, 0.01, 0.00],
+        }
+    )
+    df.to_csv(csv_path, index=False)
+
+    # Config with no cache / performance flags set (simulate disabled cache)
+    cfg = SimpleNamespace(
+        sample_split={
+            "in_start": "2020-01",
+            "in_end": "2020-02",
+            "out_start": "2020-03",
+            "out_end": "2020-03",
+        },
+        export={"directory": "ignored", "formats": []},
+        vol_adjust={},
+        portfolio={},
+        benchmarks={},
+        metrics={},
+        run={},
+        performance={"enable_cache": False},
+        seed=11,
+    )
+
+    # Monkeypatch loaders
+    monkeypatch.setattr(cli, "load_config", lambda path: cfg)
+    monkeypatch.setattr(cli, "load_csv", lambda path: df.copy())
+
+    # Fake structured logging to capture events
+    log_calls = []
+
+    def fake_log_step(run_id, step, message, level="INFO", **extra):
+        payload = dict(extra)
+        payload.setdefault("event", step)
+        log_calls.append((run_id, step, message, payload))
+
+    from trend_analysis import logging as run_logging
+
+    monkeypatch.setattr(run_logging, "log_step", fake_log_step)
+    monkeypatch.setattr(cli, "_log_step", fake_log_step)
+    monkeypatch.setattr(run_logging, "init_run_logger", lambda run_id, path: None)
+    monkeypatch.setattr(
+        run_logging, "get_default_log_path", lambda run_id: tmp_path / "log.jsonl"
+    )
+
+    # Stub formatting and export side effects
+    monkeypatch.setattr(cli.export, "format_summary_text", lambda *a, **k: "summary")
+    monkeypatch.setattr(cli.export, "export_to_excel", lambda *a, **k: None)
+    monkeypatch.setattr(cli.export, "export_data", lambda *a, **k: None)
+    monkeypatch.setattr(
+        cli.export, "make_summary_formatter", lambda *a, **k: lambda *_a, **_k: None
+    )
+
+    # RunResult without any embedded cache_stats structures
+    run_result = RunResult(
+        metrics=pd.DataFrame({"metric": [1.0]}),
+        details={"periods": [{"note": "no cache"}]},
+        seed=11,
+        environment={"python": "3.11", "numpy": "1.26", "pandas": "2.2"},
+    )
+    monkeypatch.setattr(cli, "run_simulation", lambda *a, **k: run_result)
+
+    rc = cli.main(
+        [
+            "run",
+            "-c",
+            str(tmp_path / "cfg.yml"),
+            "-i",
+            str(csv_path),
+        ]
+    )
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    # Assert that cache statistics header is NOT printed
+    assert "Cache statistics:" not in out
+
+    # Ensure no cache_stats structured event emitted
+    assert not any(
+        evt for evt in log_calls if evt[1] == "cache_stats"
+    ), "unexpected cache_stats event when cache disabled"

--- a/tests/test_cli_cache_stats_disabled.py
+++ b/tests/test_cli_cache_stats_disabled.py
@@ -93,4 +93,4 @@ def test_cli_suppresses_cache_stats_when_absent(monkeypatch, capsys, tmp_path):
     # Ensure no cache_stats structured event emitted
     assert not any(
         evt for evt in log_calls if evt[1] == "cache_stats"
-    ), "unexpected cache_stats event when cache disabled"
+    ), "No cache_stats events should be emitted when caching is disabled"

--- a/tests/test_cli_cache_stats_disabled.py
+++ b/tests/test_cli_cache_stats_disabled.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import pandas as pd
 from types import SimpleNamespace
+
+import pandas as pd
 
 from trend_analysis import cli
 from trend_analysis.api import RunResult


### PR DESCRIPTION
Adds optional enhancement requested in Issue #1161.\n\nChanges:\n- New test: tests/test_cli_cache_stats_disabled.py ensuring no stdout block or structured event when cache disabled / absent\n- Doc clarification in docs/phase-2/performance_cache.md describing zero-output behaviour\n\nAcceptance Criteria Alignment:\n- Positive path already covered by existing tests.\n- Negative path now explicitly validated.\n- Documentation now states disabled path produces no output/event.\n\nCloses #1161.