### PR TITLE
Fix suppress_activate input reference

### DIFF
--- a/.github/workflows/verify-codex-bootstrap-matrix.yml
+++ b/.github/workflows/verify-codex-bootstrap-matrix.yml
@@ -128,7 +128,7 @@ jobs:
           OVERRIDE_ALLOW_FALLBACK: ${{ github.event.inputs.override_allow_fallback }}
           OVERRIDE_CODEX_COMMAND: ${{ github.event.inputs.codex_command }}
           OVERRIDE_PR_MODE: ${{ github.event.inputs.pr_mode }}
-          SUPPRESS_ACTIVATE: ${{ github.event.inputs.suppress_activate || 'false' }}
+          SUPPRESS_ACTIVATE: ${{ github.event.inputs.suppress_activate != '' && github.event.inputs.suppress_activate || 'false' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SERVICE_BOT_PAT: ${{ secrets.SERVICE_BOT_PAT }}
         run: |


### PR DESCRIPTION
## Summary
- ensure suppress_activate input is only used when provided to avoid workflow errors

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd04236e6483319a41516480d78e01