### PR TITLE
Fix duplicate placeholder keys for out-of-sample stats

### DIFF
--- a/src/trend_analysis/core/rank_selection.py
+++ b/src/trend_analysis/core/rank_selection.py
@@ -952,9 +952,7 @@ def blended_score(
 ) -> pd.Series:
     """Z‑score each contributing metric, then weighted linear combo."""
     if not weights:
-        raise ValueError(
-            "blended_score requires non-empty weights dict"
-        )
+        raise ValueError("blended_score requires non-empty weights dict")
     # Normalize metric names using _METRIC_ALIASES
     canonical_weights: dict[str, float] = {}
     for k, v in weights.items():

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -834,8 +834,6 @@ def run(
                         "score_frame": pd.DataFrame(),
                         "weight_engine_fallback": None,
                         "manager_changes": [],
-                        "out_ew_stats": None,
-                        "out_user_stats": None,
                     },
                 )
             )

--- a/src/trend_analysis/typing.py
+++ b/src/trend_analysis/typing.py
@@ -16,4 +16,3 @@ class MultiPeriodPeriodResult(TypedDict, total=False):
     transaction_cost: float
     cov_diag: list[float]
     cache_stats: Mapping[str, float] | MutableMapping[str, float]
-

--- a/tests/test_multi_period_engine.py
+++ b/tests/test_multi_period_engine.py
@@ -67,7 +67,9 @@ class DummyRebalancer:
     def __init__(self) -> None:
         self.calls: list[tuple[pd.Series, list[str]]] = []
 
-    def apply_triggers(self, prev_weights: pd.Series, score_frame: pd.DataFrame) -> pd.Series:
+    def apply_triggers(
+        self, prev_weights: pd.Series, score_frame: pd.DataFrame
+    ) -> pd.Series:
         self.calls.append((prev_weights.copy(), score_frame.index.tolist()))
         return prev_weights.sort_index()
 
@@ -153,6 +155,7 @@ class DummyCfg:
     def model_dump(self) -> dict[str, object]:
         return {}
 
+
 def test_run_price_frames_validation_errors():
     cfg = DummyCfg()
 
@@ -219,4 +222,3 @@ def test_run_with_price_frames_builds_covariance(monkeypatch):
     assert "cov_diag" in result
     assert len(result["cov_diag"]) == 2
     assert "cache_stats" in result
-

--- a/tests/test_multi_period_engine_additional.py
+++ b/tests/test_multi_period_engine_additional.py
@@ -24,7 +24,9 @@ def test_compute_turnover_state_with_previous_allocation() -> None:
     assert next_vals.tolist() == [0.5, 0.1]
 
 
