### PR TITLE
Fix TypeAlias exports and remove outdated yaml ignores

### DIFF
--- a/src/trend_analysis/_ci_probe_faults.py
+++ b/src/trend_analysis/_ci_probe_faults.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import math
 from typing import List
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 PROBE_VERSION = "style_only_v3"
 

--- a/src/trend_analysis/config/legacy.py
+++ b/src/trend_analysis/config/legacy.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 if TYPE_CHECKING:  # pragma: no cover - mypy only
 

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -12,7 +12,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Protocol, cast
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 
 class ConfigProtocol(Protocol):

--- a/src/trend_analysis/gui/app.py
+++ b/src/trend_analysis/gui/app.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, cast
 
 import ipywidgets as widgets
 import pandas as pd
-import yaml  # type: ignore[import-untyped]
+import yaml
 from IPython.display import FileLink, Javascript, display
 
 from ..config import Config

--- a/src/trend_analysis/gui/store.py
+++ b/src/trend_analysis/gui/store.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 
 @dataclass

--- a/src/trend_analysis/typing.py
+++ b/src/trend_analysis/typing.py
@@ -7,10 +7,7 @@ from typing import Mapping, MutableMapping, MutableSequence, TYPE_CHECKING, Type
 if TYPE_CHECKING:
     from typing import TypeAlias
 else:  # pragma: no cover - runtime fallback for older interpreters.
-    try:
-        from typing import TypeAlias
-    except ImportError:
-        from typing_extensions import TypeAlias
+    from typing_extensions import TypeAlias
 
 
 CovarianceDiagonal: TypeAlias = list[float]

--- a/src/trend_analysis/typing.py
+++ b/src/trend_analysis/typing.py
@@ -2,21 +2,35 @@
 
 from __future__ import annotations
 
-from typing import (Mapping, MutableMapping, MutableSequence, TypeAlias,
-                    TypedDict)
+from typing import Mapping, MutableMapping, MutableSequence, TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:
+    from typing import TypeAlias
+else:  # pragma: no cover - runtime fallback for older interpreters.
+    try:
+        from typing import TypeAlias
+    except ImportError:
+        from typing_extensions import TypeAlias
 
 
 CovarianceDiagonal: TypeAlias = list[float]
+StatsMapping: TypeAlias = Mapping[str, float] | MutableMapping[str, float]
+
+__all__ = [
+    "CovarianceDiagonal",
+    "StatsMapping",
+    "MultiPeriodPeriodResult",
+]
 
 
 class MultiPeriodPeriodResult(TypedDict, total=False):
     """Typed contract for multi-period analysis results."""
 
     period: tuple[str, str, str, str]
-    out_ew_stats: Mapping[str, float] | MutableMapping[str, float]
-    out_user_stats: Mapping[str, float] | MutableMapping[str, float]
+    out_ew_stats: StatsMapping
+    out_user_stats: StatsMapping
     manager_changes: MutableSequence[dict[str, object]]
     turnover: float
     transaction_cost: float
     cov_diag: CovarianceDiagonal
-    cache_stats: Mapping[str, float] | MutableMapping[str, float]
+    cache_stats: StatsMapping

--- a/tests/test_trend_analysis_typing_contract.py
+++ b/tests/test_trend_analysis_typing_contract.py
@@ -4,7 +4,8 @@ from collections import UserDict
 from types import MappingProxyType
 from typing import Any, List, Mapping, MutableMapping, MutableSequence, Union, cast, get_args, get_origin, get_type_hints
 
-from trend_analysis.typing import MultiPeriodPeriodResult
+from trend_analysis.typing import (MultiPeriodPeriodResult, StatsMapping,
+                                   CovarianceDiagonal)
 
 
 def test_multi_period_period_result_schema_matches_expected_contract() -> None:
@@ -41,6 +42,10 @@ def test_multi_period_period_result_schema_matches_expected_contract() -> None:
     # ``list`` keeps the assertion type-friendly while remaining precise about
     # the expected element type.
     assert cov_diag_hint == list[float]
+    assert CovarianceDiagonal == list[float]
+
+    stats_mapping_hint = cast(Any, hints["out_ew_stats"])
+    assert stats_mapping_hint == StatsMapping
 def test_multi_period_period_result_supports_incremental_population() -> None:
     """Ensure the TypedDict behaves like a mutable dictionary at runtime."""
 


### PR DESCRIPTION
## Summary
- ensure the trend_analysis.typing module exports CovarianceDiagonal and the new StatsMapping TypeAlias with a runtime fallback
- extend the typing contract test coverage for the aliases and keep the TypedDict fields aligned
- remove now-unnecessary import-untyped ignores from yaml imports after stub installation

## Testing
- poetry run mypy .
- poetry run pytest tests/test_trend_analysis_typing_contract.py


------
https://chatgpt.com/codex/tasks/task_e_68cda9e5f9448331aceca8641c0d3ba9