### PR TITLE
Fix weighting test doubles to accept schedule date context

### DIFF
--- a/tests/test_multi_period_engine.py
+++ b/tests/test_multi_period_engine.py
@@ -54,7 +54,10 @@ class DummyWeighting:
     def __init__(self) -> None:
         self.update_calls: list[tuple[pd.Series, int]] = []
 
-    def weight(self, selected: pd.DataFrame) -> pd.DataFrame:
+    def weight(
+        self, selected: pd.DataFrame, date: pd.Timestamp | None = None
+    ) -> pd.DataFrame:
+        del date
         weights = selected[["weight"]].astype(float)
         weights["weight"] = weights["weight"].to_numpy() / weights["weight"].sum()
         return weights

--- a/tests/test_multi_period_engine_additional.py
+++ b/tests/test_multi_period_engine_additional.py
@@ -37,7 +37,10 @@ def test_run_schedule_with_rebalance_strategies(
         def __init__(self) -> None:
             self.updates: list[tuple[pd.Series, int]] = []
 
-        def weight(self, selected: pd.DataFrame) -> pd.DataFrame:
+        def weight(
+            self, selected: pd.DataFrame, date: pd.Timestamp | None = None
+        ) -> pd.DataFrame:
+            del date
             weights = selected["score"].astype(float)
             weights = weights / weights.sum()
             return pd.DataFrame({"weight": weights})

--- a/tests/test_multi_period_engine_debug.py
+++ b/tests/test_multi_period_engine_debug.py
@@ -34,7 +34,10 @@ class SequenceWeighting:
         # not need to adjust any internal state here.
         pass
 
-    def weight(self, selected: pd.DataFrame) -> pd.DataFrame:
+    def weight(
+        self, selected: pd.DataFrame, date: pd.Timestamp | None = None
+    ) -> pd.DataFrame:
+        del date
         weights = self.sequences[self._idx]
         self._idx += 1
         ordered = pd.Series(weights, index=selected.index, dtype=float).fillna(0.0)

--- a/tests/test_multi_period_engine_extended.py
+++ b/tests/test_multi_period_engine_extended.py
@@ -28,11 +28,10 @@ class DummyWeighting(engine.BaseWeighting):
     def __init__(self) -> None:
         self.updates: list[tuple[pd.Series, int]] = []
 
-    # The signature of this method intentionally differs from the base class for testing purposes.
-    # This override is safe because DummyWeighting is only used in controlled test scenarios
-    # where the input and output types are known and compatible. The simplified signature
-    # allows for deterministic behavior in tests.
-    def weight(self, df: pd.DataFrame) -> pd.DataFrame:  # type: ignore[override]
+    def weight(
+        self, df: pd.DataFrame, date: pd.Timestamp | None = None
+    ) -> pd.DataFrame:
+        del date
         if df.empty:
             return pd.DataFrame({"weight": pd.Series(dtype=float)})
         w = np.full(len(df.index), 1.0 / len(df.index))

--- a/tests/test_multi_period_engine_helpers_additional.py
+++ b/tests/test_multi_period_engine_helpers_additional.py
@@ -122,7 +122,10 @@ def test_run_schedule_invokes_update_and_fast_turnover(
         def __init__(self) -> None:
             self.updates: list[tuple[pd.Series, int]] = []
 
-        def weight(self, selected: pd.DataFrame) -> pd.DataFrame:
+        def weight(
+            self, selected: pd.DataFrame, date: pd.Timestamp | None = None
+        ) -> pd.DataFrame:
+            del date
             weights = pd.Series(1.0 / len(selected), index=selected.index, dtype=float)
             return weights.to_frame("weight")
 

--- a/tests/test_multi_period_engine_portfolio_unit.py
+++ b/tests/test_multi_period_engine_portfolio_unit.py
@@ -8,7 +8,10 @@ class RecordingWeighting(BaseWeighting):
     def __init__(self) -> None:
         self.update_calls: list[tuple[pd.Series, int]] = []
 
-    def weight(self, selected: pd.DataFrame) -> pd.DataFrame:
+    def weight(
+        self, selected: pd.DataFrame, date: pd.Timestamp | None = None
+    ) -> pd.DataFrame:
+        del date
         if selected.empty:
             return pd.DataFrame(columns=["weight"])
         weights = pd.Series(1.0 / len(selected), index=selected.index, dtype=float)

--- a/tests/test_multi_period_engine_run_schedule_extra.py
+++ b/tests/test_multi_period_engine_run_schedule_extra.py
@@ -29,7 +29,10 @@ class _UpdatingWeighting(BaseWeighting):
     def __init__(self) -> None:
         self.update_calls: list[tuple[pd.Series, int]] = []
 
-    def weight(self, selected: pd.DataFrame) -> pd.DataFrame:
+    def weight(
+        self, selected: pd.DataFrame, date: pd.Timestamp | None = None
+    ) -> pd.DataFrame:
+        del date
         if selected.empty:
             return pd.DataFrame({"weight": []}, index=pd.Index([], dtype=object))
         n = len(selected)

--- a/tests/test_multi_period_engine_threshold_bounds.py
+++ b/tests/test_multi_period_engine_threshold_bounds.py
@@ -87,7 +87,10 @@ class ScriptedWeighting:
             {"Alpha One": 0.9, "Beta One": 0.4, "Gamma One": 0.35},
         ]
 
-    def weight(self, selected: pd.DataFrame) -> pd.DataFrame:
+    def weight(
+        self, selected: pd.DataFrame, date: pd.Timestamp | None = None
+    ) -> pd.DataFrame:
+        del date
         seq = self.sequences[min(self.calls, len(self.sequences) - 1)]
         self.calls += 1
         weights = pd.Series(

--- a/tests/test_multi_period_engine_threshold_edgecases.py
+++ b/tests/test_multi_period_engine_threshold_edgecases.py
@@ -74,7 +74,10 @@ class SequenceWeighting:
         self.calls = 0
         self.update_calls: list[tuple[pd.Series, int]] = []
 
-    def weight(self, selected: pd.DataFrame) -> pd.DataFrame:
+    def weight(
+        self, selected: pd.DataFrame, date: pd.Timestamp | None = None
+    ) -> pd.DataFrame:
+        del date
         seq = self._sequences[min(self.calls, len(self._sequences) - 1)]
         weights = pd.Series(
             {idx: seq.get(idx, 0.05) for idx in selected.index},
@@ -815,7 +818,10 @@ def test_threshold_hold_enforces_bounds_and_replacement_flow(
         def __init__(self, *_, **__) -> None:
             self.calls = 0
 
-        def weight(self, selected: pd.DataFrame) -> pd.DataFrame:
+        def weight(
+            self, selected: pd.DataFrame, date: pd.Timestamp | None = None
+        ) -> pd.DataFrame:
+            del date
             sequences = [
                 {
                     "Alpha One": 0.90,

--- a/tests/test_multi_period_engine_turnover_extended.py
+++ b/tests/test_multi_period_engine_turnover_extended.py
@@ -40,7 +40,10 @@ class TrackingWeighting(BaseWeighting):
     def __init__(self) -> None:
         self.updates: list[tuple[pd.Series, int]] = []
 
-    def weight(self, selected: pd.DataFrame) -> pd.DataFrame:
+    def weight(
+        self, selected: pd.DataFrame, date: pd.Timestamp | None = None
+    ) -> pd.DataFrame:
+        del date
         if selected.empty:
             return pd.DataFrame(columns=["weight"])
         values = np.linspace(1.0, 0.6, num=len(selected), dtype=float)


### PR DESCRIPTION
## Summary
- update every multi-period engine weighting test double to accept the optional date/context argument passed by the engine
- ensure dummy weight implementations remain deterministic while discarding unused date inputs

## Testing
- pytest tests/test_multi_period_engine.py tests/test_multi_period_engine_extended.py tests/test_multi_period_engine_additional.py tests/test_multi_period_engine_debug.py tests/test_multi_period_engine_turnover_extended.py tests/test_multi_period_engine_threshold_bounds.py tests/test_multi_period_engine_threshold_edgecases.py tests/test_multi_period_engine_run_schedule_extra.py tests/test_multi_period_engine_portfolio_unit.py tests/test_multi_period_engine_helpers_additional.py

------
https://chatgpt.com/codex/tasks/task_e_68cf01130ad08331a2e4f56940aca5ca