### PR TITLE
Fix mypy typing contract checks and annotate cache stats

### DIFF
--- a/src/trend_analysis/core/metric_cache.py
+++ b/src/trend_analysis/core/metric_cache.py
@@ -46,7 +46,7 @@ class MetricCache:
         self.hits = 0
         self.misses = 0
 
-    def stats(self) -> dict:
+    def stats(self) -> dict[str, int | float]:
         total = self.hits + self.misses
         hit_rate = (self.hits / total) if total else 0.0
         return {

--- a/tests/test_trend_analysis_typing_contract.py
+++ b/tests/test_trend_analysis_typing_contract.py
@@ -34,7 +34,9 @@ def test_multi_period_period_result_schema_matches_expected_contract() -> None:
     assert hints["manager_changes"] == MutableSequence[dict[str, object]]
     assert hints["turnover"] == float
     assert hints["transaction_cost"] == float
-    assert hints["cov_diag"] == list[float]
+    cov_diag_hint = hints["cov_diag"]
+    assert get_origin(cov_diag_hint) is list
+    assert get_args(cov_diag_hint) == (float,)
 
 
 def test_multi_period_period_result_supports_incremental_population() -> None:


### PR DESCRIPTION
## Summary
- validate the `cov_diag` type hint in the typing contract test using typing introspection helpers
- give the metric cache stats helper a precise return type so mypy sees concrete key/value types

## Testing
- `MYPYPATH=src mypy tests/test_trend_analysis_typing_contract.py`
- `pytest tests/test_trend_analysis_typing_contract.py`


------
https://chatgpt.com/codex/tasks/task_e_68cd08f57500833191f7105b443d9083