### PR TITLE
Adjust agent label workflow sparse checkout guard

### DIFF
--- a/.github/workflows/label-agent-prs.yml
+++ b/.github/workflows/label-agent-prs.yml
@@ -75,9 +75,12 @@ jobs:
       - name: Assert sparse checkout scope (Issue #1140)
         run: |
           set -euo pipefail
-          COUNT=$(find trusted-config -type f | wc -l | tr -d ' ')
-          if [ "$COUNT" -gt 2 ]; then
-            echo "::error::Unexpected file expansion in sparse checkout (found $COUNT files)"; exit 1;
+          EXPECTED=1
+          COUNT=$(git -C trusted-config ls-tree --full-tree --name-only HEAD | wc -l | tr -d ' ')
+          if [ "$COUNT" -ne "$EXPECTED" ]; then
+            echo "::error::Unexpected tracked file count in sparse checkout (expected $EXPECTED, found $COUNT)";
+            git -C trusted-config ls-tree --full-tree --name-only HEAD || true
+            exit 1
           fi
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/label-agent-prs.yml
+++ b/.github/workflows/label-agent-prs.yml
@@ -75,10 +75,11 @@ jobs:
       - name: Assert sparse checkout scope (Issue #1140)
         run: |
           set -euo pipefail
-          EXPECTED=1
+          # Only the agent label rules file should be present after sparse checkout.
+          EXPECTED_AGENT_RULES_FILE_COUNT=1
           COUNT=$(git -C trusted-config ls-tree --full-tree --name-only HEAD | wc -l | tr -d ' ')
-          if [ "$COUNT" -ne "$EXPECTED" ]; then
-            echo "::error::Unexpected tracked file count in sparse checkout (expected $EXPECTED, found $COUNT)";
+          if [ "$COUNT" -ne "$EXPECTED_AGENT_RULES_FILE_COUNT" ]; then
+            echo "::error::Unexpected tracked file count in sparse checkout (expected $EXPECTED_AGENT_RULES_FILE_COUNT, found $COUNT)";
             git -C trusted-config ls-tree --full-tree --name-only HEAD || true
             exit 1
           fi


### PR DESCRIPTION
## Summary
- use git ls-tree to count sparse checkout contents and only consider tracked files
- tighten the expected file count to the single trusted agent label rules file
- emit the tracked file list when the guard fails to aid future debugging

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68ccdbaa1d508331948cd7fe4896eee1