### PR TITLE
Fix proxy HTTP query handling for byte queries

### DIFF
--- a/src/trend_analysis/proxy/server.py
+++ b/src/trend_analysis/proxy/server.py
@@ -202,8 +202,18 @@ class StreamlitProxy:
         _assert_deps()
         normalized = path if path.startswith("/") else f"/{path}"
         target_url = urljoin(self.streamlit_base_url, normalized)
-        if q := str(request.url.query):
-            target_url += f"?{q}"
+        query = getattr(request.url, "query", "")
+        if isinstance(query, bytes):
+            try:
+                decoded_query = query.decode()
+            except UnicodeDecodeError:
+                decoded_query = query.decode("latin-1", errors="ignore")
+        elif query is None:
+            decoded_query = ""
+        else:
+            decoded_query = str(query)
+        if decoded_query:
+            target_url += f"?{decoded_query}"
         logger.debug(
             "Proxying HTTP %s -> %s", getattr(request, "method", "?"), target_url
         )

--- a/src/trend_analysis/proxy/server.py
+++ b/src/trend_analysis/proxy/server.py
@@ -208,8 +208,6 @@ class StreamlitProxy:
                 decoded_query = query.decode()
             except UnicodeDecodeError:
                 decoded_query = query.decode("latin-1", errors="ignore")
-        elif query is None:
-            decoded_query = ""
         else:
             decoded_query = str(query)
         if decoded_query:


### PR DESCRIPTION
## Summary
- normalize HTTP proxy query strings by decoding byte-valued request.url.query attributes before forwarding

## Testing
- ./scripts/run_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68ce13720fbc8331b5f56d1afe22ce94