-def test_run_schedule_with_rebalance_strategies(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_schedule_with_rebalance_strategies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     class DummySelector:
         rank_column = "score"
 
@@ -59,12 +61,8 @@ def test_run_schedule_with_rebalance_strategies(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setenv("DEBUG_TURNOVER_VALIDATE", "1")
 
     score_frames = {
-        "2020-01-31": pd.DataFrame(
-            {"score": [1.0, 2.0]}, index=["Fund A", "Fund B"]
-        ),
-        "2020-02-29": pd.DataFrame(
-            {"score": [1.5, 1.0]}, index=["Fund A", "Fund C"]
-        ),
+        "2020-01-31": pd.DataFrame({"score": [1.0, 2.0]}, index=["Fund A", "Fund B"]),
+        "2020-02-29": pd.DataFrame({"score": [1.5, 1.0]}, index=["Fund A", "Fund C"]),
     }
 
     weighting = DummyWeighting()
@@ -132,19 +130,17 @@ def test_run_combines_price_frames(monkeypatch: pytest.MonkeyPatch) -> None:
 
     captured: dict[str, Any] = {}
 
-    def fake_run_analysis(df: pd.DataFrame, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def fake_run_analysis(
+        df: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> dict[str, Any]:
         captured["df"] = df
         return {"ok": True}
 
     monkeypatch.setattr(engine, "_run_analysis", fake_run_analysis)
 
     price_frames = {
-        "first": pd.DataFrame(
-            {"Date": [pd.Timestamp("2020-02-01")], "FundB": [0.2]}
-        ),
-        "second": pd.DataFrame(
-            {"Date": [pd.Timestamp("2020-01-01")], "FundA": [0.1]}
-        ),
+        "first": pd.DataFrame({"Date": [pd.Timestamp("2020-02-01")], "FundB": [0.2]}),
+        "second": pd.DataFrame({"Date": [pd.Timestamp("2020-01-01")], "FundA": [0.1]}),
     }
 
     results = engine.run(cfg, price_frames=price_frames)
@@ -182,7 +178,9 @@ def test_run_incremental_covariance(monkeypatch: pytest.MonkeyPatch) -> None:
         diag = np.arange(1, len(df.columns) + 1, dtype=float)
         return CovPayload(diag)
 
-    def fake_incremental(payload: CovPayload, old_row: np.ndarray, new_row: np.ndarray) -> CovPayload:
+    def fake_incremental(
+        payload: CovPayload, old_row: np.ndarray, new_row: np.ndarray
+    ) -> CovPayload:
         diag = payload.cov.diagonal() + 0.5
         return CovPayload(diag)
 
@@ -216,7 +214,9 @@ def test_run_incremental_covariance(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(engine, "generate_periods", lambda _: periods)
 
-    def fake_run_analysis(df: pd.DataFrame, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def fake_run_analysis(
+        df: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> dict[str, Any]:
         return {}
 
     monkeypatch.setattr(engine, "_run_analysis", fake_run_analysis)
@@ -237,4 +237,3 @@ def test_run_incremental_covariance(monkeypatch: pytest.MonkeyPatch) -> None:
     assert results[0]["cache_stats"] == {"updates": 0}
     assert results[1]["cov_diag"] == [1.5, 2.5]
     assert results[1]["cache_stats"] == {"updates": 1}
-

--- a/tests/test_portfolio_app_helpers.py
+++ b/tests/test_portfolio_app_helpers.py
@@ -2,23 +2,28 @@
 
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any, Dict
+from unittest import mock
 
 import pandas as pd
 import pytest
-import yaml
-import importlib.util
-from unittest import mock
+import yaml  # type: ignore[import-untyped]
+
 
 def load_helper_namespace() -> Dict[str, Any]:
-    """Import the helper portion of ``app.py`` and return its globals, mocking Streamlit."""
+    """Import the helper portion of ``app.py`` and return its globals, mocking
+    Streamlit."""
     with mock.patch.dict("sys.modules", {"streamlit": mock.MagicMock()}):
-        spec = importlib.util.spec_from_file_location("trend_portfolio_app.app", "src/trend_portfolio_app/app.py")
+        spec = importlib.util.spec_from_file_location(
+            "trend_portfolio_app.app", "src/trend_portfolio_app/app.py"
+        )
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         return module.__dict__
+
+
 def test_merge_update_recurses_through_nested_dicts():
     ns = load_helper_namespace()
     merge = ns["_merge_update"]

--- a/tests/test_portfolio_app_helpers.py
+++ b/tests/test_portfolio_app_helpers.py
@@ -7,15 +7,9 @@ from pathlib import Path
 from typing import Any, Dict
 from unittest import mock
 
-import importlib.util
 import pandas as pd
 import pytest
-
-import yaml
-from unittest import mock
-
-
-from tests.test_trend_portfolio_app_helpers import _DummyStreamlit
+import yaml  # type: ignore[import-untyped]
 
 
 def load_helper_namespace() -> Dict[str, Any]:
@@ -32,7 +26,9 @@ def load_helper_namespace() -> Dict[str, Any]:
         if hasattr(loader, "exec_module") and callable(getattr(loader, "exec_module")):
             loader.exec_module(module)
         else:
-            raise TypeError(f"Loader {type(loader)} does not have an exec_module method")
+            raise TypeError(
+                f"Loader {type(loader)} does not have an exec_module method"
+            )
         return module.__dict__
 
 

--- a/tests/test_rank_selection_extended.py
+++ b/tests/test_rank_selection_extended.py
@@ -257,9 +257,7 @@ class TestBlendedScore:
         in_df = df.loc[df.index[:3], ["A", "B"]]
         cfg = rs.RiskStatsConfig(risk_free=0.0)
 
-        with pytest.raises(
-            ValueError, match=r"blended_score requires non[-‑]empty"
-        ):
+        with pytest.raises(ValueError, match=r"blended_score requires non[-‑]empty"):
             rs.blended_score(in_df, {}, cfg)
 
 

--- a/tests/test_trend_analysis_init.py
+++ b/tests/test_trend_analysis_init.py
@@ -9,4 +9,3 @@ def test_trend_analysis_init_exposes_exports():
     assert hasattr(module, "load_csv")
     assert hasattr(module, "export_to_csv")
     assert hasattr(module, "export_to_excel")
-


### PR DESCRIPTION
## Summary
- remove duplicate placeholder entries for out-of-sample equal-weight and user-weight stats when no funds are available
- keep the fallback period result structure consistent without redefining keys

## Testing
- pytest tests/test_multi_period_engine_incremental_extra.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cce14106d08331be1401d38026959a