### PR TITLE
ci: e2e autofix validation scenario

### DIFF
--- a/.github/actions/autofix/action.yml
+++ b/.github/actions/autofix/action.yml
@@ -33,10 +33,21 @@ runs:
       id: runfix
       shell: bash
       run: |
-        ruff check --fix .
+        echo "[autofix] Phase 1: applying safe fixes (ruff + formatters)"
+        # Make ruff non-fatal so unresolved errors don't stop formatting/commit
+        ruff check --fix --exit-zero .
         black .
         isort .
         docformatter -r -i src tests || true
+
+        echo "[autofix] Phase 2: collect remaining ruff diagnostics (non-fatal)"
+        # Capture remaining issues for summary; never fail this job here
+        if ! ruff check . > ruff_remaining.log 2>&1; then
+          echo "[autofix] Ruff reported remaining issues (expected for non-auto-fixable codes)."
+        fi
+        remaining_count=$(grep -cE '^[^ ]+:[0-9]+:[0-9]+:' ruff_remaining.log || true)
+        echo "remaining_issues=$remaining_count" >> $GITHUB_OUTPUT
+
         # --- Type hygiene (lightweight) ---
         echo "[autofix] Running auto_type_hygiene..."
         if [ -f scripts/auto_type_hygiene.py ]; then
@@ -48,9 +59,11 @@ runs:
         mypy --install-types --non-interactive || true
         # Optional warm cache (do not fail build)
         mypy src/ --ignore-missing-imports --follow-imports=silent > /dev/null 2>&1 || true
+
         if ! git diff --quiet; then echo "changed=true" >> $GITHUB_OUTPUT; else echo "changed=false" >> $GITHUB_OUTPUT; fi
     - name: Summary
       shell: bash
       run: |
         echo "### Composite Autofix Summary" >> $GITHUB_STEP_SUMMARY
         echo "Changed: ${{ steps.runfix.outputs.changed }}" >> $GITHUB_STEP_SUMMARY
+        echo "Remaining Ruff Issues: ${{ steps.runfix.outputs.remaining_issues }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/autofix-consumer.yml
+++ b/.github/workflows/autofix-consumer.yml
@@ -15,3 +15,30 @@ jobs:
     with:
       opt_in_label: ${{ vars.AUTOFIX_OPT_IN_LABEL || 'autofix' }}
       commit_prefix: 'ci: autofix'
+  label-applied:
+    needs: call-reusable
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Check latest commit message for autofix
+        id: msg
+        run: |
+          git fetch --depth=2 origin ${{ github.event.pull_request.head.ref }}
+          git checkout FETCH_HEAD
+          msg=$(git log -1 --pretty=%B | tr -d '\r')
+          echo "message<<END" >> $GITHUB_OUTPUT
+          echo "$msg" >> $GITHUB_OUTPUT
+          echo "END" >> $GITHUB_OUTPUT
+          if echo "$msg" | grep -qi 'ci: autofix'; then echo "applied=true" >> $GITHUB_OUTPUT; else echo "applied=false" >> $GITHUB_OUTPUT; fi
+      - name: Add label
+        if: steps.msg.outputs.applied == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = process.env.APPLIED_LABEL || 'autofix:applied';
+            const pr = context.payload.pull_request.number;
+            try {
+              await github.rest.issues.addLabels({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pr, labels: [label] });
+            } catch (e) { core.warning('Could not add label: ' + e.message); }
+        env:
+          APPLIED_LABEL: ${{ vars.AUTOFIX_APPLIED_LABEL || 'autofix:applied' }}

--- a/.github/workflows/autofix-consumer.yml
+++ b/.github/workflows/autofix-consumer.yml
@@ -20,6 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
     steps:
+      - name: Checkout PR HEAD
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Check latest commit message for autofix
         id: msg
         run: |

--- a/.github/workflows/autofix-on-failure.yml
+++ b/.github/workflows/autofix-on-failure.yml
@@ -97,6 +97,18 @@ jobs:
           git add -A
           git commit -m "ci: autofix after failed checks"
           git push origin HEAD:${{ steps.find_pr.outputs.head_ref }}
+      - name: Label PR (applied autofix)
+        if: steps.fix.outputs.changed == 'true' && steps.find_pr.outputs.same_repo == 'true' && steps.guard.outputs.already != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = Number('${{ steps.find_pr.outputs.pr }}');
+            const label = process.env.APPLIED_LABEL || 'autofix:applied';
+            try {
+              await github.rest.issues.addLabels({ owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber, labels: [label] });
+            } catch (e) { core.warning('Could not add label: ' + e.message); }
+        env:
+          APPLIED_LABEL: ${{ vars.AUTOFIX_APPLIED_LABEL || 'autofix:applied' }}
       - name: Fork patch artifact
         if: steps.fix.outputs.changed == 'true' && steps.find_pr.outputs.same_repo != 'true' && steps.guard.outputs.already != 'true'
         run: |
@@ -131,6 +143,18 @@ jobs:
               issue_number: prNumber,
               body
             });
+      - name: Label PR (patch provided)
+        if: steps.fix.outputs.changed == 'true' && steps.find_pr.outputs.same_repo != 'true' && steps.guard.outputs.already != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = Number('${{ steps.find_pr.outputs.pr }}');
+            const label = process.env.APPLIED_LABEL || 'autofix:applied';
+            try {
+              await github.rest.issues.addLabels({ owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber, labels: [label] });
+            } catch (e) { core.warning('Could not add label: ' + e.message); }
+        env:
+          APPLIED_LABEL: ${{ vars.AUTOFIX_APPLIED_LABEL || 'autofix:applied' }}
       - name: Summary
         if: always()
         run: |

