### PR TITLE
Add chore(autofix) guard to prevent workflow loops

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -79,6 +79,7 @@ jobs:
   call:
     uses: stranske/Trend_Model_Project/.github/workflows/reuse-autofix.yml@phase-2-dev
 ```
+Autofix commits are tagged with the `chore(autofix):` prefix. The consumer workflow exits early when a run is triggered by `github-actions` on a head commit whose subject starts with that prefix so that bot pushes do not retrigger themselves.
 Agents (subset):
 ```yaml
 name: Agents

--- a/.github/workflows/autofix-consumer.yml
+++ b/.github/workflows/autofix-consumer.yml
@@ -10,15 +10,61 @@ permissions:
   pull-requests: write
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.guard.outputs.skip }}
+    steps:
+      - name: Guard against loops
+        id: guard
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prefix = process.env.COMMIT_PREFIX || 'chore(autofix):';
+            const actor = context.actor;
+            if (actor !== 'github-actions') {
+              core.setOutput('skip', 'false');
+              return;
+            }
+
+            const sha = context.payload.pull_request?.head?.sha;
+            if (!sha) {
+              core.warning('Guard: pull_request.head.sha missing; continuing.');
+              core.setOutput('skip', 'false');
+              return;
+            }
+
+            try {
+              const commit = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: sha,
+              });
+              const message = commit.data.commit.message.split('\n')[0];
+              if (message.startsWith(prefix)) {
+                core.info('Skipping: autofix commit detected');
+                core.setOutput('skip', 'true');
+                return;
+              }
+            } catch (error) {
+              core.warning(`Guard: failed to inspect commit message (${error.message}).`);
+            }
+
+            core.setOutput('skip', 'false');
+        env:
+          COMMIT_PREFIX: 'chore(autofix):'
+
   call-reusable:
+    needs: guard
+    if: ${{ needs.guard.outputs.skip != 'true' }}
     uses: ./.github/workflows/reuse-autofix.yml
     with:
       opt_in_label: ${{ vars.AUTOFIX_OPT_IN_LABEL || 'autofix' }}
-      commit_prefix: 'ci: autofix'
+      commit_prefix: 'chore(autofix):'
   label-applied:
-    needs: call-reusable
+    needs: [guard, call-reusable]
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && needs.guard.outputs.skip != 'true' }}
     steps:
       - name: Checkout PR HEAD
         uses: actions/checkout@v4
@@ -33,7 +79,7 @@ jobs:
           echo "message<<END" >> $GITHUB_OUTPUT
           echo "$msg" >> $GITHUB_OUTPUT
           echo "END" >> $GITHUB_OUTPUT
-          if echo "$msg" | grep -qi 'ci: autofix'; then echo "applied=true" >> $GITHUB_OUTPUT; else echo "applied=false" >> $GITHUB_OUTPUT; fi
+          if echo "$msg" | grep -q '^chore(autofix):'; then echo "applied=true" >> $GITHUB_OUTPUT; else echo "applied=false" >> $GITHUB_OUTPUT; fi
       - name: Add label
         if: steps.msg.outputs.applied == 'true'
         uses: actions/github-script@v7

--- a/.github/workflows/autofix-consumer.yml
+++ b/.github/workflows/autofix-consumer.yml
@@ -22,7 +22,7 @@ jobs:
           script: |
             const prefix = process.env.COMMIT_PREFIX || 'chore(autofix):';
             const actor = context.actor;
