### PR TITLE
ci(coverage): add low coverage spotlight (<50%) to soft gate (Issue #1386 follow-up)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -156,6 +156,11 @@ Troubleshooting: If branch/PR not created, verify the label `codex-ready`, permi
 ## 7.3 Coverage Soft Gate (Issues #1351, #1352)
 Purpose: Provide early visibility of coverage / hotspot data without failing PRs.
 
+
+Low Coverage Spotlight (follow-up Issue #1386):
+- A secondary table "Low Coverage (<50%)" appears when any parsed file has <50% line coverage.
+- Threshold is currently static (50%) to keep the workflow input surface minimal; can be elevated to a configurable input later.
+- Table is separately truncated to the hotspot limit (15) with a truncation notice if more remain.
 Implemented follow-ups (Issue #1352):
 - Normalized artifact naming: `coverage-<python-version>` (e.g. `coverage-3.11`).
 - Consistent file set per matrix job: `coverage.xml`, `coverage.json`, `htmlcov/**`, `pytest-junit.xml`, `pytest-report.xml`.

--- a/.github/workflows/reusable-ci-python.yml
+++ b/.github/workflows/reusable-ci-python.yml
@@ -255,7 +255,7 @@ jobs:
               for p,f in low_cov[:HOTSPOT_LIMIT]:  # cap separately to avoid huge tables
                   lines.append(f"| `{f}` | {p:.1f}% |")
               if len(low_cov) > HOTSPOT_LIMIT:
-                  lines.append(f"| *(+{len(low_cov)-HOTSPOT_LIMIT} more below {LOW_COVERAGE_THRESHOLD:.0f}% – truncated)* |  |")
+                  lines.append(f"| *(+{len(low_cov)-HOTSPOT_LIMIT} more below {LOW_COVERAGE_THRESHOLD:.0f}% – truncated)* |")
           with open('coverage_summary.md','w') as w:
               w.write("\n".join(lines)+"\n")
           print('\n'.join(lines[:6])+'\n...')

--- a/.github/workflows/reusable-ci-python.yml
+++ b/.github/workflows/reusable-ci-python.yml
@@ -195,6 +195,7 @@ jobs:
           import glob, json, os, sys
 
           HOTSPOT_LIMIT = 15
+          LOW_COVERAGE_THRESHOLD = 50.0  # Files below this percent get an explicit highlight table
           candidates = sorted(set(glob.glob('coverage-*.json') + glob.glob('**/coverage.json', recursive=True)))
           # Filter out duplicate same-path entries
           seen=set(); ordered=[]
@@ -244,6 +245,17 @@ jobs:
               lines.append(f"| `{f}` | {fpct:.1f}% |")
           if len(lines)==4:
               lines.append('| *(no files parsed)* | — |')
+          # Low coverage spotlight (below threshold) – reuse already sorted hotspot list
+          low_cov=[(p,f) for p,f in hotspots if p < LOW_COVERAGE_THRESHOLD]
+          if low_cov:
+              lines.append("")
+              lines.append(f"#### Low Coverage (<{LOW_COVERAGE_THRESHOLD:.0f}% )")
+              lines.append("| File | % covered |")
+              lines.append("|---|---:|")
+              for p,f in low_cov[:HOTSPOT_LIMIT]:  # cap separately to avoid huge tables
+                  lines.append(f"| `{f}` | {p:.1f}% |")
+              if len(low_cov) > HOTSPOT_LIMIT:
+                  lines.append(f"| *(+{len(low_cov)-HOTSPOT_LIMIT} more below {LOW_COVERAGE_THRESHOLD:.0f}% – truncated)* |  |")
           with open('coverage_summary.md','w') as w:
               w.write("\n".join(lines)+"\n")
           print('\n'.join(lines[:6])+'\n...')

--- a/ci/autofix/history.json
+++ b/ci/autofix/history.json
@@ -68,6 +68,12 @@
     "new": 0,
     "remaining": 0,
     "timestamp": "2025-09-21T03:16:42Z"
-
+  },
+  {
+    "allowed": 0,
+    "by_code": {},
+    "new": 0,
+    "remaining": 0,
+    "timestamp": "2025-09-21T03:19:06Z"
   }
 ]

--- a/ci/autofix/history.json
+++ b/ci/autofix/history.json
@@ -61,5 +61,12 @@
     "new": 0,
     "remaining": 0,
     "timestamp": "2025-09-21T03:06:58Z"
+  },
+  {
+    "allowed": 0,
+    "by_code": {},
+    "new": 0,
+    "remaining": 0,
+    "timestamp": "2025-09-21T03:16:42Z"
   }
 ]


### PR DESCRIPTION
Adds a secondary "Low Coverage (<50%)" table to the soft coverage gate summary + canonical coverage issue comment. Static 50% threshold; truncated to hotspot limit (15) with overflow note. Docs updated in workflows README (section 7.3). Also fixes YAML indentation from prior patch iteration. Non-blocking; gracefully degrades if coverage JSON absent. Closes #1386 once verified on a run with coverage data.