### PR TITLE
Follow-up: fix coverage artifact aggregation collisions

### DIFF
--- a/.github/workflows/reusable-ci-python.yml
+++ b/.github/workflows/reusable-ci-python.yml
@@ -56,6 +56,7 @@ jobs:
           # Basic sanity checks
           test -f coverage.xml || { echo 'coverage.xml missing'; exit 1; }
           test -f coverage.json || { echo 'coverage.json missing'; exit 1; }
+          mv coverage.json coverage-${{ matrix.python-version }}.json
         shell: bash
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v4
@@ -64,7 +65,7 @@ jobs:
           retention-days: ${{ inputs.coverage-artifact-retention-days }}
           path: |
             coverage.xml
-            coverage.json
+            coverage-${{ matrix.python-version }}.json
             htmlcov/**
             pytest-junit.xml
             pytest-report.xml
@@ -179,7 +180,10 @@ jobs:
         id: cov
         shell: python
         run: |
-          import json, glob, os
+          import glob, json
+
+          HOTSPOT_LIMIT = 15
+
           totals=[]; hotspots=[]
           for jf in glob.glob('coverage-*.json'):
               with open(jf,'r') as fh:
@@ -205,7 +209,7 @@ jobs:
           avg= round(sum(totals)/len(totals),2) if totals else 0.0
           worst= round(min(totals),2) if totals else 0.0
           lines=[f"**Coverage (avg across jobs): {avg}% | worst job: {worst}%**", "", "| File | % covered |", "|---|---:|"]
-          for fpct,f in hotspots[:15]:
+          for fpct,f in hotspots[:HOTSPOT_LIMIT]:
               lines.append(f"| `{f}` | {fpct:.1f}% |")
           with open('coverage_summary.md','w') as w: w.write("\n".join(lines)+"\n")
           print('\n'.join(lines[:6])+'\n...')

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -126,7 +126,7 @@ jobs:
 The workflow writes a Markdown overview (artifacts presence + coverage stats) into the GitHub Actions run summary using `GITHUB_STEP_SUMMARY`.
 
 ### Universal Job Log Table (Issue #1344)
-A dedicated `logs_summary` job runs on every workflow execution (even if advanced phases are disabled) and appends a per‑job log links table plus a brief success/failure explanation. This makes it easy to jump directly to failing job logs without enabling any optional features. The soft coverage gate job no longer duplicates the table.
+A dedicated `logs_summary` job runs on every workflow execution (even if advanced phases are disabled) and appends a per-job log links table plus a brief success/failure explanation. This makes it easy to jump directly to failing job logs without enabling any optional features. The soft coverage gate job no longer duplicates the table.
 
 ### Design Principles
 1. Backward compatible defaults (all advanced phases off).


### PR DESCRIPTION
## Summary
- rename per-interpreter coverage.json outputs before upload so the soft gate can aggregate each job
- update the coverage aggregation script to glob the new filenames and centralize the hotspot limit constant
- fix the per-job hyphen in the CI workflow documentation for consistent ASCII punctuation

## Testing
- not run (YAML / docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cf5e0d5700833185d896287bd76653