### PR TITLE
Add per-job log links to the PR Summary for all CI runs - Follow-up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,69 @@ jobs:
     name: gate / all-required-green
     runs-on: ubuntu-latest
     needs: [reuse]
+    if: ${{ always() }}
     steps:
-      - run: echo "Core tests passed (reusable workflow)."
+      - name: Report reusable workflow status
+        run: |
+          if [ "${{ needs.reuse.result }}" = "success" ]; then
+            echo "Core tests passed (reusable workflow)."
+          else
+            echo "::error title=CI gate::Required job 'reuse' result: ${{ needs.reuse.result }}"
+            exit 1
+          fi
+  summarize-logs:
+    name: summarize / logs-for-this-run
+    runs-on: ubuntu-latest
+    needs: [reuse, gate]
+    if: ${{ always() }}
+    steps:
+      - name: Append job log links to summary
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const core = require('@actions/core');
+            const { owner, repo } = context.repo;
+            const run_id = context.runId;
+
+            const jobs = [];
+            const iterator = github.paginate.iterator(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner,
+                repo,
+                run_id,
+                per_page: 100,
+              },
+            );
+
+            for await (const { data }) of iterator {
+              jobs.push(...data.jobs);
+            }
+
+            const heading = 'Logs for this run';
+            if (jobs.length === 0) {
+              await core.summary
+                .addHeading(heading)
+                .addRaw('_No jobs found for this run._', true)
+                .write();
+              return;
+            }
+
+            const rows = jobs.map(job => {
+              const name = job.name.replace(/\|/g, '\\|');
+              const result = job.conclusion ?? job.status;
+              const url = job.html_url ?? job.url;
+              return `| ${name} | ${result} | [Logs](${url}) |`;
+            });
+
+            const table = [
+              '| Job | Result | Logs |',
+              '| --- | ------ | ---- |',
+              ...rows,
+            ].join('\n');
+
+            await core.summary
+              .addHeading(heading)
+              .addRaw(table, true)
+              .write();

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -126,3 +126,59 @@ jobs:
       - name: Push image
         if: github.event_name == 'push' && github.ref == 'refs/heads/phase-2-dev'
         run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+  summarize-logs:
+    name: summarize / logs-for-this-run
+    runs-on: ubuntu-latest
+    needs: [lint, build]
+    if: ${{ always() }}
+    steps:
+      - name: Append job log links to summary
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const core = require('@actions/core');
+            const { owner, repo } = context.repo;
+            const run_id = context.runId;
+
+            const jobs = [];
+            const iterator = github.paginate.iterator(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner,
+                repo,
+                run_id,
+                per_page: 100,
+              },
+            );
+
+            for await (const { data }) of iterator {
+              jobs.push(...data.jobs);
+            }
+
+            const heading = 'Logs for this run';
+            if (jobs.length === 0) {
+              await core.summary
+                .addHeading(heading)
+                .addRaw('_No jobs found for this run._', true)
+                .write();
+              return;
+            }
+
+            const rows = jobs.map(job => {
+              const name = job.name.replace(/\|/g, '\\|');
+              const result = job.conclusion ?? job.status;
+              const url = job.html_url ?? job.url;
+              return `| ${name} | ${result} | [Logs](${url}) |`;
+            });
+
+            const table = [
+              '| Job | Result | Logs |',
+              '| --- | ------ | ---- |',
+              ...rows,
+            ].join('\n');
+
+            await core.summary
+              .addHeading(heading)
+              .addRaw(table, true)
+              .write();


### PR DESCRIPTION
## Summary
- add a gate status report that always runs and fails when the reusable CI job fails
- append a run-level log summary table to the CI and Docker workflows using the Actions API

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cee9b371648331bbc7692196276c67