### PR TITLE
Add tests for multi-period schedule update and proxy error handling

### DIFF
--- a/tests/test_proxy_server_additional.py
+++ b/tests/test_proxy_server_additional.py
@@ -341,4 +341,4 @@ def test_handle_http_request_accepts_non_string_query(patched_server: Any) -> No
     result = asyncio.run(proxy._handle_http_request(DummyRequest(), "/metrics"))
     assert result.status_code == 200
     recorded = proxy.client.calls[-1]
-    assert recorded["url"].endswith("/metrics?b'id=42'")
+    assert recorded["url"].endswith("/metrics?id=42")


### PR DESCRIPTION
## Summary
- extend multi-period engine helper tests to cover Series rebalance inputs and the schedule update path
- add proxy server tests for uvicorn startup, websocket failures, and byte query handling

## Testing
- pytest tests/test_multi_period_engine_helpers_additional.py -q
- pytest tests/test_proxy_server_additional.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cdc3ac76ac8331b858e2216509cb1e