### PR TITLE
Fix workflow inputs scope

### DIFF
--- a/.github/workflows/verify-codex-bootstrap-matrix.yml
+++ b/.github/workflows/verify-codex-bootstrap-matrix.yml
@@ -2,13 +2,6 @@ name: Verify Codex Bootstrap Matrix
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '17 3 * * *'
-  push:
-    paths:
-      - '.github/workflows/verify-codex-bootstrap-matrix.yml'
-      - 'scripts/verify_codex_bootstrap.py'
-      - 'docs/codex-simulation.md'
     inputs:
       scenarios:
         description: "Comma-separated list: all or subset. See scripts/verify_codex_bootstrap.py SCENARIOS_IMPL for available scenarios."
@@ -38,6 +31,13 @@ on:
         description: "Set to true for t13_suppressed"
         required: false
         default: "false"
+  schedule:
+    - cron: '17 3 * * *'
+  push:
+    paths:
+      - '.github/workflows/verify-codex-bootstrap-matrix.yml'
+      - 'scripts/verify_codex_bootstrap.py'
+      - 'docs/codex-simulation.md'
 
 jobs:
   plan:


### PR DESCRIPTION
## Summary
- nest workflow_dispatch inputs under the correct on.workflow_dispatch trigger in verify-codex-bootstrap-matrix
- keep schedule and push triggers unchanged while ensuring suppress_activate and other inputs resolve correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdb42ab9488331a0cb6bb74941904f