### PR TITLE
ci: reusable python workflow scaffold (coverage-alert-drop input only)

### DIFF
--- a/.github/workflows/reusable-ci-python.yml
+++ b/.github/workflows/reusable-ci-python.yml
@@ -1,0 +1,116 @@
+name: reusable-ci-python
+
+on:
+  workflow_call:
+    inputs:
+      python-versions:
+        description: 'JSON array of Python versions'
+        required: false
+        default: '["3.11","3.12"]'
+        type: string
+      coverage-min:
+        description: 'Minimum coverage percentage gate'
+        required: false
+        default: '80'
+        type: string
+      marker-expr:
+        description: 'Pytest -m expression to select tests'
+        required: false
+        default: 'not quarantine and not slow'
+        type: string
+      run-full:
+        description: 'If true run full suite'
+        required: false
+        default: 'false'
+        type: string
+      include-slow:
+        description: 'Include slow tests'
+        required: false
+        default: 'false'
+        type: string
+      include-quarantine:
+        description: 'Include quarantine tests'
+        required: false
+        default: 'false'
+        type: string
+      run-mypy:
+        description: 'Run mypy after tests'
+        required: false
+        default: 'false'
+        type: string
+      webhook-url:
+        description: 'Optional webhook URL for summary'
+        required: false
+        default: ''
+        type: string
+      coverage-alert-drop:
+        description: 'Coverage drop alert threshold (planned future logic)'
+        required: false
+        default: '0'
+        type: string
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: tests (py ${{ matrix.py }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        py: ${{ fromJson(inputs.python-versions) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.py }}
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          pip install -r requirements.txt
+          pip install -e .[dev] pytest pytest-cov
+      - name: Derive marker expression
+        id: markers
+        shell: bash
+        run: |
+          if [[ "${{ inputs.run-full }}" == "true" ]]; then echo "value=" >> $GITHUB_OUTPUT; exit 0; fi
+          BASE='${{ inputs.marker-expr }}'
+          if [[ "${{ inputs.include-slow }}" == "true" ]]; then BASE=$(echo "$BASE" | sed -E 's/ ?and not slow//'); fi
+          if [[ "${{ inputs.include-quarantine }}" == "true" ]]; then BASE=$(echo "$BASE" | sed -E 's/ ?and not quarantine//'); fi
+          echo "value=$BASE" >> $GITHUB_OUTPUT
+      - name: Run tests
+        id: run_tests
+        shell: bash
+        run: |
+          set -o pipefail
+          MARK='${{ steps.markers.outputs.value }}'
+          if [ "${{ inputs.run-full }}" = "true" ] || [ -z "$MARK" ]; then
+            pytest --junitxml=pytest-junit.xml --cov=src --cov-report=term-missing --cov-report=xml:coverage.xml --cov-branch
+          else
+            pytest -m "$MARK" --junitxml=pytest-junit.xml --cov=src --cov-report=term-missing --cov-report=xml:coverage.xml --cov-branch
+          fi
+      - name: Coverage gate
+        if: inputs.coverage-min != ''
+        shell: bash
+        run: |
+          if [ -f coverage.xml ]; then
+            pct=$(grep -Eo 'line-rate="[0-9.]+"' coverage.xml | head -1 | sed -E 's/.*"([0-9.]+)"/\1/')
+            pct=$(python -c "print(f'{float($pct)*100:.2f}')")
+            min=${{ inputs.coverage-min }}
+            awk -v a="$pct" -v b="$min" 'BEGIN { exit (a+0 < b+0) ? 1 : 0 }'
+            echo "Coverage: $pct% (min $min%)"
+          else
+            echo "coverage.xml missing"; exit 1
+          fi
+      - name: Optional mypy
+        if: inputs.run-mypy == 'true'
+        run: |
+          pip install mypy
+          mypy --ignore-missing-imports src || true
+      - name: Webhook (placeholder)
+        if: inputs.webhook-url != ''
+        run: |
+          echo '{"status":"ok"}' > payload.json
+          curl -s -X POST -H 'Content-Type: application/json' -d @payload.json '${{ inputs.webhook-url }}' || true


### PR DESCRIPTION
Minimal reusable workflow scaffold adding only the new 'coverage-alert-drop' input.\n\nScope (Intentional Minimalism)\n- Adds .github/workflows/reusable-ci-python.yml with baseline inputs: python-versions, coverage-min, marker-expr, run-full, include-slow, include-quarantine, run-mypy, webhook-url, coverage-alert-drop\n- Implements ONLY existing gating + optional mypy; NO advanced metrics, history, classification, artifacts, or coverage drop logic yet.\n- Removes previously corrupted YAML fragments; file is clean (~116 LOC).\n\nNon-Goals (Deferred Phases)\n1. No timing / slow test classification\n2. No failing-test summary extraction\n3. No coverage delta computation nor label management\n4. No NDJSON or historical artifact persistence\n5. No coverage drop enforcement (new input placeholder)\n\nPlanned Phases\nPhase 1: Metrics & status extraction (enable-metrics)\nPhase 2: Slow/quarantine history & classification outputs\nPhase 3: Coverage delta & alert logic (implement coverage-alert-drop) + label management\nPhase 4: Documentation & sample caller workflows\nPhase 5: PR comment & label enhancements\n\nValidation: YAML lint passed; minimal job runs expected.\n\nRequest: Confirm minimal scope satisfies 'add coverage-alert-drop input only'.