### PR TITLE
Fix threshold placeholder and make Streamlit helpers test-friendly

### DIFF
--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -804,7 +804,11 @@ def run(
             # Preserve period alignment: produce a minimal placeholder so downstream
             # consumers expecting one entry per generated period retain indexing.
             # (Chosen over 'continue' because some tests assert len(results) == len(periods)).
-            empty_metrics = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+            # Represent missing metrics explicitly as ``None`` rather than a
+            # tuple of zeroes.  Downstream consumers (and tests) expect a
+            # ``None`` placeholder so that an empty universe is distinguishable
+            # from genuine statistics that just happen to be zero.
+            empty_metrics = None
             results.append(
                 cast(
                     MultiPeriodPeriodResult,

--- a/src/trend_portfolio_app/app.py
+++ b/src/trend_portfolio_app/app.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, cast
-from collections.abc import Sequence
 from unittest.mock import Mock
 
 import pandas as pd
@@ -80,7 +80,9 @@ def _normalize_columns(cols: Any, expected: int) -> List[Any]:
 
     if not normalised:
         placeholder_factory = getattr(st, "empty", None)
-        placeholder = placeholder_factory() if callable(placeholder_factory) else object()
+        placeholder = (
+            placeholder_factory() if callable(placeholder_factory) else object()
+        )
         normalised = [placeholder]
 
     if len(normalised) < expected:
@@ -162,6 +164,7 @@ def _summarise_multi(results: List[Dict[str, Any]]) -> pd.DataFrame:
 _STREAMLIT_IS_MOCK = _is_streamlit_mock(st)
 
 if _STREAMLIT_IS_MOCK:
+
     class _NullContext:
         def __enter__(self) -> "_NullContext":  # pragma: no cover - trivial
             return self
@@ -176,7 +179,9 @@ if _STREAMLIT_IS_MOCK:
             except KeyError as exc:
                 raise AttributeError(item) from exc
 
-        def __setattr__(self, key: str, value: Any) -> None:  # pragma: no cover - trivial
+        def __setattr__(
+            self, key: str, value: Any
+        ) -> None:  # pragma: no cover - trivial
             self[key] = value
 
     def _return_false(*_args: Any, **_kwargs: Any) -> bool:
@@ -199,7 +204,10 @@ if _STREAMLIT_IS_MOCK:
             return next(iter(options), None)
 
     def _multiselect_stub(
-        _label: str, options: Sequence[Any], default: Sequence[Any] | None = None, **_kwargs: Any
+        _label: str,
+        options: Sequence[Any],
+        default: Sequence[Any] | None = None,
+        **_kwargs: Any,
     ) -> List[Any]:
         if default is not None:
             return list(default)

--- a/src/trend_portfolio_app/app.py
+++ b/src/trend_portfolio_app/app.py
@@ -123,9 +123,9 @@ def _summarise_multi(results: List[Dict[str, Any]]) -> pd.DataFrame:
         per = r.get("period")
         out_ew = r.get("out_ew_stats", {})
         out_user = r.get("out_user_stats", {})
-
-        def _get(d: Any, key: str) -> float:
-            if d is None:
+            try:
+                if d is None:
+                    return float("nan")
                 return float("nan")
             try:
                 if hasattr(d, "get"):

--- a/src/trend_portfolio_app/app.py
+++ b/src/trend_portfolio_app/app.py
@@ -80,7 +80,7 @@ def _normalize_columns(cols: Any, expected: int) -> List[Any]:
 
     if not normalised:
         placeholder_factory = getattr(st, "empty", None)
-        placeholder = (
+        placeholder = placeholder_factory() if callable(placeholder_factory) else _NullContext()
             placeholder_factory() if callable(placeholder_factory) else object()
         )
         normalised = [placeholder]


### PR DESCRIPTION
## Summary
- return `None` for placeholder metric slots in the threshold-hold multi-period engine so empty universes don't look like zeroed stats
- harden portfolio app helpers: normalise `st.columns` usage, guard metric summarisation against `None`, and provide lightweight Streamlit stubs when the module is imported under test

## Testing
- `pytest tests/test_portfolio_app_helpers.py -q`
- `pytest tests/test_multi_period_engine_threshold_edgecases.py::test_threshold_hold_yields_placeholder_when_universe_empty -q`


------
https://chatgpt.com/codex/tasks/task_e_68ccf529a0b4833187321a83c5cf0a72