### PR TITLE
Fix multi-period engine typing alias import

### DIFF
--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -29,11 +29,15 @@ from ..core.rank_selection import ASCENDING_METRICS
 from ..data import load_csv
 from ..pipeline import _run_analysis
 from ..rebalancing import apply_rebalancing_strategies
-from ..typing import MultiPeriodPeriodResult  # structural alias
 from ..weighting import (AdaptiveBayesWeighting, BaseWeighting, EqualWeight,
                          ScorePropBayesian)
 from .replacer import Rebalancer
 from .scheduler import generate_periods
+
+# ``trend_analysis.typing`` does not exist in this project; keep the structural
+# intent of ``MultiPeriodPeriodResult`` using a simple mapping alias so the
+# engine remains importable without introducing a new module dependency.
+MultiPeriodPeriodResult = Dict[str, Any]
 
 SHIFT_DETECTION_MAX_STEPS_DEFAULT = 10
 


### PR DESCRIPTION
## Summary
- replace the broken MultiPeriodPeriodResult import with a local Dict alias so the multi-period engine module remains importable

## Testing
- python - <<'PY'\nimport sys\nsys.path.append('src')\nimport trend_analysis.multi_period.engine as engine\nprint(engine.MultiPeriodPeriodResult)\nPY

------
https://chatgpt.com/codex/tasks/task_e_68cccb200af083318e4fb18e1b91c13e