### PR TITLE
Fix mypy typing issues for yaml and test docstring

### DIFF
--- a/src/trend_analysis/_ci_probe_faults.py
+++ b/src/trend_analysis/_ci_probe_faults.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import math
 from typing import List
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 PROBE_VERSION = "style_only_v3"
 

--- a/src/trend_analysis/config/legacy.py
+++ b/src/trend_analysis/config/legacy.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 if TYPE_CHECKING:  # pragma: no cover - mypy only
 

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -12,7 +12,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Protocol, cast
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 
 class ConfigProtocol(Protocol):

--- a/src/trend_analysis/gui/app.py
+++ b/src/trend_analysis/gui/app.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, cast
 
 import ipywidgets as widgets
 import pandas as pd
-import yaml
+import yaml  # type: ignore[import-untyped]
 from IPython.display import FileLink, Javascript, display
 
 from ..config import Config

--- a/src/trend_analysis/gui/store.py
+++ b/src/trend_analysis/gui/store.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 
 @dataclass

--- a/tests/golden/test_demo.py
+++ b/tests/golden/test_demo.py
@@ -397,15 +397,11 @@ class TestDemoGoldenMaster:
         # workflow do not require test changes.
         # 
         # Regex explanation:
-        #   Matches a YAML workflow input block like:
-        #     cov_min:
-        #       description: Minimum coverage
-        #       type: int
-        #       default: 10
-        #   - {key}:\s*\n         → The input name followed by a newline
-        #   - (?:\s+[^\n]*\n)*?   → Any number of indented lines (description/type/etc.)
-        #   - \s+default:\s*      → Indented 'default:' line
-        #   - '?(?P<value>\d+)'?  → The integer value, possibly quoted
+        #   Matches a YAML workflow input block with the specified key,
+        #   including any indented metadata lines, followed by a ``default``
+        #   entry containing the integer value. Backslashes in the raw string
+        #   escape whitespace and newline tokens so the expression remains
+        #   resilient to minor formatting changes in the workflow file.
         pattern = rf"{key}:\s*\n(?:\s+[^\n]*\n)*?\s+default:\s*'?(?P<value>\d+)'?"
         match = re.search(pattern, content)
         if not match:


### PR DESCRIPTION
## Summary
- silence missing type stub warnings for PyYAML imports using targeted ignores
- rewrite the regex commentary in the demo golden test to avoid characters that break mypy parsing

## Testing
- mypy .
- python scripts/auto_type_hygiene.py

------
https://chatgpt.com/codex/tasks/task_e_68cdcb80fd048331a3919c32de2c7ff5