### PR TITLE
Fix sparse checkout file count check

### DIFF
--- a/.github/workflows/autoapprove.yml
+++ b/.github/workflows/autoapprove.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Assert sparse checkout scope (Issue #1140)
         run: |
           set -euo pipefail
-          COUNT=$(find trusted-config -path 'trusted-config/.git' -prune -o -type f -print | wc -l | tr -d ' ')
+          COUNT=$(find trusted-config -type f ! -path 'trusted-config/.git/*' | wc -l | tr -d ' ')
           if [ "$COUNT" -gt 2 ]; then
             echo "::error::Unexpected file expansion in sparse checkout (found $COUNT files outside .git)"; exit 1;
           fi


### PR DESCRIPTION
## Summary
- ignore the trusted-config/.git directory when counting files in the sparse checkout assertion so only working tree files are checked

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cceeca60008331b8e0ec20d8855875