### PR TITLE
Improve auto type hygiene import ignore handling

### DIFF
--- a/scripts/auto_type_hygiene.py
+++ b/scripts/auto_type_hygiene.py
@@ -72,9 +72,28 @@ def process_file(path: Path) -> tuple[bool, list[str]]:
             new_lines.append(line)
             continue
         module = m.group("module")
-        if needs_ignore(module) and IGNORE_TOKEN not in line:
-            # Do not append if another type: ignore already covers it more specifically
-            if "type: ignore" not in line:
+        if needs_ignore(module):
+            if IGNORE_TOKEN in line:
+                new_lines.append(line)
+                continue
+
+            ignore_match = re.search(r"#\s*type:\s*ignore(?P<bracket>\[[^\]]*\])?", line)
+            if ignore_match:
+                bracket = ignore_match.group("bracket")
+                if bracket is None:
+                    replacement = "# type: ignore[import-untyped]"
+                else:
+                    codes = [code.strip() for code in bracket[1:-1].split(",") if code.strip()]
+                    if "import-untyped" in codes:
+                        new_lines.append(line)
+                        continue
+                    codes.append("import-untyped")
+                    replacement = f"# type: ignore[{', '.join(codes)}]"
+
+                start, end = ignore_match.span()
+                line = f"{line[:start]}{replacement}{line[end:]}"
+                changed = True
+            else:
                 line = f"{line.rstrip()}  {IGNORE_TOKEN}"
                 changed = True
         new_lines.append(line)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import pytest
 
 try:
-    import yaml  # type: ignore
+    import yaml  # type: ignore[import-untyped]
 except ImportError:
     yaml = None
 


### PR DESCRIPTION
## Summary
- ensure auto_type_hygiene upgrades existing type ignore comments with the specific import-untyped code instead of skipping them
- normalize the yaml import ignore in tests/conftest.py so the automation and static checks agree

## Testing
- python scripts/auto_type_hygiene.py
- pytest tests/test_trend_analysis_typing_contract.py

------
https://chatgpt.com/codex/tasks/task_e_68cd192871ec833181c7e9d866af962e