-            if (actor !== 'github-actions') {
+            if (actor !== 'github-actions[bot]') {
               core.setOutput('skip', 'false');
               return;
             }

--- a/.github/workflows/autofix-on-failure.yml
+++ b/.github/workflows/autofix-on-failure.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           last_msg=$(git log -1 --pretty=%B | tr -d '\r')
           echo "Last commit: $last_msg"
-          if echo "$last_msg" | grep -qi 'ci: autofix'; then
+          if echo "$last_msg" | grep -q '^chore(autofix):'; then
             echo "already=true" >> $GITHUB_OUTPUT
           else
             echo "already=false" >> $GITHUB_OUTPUT
@@ -95,7 +95,7 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "ci: autofix after failed checks"
+          git commit -m "chore(autofix): after failed checks"
           git push origin HEAD:${{ steps.find_pr.outputs.head_ref }}
       - name: Label PR (applied autofix)
         if: steps.fix.outputs.changed == 'true' && steps.find_pr.outputs.same_repo == 'true' && steps.guard.outputs.already != 'true'
@@ -115,7 +115,7 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A || true
-          git commit -m "ci: autofix after failed checks (patch)" || true
+          git commit -m "chore(autofix): after failed checks (patch)" || true
           git format-patch -1 --stdout > failure-autofix.patch
       - name: Upload fork patch
         if: steps.fix.outputs.changed == 'true' && steps.find_pr.outputs.same_repo != 'true' && steps.guard.outputs.already != 'true'

--- a/.github/workflows/lint-verification.yml
+++ b/.github/workflows/lint-verification.yml
@@ -52,7 +52,7 @@ jobs:
           echo "message<<END" >> $GITHUB_OUTPUT
           echo "$msg" >> $GITHUB_OUTPUT
           echo "END" >> $GITHUB_OUTPUT
-          if echo "$msg" | grep -qiE '^ci: autofix'; then
+          if echo "$msg" | grep -q '^chore(autofix):'; then
             echo "autofix=true" >> $GITHUB_OUTPUT
           else
             echo "autofix=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/reuse-autofix.yml
+++ b/.github/workflows/reuse-autofix.yml
@@ -11,7 +11,7 @@ on:
       commit_prefix:
         description: 'Commit message prefix'
         required: false
-        default: 'ci: autofix'
+        default: 'chore(autofix):'
         type: string
 
 permissions:

--- a/docs/agent-automation.md
+++ b/docs/agent-automation.md
@@ -92,7 +92,7 @@ Trigger: `workflow_run` (CI, Docker, Lint, Tests) when conclusion != success.
 Steps:
 - Finds related open PR by head ref.
 - Applies same composite autofix action (idempotent).
-- Commits with canonical message `ci: autofix after failed checks` (loop guard in main autofix to avoid recursion).
+- Commits with canonical message `chore(autofix): after failed checks` (loop guard in main autofix to avoid recursion).
 
 ### 6. `agent-watchdog.yml`
 Purpose: Detect issues labeled for Codex where bootstrap PR not yet created OR gather fast telemetry.
@@ -153,7 +153,7 @@ Set the repository (or org) variable `CODEX_ALLOW_FALLBACK=true` only if you acc
 | PAT missing for Codex bootstrap | Early fail (exit 86) unless fallback explicitly allowed; issue comment provides remediation. |
 | Copilot not enabled (no `copilot-swe-agent`) | GraphQL result triggers explicit failure + breadcrumb guidance. |
 | Duplicate Codex label events | Marker file short-circuits re-bootstrap. |
-| Autofix loop risk | Guard: skip when PR title starts with `ci: autofix`. |
+| Autofix loop risk | Guard: skip when PR title starts with `chore(autofix):` and auto-skip GitHub Actions runs when the head commit uses that prefix. |
 | Formatting version drift | Shared `autofix-versions.env` ensures uniform versions. |
 
 ## Operational Playbook

--- a/docs/ops/codex-bootstrap-facts.md
+++ b/docs/ops/codex-bootstrap-facts.md
@@ -105,7 +105,7 @@ This catalog explains what each active workflow does, how it’s triggered, the 
    - Triggers: `pull_request` (various types) on `phase-2-dev`/`main`
    - Jobs: `autofix`
      - Uses local composite `.github/actions/autofix` which only runs fixers and exposes `outputs.changed` (no internal commits)
-     - Same‑repo PRs: commits `ci: autofix formatting/lint` and pushes directly to the PR branch
+    - Same‑repo PRs: commits `chore(autofix): formatting/lint` and pushes directly to the PR branch
      - Fork PRs: generates `autofix.patch` (`git format-patch -1 --stdout`), uploads as an artifact named `autofix-patch-pr-<num>`, and comments on the PR with step‑by‑step apply instructions (`git am < autofix.patch`; push to branch)
      - The job summary reports whether changes were applied and whether this was a same‑repo or fork path. For forks, it includes the artifact name
 


### PR DESCRIPTION
## Summary
- add a guard job to the autofix consumer so GitHub Actions skips runs triggered by its own `chore(autofix):` commits
- update the reusable autofix workflow, failure handler, and lint verification to use the new commit prefix consistently
- refresh workflow documentation to describe the new guard and prefix

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cf4dcbdbdc83319ef8cf3e74f93d0c