### PR TITLE
Fix GitHub Actions error annotation spacing

### DIFF
--- a/.github/workflows/chatgpt-issue-sync.yml
+++ b/.github/workflows/chatgpt-issue-sync.yml
@@ -35,7 +35,7 @@ jobs:
                 exit 1
               fi
             else
-              echo "::error::curl is not available on the runner" >&2
+              echo "::error ::curl is not available on the runner" >&2
               exit 1
             fi
           else


### PR DESCRIPTION
## Summary
- ensure error annotations in the ChatGPT issue sync workflow use the expected spacing

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68cdb302d25c8331aa6e536296efff5d