### PR TITLE
Restore the “CI” check name until the gate is turned on - Source Issue #1345

### DIFF
--- a/agents/codex-1345.md
+++ b/agents/codex-1345.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1345 -->


### PR DESCRIPTION
### Source Issue #1345: Restore the “CI” check name until the gate is turned on

Source: https://github.com/stranske/Trend_Model_Project/issues/1345

> Topic GUID: 554ada22-0f9a-51ca-87b8-8b260ed76019
> 
> ## Why
> Branch protection still expects “CI,” but you moved to lane‑specific workflows. That’s why you see “Required: CI: missing.”
> 
> ## Tasks
> Add a thin wrapper workflow named CI that depends on your real jobs (or simply calls your main CI via workflow_call).
> 
> Make the wrapper run on pull_request and set a single success status when the underlying jobs pass.
> 
> Keep the wrapper until you switch branch protection to the gate job.
> 
> ## Acceptance criteria
> New PRs no longer show “Required: CI: missing.”
> 
> Wrapper is documented as temporary.
> 
> ## Implementation notes
> name: CI
> on: { pull_request: {} }
> jobs:
>   run-main:
>     uses: ./.github/workflows/<your-main-ci>.yml   # or call the reusable workflow
>     with: {}
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/17878021063).

—
(After opening the PR, comment with `@codex start`.)