--- a/ruff_remaining.log
+++ b/ruff_remaining.log
@@ -1,0 +1,65 @@
+src/trend_analysis/_autofix_trigger_sample.py:1:1: F403 `from typing import *` used; unable to detect undefined names
+  |
+1 | from typing import *
+  | ^^^^^^^^^^^^^^^^^^^^ F403
+2 | 
+3 | #  This file intentionally violates style conventions for test of autofix workflows.
+  |
+
+src/trend_analysis/_autofix_trigger_sample.py:20:21: F405 `List` may be undefined, or defined from star imports
+   |
+20 | def another_func(a: List[int], b: List[int]):
+   |                     ^^^^ F405
+21 |     result = [i + j for i, j in zip(a, b)]
+22 |     return result
+   |
+
+src/trend_analysis/_autofix_trigger_sample.py:20:35: F405 `List` may be undefined, or defined from star imports
+   |
+20 | def another_func(a: List[int], b: List[int]):
+   |                                   ^^^^ F405
+21 |     result = [i + j for i, j in zip(a, b)]
+22 |     return result
+   |
+
+src/trend_analysis/_autofix_violation_case2.py:49:5: F841 Local variable `data` is assigned to but never used
+   |
+47 |     a, b, c
+48 | ):  # parameters intentionally unused; add mutable default below (B006)
+49 |     data = []  # mutable list (not default param) but harmless; keeps function non-empty
+   |     ^^^^ F841
+50 |     return None  # explicit return for clarity
+   |
+   = help: Remove assignment to unused variable `data`
+
+tests/test_multi_period_engine_threshold_events_extended.py:109:28: F821 Undefined name `Tuple`
+    |
+107 |         self.sequences = sequences
+108 |         self.calls = 0
+109 |         self.updates: List[Tuple[pd.Series, int]] = []
+    |                            ^^^^^ F821
+110 | 
+111 |     def weight(self, selected: pd.DataFrame, date: pd.Timestamp) -> pd.DataFrame:
+    |
+
+tests/test_trend_analysis_typing_contract.py:38:12: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
+   |
+37 |     assert hints["manager_changes"] == MutableSequence[dict[str, object]]
+38 |     assert hints["turnover"] == float
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^ E721
+39 |     assert hints["transaction_cost"] == float
+40 |     cov_diag_hint = cast(Any, hints["cov_diag"])
+   |
+
+tests/test_trend_analysis_typing_contract.py:39:12: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
+   |
+37 |     assert hints["manager_changes"] == MutableSequence[dict[str, object]]
+38 |     assert hints["turnover"] == float
+39 |     assert hints["transaction_cost"] == float
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E721
+40 |     cov_diag_hint = cast(Any, hints["cov_diag"])
+41 |     # ``TypeAlias`` annotations resolve to ``list[float]`` at runtime on
+   |
+
+Found 7 errors.
+No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -44,6 +44,7 @@ if FAST_SENTINEL.exists():
 import numpy as np  # noqa: E402
 import openpyxl  # noqa: E402
 import pandas as pd  # noqa: E402
+
 import yaml  # type: ignore[import-untyped]  # noqa: E402
 
 # ---------------------------------------------------------------------------

--- a/src/trend_analysis/_autofix_trigger_sample.py
+++ b/src/trend_analysis/_autofix_trigger_sample.py
@@ -1,0 +1,31 @@
+import  os,sys,   math
+from   typing import  *
+
+#  This file intentionally violates style conventions for test of autofix workflows.
+#  Issues included:
+#  - extra spaces in imports
+#  - wildcard import usage
+#  - inconsistent indentation
+#  - double spaces
+#  - badly formatted function definitions
+#  - trailing whitespace
+#  - long line exceeding typical 88 char limit
+#  - unused variables
+
+def  badly_formatted_function ( x:int ,y : int=  5)->int:
+        temp   =  x + y   
+        return  temp
+
+def another_func(  a: List[int] , b :List[int]):
+          result=[ i + j  for i , j in zip( a , b ) ]
+          return   result   
+
+class  Demo:    
+      def  method( self,value:float)->float: 
+             return  value* 2.0   
+
+CONSTANT_VALUE=  42  #unused constant for test
+
+def long_line():
+    # Next line deliberately exceeds 120 chars to exercise any length trimming expectations (though black will wrap appropriately on reformat)
+    return "This is an intentionally overly verbose string whose primary purpose is to exceed the standard enforced line length so that formatting tools act."  

--- a/src/trend_analysis/_autofix_trigger_sample.py
+++ b/src/trend_analysis/_autofix_trigger_sample.py
@@ -1,5 +1,4 @@
-import  os,sys,   math
-from   typing import  *
+from typing import *
 
 #  This file intentionally violates style conventions for test of autofix workflows.
 #  Issues included:
@@ -12,20 +11,25 @@ from   typing import  *
 #  - long line exceeding typical 88 char limit
 #  - unused variables
 
-def  badly_formatted_function ( x:int ,y : int=  5)->int:
-        temp   =  x + y   
-        return  temp
 
-def another_func(  a: List[int] , b :List[int]):
-          result=[ i + j  for i , j in zip( a , b ) ]
-          return   result   
+def badly_formatted_function(x: int, y: int = 5) -> int:
+    temp = x + y
+    return temp
 
-class  Demo:    
-      def  method( self,value:float)->float: 
-             return  value* 2.0   
 
-CONSTANT_VALUE=  42  #unused constant for test
+def another_func(a: List[int], b: List[int]):
+    result = [i + j for i, j in zip(a, b)]
+    return result
+
+
+class Demo:
+    def method(self, value: float) -> float:
+        return value * 2.0
+
+
+CONSTANT_VALUE = 42  # unused constant for test
+
 
 def long_line():
     # Next line deliberately exceeds 120 chars to exercise any length trimming expectations (though black will wrap appropriately on reformat)
-    return "This is an intentionally overly verbose string whose primary purpose is to exceed the standard enforced line length so that formatting tools act."  
+    return "This is an intentionally overly verbose string whose primary purpose is to exceed the standard enforced line length so that formatting tools act."

--- a/src/trend_analysis/_autofix_violation_case2.py
+++ b/src/trend_analysis/_autofix_violation_case2.py
@@ -1,18 +1,25 @@
-"""Intentional style violations to force the reusable autofix workflow to act.
+"""Intentional style violations to force the reusable autofix workflow to act. This opening
+docstring is intentionally written as one very long, run‑on paragraph lacking proper line
+wrapping or formatting so that ``docformatter`` will reflow it into a canonical width. The
+goal is to introduce a deterministic diff ignored by our pre-commit pipeline (which does
+not invoke docformatter) while still being caught by the composite autofix action in CI.
 
