### PR TITLE
Include chatgpt parser script in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -74,7 +74,9 @@ docker-compose.override.yml
 Dockerfile.dev
 
 # CI/CD
-.github/
+.github/*
+!.github/scripts/
+!.github/scripts/parse_chatgpt_topics.py
 
 # Local configuration
 .env.local

--- a/.dockerignore
+++ b/.dockerignore
@@ -76,8 +76,6 @@ Dockerfile.dev
 # CI/CD
 .github/*
 !.github/scripts/
-!.github/scripts/parse_chatgpt_topics.py
-
 # Local configuration
 .env.local
 .env.*.local


### PR DESCRIPTION
## Summary
- adjust the Docker ignore rules to include the ChatGPT topics parser script

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ce1ee0db08833196f681c402bc9aa3