### PR TITLE
chore: allow PAT fallback for automerge

### DIFF
--- a/.github/workflows/enable-automerge.yml
+++ b/.github/workflows/enable-automerge.yml
@@ -6,6 +6,8 @@ on:
   workflow_run:
     workflows: ["CI", "Docker"]
     types: [completed]
+env:
+  GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN != '' && secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 permissions:
   pull-requests: write
   contents: read
@@ -28,7 +30,7 @@ jobs:
         id: enable
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ env.GH_TOKEN }}
           merge-method: squash
           pull-request-number: ${{ github.event.pull_request.number }}
       - name: Capture failure reason
@@ -97,7 +99,7 @@ jobs:
         id: post_enable
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ env.GH_TOKEN }}
           merge-method: squash
           pull-request-number: ${{ steps.find_pr.outputs.pr }}
       - name: Capture failure reason (post-status)


### PR DESCRIPTION
## Summary
- default automerge workflow to use a PAT secret when provided so merges can run with the needed permissions
- fall back to the GitHub token when no PAT is configured

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cedbaedc908331932e69308f95197d