### PR TITLE
ci(stale): implement stale PR TTL workflow (14+7)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -138,4 +138,30 @@ jobs:
 ## 10. Change Process
 Submit a PR updating this README plus any workflow changes. Major workflow semantics should be noted in a short “Design Note” block inside the workflow file and linked here if impactful.
 
-_Last updated: 2025-09-19 (implements Issue #1204)_
+---
+## 11. Stale PR TTL Policy (Issue #1205)
+Purpose: Keep the open PR queue reviewable and reduce CI load.
+
+Workflow: `stale-prs.yml` (scheduled daily @ 02:23 UTC + manual dispatch).
+
+Policy Defaults:
+- Warn (mark stale + add `stale` label) after 14 days of no activity (no commits, comments, or reviews).
+- Auto-close after an additional 7 days (21 days total inactivity).
+- Exempt labels: `pinned`, `work-in-progress`, `security`, `blocked` (presence of any prevents stale processing).
+- Activity (push/comment / label removal) removes the `stale` label automatically.
+
+Operator Guidance:
+- To keep a long‑running draft alive: apply `work-in-progress`.
+- To pause due to external dependency: apply `blocked`.
+- Reopen a closed stale PR via the GitHub UI if work resumes (or open a new PR referencing the old number if history is heavy).
+- Adjust timings by editing `days-before-pr-stale` / `days-before-pr-close` in the workflow.
+
+Rationale:
+- Ensures reviewer focus on active contributions.
+- Prevents silent accumulation of outdated branches soaking CI cycles.
+
+Future Enhancements (not yet implemented):
+- Telemetry summary comment with counts of newly stale and closed PRs.
+- Org-level override via repository variable (e.g. `STALE_PR_TTL_DAYS`).
+
+_Last updated: 2025-09-19 (adds Issue #1205 implementation)_

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,38 @@
+name: Stale PR TTL
+
+on:
+  schedule:
+    - cron: '23 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  mark_stale_and_close:
+    name: Mark stale & close PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run stale action
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # PR-only scope (issues disabled per Issue #1205 scope)
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          stale-pr-label: stale
+          exempt-pr-labels: pinned,work-in-progress,security,blocked
+          remove-stale-when-updated: true
+          operations-per-run: 200
+          ascending: false
+          stale-pr-message: >
+            This pull request has had no activity for 14 days and has been marked as **stale**.
+            Please push new commits, comment, or apply an exempt label (pinned / work-in-progress / security / blocked) to keep it open.
+            Without further activity it will be closed automatically in 7 days.
+          close-pr-message: >
+            Closing due to 21 days of inactivity (14 days to stale + 7 day grace period).
+            If you plan to continue the work, feel free to **reopen** the PR or open a fresh one referencing this number.
+            Maintaining an active PR queue helps CI and review throughput.


### PR DESCRIPTION
Implements Issue #1205.

Summary:
- Adds scheduled + manual  workflow (14 days to mark stale, 7 additional days to auto-close).
- PR-only scope (issues excluded) as per acceptance.
- Exempt labels: pinned, work-in-progress, security, blocked.
- Documentation: added Section 11 to .github/workflows/README.md covering policy, operator guidance, and future enhancements.

Configuration:
- Schedule: 02:23 UTC daily.
- Safe defaults: remove stale label on any activity; no impact on issues.

Testing / Validation:
- YAML validation passed via pre-commit hooks.
- Parameter keys validated (correct stale/close message keys).

Future Enhancements (deferred):
- Telemetry summary comment.
- Repo variable overrides for TTL.

Closes #1205.