### PR TITLE
chore: ensure autofix history is tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ results/
 *.xlsx
 *.csv
 *.json
+!ci/autofix/history.json
 !perf/perf_baseline.json
 !src/trend_analysis/export/manifest_schema.json
 *.txt


### PR DESCRIPTION
## Summary
- stop ignoring ci/autofix/history.json so the autofix workflow can commit the history snapshots it generates

## Testing
- python scripts/update_residual_history.py

------
https://chatgpt.com/codex/tasks/task_e_68cf4ca512a8833180755d8ed5a60fdb