### PR TITLE
refactor: define covariance diagonal type alias

### DIFF
--- a/src/trend_analysis/typing.py
+++ b/src/trend_analysis/typing.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Mapping, MutableMapping, MutableSequence, TypedDict
+from typing import (Mapping, MutableMapping, MutableSequence, TypeAlias,
+                    TypedDict)
+
+
+CovarianceDiagonal: TypeAlias = list[float]
 
 
 class MultiPeriodPeriodResult(TypedDict, total=False):
@@ -14,5 +18,5 @@ class MultiPeriodPeriodResult(TypedDict, total=False):
     manager_changes: MutableSequence[dict[str, object]]
     turnover: float
     transaction_cost: float
-    cov_diag: list[float]
+    cov_diag: CovarianceDiagonal
     cache_stats: Mapping[str, float] | MutableMapping[str, float]


### PR DESCRIPTION
## Summary
- introduce a dedicated `CovarianceDiagonal` type alias for the multi-period result schema
- use the alias in the `MultiPeriodPeriodResult` TypedDict so typing utilities resolve the list origin reliably

## Testing
- pytest tests/test_trend_analysis_typing_contract.py -k schema -vv

------
https://chatgpt.com/codex/tasks/task_e_68cd0eb7b0bc83319e58f06475a42bdb