### PR TITLE
Increase coverage for logging and IO helpers

### DIFF
--- a/tests/test_metric_cache.py
+++ b/tests/test_metric_cache.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pandas as pd
+import pytest
 
-from trend_analysis.core.metric_cache import (clear_metric_cache,
+from trend_analysis.core.metric_cache import (MetricCache,
+                                              clear_metric_cache,
+                                              get_or_compute_metric_series,
                                               global_metric_cache)
 from trend_analysis.core.rank_selection import (RiskStatsConfig,
                                                 WindowMetricBundle,
@@ -93,3 +96,53 @@ def test_metric_cache_key_differs_by_metric():
     s1 = bundle.ensure_metric("Sharpe", stats_cfg)
     s2 = bundle.ensure_metric("AnnualReturn", stats_cfg)
     assert not s1.equals(s2)
+
+
+def test_metric_cache_stats_tracks_hits_and_misses():
+    cache = MetricCache()
+    # Initial stats with no traffic should report zeros.
+    stats = cache.stats()
+    assert stats == {"entries": 0, "hits": 0, "misses": 0, "hit_rate": 0.0}
+
+    series = pd.Series([1.0, 2.0], index=["A", "B"])
+    cache.put("alpha", series)
+
+    # One hit and one miss to exercise both code paths.
+    assert cache.get("alpha") is series
+    assert cache.get("beta") is None
+
+    stats = cache.stats()
+    assert stats["entries"] == 1
+    assert stats["hits"] == 1
+    assert stats["misses"] == 1
+    assert stats["hit_rate"] == pytest.approx(0.5)
+
+
+def test_get_or_compute_metric_series_reorders_index_and_caches(monkeypatch):
+    cache = MetricCache()
+    calls = {"count": 0}
+
+    def compute() -> pd.Series:
+        calls["count"] += 1
+        # Return series in a different order to trigger the reindex branch.
+        return pd.Series([2.0, 1.0], index=["B", "A"])
+
+    kwargs = {
+        "start": "2020-01",
+        "end": "2020-02",
+        "universe_cols": ("A", "B"),
+        "metric_name": "Sharpe",
+        "cfg_hash": "cfg",
+        "compute": compute,
+        "enable": True,
+        "cache": cache,
+    }
+
+    series = get_or_compute_metric_series(**kwargs)
+    assert list(series.index) == ["A", "B"]
+    assert calls["count"] == 1
+
+    # Second call should hit the cache and avoid recomputing.
+    cached = get_or_compute_metric_series(**kwargs)
+    assert cached is series
+    assert calls["count"] == 1

--- a/tests/test_metrics_turnover_extra.py
+++ b/tests/test_metrics_turnover_extra.py
@@ -1,0 +1,48 @@
+from collections import OrderedDict
+
+import pandas as pd
+import pytest
+
+from trend_analysis.metrics.turnover import realized_turnover, turnover_cost
+
+
+def test_realized_turnover_sorts_mapping_and_handles_missing():
+    weights = OrderedDict(
+        {
+            pd.Timestamp("2020-03-31"): pd.Series({"A": 0.6, "B": 0.4}),
+            pd.Timestamp("2020-01-31"): pd.Series({"A": 0.5, "B": 0.5}),
+            pd.Timestamp("2020-02-29"): pd.Series({"A": 0.55}),
+        }
+    )
+
+    turnover = realized_turnover(weights)
+
+    # Index should be sorted chronologically and missing assets filled with 0.
+    assert list(turnover.index) == [
+        pd.Timestamp("2020-01-31"),
+        pd.Timestamp("2020-02-29"),
+        pd.Timestamp("2020-03-31"),
+    ]
+    # Feb row compares against Jan weights -> |0.55-0.5| + |0-0.5|.
+    feb_turnover = abs(0.55 - 0.5) + abs(0.0 - 0.5)
+    mar_turnover = abs(0.6 - 0.55) + abs(0.4 - 0.0)
+    assert turnover.loc[pd.Timestamp("2020-02-29"), "turnover"] == pytest.approx(
+        feb_turnover
+    )
+    assert turnover.loc[pd.Timestamp("2020-03-31"), "turnover"] == pytest.approx(
+        mar_turnover
+    )
+
+
+def test_turnover_cost_scales_basis_points():
+    df = pd.DataFrame(
+        {
+            "A": [0.5, 0.45, 0.55],
+            "B": [0.5, 0.55, 0.45],
+        },
+        index=pd.to_datetime(["2020-01-31", "2020-02-29", "2020-03-31"]),
+    )
+    costs = turnover_cost(df, cost_bps=25)
+
+    expected_turnover = realized_turnover(df)["turnover"]
+    assert costs.equals(expected_turnover * 0.0025)

--- a/tests/test_run_analysis_cli.py
+++ b/tests/test_run_analysis_cli.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+import types
 
 import pandas as pd
+import pytest
 
 from trend_analysis import run_analysis
 
@@ -38,3 +40,30 @@ def test_cli_detailed(tmp_path, capsys):
     captured = capsys.readouterr().out
     assert rc == 0
     assert "cagr" in captured.lower()
+
+
+def test_main_raises_when_csv_path_missing(monkeypatch):
+    cfg = types.SimpleNamespace(
+        data={},
+        sample_split={},
+        export={},
+    )
+
+    monkeypatch.setattr(run_analysis, "load", lambda path: cfg)
+
+    with pytest.raises(KeyError):
+        run_analysis.main(["-c", "dummy.yml"])
+
+
+def test_main_raises_when_csv_missing(monkeypatch):
+    cfg = types.SimpleNamespace(
+        data={"csv_path": "missing.csv"},
+        sample_split={},
+        export={},
+    )
+
+    monkeypatch.setattr(run_analysis, "load", lambda path: cfg)
+    monkeypatch.setattr(run_analysis, "load_csv", lambda path: None)
+
+    with pytest.raises(FileNotFoundError):
+        run_analysis.main(["-c", "dummy.yml"])


### PR DESCRIPTION
## Summary
- extend metric cache tests to validate stats reporting and cached reindex behaviour
- cover logging helpers for latest error extraction, default paths, and handler-free logging
- harden portfolio app bundle cleanup tests and exercise turnover helper edge cases
- ensure run_analysis CLI raises clear errors when CSV configuration is missing

## Testing
- `pytest tests/test_metric_cache.py tests/test_logging_helpers.py tests/test_portfolio_app_io_utils.py tests/test_metrics_turnover_extra.py tests/test_run_analysis_cli.py -q`
- `pytest --cov=src --cov-report=term-missing tests/test_metric_cache.py tests/test_logging_helpers.py tests/test_portfolio_app_io_utils.py tests/test_metrics_turnover_extra.py tests/test_run_analysis_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ce2f23b5908331b9c05371b9b34669