### PR TITLE
Add tests for Streamlit app state handling

### DIFF
--- a/tests/test_trend_portfolio_app_helpers.py
+++ b/tests/test_trend_portfolio_app_helpers.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -173,8 +174,20 @@ def _load_app(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
 
     source = Path(module.__file__).read_text(encoding="utf-8")
     prefix = source.split("st.set_page_config", 1)[0]
-    code = compile(prefix, module.__file__, "exec")
+    code = compile(prefix + "    pass\n", module.__file__, "exec")
     exec(code, module.__dict__)
+
+    is_mock_impl = module._is_mock_streamlit  # type: ignore[attr-defined]
+
+    def _compat_streamlit_mock(candidate: Any) -> bool:
+        name = type(candidate).__name__
+        if name in {"Mock", "MagicMock"}:
+            return True
+        return is_mock_impl(candidate)
+
+    module._is_streamlit_mock = _compat_streamlit_mock  # type: ignore[attr-defined]
+    module._STREAMLIT_IS_MOCK = _compat_streamlit_mock(module.st)  # type: ignore[attr-defined]
+    module._SessionState = _SessionState  # type: ignore[attr-defined]
 
     sys.modules[module.__name__] = module
     return module
@@ -189,6 +202,8 @@ def _load_app_with_magicmock(
     # Ensure placeholder helpers fall back to the module-defined ``_NullContext``.
     stub.empty = None
     stub.columns.return_value = []
+    stub.button.return_value = False
+    stub.session_state = _SessionState()
     monkeypatch.setitem(sys.modules, "streamlit", stub)
     sys.modules.pop("trend_portfolio_app.app", None)
 
@@ -197,8 +212,20 @@ def _load_app_with_magicmock(
 
     source = Path(module.__file__).read_text(encoding="utf-8")
     prefix = source.split("st.set_page_config", 1)[0]
-    code = compile(prefix, module.__file__, "exec")
+    code = compile(prefix + "    pass\n", module.__file__, "exec")
     exec(code, module.__dict__)
+
+    is_mock_impl = module._is_mock_streamlit  # type: ignore[attr-defined]
+
+    def _compat_streamlit_mock(candidate: Any) -> bool:
+        name = type(candidate).__name__
+        if name in {"Mock", "MagicMock"}:
+            return True
+        return is_mock_impl(candidate)
+
+    module._is_streamlit_mock = _compat_streamlit_mock  # type: ignore[attr-defined]
+    module._STREAMLIT_IS_MOCK = _compat_streamlit_mock(module.st)  # type: ignore[attr-defined]
+    module._SessionState = _SessionState  # type: ignore[attr-defined]
 
     sys.modules[module.__name__] = module
     return module, stub
@@ -362,3 +389,218 @@ def test_magicmock_streamlit_bootstrap_installs_null_context(
         assert isinstance(app_mod.st.session_state, app_mod._SessionState)
     finally:
         sys.modules.pop("trend_portfolio_app.app", None)
+
+
+def test_apply_session_state_expands_session_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    app_mod = _load_app(monkeypatch)
+
+    state = app_mod.st.session_state
+    state.clear()
+    state.update(
+        {
+            "data.csv_path": "override.csv",
+            "portfolio.policy": "aggressive",
+            "multi_period.window._months": "6",
+            "metrics.alpha": 0.75,
+            "unrelated": "ignored",
+            "custom.key": "skipped",  # Prefix missing from allow list
+        }
+    )
+
+    cfg: dict[str, Any] = {"data": {"csv_path": "initial.csv"}}
+
+    app_mod._apply_session_state(cfg)
+
+    assert cfg["data"]["csv_path"] == "override.csv"
+    assert cfg["portfolio"]["policy"] == "aggressive"
+    assert cfg["multi_period"]["window"]["length"] == 126
+    assert cfg["metrics"]["alpha"] == 0.75
+    assert "custom" not in cfg
+    assert "unrelated" not in cfg
+
+
+def test_render_sidebar_resets_and_serialises(monkeypatch: pytest.MonkeyPatch) -> None:
+    app_mod = _load_app(monkeypatch)
+
+    defaults = {"data": {"csv_path": "reset.csv"}, "portfolio": {"policy": "reset"}}
+    monkeypatch.setattr(app_mod, "_read_defaults", lambda: json.loads(json.dumps(defaults)))
+
+    button_calls: list[str] = []
+
+    def fake_button(label: str, *_, **__) -> bool:
+        button_calls.append(label)
+        return label == "Reset to defaults"
+
+    app_mod.st.button = fake_button  # type: ignore[assignment]
+
+    seen_values: list[str] = []
+
+    def fake_text_input(
+        label: str, *, key: str, value: str, help: str
+    ) -> str:  # pragma: no cover - signature guard
+        seen_values.append(value)
+        assert key == "data.csv_path"
+        assert "manager returns" in help
+        return "user.csv"
+
+    app_mod.st.text_input = fake_text_input  # type: ignore[assignment]
+
+    downloads: list[tuple[str, bytes, str, str]] = []
+
+    def fake_download(
+        label: str, *, data: bytes, file_name: str, mime: str
+    ) -> None:  # pragma: no cover - signature guard
+        downloads.append((label, data, file_name, mime))
+
+    app_mod.st.download_button = fake_download  # type: ignore[assignment]
+
+    cfg: dict[str, Any] = {"data": {"csv_path": "initial.csv"}}
+
+    app_mod._render_sidebar(cfg)
+
+    assert button_calls == ["Reset to defaults"]
+    assert app_mod.st.session_state.config_dict["portfolio"]["policy"] == "reset"
+    assert app_mod.st.session_state.config_dict["data"]["csv_path"] == "user.csv"
+    assert seen_values == ["reset.csv"]
+    assert cfg["data"]["csv_path"] == "user.csv"
+
+    assert len(downloads) == 1
+    label, payload, file_name, mime = downloads[0]
+    assert label == "Download YAML"
+    assert file_name == "config.yml"
+    assert mime == "text/yaml"
+    dumped = app_mod.yaml.safe_load(payload.decode("utf-8"))
+    assert dumped["data"]["csv_path"] == "user.csv"
+
+
+def test_render_run_section_executes_single_period(monkeypatch: pytest.MonkeyPatch) -> None:
+    app_mod = _load_app(monkeypatch)
+
+    def fake_button(label: str, *_, **__) -> bool:
+        return label == "Run Single Period"
+
+    app_mod.st.button = fake_button  # type: ignore[assignment]
+
+    successes: list[str] = []
+    app_mod.st.success = successes.append  # type: ignore[assignment]
+
+    tables: list[pd.DataFrame] = []
+    app_mod.st.dataframe = lambda df, **__: tables.append(df)  # type: ignore[assignment]
+
+    downloads: list[tuple[str, bytes, str, str]] = []
+
+    def fake_download(
+        label: str, *, data: bytes, file_name: str, mime: str
+    ) -> None:  # pragma: no cover - signature guard
+        downloads.append((label, data, file_name, mime))
+
+    app_mod.st.download_button = fake_download  # type: ignore[assignment]
+
+    app_mod.st.session_state.clear()
+    app_mod.st.session_state.update({"data.csv_path": "from-state.csv"})
+
+    cfg: dict[str, Any] = {"data": {"csv_path": "initial.csv"}}
+
+    summary = pd.DataFrame({"value": [1, 2]})
+    monkeypatch.setattr(app_mod, "_summarise_run_df", lambda _df: summary)
+
+    run_calls: list[Any] = []
+    monkeypatch.setattr(app_mod.pipeline, "run", lambda cfg_obj: run_calls.append(cfg_obj) or summary)
+
+    built_cfg_objects: list[Any] = []
+
+    def fake_build(d: dict[str, Any]) -> dict[str, Any]:
+        cfg_obj = {"__cfg__": dict(d)}
+        built_cfg_objects.append(cfg_obj)
+        return cfg_obj
+
+    monkeypatch.setattr(app_mod, "_build_cfg", fake_build)
+
+    app_mod._render_run_section(cfg)
+
+    assert built_cfg_objects
+    assert run_calls == built_cfg_objects
+    assert cfg["data"]["csv_path"] == "from-state.csv"
+    assert successes == ["Completed. 2 rows."]
+    assert tables == [summary]
+    assert len(downloads) == 1
+    label, payload, file_name, mime = downloads[0]
+    assert label == "Download CSV"
+    assert file_name == "single_period_summary.csv"
+    assert mime == "text/csv"
+    rows = payload.decode("utf-8").strip().splitlines()
+    assert rows[0] == "value"
+    assert rows[1:] == ["1", "2"]
+
+
+def test_render_run_section_executes_multi_period(monkeypatch: pytest.MonkeyPatch) -> None:
+    app_mod = _load_app(monkeypatch)
+
+    def fake_button(label: str, *_, **__) -> bool:
+        return label == "Run Multi-Period"
+
+    app_mod.st.button = fake_button  # type: ignore[assignment]
+
+    successes: list[str] = []
+    app_mod.st.success = successes.append  # type: ignore[assignment]
+
+    tables: list[pd.DataFrame] = []
+    app_mod.st.dataframe = lambda df, **__: tables.append(df)  # type: ignore[assignment]
+
+    downloads: list[tuple[str, bytes, str, str]] = []
+
+    def fake_download(
+        label: str, *, data: bytes, file_name: str, mime: str
+    ) -> None:  # pragma: no cover - signature guard
+        downloads.append((label, data, file_name, mime))
+
+    app_mod.st.download_button = fake_download  # type: ignore[assignment]
+
+    app_mod.st.session_state.clear()
+    app_mod.st.session_state.update({"data.csv_path": "from-state.csv"})
+
+    cfg: dict[str, Any] = {"data": {"csv_path": "initial.csv"}}
+
+    summary = pd.DataFrame({"ew_sharpe": [1.0]})
+    monkeypatch.setattr(app_mod, "_summarise_multi", lambda _results: summary)
+
+    payload = [
+        {"period": ("2020", "2020", "2021", "2021"), "out_ew_stats": {"sharpe": 1.0}},
+        {"period": ("2021", "2021", "2022", "2022"), "out_ew_stats": {"sharpe": 1.1}},
+    ]
+
+    monkeypatch.setattr(app_mod, "run_multi", lambda _cfg: payload)
+
+    built_cfg_objects: list[dict[str, Any]] = []
+
+    def fake_build(d: dict[str, Any]) -> dict[str, Any]:
+        cfg_obj = dict(d)
+        built_cfg_objects.append(cfg_obj)
+        return cfg_obj
+
+    monkeypatch.setattr(app_mod, "_build_cfg", fake_build)
+
+    app_mod._render_run_section(cfg)
+
+    assert cfg["data"]["csv_path"] == "from-state.csv"
+    assert built_cfg_objects and built_cfg_objects[0]["data"]["csv_path"] == "from-state.csv"
+    assert successes == ["Completed. Periods: 2"]
+    assert tables == [summary]
+    assert len(downloads) == 2
+    csv_label, csv_payload, csv_name, csv_mime = downloads[0]
+    assert csv_label == "Download periods CSV"
+    assert csv_name == "multi_period_summary.csv"
+    assert csv_mime == "text/csv"
+    csv_rows = csv_payload.decode("utf-8").strip().splitlines()
+    assert csv_rows[0] == "ew_sharpe"
+    assert csv_rows[1:] == ["1.0"]
+
+    raw_label, raw_payload, raw_name, raw_mime = downloads[1]
+    assert raw_label == "Download raw JSON"
+    assert raw_name == "multi_period_raw.json"
+    assert raw_mime == "application/json"
+    decoded_payload = json.loads(raw_payload.decode("utf-8"))
+    expected = []
+    for item in payload:
+        expected.append({**item, "period": list(item["period"])})
+    assert decoded_payload == expected

--- a/tests/test_trend_portfolio_app_helpers.py
+++ b/tests/test_trend_portfolio_app_helpers.py
@@ -216,7 +216,10 @@ def _load_app_with_magicmock(
 
     source = Path(module.__file__).read_text(encoding="utf-8")
     prefix = source.split("st.set_page_config", 1)[0]
-    code = compile(prefix + "    pass\n", module.__file__, "exec")
+    # Dynamically determine indentation for injected "pass" statement
+    last_line = prefix.splitlines()[-1] if prefix.splitlines() else ""
+    indentation = last_line[:len(last_line) - len(last_line.lstrip())]
+    code = compile(prefix + f"{indentation}pass\n", module.__file__, "exec")
     exec(code, module.__dict__)
 
     is_mock_impl = module._is_mock_streamlit  # type: ignore[attr-defined]

--- a/tests/test_trend_portfolio_app_helpers.py
+++ b/tests/test_trend_portfolio_app_helpers.py
@@ -174,7 +174,11 @@ def _load_app(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
 
     source = Path(module.__file__).read_text(encoding="utf-8")
     prefix = source.split("st.set_page_config", 1)[0]
-    code = compile(prefix + "    pass\n", module.__file__, "exec")
+    # Find indentation of last non-empty line in prefix
+    last_line = [line for line in prefix.splitlines() if line.strip()][-1] if any(line.strip() for line in prefix.splitlines()) else ""
+    indent = last_line[:len(last_line) - len(last_line.lstrip())]
+    code_str = prefix + f"{indent}pass\n"
+    code = compile(code_str, module.__file__, "exec")
     exec(code, module.__dict__)
 
     is_mock_impl = module._is_mock_streamlit  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- enhance the Streamlit test harness to keep `_render_app` inert and surface the compatibility helpers used in production
- cover `_apply_session_state`, the sidebar reset flow, and both single and multi-period run triggers with new unit tests
- assert download payloads and session-state propagation to ensure UI wiring is exercised under test stubs

## Testing
- pytest tests/test_trend_portfolio_app_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68cd0c9689088331879a65fcc79e06c8