### PR TITLE
Add coverage soft gate automation to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
         with:
+          run-id: ${{ needs.reuse.outputs.run_id || github.run_id }}
           pattern: coverage-*
           merge-multiple: true
           path: coverage_artifacts
@@ -93,7 +94,8 @@ jobs:
           else:
             header = "**Coverage data unavailable**\n\n"
 
-          hotspots = sorted(file_stats.items(), key=lambda item: item[1])[:15]
+          HOTSPOT_LIMIT = 15  # Capture the 15 lowest-covered files to keep the table concise.
+          hotspots = sorted(file_stats.items(), key=lambda item: item[1])[:HOTSPOT_LIMIT]
 
           with coverage_path.open('w', encoding='utf-8') as handle:
             handle.write(header)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,220 @@ jobs:
       # Coverage gate enforced in the reusable workflow via
       # pytest --cov --cov-fail-under=${{ vars.COV_MIN || 85 }}
       run_quarantine: 'false'
+  coverage_soft_gate:
+    name: coverage soft gate (file/update issue)
+    needs: [reuse]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    steps:
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+          path: coverage_artifacts
+          if-no-artifacts-found: warn
+      - name: Compute coverage summary and hotspots
+        id: cov
+        shell: python
+        run: |
+          import json
+          from pathlib import Path
+
+          def _as_float(value):
+            if value is None:
+              return None
+            try:
+              return float(str(value).strip('%'))
+            except (TypeError, ValueError):
+              return None
+
+          base = Path('coverage_artifacts')
+          candidates = []
+          if base.exists():
+            candidates.extend(base.rglob('coverage.json'))
+          standalone = Path('coverage.json')
+          if standalone.exists():
+            candidates.append(standalone)
+
+          totals = []
+          file_stats = {}
+          for path in candidates:
+            try:
+              data = json.loads(path.read_text())
+            except Exception as exc:  # pragma: no cover - diagnostic only
+              print(f"::warning::Failed to parse {path}: {exc}")
+              continue
+
+            totals_meta = data.get('totals') or {}
+            job_pct = _as_float(totals_meta.get('percent_covered'))
+            if job_pct is None:
+              job_pct = _as_float(totals_meta.get('percent_covered_display'))
+            if job_pct is not None:
+              totals.append(job_pct)
+
+            for fname, meta in (data.get('files') or {}).items():
+              summary = meta.get('summary') or {}
+              pct = _as_float(summary.get('percent_covered'))
+              if pct is None:
+                pct = _as_float(summary.get('percent_covered_display'))
+              if pct is None:
+                continue
+              current = file_stats.get(fname)
+              if current is None or pct < current:
+                file_stats[fname] = pct
+
+          coverage_path = Path('coverage_summary.md')
+          if totals:
+            avg = round(sum(totals) / len(totals), 2)
+            worst = round(min(totals), 2)
+            header = f"**Coverage (avg across jobs): {avg:.2f}% | worst job: {worst:.2f}%**\n\n"
+          else:
+            header = "**Coverage data unavailable**\n\n"
+
+          hotspots = sorted(file_stats.items(), key=lambda item: item[1])[:15]
+
+          with coverage_path.open('w', encoding='utf-8') as handle:
+            handle.write(header)
+            if hotspots:
+              handle.write("| File | % covered |\n|---|---:|\n")
+              for fname, pct in hotspots:
+                handle.write(f"| `{fname}` | {pct:.1f}% |\n")
+            else:
+              handle.write("_No coverage hotspots were detected._\n")
+      - name: Build job log links table
+        id: jobs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const run_id = context.runId;
+            const { data } = await github.rest.actions.listJobsForWorkflowRun({ owner, repo, run_id, per_page: 100 });
+            const jobs = [...data.jobs].sort((a, b) => {
+              const aStart = a.started_at ? Date.parse(a.started_at) : 0;
+              const bStart = b.started_at ? Date.parse(b.started_at) : 0;
+              return aStart - bStart;
+            });
+            const rows = jobs.map(j => `| ${j.name} | ${j.conclusion || j.status} | [logs](${j.html_url}) |`);
+            const table = [
+              '### Logs for this run',
+              '| Job | Result | Logs |',
+              '|---|---|---|',
+              ...rows,
+            ].join('\n');
+            core.setOutput('table', table);
+      - name: Create or update coverage issue
+        id: issue
+        env:
+          TABLE: ${{ steps.jobs.outputs.table }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const core = require('@actions/core');
+            const { owner, repo } = context.repo;
+            const title = 'Increase test coverage (soft gate)';
+            const label = 'tech:coverage';
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const runNumber = context.runNumber;
+            const isoNow = new Date().toISOString();
+
+            let summary;
+            try {
+              summary = fs.readFileSync('coverage_summary.md', 'utf8').trim();
+            } catch (error) {
+              summary = '**Coverage data unavailable**';
+            }
+
+            const logsTable = (process.env.TABLE || '').trim();
+            const bodySections = [
+              '## Latest coverage summary',
+              summary || '**Coverage data unavailable**',
+              logsTable || '_No job logs were collected._',
+              `_Last updated: ${isoNow} ([workflow run #${runNumber}](${runUrl}))._`,
+            ];
+            const issueBody = bodySections.join('\n\n');
+
+            const commentSections = [
+              `Run [#${runNumber}](${runUrl})`,
+              summary || '**Coverage data unavailable**',
+            ];
+            if (logsTable) {
+              commentSections.push(logsTable);
+            }
+            const commentBody = commentSections.join('\n\n');
+
+            async function ensureLabel() {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label });
+              } catch (error) {
+                if (error.status === 404) {
+                  await github.rest.issues.createLabel({ owner, repo, name: label, color: '0e8a16' });
+                } else {
+                  throw error;
+                }
+              }
+            }
+
+            async function run() {
+              try {
+                await ensureLabel();
+                const search = await github.rest.search.issuesAndPullRequests({
+                  q: `repo:${owner}/${repo} "${title}" in:title state:open type:issue`,
+                  per_page: 5,
+                });
+
+                let issue = (search.data.items || []).find(item => item.title === title);
+                if (!issue) {
+                  const created = await github.rest.issues.create({
+                    owner,
+                    repo,
+                    title,
+                    body: issueBody,
+                    labels: [label],
+                  });
+                  issue = created.data;
+                } else {
+                  await github.rest.issues.update({ owner, repo, issue_number: issue.number, body: issueBody });
+                  const labels = issue.labels || [];
+                  const hasLabel = labels.some(l => (typeof l === 'string' ? l : l.name) === label);
+                  if (!hasLabel) {
+                    await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: [label] });
+                  }
+                }
+
+                await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body: commentBody });
+                core.setOutput('issue_url', issue.html_url);
+              } catch (error) {
+                core.warning(`Failed to update coverage issue: ${error.message}`);
+              }
+            }
+
+            await run();
+      - name: Append summary to run summary
+        if: always()
+        env:
+          TABLE: ${{ steps.jobs.outputs.table }}
+          ISSUE_URL: ${{ steps.issue.outputs.issue_url }}
+        run: |
+          if [ -f coverage_summary.md ]; then
+            cat coverage_summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "**Coverage data unavailable**" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -n "${TABLE}" ]; then
+            printf '\n%s\n' "${TABLE}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -n "${ISSUE_URL}" ]; then
+            printf '\nFor details or follow-up, see the coverage tracker issue: %s\n' "${ISSUE_URL}" >> "$GITHUB_STEP_SUMMARY"
+          fi
   gate:
     name: gate / all-required-green
     runs-on: ubuntu-latest
