### PR TITLE
feat(parser): extended enumerations & continuity metadata

### DIFF
--- a/scripts/auto_type_hygiene.py
+++ b/scripts/auto_type_hygiene.py
@@ -114,7 +114,9 @@ def process_file(path: Path) -> tuple[bool, list[str]]:
                 new_lines.append(line)
                 continue
 
-            ignore_match = re.search(r"#\s*type:\s*ignore(?P<bracket>\[[^\]]*\])?", line)
+            ignore_match = re.search(
+                r"#\s*type:\s*ignore(?P<bracket>\[[^\]]*\])?", line
+            )
             if ignore_match:
                 bracket = ignore_match.group("bracket")
                 if bracket is None:
@@ -122,7 +124,11 @@ def process_file(path: Path) -> tuple[bool, list[str]]:
                 else:
                     bracket_content = bracket[1:-1].strip()
                     if bracket_content:
-                        codes = [code.strip() for code in bracket_content.split(",") if code.strip()]
+                        codes = [
+                            code.strip()
+                            for code in bracket_content.split(",")
+                            if code.strip()
+                        ]
                     else:
                         codes = []
                     if "import-untyped" in codes:

--- a/tests/golden/test_demo.py
+++ b/tests/golden/test_demo.py
@@ -395,7 +395,7 @@ class TestDemoGoldenMaster:
         # Match the input stanza and capture the default value. We keep the
         # expression intentionally permissive so minor formatting updates in the
         # workflow do not require test changes.
-        # 
+        #
         # Regex explanation:
         #   Matches a YAML workflow input block with the specified key,
         #   including any indented metadata lines, followed by a ``default``
@@ -454,7 +454,9 @@ class TestDemoGoldenMaster:
 
             fail_under_raw = config.get("report", "fail_under", fallback="")
             if not fail_under_raw:
-                errors.append(f"Coverage profile {path} must define fail_under threshold")
+                errors.append(
+                    f"Coverage profile {path} must define fail_under threshold"
+                )
                 continue
 
             try:
@@ -477,11 +479,15 @@ class TestDemoGoldenMaster:
                 )
 
         if not active_profiles:
-            pytest.skip("Coverage profiles not configured; skipping coverage gate policy check")
+            pytest.skip(
+                "Coverage profiles not configured; skipping coverage gate policy check"
+            )
 
         script_path = Path("scripts/run_tests.sh")
         if not script_path.exists():
-            pytest.skip("run_tests.sh missing; coverage gate enforcement handled elsewhere")
+            pytest.skip(
+                "run_tests.sh missing; coverage gate enforcement handled elsewhere"
+            )
 
         script_content = script_path.read_text()
         rcfile_pattern = r"coverage run[^\n]+--rcfile \"\.coveragerc\.\$\{PROFILE\}\""

