### PR TITLE
Relax cov_diag origin assertion for typing contract test

### DIFF
--- a/tests/test_trend_analysis_typing_contract.py
+++ b/tests/test_trend_analysis_typing_contract.py
@@ -2,7 +2,7 @@
 
 from collections import UserDict
 from types import MappingProxyType
-from typing import Mapping, MutableMapping, MutableSequence, Union, get_args, get_origin, get_type_hints
+from typing import List, Mapping, MutableMapping, MutableSequence, Union, get_args, get_origin, get_type_hints
 
 from trend_analysis.typing import MultiPeriodPeriodResult
 
@@ -35,7 +35,8 @@ def test_multi_period_period_result_schema_matches_expected_contract() -> None:
     assert hints["turnover"] == float
     assert hints["transaction_cost"] == float
     cov_diag_hint = hints["cov_diag"]
-    assert get_origin(cov_diag_hint) is list
+    origin = get_origin(cov_diag_hint)
+    assert origin in (list, List)
     assert get_args(cov_diag_hint) == (float,)
 
 


### PR DESCRIPTION
## Summary
- update the typing contract test to accept either `list` or `typing.List` as the origin for the `cov_diag` hint
- import `List` so the assertion can handle both typing spellings while still checking the element type

## Testing
- pytest tests/test_trend_analysis_typing_contract.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1291c3bc8331964e505bf1a8ab59