-This file is crafted so that at least one of ruff / black / isort / docformatter
-will introduce changes (imports ordering, spacing, line length, unused imports,
-mixed quote styles) ensuring `changed=true` when the composite action runs.
+Additional context: we also include import ordering / spacing issues that are subtle enough
+that isort will act, and we add a secondary, excessively long explanatory paragraph to
+reinforce deterministic wrapping behaviour. The quick brown fox jumps over the lazy dog
+sentence is repeated to inflate length without semantic complexity. The quick brown fox
+jumps over the lazy dog; the quick brown fox jumps over the lazy dog; the quick brown fox
+jumps over the lazy dog. End of deliberately verbose section.
 """
 
-from typing import List, Dict  # double spaces
+import   os,   sys   # deliberately unordered & spaced (isort will normalize)
+import json,   math  # more spacing issues
+from   typing import  List,  Dict   # spacing
 
 CONSTANT = 3.14159  # spacing
 
 
-def compute(
-    values: List[int] | None = None,
-) -> Dict[str, float]:  # spacing & annotations formatting
+def compute(values: List[int] | None = None) -> Dict[str, float]:  # compact signature to invite wrap
     if values is None:
         values = [1, 2, 3]  # inline if; spacing
     total = sum(values)  # no spaces around operators for ruff rule (will be fixed)
@@ -25,18 +32,19 @@ def compute(
     return payload
 
 
-class Example:  # double spaces
+class  Example:  # extra internal spacing
     def method(self, x: float, y: float = 2) -> float:  # spacing
         return x + y
 
 
-def long_line_function():
+def long_line_function():  # docformatter should leave this comment but black may wrap return
     # black will re-wrap the following very long line (> 140 chars)
     return "This is a purposely extremely, extravagantly, unnecessarily, disproportionately, egregiously long string that black will wrap for demonstration purposes and diff generation."  # noqa: E501
 
 
-def unused_func(a, b, c):  # parameters intentionally unused
-    pass  # ruff may flag but autofix won't remove; that's fine
+def unused_func(a, b, c):  # parameters intentionally unused; add mutable default below (B006)
+    data = []  # mutable list (not default param) but harmless; keeps function non-empty
+    return None  # explicit return for clarity
 
 
 if __name__ == "__main__":

--- a/src/trend_analysis/_autofix_violation_case2.py
+++ b/src/trend_analysis/_autofix_violation_case2.py
@@ -1,8 +1,9 @@
-"""Intentional style violations to force the reusable autofix workflow to act. This opening
-docstring is intentionally written as one very long, run‑on paragraph lacking proper line
-wrapping or formatting so that ``docformatter`` will reflow it into a canonical width. The
-goal is to introduce a deterministic diff ignored by our pre-commit pipeline (which does
-not invoke docformatter) while still being caught by the composite autofix action in CI.
+"""Intentional style violations to force the reusable autofix workflow to act.
+This opening docstring is intentionally written as one very long, run‑on
+paragraph lacking proper line wrapping or formatting so that ``docformatter``
+will reflow it into a canonical width. The goal is to introduce a deterministic
+diff ignored by our pre-commit pipeline (which does not invoke docformatter)
+while still being caught by the composite autofix action in CI.
 
 Additional context: we also include import ordering / spacing issues that are subtle enough
 that isort will act, and we add a secondary, excessively long explanatory paragraph to
@@ -12,14 +13,14 @@ jumps over the lazy dog; the quick brown fox jumps over the lazy dog; the quick 
 jumps over the lazy dog. End of deliberately verbose section.
 """
 
-import   os,   sys   # deliberately unordered & spaced (isort will normalize)
-import json,   math  # more spacing issues
-from   typing import  List,  Dict   # spacing
+from typing import Dict, List  # spacing
 
 CONSTANT = 3.14159  # spacing
 
 
-def compute(values: List[int] | None = None) -> Dict[str, float]:  # compact signature to invite wrap
+def compute(
+    values: List[int] | None = None,
+) -> Dict[str, float]:  # compact signature to invite wrap
     if values is None:
         values = [1, 2, 3]  # inline if; spacing
     total = sum(values)  # no spaces around operators for ruff rule (will be fixed)
@@ -32,7 +33,7 @@ def compute(values: List[int] | None = None) -> Dict[str, float]:  # compact sig
     return payload
 
 
-class  Example:  # extra internal spacing
+class Example:  # extra internal spacing
     def method(self, x: float, y: float = 2) -> float:  # spacing
         return x + y
 
@@ -42,7 +43,9 @@ def long_line_function():  # docformatter should leave this comment but black ma
     return "This is a purposely extremely, extravagantly, unnecessarily, disproportionately, egregiously long string that black will wrap for demonstration purposes and diff generation."  # noqa: E501
 
 
-def unused_func(a, b, c):  # parameters intentionally unused; add mutable default below (B006)
+def unused_func(
+    a, b, c
+):  # parameters intentionally unused; add mutable default below (B006)
     data = []  # mutable list (not default param) but harmless; keeps function non-empty
     return None  # explicit return for clarity
 

--- a/src/trend_analysis/_autofix_violation_case2.py
+++ b/src/trend_analysis/_autofix_violation_case2.py
@@ -1,0 +1,43 @@
+"""Intentional style violations to force the reusable autofix workflow to act.
+
+This file is crafted so that at least one of ruff / black / isort / docformatter
+will introduce changes (imports ordering, spacing, line length, unused imports,
+mixed quote styles) ensuring `changed=true` when the composite action runs.
+"""
+
+from typing import List, Dict  # double spaces
+
+CONSTANT = 3.14159  # spacing
+
+
+def compute(
+    values: List[int] | None = None,
+) -> Dict[str, float]:  # spacing & annotations formatting
+    if values is None:
+        values = [1, 2, 3]  # inline if; spacing
+    total = sum(values)  # no spaces around operators for ruff rule (will be fixed)
+    mean = total / len(values)
+    payload = {
+        "total": total,
+        "mean": mean,
+        "count": len(values),
+    }  # mixed quotes, spacing
+    return payload
+
+
+class Example:  # double spaces
+    def method(self, x: float, y: float = 2) -> float:  # spacing
+        return x + y
+
+
+def long_line_function():
+    # black will re-wrap the following very long line (> 140 chars)
+    return "This is a purposely extremely, extravagantly, unnecessarily, disproportionately, egregiously long string that black will wrap for demonstration purposes and diff generation."  # noqa: E501
+
+
+def unused_func(a, b, c):  # parameters intentionally unused
+    pass  # ruff may flag but autofix won't remove; that's fine
+
+
+if __name__ == "__main__":
+    print(compute())

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -382,5 +382,6 @@ def main(argv: list[str] | None = None) -> int:
     # This shouldn't be reached with required=True.
     return 0
 
