### PR TITLE
chore(ci): enforce coverage gate via pytest flag

### DIFF
--- a/.github/workflows/reusable-ci-python.yml
+++ b/.github/workflows/reusable-ci-python.yml
@@ -117,9 +117,9 @@ jobs:
           set -o pipefail
           MARK='${{ steps.markers.outputs.value }}'
           if [ "${{ inputs.run-full }}" = "true" ] || [ -z "$MARK" ]; then
-            pytest --junitxml=pytest-junit.xml --cov=src --cov-report=term-missing --cov-report=xml:coverage.xml --cov-branch 2>&1 | tee pytest.log || echo $? > test_status
+            pytest --junitxml=pytest-junit.xml --cov=src --cov-report=term-missing --cov-report=xml:coverage.xml --cov-branch --cov-fail-under=${{ inputs.coverage-min }} 2>&1 | tee pytest.log || echo $? > test_status
           else
-            pytest -m "$MARK" --junitxml=pytest-junit.xml --cov=src --cov-report=term-missing --cov-report=xml:coverage.xml --cov-branch 2>&1 | tee pytest.log || echo $? > test_status
+            pytest -m "$MARK" --junitxml=pytest-junit.xml --cov=src --cov-report=term-missing --cov-report=xml:coverage.xml --cov-branch --cov-fail-under=${{ inputs.coverage-min }} 2>&1 | tee pytest.log || echo $? > test_status
           fi
           echo "status=$(cat test_status 2>/dev/null || echo 0)" >> $GITHUB_OUTPUT
       - name: Classify (Phase2)


### PR DESCRIPTION
## Summary
- ensure the reusable Python CI workflow fails immediately when coverage drops below the configured gate by passing `--cov-fail-under`
- retain the existing coverage summary step so diagnostics still emit the canonical gate message

## Testing
- pytest tests/golden/test_demo.py::TestDemoGoldenMaster::test_coverage_gate_enforcement -k coverage --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68cdbaf0493c8331b8b2196a405c95b3