-    needs: [reuse]
+    needs: [reuse, coverage_soft_gate]
     steps:
       - run: echo "Core tests passed (reusable workflow)."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           for path in candidates:
             try:
               data = json.loads(path.read_text())
-            except Exception as exc:  # pragma: no cover - diagnostic only
+            except (json.JSONDecodeError, FileNotFoundError, UnicodeDecodeError) as exc:  # pragma: no cover - diagnostic only
               print(f"::warning::Failed to parse {path}: {exc}")
               continue
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,12 +165,14 @@ jobs:
             }
             const commentBody = commentSections.join('\n\n');
 
+            // GitHub green for coverage label (see https://primer.style/design/foundations/colors)
+            const COVERAGE_LABEL_COLOR = '0e8a16';
             async function ensureLabel() {
               try {
                 await github.rest.issues.getLabel({ owner, repo, name: label });
               } catch (error) {
                 if (error.status === 404) {
-                  await github.rest.issues.createLabel({ owner, repo, name: label, color: '0e8a16' });
+                  await github.rest.issues.createLabel({ owner, repo, name: label, color: COVERAGE_LABEL_COLOR });
                 } else {
                   throw error;
                 }

--- a/.github/workflows/reuse-ci-python.yml
+++ b/.github/workflows/reuse-ci-python.yml
@@ -25,6 +25,9 @@ on:
       coverage:
         description: 'Reported coverage percentage (approx)'
         value: ${{ jobs.core-tests.outputs.coverage }}
+      run_id:
+        description: 'Workflow run id for artifact retrieval'
+        value: ${{ jobs.core-tests.outputs.run_id }}
 
 permissions:
   contents: read
@@ -40,6 +43,7 @@ jobs:
         py: ${{ fromJson(inputs.python_matrix) }}
     outputs:
       coverage: ${{ steps.cov_out.outputs.cov || '' }}
+      run_id: ${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/reuse-ci-python.yml
+++ b/.github/workflows/reuse-ci-python.yml
@@ -76,7 +76,36 @@ jobs:
           fi
           pytest -m "$MARK_EXPR" \
             --reruns 1 --reruns-delay 1 \
-            --cov=src --cov-report=term-missing --cov-fail-under=${COV_MIN} --cov-branch
+            --cov=src \
+            --cov-report=term-missing:skip-covered \
+            --cov-report=xml \
+            --cov-report=json \
+            --cov-report=html \
+            --cov-fail-under=${COV_MIN} \
+            --cov-branch \
+            --junitxml=pytest-report.xml
+      - name: Prepare coverage artifacts
+        if: always()
+        run: |
+          dest="coverage_artifacts/${{ matrix.py }}"
+          mkdir -p "${dest}"
+          for f in coverage.xml coverage.json pytest-report.xml; do
+            if [ -f "$f" ]; then
+              cp "$f" "${dest}/"
+            fi
+          done
+          if [ -d htmlcov ]; then
+            rm -rf "${dest}/htmlcov"
+            cp -R htmlcov "${dest}/htmlcov"
+          fi
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.py }}
+          path: coverage_artifacts/${{ matrix.py }}
+          if-no-files-found: warn
+          retention-days: 7
       - name: Extract coverage
         id: cov_out
         run: |


### PR DESCRIPTION
## Summary
- update the reusable Python CI workflow to emit coverage artifacts and JUnit XML for every matrix job
- introduce a coverage soft gate job that aggregates artifacts, generates a hotspots summary, updates the coverage tracking issue, and publishes the data to the workflow summary
- ensure the overall CI gate waits for the soft gate job while keeping coverage from blocking merges

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cee549d588833183f54f4938016e1c