### PR TITLE
Fix type assertion for covariance diagonal alias

### DIFF
--- a/tests/test_trend_analysis_typing_contract.py
+++ b/tests/test_trend_analysis_typing_contract.py
@@ -41,9 +41,6 @@ def test_multi_period_period_result_schema_matches_expected_contract() -> None:
     # ``list`` keeps the assertion type-friendly while remaining precise about
     # the expected element type.
     assert cov_diag_hint == list[float]
-    assert get_args(cov_diag_hint) == (float,)
-
-
 def test_multi_period_period_result_supports_incremental_population() -> None:
     """Ensure the TypedDict behaves like a mutable dictionary at runtime."""
 


### PR DESCRIPTION
## Summary
- simplify the covariance diagonal contract test to compare directly against `list[float]`
- ensure the assertion remains type-friendly and retains the element-type check

## Testing
- `pytest tests/test_trend_analysis_typing_contract.py`
- `poetry run mypy tests/test_trend_analysis_typing_contract.py`


------
https://chatgpt.com/codex/tasks/task_e_68cd18fb082083318b1ac5641e02148e