### PR TITLE
Add job‑log links to the “Automated Status Summary” table - Source Issue #1350

### DIFF
--- a/agents/codex-1350.md
+++ b/agents/codex-1350.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1350 -->

--- a/ci/autofix/history.json
+++ b/ci/autofix/history.json
@@ -19,5 +19,12 @@
     "new": 0,
     "remaining": 0,
     "timestamp": "2025-09-21T01:34:55Z"
+  },
+  {
+    "allowed": 0,
+    "by_code": {},
+    "new": 0,
+    "remaining": 0,
+    "timestamp": "2025-09-21T01:50:06Z"
   }
 ]

--- a/ci/autofix/history.json
+++ b/ci/autofix/history.json
@@ -26,5 +26,12 @@
     "new": 0,
     "remaining": 0,
     "timestamp": "2025-09-21T01:50:06Z"
+  },
+  {
+    "allowed": 0,
+    "by_code": {},
+    "new": 0,
+    "remaining": 0,
+    "timestamp": "2025-09-21T01:55:14Z"
   }
 ]


### PR DESCRIPTION
### Source Issue #1350: Add job‑log links to the “Automated Status Summary” table

Source: https://github.com/stranske/Trend_Model_Project/issues/1350

> Topic GUID: a9ab6b37-bf0f-5696-910e-1904b67db676
> 
> ## Why
> Your current summary sometimes misses jobs and gives no direct log links. Make the table authoritative and clickable.
> 
> ## Tasks
> In the summary‑generation step, replace any hard‑coded job list with enumeration from the Actions API for the current run.
> 
> Include one row per job: name, result, and a [logs](html_url) link.
> 
> ## Acceptance criteria
> The “Automated Status Summary” consistently lists every job, including matrix jobs, with working log links.
> 
> Manual spot check: failing job links directly to the correct log page.
> 
> ## Implementation notes
> Reuse the actions.listJobsForWorkflowRun snippet from Issue 1.
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/17878021063).

—
(After opening the PR, comment with `@codex start`.)