+
 if __name__ == "__main__":  # pragma: no cover - manual invocation
     raise SystemExit(main())

--- a/src/trend_analysis/gui/app.py
+++ b/src/trend_analysis/gui/app.py
@@ -9,8 +9,9 @@ from typing import TYPE_CHECKING, Any, Dict, cast
 
 import ipywidgets as widgets
 import pandas as pd
-import yaml  # type: ignore[import-untyped]
 from IPython.display import FileLink, Javascript, display
+
+import yaml  # type: ignore[import-untyped]
 
 from ..config import Config
 from .plugins import discover_plugins, iter_plugins

--- a/src/trend_portfolio_app/app.py
+++ b/src/trend_portfolio_app/app.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, cast
 
 import pandas as pd
 import streamlit as st
-import yaml  # type: ignore[import-untyped]
 
+import yaml  # type: ignore[import-untyped]
 from trend_analysis import pipeline
 from trend_analysis.config import DEFAULTS as DEFAULT_CFG_PATH
 from trend_analysis.config import Config
@@ -41,7 +41,8 @@ def _is_mock_streamlit(module: Any) -> bool:
 
 
 def _read_defaults() -> Dict[str, Any]:
-    """Load the default YAML configuration bundled with the analysis package."""
+    """Load the default YAML configuration bundled with the analysis
+    package."""
 
     data = yaml.safe_load(Path(DEFAULT_CFG_PATH).read_text(encoding="utf-8"))
     if not isinstance(data, dict):  # pragma: no cover - defensive
@@ -329,4 +330,3 @@ def _render_app() -> None:
 
 if not _is_mock_streamlit(st):
     _render_app()
-

--- a/src/yaml/__init__.pyi
+++ b/src/yaml/__init__.pyi
@@ -7,43 +7,21 @@ from typing import IO, Any, TypeVar
 
 _T = TypeVar("_T")
 
-
-class YAMLError(Exception):
-    ...
-
-
-class ScannerError(YAMLError):
-    ...
-
+class YAMLError(Exception): ...
+class ScannerError(YAMLError): ...
 
 class scanner:
     ScannerError = ScannerError
 
-
-class Loader:
-    ...
-
-
-class SafeLoader(Loader):
-    ...
-
-
-class Dumper:
-    ...
-
-
-class SafeDumper(Dumper):
-    ...
-
+class Loader: ...
+class SafeLoader(Loader): ...
+class Dumper: ...
+class SafeDumper(Dumper): ...
 
 def safe_load(stream: str | bytes | bytearray | IO[str] | IO[bytes]) -> Any: ...
-
-
 def safe_load_all(
     stream: str | bytes | bytearray | IO[str] | IO[bytes],
 ) -> Iterable[Any]: ...
