### PR TITLE
test: expand multi-period engine and proxy coverage

### DIFF
--- a/tests/test_multi_period_engine_run_schedule_extra.py
+++ b/tests/test_multi_period_engine_run_schedule_extra.py
@@ -1,0 +1,123 @@
+"""Additional coverage tests for ``run_schedule`` and ``Portfolio`` helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from trend_analysis.multi_period.engine import Portfolio, run_schedule
+from trend_analysis.weighting import BaseWeighting
+
+
+class _Selector:
+    """Deterministic selector returning the incoming frame as-is."""
+
+    def __init__(self, top_n: int = 2) -> None:
+        self.top_n = top_n
+
+    def select(self, score_frame: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+        selected = score_frame.iloc[: self.top_n].copy()
+        return selected, selected
+
+
+class _UpdatingWeighting(BaseWeighting):
+    """Toy weighting scheme that records update calls for verification."""
+
+    def __init__(self) -> None:
+        self.update_calls: list[tuple[pd.Series, int]] = []
+
+    def weight(self, selected: pd.DataFrame) -> pd.DataFrame:
+        if selected.empty:
+            return pd.DataFrame({"weight": []}, index=pd.Index([], dtype=object))
+        n = len(selected)
+        weights = np.linspace(1.0, 2.0, n) / np.linspace(1.0, 2.0, n).sum()
+        return pd.DataFrame({"weight": weights}, index=selected.index)
+
+    def update(self, scores: pd.Series, days: int) -> None:  # pragma: no cover - runtime hook
+        self.update_calls.append((scores.copy(), days))
+
+
+@dataclass
+class _StrategyCall:
+    strategies: list[str]
+    params: dict[str, dict[str, object]]
+    current_weights: pd.Series
+    target_weights: pd.Series
+    scores: pd.Series | None
+
+
+def _make_score_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Sharpe": [1.0, 0.5, -0.1],
+            "zscore": [1.2, 0.0, -1.0],
+        },
+        index=["FundA", "FundB", "FundC"],
+    )
+
+
+def test_portfolio_rebalance_accepts_series_and_tracks_totals() -> None:
+    pf = Portfolio()
+    weights = pd.Series({"FundA": 0.6, "FundB": 0.4})
+    pf.rebalance("2023-03-15", weights, turnover=0.12, cost=7.5)
+
+    key = "2023-03-15"
+    assert key in pf.history
+    assert pf.history[key].to_dict() == {"FundA": 0.6, "FundB": 0.4}
+    assert pf.turnover[key] == pytest.approx(0.12)
+    assert pf.costs[key] == pytest.approx(7.5)
+    assert pf.total_rebalance_costs == pytest.approx(7.5)
+
+
+def test_run_schedule_invokes_rebalance_strategies_and_weighting_update(monkeypatch):
+    frames = {
+        "2020-01-31": _make_score_frame(),
+        "2020-02-29": _make_score_frame(),
+    }
+    selector = _Selector(top_n=2)
+    weighting = _UpdatingWeighting()
+
+    calls: list[_StrategyCall] = []
+
+    def fake_apply(strategies, params, current_weights, target_weights, *, scores=None):
+        calls.append(
+            _StrategyCall(
+                strategies=list(strategies),
+                params=params,
+                current_weights=current_weights.copy(),
+                target_weights=target_weights.copy(),
+                scores=None if scores is None else scores.copy(),
+            )
+        )
+        final = target_weights.copy()
+        final[:] = np.linspace(0.7, 0.3, len(final))
+        return final, 1.25
+
+    monkeypatch.setattr(
+        "trend_analysis.multi_period.engine.apply_rebalancing_strategies",
+        fake_apply,
+    )
+
+    portfolio = run_schedule(
+        frames,
+        selector,
+        weighting,
+        rank_column="Sharpe",
+        rebalance_strategies=["mock"],
+        rebalance_params={"mock": {"alpha": 0.5}},
+    )
+
+    assert len(portfolio.history) == 2
+    assert calls, "Rebalancing strategies should be invoked"
+    first_call = calls[0]
+    assert first_call.strategies == ["mock"]
+    assert first_call.params["mock"] == {"alpha": 0.5}
+    assert list(first_call.target_weights.index) == ["FundA", "FundB"]
+    assert weighting.update_calls, "Weighting.update should be called"
+    # First update occurs with zero elapsed days; second uses actual delta (~29 days)
+    assert weighting.update_calls[0][1] == 0
+    assert weighting.update_calls[1][1] > 0
+

--- a/tests/test_proxy_server_runtime_extra.py
+++ b/tests/test_proxy_server_runtime_extra.py
@@ -1,0 +1,194 @@
+"""Extra runtime coverage for :mod:`trend_analysis.proxy.server`."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from trend_analysis.proxy import server
+
+
+class _DummyRouter:
+    def __init__(self) -> None:
+        self.routes: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def add_api_websocket_route(self, *args: Any) -> None:
+        self.routes.append(("ws", args, {}))
+
+    def add_api_route(self, *args: Any, **kwargs: Any) -> None:
+        self.routes.append(("http", args, kwargs))
+
+
+class _DummyApp:
+    def __init__(self, *_, **__) -> None:
+        self.router = _DummyRouter()
+
+
+class _DummyBackgroundTask:
+    def __init__(self, func) -> None:
+        self.func = func
+
+
+class _DummyStreamingResponse:
+    def __init__(self, iterator, *, status_code, headers, background):
+        self.iterator = iterator
+        self.status_code = status_code
+        self.headers = headers
+        self.background = background
+
+
+class _DummyAsyncClient:
+    def __init__(self) -> None:
+        self.requests: list[dict[str, Any]] = []
+        self.closed = False
+
+    async def request(self, **kwargs: Any):
+        self.requests.append(kwargs)
+
+        class _Resp:
+            status_code = 204
+            headers = {"content-encoding": "gzip", "x-test": "value"}
+
+            async def aiter_bytes(self):
+                yield b"payload"
+
+            async def aclose(self):
+                return None
+
+        return _Resp()
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _setup_proxy_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "_assert_deps", lambda: None)
+    monkeypatch.setattr(server, "FastAPI", _DummyApp)
+    monkeypatch.setattr(server, "httpx", SimpleNamespace(AsyncClient=_DummyAsyncClient))
+    monkeypatch.setattr(server, "StreamingResponse", _DummyStreamingResponse)
+    monkeypatch.setattr(server, "BackgroundTask", _DummyBackgroundTask)
+
+
+def test_streamlit_proxy_init_requires_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "_assert_deps", lambda: None)
+    monkeypatch.setattr(server, "FastAPI", None)
+    monkeypatch.setattr(server, "httpx", None)
+
+    with pytest.raises(RuntimeError):
+        server.StreamlitProxy()
+
+
+def test_streamlit_proxy_websocket_and_http_routing(monkeypatch: pytest.MonkeyPatch) -> None:
+    _setup_proxy_deps(monkeypatch)
+
+    dummy_websockets_calls: list[str] = []
+
+    class _DummyTarget:
+        async def send(self, _payload):
+            return None
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    class _DummyConnect:
+        def __init__(self, url: str) -> None:
+            self.url = url
+
+        async def __aenter__(self):
+            dummy_websockets_calls.append(self.url)
+            return _DummyTarget()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _DummyWebsockets:
+        def connect(self, url: str):
+            return _DummyConnect(url)
+
+    monkeypatch.setattr(server, "websockets", _DummyWebsockets())
+
+    gathered: list[tuple[Any, ...]] = []
+
+    async def fake_gather(*coros: Any):
+        gathered.append(coros)
+        for coro in coros:
+            coro.close()
+        return None
+
+    monkeypatch.setattr(server.asyncio, "gather", fake_gather)
+
+    proxy = server.StreamlitProxy("example.com", 9000)
+
+    class _DummyClientSocket:
+        def __init__(self) -> None:
+            self.accepted = False
+            self.url = SimpleNamespace(query="token=abc")
+
+        async def accept(self):
+            self.accepted = True
+
+        async def close(self, code: int) -> None:  # pragma: no cover - defensive
+            self.closed_with = code
+
+        async def receive(self):
+            return {"text": "noop"}
+
+        async def send_bytes(self, data: bytes):  # pragma: no cover - defensive
+            self.last_bytes = data
+
+        async def send_text(self, data: str):  # pragma: no cover - defensive
+            self.last_text = data
+
+    websocket = _DummyClientSocket()
+
+    class _DummyURL:
+        def __init__(self, query: str) -> None:
+            self.query = query
+
+    class _DummyRequest:
+        def __init__(self) -> None:
+            self.url = _DummyURL("q=1")
+            self.method = "POST"
+            self.headers = {"host": "proxy", "x-test": "1"}
+
+        async def body(self) -> bytes:
+            return b"payload"
+
+    async def runner() -> None:
+        await proxy._websocket_entry(websocket, "foo")
+        assert websocket.accepted is True
+        expected_url = "ws://example.com:9000/foo?token=abc"
+        assert dummy_websockets_calls == [expected_url]
+        assert gathered, "asyncio.gather should be invoked"
+
+        response = await proxy._http_entry(_DummyRequest(), "status")
+        assert isinstance(response, _DummyStreamingResponse)
+        assert dummy_websockets_calls[0] == expected_url
+
+        client = proxy.client
+        assert isinstance(client, _DummyAsyncClient)
+        assert client.requests
+        sent_request = client.requests[0]
+        assert sent_request["url"].endswith("/status?q=1")
+
+    asyncio.run(runner())
+
+
+def test_streamlit_proxy_start_requires_uvicorn(monkeypatch: pytest.MonkeyPatch) -> None:
+    _setup_proxy_deps(monkeypatch)
+    monkeypatch.setattr(server, "uvicorn", None)
+
+    proxy = server.StreamlitProxy()
+
+    async def runner() -> None:
+        with pytest.raises(RuntimeError):
+            await proxy.start()
+
+    asyncio.run(runner())
+


### PR DESCRIPTION
## Summary
- add run_schedule regression tests to exercise weighting update hooks and Portfolio storage
- add Streamlit proxy coverage for dependency guards and routing helpers

## Testing
- pytest tests/test_multi_period_engine_run_schedule_extra.py tests/test_proxy_server_runtime_extra.py

------
https://chatgpt.com/codex/tasks/task_e_68cdc3ac76ac8331b858e2216509cb1e