### PR TITLE
perf(ci): pip cache for reusable Python workflow

### DIFF
--- a/.github/workflows/reuse-ci-python.yml
+++ b/.github/workflows/reuse-ci-python.yml
@@ -45,6 +45,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
+      - name: Cache pip
+        id: cache-pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: >-
+            pip-${{ runner.os }}-${{ matrix.py }}-
+            ${{ hashFiles('requirements.txt', 'requirements.lock', 'pyproject.toml') }}
+          restore-keys: |
+            pip-${{ runner.os }}-${{ matrix.py }}-
+            pip-${{ runner.os }}-
       - name: Install
         run: |
           python -m pip install -U pip


### PR DESCRIPTION
Add pip caching to reusable CI workflow.

Changes
- Introduces `actions/cache@v4` step caching `~/.cache/pip` keyed on: OS, Python version, and hash of `requirements.txt`, `requirements.lock`, `pyproject.toml`.
- Provides restore fallbacks (Python+OS, then OS) to improve hit rate after minor dependency churn.

Rationale
- Reduces redundant dependency downloads/install time across matrix builds.
- Keeps cache invalidation deterministic via dependency file hashing.

Expected Impact
- Cold run: identical to current behavior (cache miss).
- Warm runs: shave ~30-60s (network + wheel build) per Python version depending on dependency set size.

Safety / Backwards Compatibility
- No change to test commands or coverage extraction.
- If cache corruption occurs, touching dependency file (or manual cache purge) invalidates key.

Follow-ups (Optional)
- Add summary line showing cache hit via `${{ steps.cache-pip.outputs.cache-hit }}`.
- Extend caching to `.mypy_cache` and `.pytest_cache` for iterative PR cycles.
- Introduce pip download-only stage to further parallelize environment prep.

Let me know if you'd like those follow-ups in this PR or a separate one.
