### PR TITLE
Add TypeAlias fallback for older Python runtimes

### DIFF
--- a/src/trend_analysis/typing.py
+++ b/src/trend_analysis/typing.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-from typing import (Mapping, MutableMapping, MutableSequence, TypeAlias,
-                    TypedDict)
+from typing import Mapping, MutableMapping, MutableSequence, TypedDict
+
+try:  # pragma: no cover - import fallback only exercised on <3.10
+    from typing import TypeAlias
+except ImportError:  # pragma: no cover - maintained for older runtimes
+    from typing_extensions import TypeAlias
 
 
 CovarianceDiagonal: TypeAlias = list[float]


### PR DESCRIPTION
## Summary
- adjust typing imports to gracefully fall back to typing_extensions.TypeAlias when running on Python versions older than 3.10
- retain the CovarianceDiagonal alias definition so runtime type checks continue to pass

## Testing
- `poetry run mypy src/trend_analysis/typing.py tests/test_trend_analysis_typing_contract.py`
- `poetry run pytest tests/test_trend_analysis_typing_contract.py`


------
https://chatgpt.com/codex/tasks/task_e_68cdb07c9c7c83319a2895041234dd8e