### PR TITLE
Use service bot token for auto-merge

### DIFF
--- a/.github/workflows/enable-automerge.yml
+++ b/.github/workflows/enable-automerge.yml
@@ -7,7 +7,7 @@ on:
     workflows: ["CI", "Docker"]
     types: [completed]
 env:
-  GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN != '' && secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+  GH_TOKEN: ${{ secrets.SERVICE_BOT_PAT || secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 permissions:
   pull-requests: write
   contents: read


### PR DESCRIPTION
## Summary
- update the auto-merge workflow to prefer the SERVICE_BOT_PAT secret when selecting a token
- fall back to the previous personal access token or the default GITHUB_TOKEN if the service bot secret is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cef82210b88331b7ac23d7411e4304