### PR TITLE
Align CI coverage defaults with core threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     uses: ./.github/workflows/reuse-ci-python.yml
     with:
       python_matrix: ${{ vars.CI_PY_VERSIONS || '["3.11","3.12"]' }}
-      cov_min: ${{ vars.COV_MIN || 80 }}
+      cov_min: ${{ vars.COV_MIN || 85 }}
       # Coverage gate enforced in the reusable workflow via
-      # pytest --cov --cov-fail-under=${{ vars.COV_MIN || 80 }}
+      # pytest --cov --cov-fail-under=${{ vars.COV_MIN || 85 }}
       run_quarantine: 'false'
   gate:
     name: gate / all-required-green

--- a/.github/workflows/reusable-ci-python.yml
+++ b/.github/workflows/reusable-ci-python.yml
@@ -11,7 +11,7 @@ on:
       coverage-min:
         description: 'Minimum coverage percentage gate'
         required: false
-        default: '80'
+        default: '85'
         type: string
       marker-expr:
         description: 'Pytest -m expression to select tests'

--- a/.github/workflows/reuse-ci-python.yml
+++ b/.github/workflows/reuse-ci-python.yml
@@ -11,7 +11,7 @@ on:
       cov_min:
         description: 'Coverage minimum threshold'
         required: false
-        default: '80'
+        default: '85'
         type: string
       run_quarantine:
         description: 'Include tests marked quarantine'

--- a/docs/ops/template-setup.md
+++ b/docs/ops/template-setup.md
@@ -18,7 +18,7 @@ Set these variables to tailor behavior (all have sensible defaults if omitted):
 - `APPROVE_PATTERNS` (default: `src/**,docs/**,tests/**,**/*.md`)
 - `MAX_LINES_CHANGED` (default: `1000`)
 - `CI_PY_VERSIONS` (default: `["3.11","3.12"]`)
-- `COV_MIN` (default: `80`)
+- `COV_MIN` (default: `85`)
 - `REGISTRY` (default: `ghcr.io`)
 - `IMAGE_NAME` (default: `<owner>/trend-model`) – override per project
 - `HEALTH_PORT` (default: `8000`)


### PR DESCRIPTION
## Summary
- raise the reusable workflow coverage gate defaults to 85% to match the focused .coveragerc threshold
- update the CI wrapper and documentation so the fallback COV_MIN guidance reflects the higher bar

## Testing
- `pytest tests/golden/test_demo.py::TestDemoGoldenMaster::test_coverage_gate_enforcement -q`
- `pytest tests/test_multi_period_engine_incremental_cov.py::test_run_incremental_covariance_updates -q`


------
https://chatgpt.com/codex/tasks/task_e_68cdb107956c833183d80b2abb86881f