### PR TITLE
Add coverage tests for rolling metrics and event log

### DIFF
--- a/tests/app/test_sim_runner_extra.py
+++ b/tests/app/test_sim_runner_extra.py
@@ -114,6 +114,28 @@ def test_simresult_helpers():
     assert "total_return" in summary
 
 
+def test_event_log_to_frame_handles_empty_and_sorting():
+    """The EventLog frame output preserves shape and ordering."""
+
+    log = EventLog()
+    empty_frame = log.to_frame()
+    # Empty log should still expose the schema with the date index
+    assert list(empty_frame.columns) == ["action", "manager", "reason", "details"]
+    assert empty_frame.index.name == "date"
+
+    later = pd.Timestamp("2020-03-31")
+    earlier = pd.Timestamp("2020-01-31")
+    log.append(Event(date=later, action="hire", manager="B", reason="alpha"))
+    log.append(Event(date=earlier, action="fire", manager="A", reason="beta"))
+
+    frame = log.to_frame()
+    # Events are sorted chronologically despite append order
+    assert list(frame.index) == [earlier, later]
+    # Original payloads preserved
+    assert frame.loc[earlier, "action"] == "fire"
+    assert frame.loc[later, "manager"] == "B"
+
+
 def test_gen_review_dates_quarterly():
     df = pd.DataFrame(
         {

--- a/tests/test_metrics_rolling.py
+++ b/tests/test_metrics_rolling.py
@@ -32,3 +32,20 @@ def test_rolling_information_ratio_scalar_benchmark():
     assert isinstance(result, pd.Series)
     assert result.name == "rolling_ir"
     assert len(result) == len(returns)
+
+
+def test_rolling_information_ratio_defaults_to_zero_benchmark():
+    """Passing ``None`` for the benchmark uses a zero baseline."""
+
+    returns = pd.Series(
+        [0.02, 0.01, -0.03, 0.015],
+        index=pd.date_range("2020-01-31", periods=4, freq="ME"),
+    )
+
+    result = rolling.rolling_information_ratio(returns, benchmark=None, window=2)
+
+    zero_benchmark = pd.Series(0.0, index=returns.index)
+    expected = (returns - zero_benchmark).rolling(2).mean() / (
+        (returns - zero_benchmark).rolling(2).std(ddof=1)
+    )
+    pd.testing.assert_series_equal(result, expected.rename("rolling_ir"))


### PR DESCRIPTION
## Summary
- add a regression test ensuring the rolling information ratio handles a missing benchmark by falling back to zero returns
- exercise EventLog.to_frame for empty logs and chronological sorting to tighten its coverage

## Testing
- pytest tests/test_metrics_rolling.py tests/app/test_sim_runner_extra.py
- PYTHONPATH=./src coverage run --branch -m pytest tests/test_metrics_rolling.py tests/app/test_sim_runner_extra.py
- coverage report -m src/trend_analysis/metrics/rolling.py src/trend_portfolio_app/event_log.py

------
https://chatgpt.com/codex/tasks/task_e_68ce34a0c2e483319d8a5cd7e57d0655