### PR TITLE
Add tests for incremental covariance and init import fallback

### DIFF
--- a/tests/test_multi_period_engine_incremental_cov.py
+++ b/tests/test_multi_period_engine_incremental_cov.py
@@ -1,0 +1,148 @@
+"""Tests covering the incremental covariance path in the multi-period engine."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+
+from trend_analysis.multi_period import engine as mp_engine
+from trend_analysis.perf import cache as cache_mod
+
+
+class _Cfg:
+    """Minimal configuration object for exercising ``engine.run``."""
+
+    def __init__(self) -> None:
+        self.data: dict[str, str] = {}
+        self.portfolio: dict[str, object] = {
+            "policy": "",  # ensure Phase-1 style path is used
+            "selection_mode": "all",
+            "random_n": 2,
+            "rank": {},
+            "custom_weights": None,
+            "manual_list": None,
+            "indices_list": None,
+        }
+        self.vol_adjust: dict[str, float] = {"target_vol": 1.0}
+        self.run: dict[str, float] = {"monthly_cost": 0.0}
+        self.benchmarks: dict[str, str] = {}
+        self.performance: dict[str, object] = {
+            "enable_cache": True,
+            "incremental_cov": True,
+            "shift_detection_max_steps": 4,
+        }
+        self.seed = 7
+
+    def model_dump(self) -> dict[str, object]:
+        return {}
+
+
+def _make_df() -> pd.DataFrame:
+    dates = pd.to_datetime(
+        [
+            "2020-01-31",
+            "2020-02-29",
+            "2020-03-31",
+            "2020-04-30",
+            "2020-05-31",
+        ]
+    )
+    return pd.DataFrame(
+        {
+            "Date": dates,
+            "FundA": [0.01, 0.015, 0.012, 0.011, 0.013],
+            "FundB": [0.005, 0.007, 0.006, 0.008, 0.009],
+        }
+    )
+
+
+def _make_periods() -> list[SimpleNamespace]:
+    return [
+        SimpleNamespace(
+            in_start="2020-01",
+            in_end="2020-03",
+            out_start="2020-04",
+            out_end="2020-04",
+        ),
+        SimpleNamespace(
+            in_start="2020-02",
+            in_end="2020-04",
+            out_start="2020-05",
+            out_end="2020-05",
+        ),
+    ]
+
+
+def test_run_incremental_covariance_updates(monkeypatch):
+    """Exercise the shift-detection incremental covariance path."""
+
+    cfg = _Cfg()
+    df = _make_df()
+    periods = _make_periods()
+
+    monkeypatch.setattr(mp_engine, "generate_periods", lambda _cfg: periods)
+
+    run_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def fake_run_analysis(*args, **kwargs):
+        run_calls.append((args, kwargs))
+        return {"out_ew_stats": {"sharpe": 1.0}}
+
+    monkeypatch.setattr(mp_engine, "_run_analysis", fake_run_analysis)
+
+    real_incremental = cache_mod.incremental_cov_update
+    incremental_calls: list[tuple[pd.Series, pd.Series]] = []
+
+    def wrapped_incremental(prev, old_row, new_row):
+        incremental_calls.append((pd.Series(old_row), pd.Series(new_row)))
+        return real_incremental(prev, old_row, new_row)
+
+    monkeypatch.setattr(cache_mod, "incremental_cov_update", wrapped_incremental)
+
+    results = mp_engine.run(cfg, df=df)
+
+    assert len(results) == 2
+    assert len(run_calls) == 2
+    # Second period should rely on incremental updates (k == 1)
+    assert len(incremental_calls) == 1
+    second_stats = results[1]["cache_stats"]
+    assert second_stats["incremental_updates"] == 1
+
+
+def test_run_incremental_covariance_fallback_on_error(monkeypatch):
+    """If incremental updates fail, the engine recomputes the covariance."""
+
+    cfg = _Cfg()
+    df = _make_df()
+    periods = _make_periods()
+
+    monkeypatch.setattr(mp_engine, "generate_periods", lambda _cfg: periods)
+
+    def fake_run_analysis(*args, **kwargs):
+        return {"out_ew_stats": {"sharpe": 1.0}}
+
+    monkeypatch.setattr(mp_engine, "_run_analysis", fake_run_analysis)
+
+    fallback_calls: list[int] = []
+    real_compute = cache_mod.compute_cov_payload
+
+    def wrapped_compute(df: pd.DataFrame, *, materialise_aggregates: bool):
+        fallback_calls.append(df.shape[0])
+        return real_compute(df, materialise_aggregates=materialise_aggregates)
+
+    monkeypatch.setattr(cache_mod, "compute_cov_payload", wrapped_compute)
+
+    def boom(prev, old_row, new_row):
+        raise RuntimeError("incremental update failure")
+
+    monkeypatch.setattr(cache_mod, "incremental_cov_update", boom)
+
+    results = mp_engine.run(cfg, df=df)
+
+    assert len(results) == 2
+    # compute_cov_payload is invoked once per period; failure triggers a second call for the second period
+    assert fallback_calls == [3, 3]
+    second_stats = results[1]["cache_stats"]
+    # No incremental updates recorded because the helper kept failing
+    assert second_stats["incremental_updates"] == 0

--- a/tests/test_trend_analysis_init.py
+++ b/tests/test_trend_analysis_init.py
@@ -2,6 +2,7 @@ import importlib
 import importlib.metadata
 
 import pytest
+from typing import Optional
 
 
 def test_trend_analysis_init_exposes_exports():
@@ -46,3 +47,27 @@ def test_trend_analysis_version_fallback(monkeypatch: pytest.MonkeyPatch) -> Non
         assert module.__version__ == "0.1.0-dev"
 
     importlib.reload(module)  # restore original metadata-driven version
+
+
+def test_trend_analysis_missing_optional_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    import trend_analysis
+
+    module = importlib.reload(trend_analysis)
+
+    # ensure the eager attribute is absent before simulating the import failure
+    module.__dict__.pop("metrics", None)
+
+    real_import = importlib.import_module
+
+    def flaky_import(name: str, package: Optional[str] = None):
+        if name == "trend_analysis.metrics":
+            raise ImportError("optional dependency missing")
+        return real_import(name, package)
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(importlib, "import_module", flaky_import)
+        reloaded = importlib.reload(module)
+
+    assert "metrics" not in reloaded.__dict__
+    # restore pristine module state for subsequent tests
+    importlib.reload(reloaded)


### PR DESCRIPTION
## Summary
- add incremental covariance tests exercising shift detection and fallback logic in the multi-period engine
- add regression coverage for the trend_analysis package init when optional eager imports fail

## Testing
- pytest tests/test_multi_period_engine_incremental_cov.py tests/test_trend_analysis_init.py -q
- pytest --maxfail=1 --disable-warnings -q *(fails: tests/test_multi_period_engine_threshold_edgecases.py::test_threshold_hold_yields_placeholder_when_universe_empty expects out_ew_stats is None)*

------
https://chatgpt.com/codex/tasks/task_e_68cced7d6bfc83319bc658945146453c