### PR TITLE
ci(labels,#1180): path-based PR labeler + default issue risk labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_codex.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_codex.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Something broke. Keep it factual.
-labels: ["type:bug","codex-ready"]
+labels: ["type:bug","risk:low","agent:codex","automerge","codex-ready"]
 body:
   - type: input
     id: env

--- a/.github/ISSUE_TEMPLATE/feature_request_codex.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_codex.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Small, single-scope feature for the Streamlit app or sim layer
-labels: ["type:feature","codex-ready"]
+labels: ["type:feature","risk:low","agent:codex","automerge","codex-ready"]
 body:
   - type: textarea
     id: summary

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,46 @@
+# Path-based label mappings (Issue #1180)
+# Syncs labels to reflect areas of change.
+backend:
+  - 'src/**'
+  - 'trend_portfolio_app/**'
+  - 'app/**'
+
+metrics:
+  - 'src/trend_analysis/metrics.py'
+  - 'src/trend_analysis/multi_period/**'
+
+selection:
+  - 'src/trend_analysis/core/**'
+  - 'src/trend_analysis/engine/**'
+
+config:
+  - 'config/**'
+
+docs:
+  - 'docs/**'
+  - 'README*.md'
+  - 'AGENTS_APP.md'
+
+workflows:
+  - '.github/workflows/**'
+
+ci:
+  - 'scripts/**'
+  - '.github/actions/**'
+
+tests:
+  - 'tests/**'
+
+notebooks:
+  - 'notebooks/**'
+
+export:
+  - 'src/trend_analysis/export.py'
+  - 'src/trend_analysis/export/**'
+
+performance:
+  - 'perf/**'
+
+streamlit:
+  - 'streamlit_app/**'
+  - 'src/trend_portfolio_app/**'

--- a/.github/workflows/pr-path-labeler.yml
+++ b/.github/workflows/pr-path-labeler.yml
@@ -1,0 +1,19 @@
+name: PR Path Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply path-based labels
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true


### PR DESCRIPTION
Implements Issue #1180 (Issue/PR labeler and forms mapping).

## Changes
1. Added `.github/labeler.yml` providing path -> label mappings (backend, metrics, selection, config, docs, workflows, ci, tests, notebooks, export, performance, streamlit).
2. Added `pr-path-labeler.yml` workflow using `actions/labeler@v5` to apply labels automatically on PR open/update.
3. Updated issue forms:
   - `bug_report_codex.yml`
   - `feature_request_codex.yml`
   Added labels: `risk:low`, `agent:codex`, `automerge` (per guidance: auto-merge only for low risk) plus existing type + readiness label.

## Rationale
Provides deterministic baseline labeling for all PRs (not only agent-detected) and ensures new issues are categorized with risk + agent context, enabling downstream automations (automerge, watchdogs, routing).

## Notes
- `sync-labels: true` ensures labels removed from touched areas are pruned when file moves occur.
- No changes to existing agent heuristic labeler; both workflows can coexist without conflict.
- `automerge` added only alongside `risk:low` in low-risk codex issue templates.

## Follow-Up (Optional)
- Add specialized templates (e.g., security, performance) with different default risk labels.
- Extend labeler mappings for finer-grained components if needed.

Closes #1180.