-
-
 def safe_dump(
     data: Any,
     stream: IO[str] | None = ...,
@@ -52,8 +30,6 @@ def safe_dump(
     allow_unicode: bool | None = ...,
     sort_keys: bool | None = ...,
 ) -> str: ...
-
-
 def dump(
     data: Any,
     stream: IO[str] | None = ...,
@@ -62,17 +38,12 @@ def dump(
     allow_unicode: bool | None = ...,
     sort_keys: bool | None = ...,
 ) -> str: ...
-
-
 def load(
     stream: str | bytes | bytearray | IO[str] | IO[bytes],
     Loader: type[Loader] | None = ...,
 ) -> Any: ...
-
-
 def dump_all(
     documents: Iterable[Any],
     stream: IO[str] | None = ...,
     Dumper: type[Dumper] | None = ...,
 ) -> str: ...
-

--- a/streamlit_app/components/demo_runner.py
+++ b/streamlit_app/components/demo_runner.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, MutableMapping, Tuple
 
 import pandas as pd
-import yaml  # type: ignore[import-untyped]
 
+import yaml  # type: ignore[import-untyped]
 from trend_analysis.api import run_simulation
 from trend_analysis.config import Config
 from trend_portfolio_app.data_schema import (SchemaMeta, infer_benchmarks,

--- a/tests/proxy/test_server.py
+++ b/tests/proxy/test_server.py
@@ -32,7 +32,9 @@ class DummyBackgroundTask:
 
 
 class DummyStreamingResponse:
-    def __init__(self, iterable, *, status_code: int, headers: dict[str, str], background) -> None:
+    def __init__(
+        self, iterable, *, status_code: int, headers: dict[str, str], background
+    ) -> None:
         self.iterable = iterable
         self.status_code = status_code
         self.headers = headers
@@ -137,6 +139,7 @@ def test_handle_websocket_query_forwarding(proxy_fixture, monkeypatch, caplog):
         "ws://example.com:1234/stream/path?token=abc" in record.getMessage()
         for record in caplog.records
     )
+
 
 def test_handle_websocket_without_query(proxy_fixture, monkeypatch):
     """When no query string is present the base URL should remain unchanged."""
@@ -308,7 +311,9 @@ def test_start_invokes_uvicorn(proxy_fixture, monkeypatch):
     monkeypatch.setattr(
         server,
         "uvicorn",
-        types.SimpleNamespace(Config=lambda **kwargs: DummyConfig(**kwargs), Server=DummyServer),
+        types.SimpleNamespace(
+            Config=lambda **kwargs: DummyConfig(**kwargs), Server=DummyServer
+        ),
     )
 
     asyncio.run(proxy.start("0.0.0.0", 7777))

--- a/tests/test_app_coverage.py
+++ b/tests/test_app_coverage.py
@@ -13,9 +13,9 @@ from unittest.mock import ANY, MagicMock, Mock, patch
 
 import pandas as pd
 import pytest
-import yaml  # type: ignore[import-untyped]
 
 import trend_analysis.gui.app as app_module
+import yaml  # type: ignore[import-untyped]
 from trend_analysis.gui.app import (_build_rank_options, _build_step0, launch,
                                     load_state, save_state)
 from trend_analysis.gui.store import ParamStore

--- a/tests/test_chatgpt_topics_parser.py
+++ b/tests/test_chatgpt_topics_parser.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 import pathlib
 import subprocess
 import sys
@@ -8,7 +8,8 @@ SCRIPT = pathlib.Path(".github/scripts/parse_chatgpt_topics.py")
 
 
 def run_parser(text: str, env: dict | None = None) -> tuple[int, str, str]:
-    """Helper to invoke the parser script in a subprocess for exit code semantics."""
+    """Helper to invoke the parser script in a subprocess for exit code
+    semantics."""
     tmp = pathlib.Path("input.txt")
     tmp.write_text(text, encoding="utf-8")
     proc = subprocess.run(

--- a/tests/test_cli_api_golden_master.py
+++ b/tests/test_cli_api_golden_master.py
@@ -7,8 +7,8 @@ import tempfile
 from pathlib import Path
 
 import pandas as pd
-import yaml  # type: ignore[import-untyped]
 
+import yaml  # type: ignore[import-untyped]
 from trend_analysis import api
 from trend_analysis.config import Config
 

--- a/tests/test_cli_no_structured_log.py
+++ b/tests/test_cli_no_structured_log.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import pandas as pd
+
 import yaml  # type: ignore[import-untyped]
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,4 @@
 import yaml  # type: ignore[import-untyped]
-
 from trend_analysis import config
 
 

--- a/tests/test_config_legacy.py
+++ b/tests/test_config_legacy.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
 import pytest
-import yaml  # type: ignore[import-untyped]
 
+import yaml  # type: ignore[import-untyped]
 from trend_analysis.config import legacy
 
 

--- a/tests/test_config_models_additional.py
+++ b/tests/test_config_models_additional.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import yaml  # type: ignore[import-untyped]
 
+import yaml  # type: ignore[import-untyped]
 from trend_analysis.config import models
 
 

--- a/tests/test_config_turnover_validation.py
+++ b/tests/test_config_turnover_validation.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
 import pytest
-import yaml  # type: ignore[import-untyped]
 
+import yaml  # type: ignore[import-untyped]
 from trend_analysis.config import Config
 
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -3,9 +3,8 @@ import importlib
 import sys
 from types import SimpleNamespace
 
-import yaml  # type: ignore[import-untyped]
-
 import trend_analysis.gui as gui
+import yaml  # type: ignore[import-untyped]
 
 
 def test_paramstore_roundtrip(tmp_path):

--- a/tests/test_gui_app_extended.py
+++ b/tests/test_gui_app_extended.py
@@ -7,8 +7,8 @@ from typing import Callable
 
 import pandas as pd
 import pytest
-import yaml  # type: ignore[import-untyped]
 
+import yaml  # type: ignore[import-untyped]
 from trend_analysis.gui import app
 from trend_analysis.gui.store import ParamStore
 

--- a/tests/test_metric_cache.py
+++ b/tests/test_metric_cache.py
@@ -2,8 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from trend_analysis.core.metric_cache import (MetricCache,
-                                              clear_metric_cache,
+from trend_analysis.core.metric_cache import (MetricCache, clear_metric_cache,
                                               get_or_compute_metric_series,
                                               global_metric_cache)
 from trend_analysis.core.rank_selection import (RiskStatsConfig,

--- a/tests/test_multi_period_engine_helpers_additional.py
+++ b/tests/test_multi_period_engine_helpers_additional.py
@@ -105,13 +105,17 @@ def test_portfolio_rebalance_accepts_multiple_input_shapes() -> None:
     assert pf.total_rebalance_costs == pytest.approx(0.07)
 
 
-def test_run_schedule_invokes_update_and_fast_turnover(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_schedule_invokes_update_and_fast_turnover(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """``run_schedule`` should exercise fast turnover and update hooks."""
 
     class DummySelector:
         rank_column = "Sharpe"
 
-        def select(self, score_frame: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+        def select(
+            self, score_frame: pd.DataFrame
+        ) -> tuple[pd.DataFrame, pd.DataFrame]:
             return score_frame, score_frame
 
     class RecordingWeighting:

--- a/tests/test_multi_period_engine_incremental_cov.py
+++ b/tests/test_multi_period_engine_incremental_cov.py
@@ -149,11 +149,14 @@ def test_run_incremental_covariance_fallback_on_error(monkeypatch):
     # No incremental updates recorded because the helper kept failing
     assert second_stats["incremental_updates"] == 0
 
+
 def test_run_incremental_covariance_handles_bad_shift_and_strings(monkeypatch):
-    """Test that the engine correctly handles string-formatted dates and invalid
-    (non-integer) shift detection settings. Ensures that covariance computation
-    and diagnostics are performed even when input formats are incorrect or edge
-    cases are present."""
+    """Test that the engine correctly handles string-formatted dates and
+    invalid (non-integer) shift detection settings.
+
+    Ensures that covariance computation and diagnostics are performed
+    even when input formats are incorrect or edge cases are present.
+    """
     cfg = _Cfg()
     cfg.performance["shift_detection_max_steps"] = "not-an-int"
     cfg.benchmarks = {"bm": "Benchmark"}

--- a/tests/test_multi_period_engine_run_schedule_extra.py
+++ b/tests/test_multi_period_engine_run_schedule_extra.py
@@ -36,7 +36,9 @@ class _UpdatingWeighting(BaseWeighting):
         weights = np.linspace(1.0, 2.0, n) / np.linspace(1.0, 2.0, n).sum()
         return pd.DataFrame({"weight": weights}, index=selected.index)
 
-    def update(self, scores: pd.Series, days: int) -> None:  # pragma: no cover - runtime hook
+    def update(
+        self, scores: pd.Series, days: int
+    ) -> None:  # pragma: no cover - runtime hook
         self.update_calls.append((scores.copy(), days))
 
 
@@ -120,4 +122,3 @@ def test_run_schedule_invokes_rebalance_strategies_and_weighting_update(monkeypa
     # First update occurs with zero elapsed days; second uses actual delta (~29 days)
     assert weighting.update_calls[0][1] == 0
     assert weighting.update_calls[1][1] > 0
-

--- a/tests/test_multi_period_engine_threshold_edgecases.py
+++ b/tests/test_multi_period_engine_threshold_edgecases.py
@@ -549,7 +549,9 @@ def test_threshold_hold_seed_dedupe_and_rebalance_events(
         def __init__(self, ordering: Sequence[str]) -> None:
             self._ordering = list(ordering)
 
-        def select(self, score_frame: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+        def select(
+            self, score_frame: pd.DataFrame
+        ) -> tuple[pd.DataFrame, pd.DataFrame]:
             ordered = [fund for fund in self._ordering if fund in score_frame.index]
             selected = score_frame.loc[ordered]
             return selected, selected
@@ -566,7 +568,9 @@ def test_threshold_hold_seed_dedupe_and_rebalance_events(
         def __init__(self, *_cfg: Any) -> None:
             self.calls = 0
 
-        def apply_triggers(self, prev_weights: pd.Series, _sf: pd.DataFrame) -> pd.Series:
+        def apply_triggers(
+            self, prev_weights: pd.Series, _sf: pd.DataFrame
+        ) -> pd.Series:
             self.calls += 1
             series = prev_weights.astype(float).copy()
             if self.calls == 1:
@@ -794,7 +798,9 @@ def test_threshold_hold_enforces_bounds_and_replacement_flow(
             self.top_n = top_n
             self.rank_column = rank_column
 
-        def select(self, score_frame: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+        def select(
+            self, score_frame: pd.DataFrame
+        ) -> tuple[pd.DataFrame, pd.DataFrame]:
             ordered = score_frame.sort_values(self.rank_column, ascending=False)
             picked = ordered.head(self.top_n)
             return picked, picked
@@ -840,7 +846,9 @@ def test_threshold_hold_enforces_bounds_and_replacement_flow(
         def __init__(self, *_cfg: Any) -> None:
             self.invocations: list[pd.Series] = []
 
-        def apply_triggers(self, prev_weights: pd.Series, score_frame: pd.DataFrame) -> pd.Series:
+        def apply_triggers(
+            self, prev_weights: pd.Series, score_frame: pd.DataFrame
+        ) -> pd.Series:
             self.invocations.append(prev_weights.copy())
             return pd.Series(
                 {
@@ -901,4 +909,3 @@ def test_threshold_hold_enforces_bounds_and_replacement_flow(
     reasons = {event["reason"] for event in second_events}
     assert {"one_per_firm", "low_weight_strikes", "replacement"} <= reasons
     assert results[1]["turnover"] > 0
-

--- a/tests/test_multi_period_engine_threshold_events_extended.py
+++ b/tests/test_multi_period_engine_threshold_events_extended.py
@@ -248,7 +248,9 @@ def _patch_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(rank_sel, "_compute_metric_series", fake_metric_series)
 
 
-def test_threshold_hold_event_log_and_replacements(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_threshold_hold_event_log_and_replacements(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     cfg = ThresholdConfig()
     df = _build_base_frame()
 
@@ -284,10 +286,25 @@ def test_threshold_hold_event_log_and_replacements(monkeypatch: pytest.MonkeyPat
         "AdaptiveBayesWeighting",
         lambda *args, **kwargs: SequencedWeighting(
             [
-                {"Alpha One": 0.7, "Beta One": 0.1, "Gamma One": 0.05, "Delta One": 0.05},
-                {"Alpha One": 0.8, "Beta One": 0.04, "Gamma One": 0.02, "Delta One": 0.01},
+                {
+                    "Alpha One": 0.7,
+                    "Beta One": 0.1,
+                    "Gamma One": 0.05,
+                    "Delta One": 0.05,
+                },
+                {
+                    "Alpha One": 0.8,
+                    "Beta One": 0.04,
+                    "Gamma One": 0.02,
+                    "Delta One": 0.01,
+                },
                 {"Alpha One": 0.7, "Gamma One": 0.05, "Delta One": 0.2},
-                {"Alpha One": 0.7, "Delta One": 0.2, "Epsilon One": 0.1, "Beta One": 0.05},
+                {
+                    "Alpha One": 0.7,
+                    "Delta One": 0.2,
+                    "Epsilon One": 0.1,
+                    "Beta One": 0.05,
+                },
             ]
         ),
     )
@@ -303,7 +320,9 @@ def test_threshold_hold_event_log_and_replacements(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(
         selector_mod,
         "create_selector_by_name",
-        lambda *_args, **_kwargs: ScriptedSelector(order, cfg.portfolio["threshold_hold"]["target_n"]),
+        lambda *_args, **_kwargs: ScriptedSelector(
+            order, cfg.portfolio["threshold_hold"]["target_n"]
+        ),
     )
 
     analysis_calls: List[Dict[str, Any]] = []
@@ -339,12 +358,18 @@ def test_threshold_hold_event_log_and_replacements(monkeypatch: pytest.MonkeyPat
 
     second_period = results[1]
     reasons = {event["reason"] for event in second_period["manager_changes"]}
-    assert {"z_exit", "z_entry", "one_per_firm", "low_weight_strikes", "replacement"}.issubset(
-        reasons
-    )
+    assert {
+        "z_exit",
+        "z_entry",
+        "one_per_firm",
+        "low_weight_strikes",
+        "replacement",
+    }.issubset(reasons)
 
     low_weight_events = [
-        event for event in second_period["manager_changes"] if event["reason"] == "low_weight_strikes"
+        event
+        for event in second_period["manager_changes"]
+        if event["reason"] == "low_weight_strikes"
     ]
     assert low_weight_events and "below min" in low_weight_events[0]["detail"]
 
@@ -360,7 +385,9 @@ def test_threshold_hold_event_log_and_replacements(monkeypatch: pytest.MonkeyPat
     assert "Gamma One" not in manual_funds
 
     assert second_period["turnover"] == pytest.approx(0.25)
-    expected_cost = second_period["turnover"] * (cfg.portfolio["transaction_cost_bps"] / 10000.0)
+    expected_cost = second_period["turnover"] * (
+        cfg.portfolio["transaction_cost_bps"] / 10000.0
+    )
     assert second_period["transaction_cost"] == pytest.approx(expected_cost)
 
 

--- a/tests/test_multi_period_export.py
+++ b/tests/test_multi_period_export.py
@@ -2,8 +2,8 @@ from pathlib import Path
 from typing import cast
 
 import pandas as pd
-import yaml  # type: ignore[import-untyped]
 
+import yaml  # type: ignore[import-untyped]
 from trend_analysis.config import Config
 from trend_analysis.export import (combined_summary_frame,
                                    combined_summary_result,

--- a/tests/test_multi_period_stub.py
+++ b/tests/test_multi_period_stub.py
@@ -2,7 +2,6 @@ import warnings
 from pathlib import Path
 
 import yaml  # type: ignore[import-untyped]
-
 from trend_analysis.multi_period.scheduler import generate_periods
 
 CFG = yaml.safe_load(Path("config/defaults.yml").read_text())

--- a/tests/test_portfolio_app_helpers.py
+++ b/tests/test_portfolio_app_helpers.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 import pandas as pd
 import pytest
+
 import yaml  # type: ignore[import-untyped]
 
 

--- a/tests/test_proxy_server_additional.py
+++ b/tests/test_proxy_server_additional.py
@@ -245,7 +245,9 @@ def test_streamlit_proxy_requires_runtime_deps(monkeypatch: pytest.MonkeyPatch) 
         server.StreamlitProxy()
 
 
-def test_websocket_entry_delegates(patched_server: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_websocket_entry_delegates(
+    patched_server: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
     proxy = patched_server.StreamlitProxy()
     calls: list[tuple[Any, str]] = []
 
@@ -264,10 +266,16 @@ def test_handle_websocket_requires_dependency(
     proxy = patched_server.StreamlitProxy()
     monkeypatch.setattr(patched_server, "websockets", None)
     with pytest.raises(RuntimeError):
-        asyncio.run(proxy._handle_websocket(SimpleNamespace(url=SimpleNamespace(query="")), "ws"))
+        asyncio.run(
+            proxy._handle_websocket(
+                SimpleNamespace(url=SimpleNamespace(query="")), "ws"
+            )
+        )
 
 
-def test_http_entry_delegates(patched_server: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_http_entry_delegates(
+    patched_server: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
     proxy = patched_server.StreamlitProxy()
     recorded: list[tuple[Any, str]] = []
 
@@ -318,7 +326,9 @@ def test_handle_websocket_handles_connection_failure(
         assert url == "ws://example.com:1234/ws/path?token=1"
         return FailingConnection()
 
-    monkeypatch.setattr(patched_server, "websockets", SimpleNamespace(connect=failing_connect))
+    monkeypatch.setattr(
+        patched_server, "websockets", SimpleNamespace(connect=failing_connect)
+    )
 
     websocket = FakeWebsocket()
     asyncio.run(proxy._handle_websocket(websocket, "ws/path"))

--- a/tests/test_proxy_server_runtime_extra.py
+++ b/tests/test_proxy_server_runtime_extra.py
@@ -72,7 +72,9 @@ def _setup_proxy_deps(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(server, "BackgroundTask", _DummyBackgroundTask)
 
 
-def test_streamlit_proxy_init_requires_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_streamlit_proxy_init_requires_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(server, "_assert_deps", lambda: None)
     monkeypatch.setattr(server, "FastAPI", None)
     monkeypatch.setattr(server, "httpx", None)
@@ -81,7 +83,9 @@ def test_streamlit_proxy_init_requires_dependencies(monkeypatch: pytest.MonkeyPa
         server.StreamlitProxy()
 
 
-def test_streamlit_proxy_websocket_and_http_routing(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_streamlit_proxy_websocket_and_http_routing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     _setup_proxy_deps(monkeypatch)
 
     dummy_websockets_calls: list[str] = []
@@ -180,7 +184,9 @@ def test_streamlit_proxy_websocket_and_http_routing(monkeypatch: pytest.MonkeyPa
     asyncio.run(runner())
 
 
-def test_streamlit_proxy_start_requires_uvicorn(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_streamlit_proxy_start_requires_uvicorn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     _setup_proxy_deps(monkeypatch)
     monkeypatch.setattr(server, "uvicorn", None)
 
@@ -191,4 +197,3 @@ def test_streamlit_proxy_start_requires_uvicorn(monkeypatch: pytest.MonkeyPatch)
             await proxy.start()
 
     asyncio.run(runner())
-

--- a/tests/test_run_analysis_cli.py
+++ b/tests/test_run_analysis_cli.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import types
+from pathlib import Path
 
 import pandas as pd
 import pytest

--- a/tests/test_threshold_hold_alignment.py
+++ b/tests/test_threshold_hold_alignment.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
-import yaml  # type: ignore[import-untyped]
 
+import yaml  # type: ignore[import-untyped]
 from trend_analysis.config import Config
 from trend_analysis.multi_period import engine as mp_engine
 from trend_analysis.multi_period.scheduler import generate_periods

--- a/tests/test_transaction_costs_and_turnover.py
+++ b/tests/test_transaction_costs_and_turnover.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
 import pandas as pd
-import yaml  # type: ignore[import-untyped]
 
+import yaml  # type: ignore[import-untyped]
 from trend_analysis.config import Config
 from trend_analysis.export import (combined_summary_result,
                                    summary_frame_from_result)

--- a/tests/test_trend_analysis_typing_contract.py
+++ b/tests/test_trend_analysis_typing_contract.py
@@ -2,10 +2,11 @@
 
 from collections import UserDict
 from types import MappingProxyType
-from typing import Any, List, Mapping, MutableMapping, MutableSequence, Union, cast, get_args, get_origin, get_type_hints
+from typing import (Any, Mapping, MutableMapping, MutableSequence, Union, cast,
+                    get_args, get_origin, get_type_hints)
 
-from trend_analysis.typing import (MultiPeriodPeriodResult, StatsMapping,
-                                   CovarianceDiagonal)
+from trend_analysis.typing import (CovarianceDiagonal, MultiPeriodPeriodResult,
+                                   StatsMapping)
 
 
 def test_multi_period_period_result_schema_matches_expected_contract() -> None:
@@ -46,6 +47,8 @@ def test_multi_period_period_result_schema_matches_expected_contract() -> None:
 
     stats_mapping_hint = cast(Any, hints["out_ew_stats"])
     assert stats_mapping_hint == StatsMapping
+
+
 def test_multi_period_period_result_supports_incremental_population() -> None:
     """Ensure the TypedDict behaves like a mutable dictionary at runtime."""
 

--- a/tests/test_trend_portfolio_app_helpers.py
+++ b/tests/test_trend_portfolio_app_helpers.py
@@ -1,4 +1,3 @@
-import importlib
 import json
 import sys
 from pathlib import Path
@@ -175,8 +174,12 @@ def _load_app(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     source = Path(module.__file__).read_text(encoding="utf-8")
     prefix = source.split("st.set_page_config", 1)[0]
     # Find indentation of last non-empty line in prefix
-    last_line = [line for line in prefix.splitlines() if line.strip()][-1] if any(line.strip() for line in prefix.splitlines()) else ""
-    indent = last_line[:len(last_line) - len(last_line.lstrip())]
+    last_line = (
+        [line for line in prefix.splitlines() if line.strip()][-1]
+        if any(line.strip() for line in prefix.splitlines())
+        else ""
+    )
+    indent = last_line[: len(last_line) - len(last_line.lstrip())]
     code_str = prefix + f"{indent}pass\n"
     code = compile(code_str, module.__file__, "exec")
     exec(code, module.__dict__)
@@ -200,7 +203,8 @@ def _load_app(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
 def _load_app_with_magicmock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> tuple[ModuleType, MagicMock]:
-    """Import the app module while ``streamlit`` is a ``MagicMock`` instance."""
+    """Import the app module while ``streamlit`` is a ``MagicMock``
+    instance."""
 
     stub = MagicMock()
     # Ensure placeholder helpers fall back to the module-defined ``_NullContext``.
@@ -218,7 +222,7 @@ def _load_app_with_magicmock(
     prefix = source.split("st.set_page_config", 1)[0]
     # Dynamically determine indentation for injected "pass" statement
     last_line = prefix.splitlines()[-1] if prefix.splitlines() else ""
-    indentation = last_line[:len(last_line) - len(last_line.lstrip())]
+    indentation = last_line[: len(last_line) - len(last_line.lstrip())]
     code = compile(prefix + f"{indentation}pass\n", module.__file__, "exec")
     exec(code, module.__dict__)
 
@@ -341,7 +345,9 @@ def test_expected_columns_handles_various_specs(
     assert app_mod._expected_columns(None) == 1
 
 
-def test_normalize_columns_supplies_placeholders(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_normalize_columns_supplies_placeholders(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     app_mod = _load_app(monkeypatch)
 
     sentinel = object()
@@ -398,7 +404,9 @@ def test_magicmock_streamlit_bootstrap_installs_null_context(
         sys.modules.pop("trend_portfolio_app.app", None)
 
 
-def test_apply_session_state_expands_session_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_session_state_expands_session_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     app_mod = _load_app(monkeypatch)
 
     state = app_mod.st.session_state
@@ -430,7 +438,9 @@ def test_render_sidebar_resets_and_serialises(monkeypatch: pytest.MonkeyPatch) -
     app_mod = _load_app(monkeypatch)
 
     defaults = {"data": {"csv_path": "reset.csv"}, "portfolio": {"policy": "reset"}}
-    monkeypatch.setattr(app_mod, "_read_defaults", lambda: json.loads(json.dumps(defaults)))
+    monkeypatch.setattr(
+        app_mod, "_read_defaults", lambda: json.loads(json.dumps(defaults))
+    )
 
     button_calls: list[str] = []
 
@@ -480,7 +490,9 @@ def test_render_sidebar_resets_and_serialises(monkeypatch: pytest.MonkeyPatch) -
     assert dumped["data"]["csv_path"] == "user.csv"
 
 
-def test_render_run_section_executes_single_period(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_render_run_section_executes_single_period(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     app_mod = _load_app(monkeypatch)
 
     def fake_button(label: str, *_, **__) -> bool:
@@ -512,7 +524,9 @@ def test_render_run_section_executes_single_period(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(app_mod, "_summarise_run_df", lambda _df: summary)
 
     run_calls: list[Any] = []
-    monkeypatch.setattr(app_mod.pipeline, "run", lambda cfg_obj: run_calls.append(cfg_obj) or summary)
+    monkeypatch.setattr(
+        app_mod.pipeline, "run", lambda cfg_obj: run_calls.append(cfg_obj) or summary
+    )
 
     built_cfg_objects: list[Any] = []
 
@@ -540,7 +554,9 @@ def test_render_run_section_executes_single_period(monkeypatch: pytest.MonkeyPat
     assert rows[1:] == ["1", "2"]
 
 
-def test_render_run_section_executes_multi_period(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_render_run_section_executes_multi_period(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     app_mod = _load_app(monkeypatch)
 
     def fake_button(label: str, *_, **__) -> bool:
@@ -590,7 +606,10 @@ def test_render_run_section_executes_multi_period(monkeypatch: pytest.MonkeyPatc
     app_mod._render_run_section(cfg)
 
     assert cfg["data"]["csv_path"] == "from-state.csv"
-    assert built_cfg_objects and built_cfg_objects[0]["data"]["csv_path"] == "from-state.csv"
+    assert (
+        built_cfg_objects
+        and built_cfg_objects[0]["data"]["csv_path"] == "from-state.csv"
+    )
     assert successes == ["Completed. Periods: 2"]
     assert tables == [summary]
     assert len(downloads) == 2

--- a/tests/test_trend_portfolio_app_run_execute.py
+++ b/tests/test_trend_portfolio_app_run_execute.py
@@ -7,9 +7,9 @@ from typing import Any
 
 import pandas as pd
 import pytest
-import yaml  # type: ignore[import-untyped]
 
 import trend_analysis.pipeline as pipeline_mod
+import yaml  # type: ignore[import-untyped]
 from tests.test_trend_portfolio_app_helpers import _DummyStreamlit
 from trend_analysis.config import DEFAULTS as DEFAULT_CFG_PATH
 

--- a/tools/update_workflow_catalog.py
+++ b/tools/update_workflow_catalog.py
@@ -18,13 +18,15 @@ Categories (heuristic order):
 Note: Keep logic lightweight; manual curation can adjust JSON after generation.
 """
 from __future__ import annotations
+
+import datetime
 import json
+import pathlib
 import re
 import sys
-import pathlib
-import datetime
-import yaml
 from typing import Any
+
+import yaml
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 WF_DIR = ROOT / ".github" / "workflows"
@@ -109,7 +111,9 @@ def main() -> int:
         )
     catalog = {
         "_meta": {
-            "generated": datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
+            "generated": datetime.datetime.now(datetime.timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
             "source": ".github/workflows",
             "script": "tools/update_workflow_catalog.py",
         },


### PR DESCRIPTION
Add controlled violation file AFTER local hooks format it, defeating current test design because pre-commit sanitizes. Need to adjust: disable formatting via deliberate construct only fixed by action (docformatter on docstring width + import ordering). Next step: force a lint failure in CI by introducing ruff rule violation not covered by hooks or adjust hooks config.