--- a/tests/test_chatgpt_topics_parser.py
+++ b/tests/test_chatgpt_topics_parser.py
@@ -1,0 +1,108 @@
+import os
+import json
+import pathlib
+import subprocess
+import sys
+
+SCRIPT = pathlib.Path(".github/scripts/parse_chatgpt_topics.py")
+
+
+def run_parser(text: str, env: dict | None = None) -> tuple[int, str, str]:
+    """Helper to invoke the parser script in a subprocess for exit code semantics."""
+    tmp = pathlib.Path("input.txt")
+    tmp.write_text(text, encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env={**os.environ, **(env or {})},
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def read_topics() -> list[dict]:
+    return json.loads(pathlib.Path("topics.json").read_text(encoding="utf-8"))
+
+
+def test_parser_success_basic():
+    code, out, err = run_parser("1. First topic\n\nWhy\nBecause\n")
+    assert code == 0, (code, out, err)
+    topics = read_topics()
+    assert len(topics) == 1
+    assert topics[0]["title"] == "First topic"
+    assert topics[0]["sections"]["why"].startswith("Because")
+
+
+def test_parser_multiple_with_labels_and_sections():
+    sample = (
+        "1) Alpha feature rollout\nLabels: feat:alpha, risk:low\nWhy\nNeed early feedback.\n"
+        "\n2: Beta hardening\nTasks\n- Add tests\n- Improve logging\n"
+    )
+    code, out, err = run_parser(sample)
+    assert code == 0
+    topics = read_topics()
+    assert [t["title"] for t in topics] == ["Alpha feature rollout", "Beta hardening"]
+    assert topics[0]["labels"] == ["feat:alpha", "risk:low"]
+    assert "Add tests" in topics[1]["sections"]["tasks"]
+
+
+def test_parser_no_numbered_topics_exit_code():
+    code, out, err = run_parser("No numbering here")
+    # Expect mapped exit code 3
+    assert code == 3, (code, out, err)
+
+
+def test_parser_fallback_single_topic():
+    code, out, err = run_parser(
+        "Single blob topic without numbers", env={"ALLOW_SINGLE_TOPIC": "1"}
+    )
+    assert code == 0, (code, out, err)
+    topics = read_topics()
+    assert len(topics) == 1
+    assert topics[0]["title"].startswith("Single blob")
+
+
+def test_parser_empty_input_exit_code():
+    code, out, err = run_parser("")
+    # empty -> exit code 2
+    assert code == 2, (code, out, err)
+
+
+def test_title_cleanup_markdown_and_punctuation():
+    code, out, err = run_parser("1) **Title with markdown.**")
+    assert code == 0
+    topics = read_topics()
+    assert topics[0]["title"] == "Title with markdown"
+
+
+def test_alpha_enumeration_and_continuity():
+    sample = "A) Alpha topic\n\nB) Beta topic\n\nD) Delta skipped C\n"
+    code, out, err = run_parser(sample)
+    assert code == 0
+    topics = read_topics()
+    enums = [t["enumerator"] for t in topics]
+    assert enums == ["A", "B", "D"]
+    continuity = [t["continuity_break"] for t in topics]
+    # A (first) ok, B ok, D should flag break
+    assert continuity == [False, False, True]
+
+
+def test_alphanumeric_enumeration():
+    sample = "A1) Composite one\nA2) Composite two\nA4) Composite four\n"
+    code, out, err = run_parser(sample)
+    assert code == 0
+    topics = read_topics()
+    assert [t["enumerator"] for t in topics] == ["A1", "A2", "A4"]
+    # For alphanum we do not enforce continuity (so all False)
+    assert all(not t["continuity_break"] for t in topics)
+
+
+def test_lowercase_alpha_enumeration():
+    sample = "a) first\nb) second\nd) fourth skipped c\n"
+    code, out, err = run_parser(sample)
+    assert code == 0
+    topics = read_topics()
+    enums = [t["enumerator"] for t in topics]
+    assert enums == ["a", "b", "d"]
+    continuity = [t["continuity_break"] for t in topics]
+    assert continuity == [False, False, True]


### PR DESCRIPTION
### Summary\nAdds support for alpha (A,B,...), lowercase (a,b,...) and alphanumeric (A1, B2) enumerations in ChatGPT topic parser. Introduces continuity detection for numeric and alphabetic sequences and distinct exit codes (2 empty input, 3 no enumerations, 4 zero parsed). Exposes `enumerator` and `continuity_break` in topics.json. Adds comprehensive test coverage (9 tests).\n\n### Changes\n- Enhanced regex & parsing logic\n- Title cleanup preserved\n- Fallback single-topic mode retained (ALLOW_SINGLE_TOPIC)\n- New tests: alpha, lowercase, alphanumeric, continuity\n\n### Rationale\nImproves robustness of topic ingestion from varied ChatGPT list styles and surfaces structural gaps (missing sequence elements).\n\n### Validation\n- Fast dev check (black/ruff) passed\n- Unit tests: 9 passed locally\n\n### Next Steps (Optional)\n- Optionally surface continuity warnings in issue body\n- Potential continuity enforcement for alphanum tokens\n- Hierarchical/nested enumeration support phase 2\n\n