### PR TITLE
fix: restore autofix history artifact and parameterize coverage threshold

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -158,8 +158,8 @@ Purpose: Provide early visibility of coverage / hotspot data without failing PRs
 
 
 Low Coverage Spotlight (follow-up Issue #1386):
-- A secondary table "Low Coverage (<50%)" appears when any parsed file has <50% line coverage.
-- Threshold is currently static (50%) to keep the workflow input surface minimal; can be elevated to a configurable input later.
+- A secondary table "Low Coverage (<X%)" appears when any parsed file has coverage below the configured threshold (default 50%).
+- Customize the threshold with the `low-coverage-threshold` workflow input when calling `reusable-ci-python.yml`.
 - Table is separately truncated to the hotspot limit (15) with a truncation notice if more remain.
 Implemented follow-ups (Issue #1352):
 - Normalized artifact naming: `coverage-<python-version>` (e.g. `coverage-3.11`).

--- a/.github/workflows/reusable-ci-python.yml
+++ b/.github/workflows/reusable-ci-python.yml
@@ -24,6 +24,7 @@ on:
       enable-soft-gate: { description: 'Enable soft coverage gate (aggregate + issue update)', required: false, default: 'false', type: string }
       coverage-hard-fail: { description: 'Still fail build on coverage shortfall (true/false)', required: false, default: 'true', type: string }
       coverage-artifact-retention-days: { description: 'Retention days for coverage artifacts', required: false, default: '10', type: string }
+      low-coverage-threshold: { description: 'Percent threshold for low coverage spotlight table', required: false, default: '50', type: string }
 
 jobs:
   tests:
@@ -191,11 +192,16 @@ jobs:
       - name: Compute coverage summary & hotspots
         id: cov
         shell: python
+        env:
+          LOW_COVERAGE_THRESHOLD: ${{ inputs.low-coverage-threshold }}
         run: |
           import glob, json, os, sys
 
           HOTSPOT_LIMIT = 15
-          LOW_COVERAGE_THRESHOLD = 50.0  # Files below this percent get an explicit highlight table
+          try:
+              LOW_COVERAGE_THRESHOLD = float(os.environ.get('LOW_COVERAGE_THRESHOLD', '50.0'))
+          except ValueError:
+              LOW_COVERAGE_THRESHOLD = 50.0
           candidates = sorted(set(glob.glob('coverage-*.json') + glob.glob('**/coverage.json', recursive=True)))
           # Filter out duplicate same-path entries
           seen=set(); ordered=[]

--- a/.github/workflows/reuse-autofix.yml
+++ b/.github/workflows/reuse-autofix.yml
@@ -133,6 +133,50 @@ jobs:
               core.warning('Label management warning: ' + e.message);
             }
 
+      - name: Restore prior autofix history artifact (same-repo)
+        if: steps.same_repo.outputs.same == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          TARGET_REPO: ${{ github.repository }}
+          TARGET_RUN_ID: ${{ github.run_id }}
+          TARGET_PR: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p ci/autofix
+          rm -f ci/autofix/history.json
+          artifact_name="autofix-history-pr-${TARGET_PR}"
+          echo "[history] Attempting to restore ${artifact_name} from previous runs"
+          set +e
+          response=$(gh api repos/${TARGET_REPO}/actions/artifacts --paginate)
+          status=$?
+          set -e
+          if [ $status -ne 0 ] || [ -z "$response" ]; then
+            echo "[history] No prior artifact found"
+            exit 0
+          fi
+          artifact_lines=$(printf '%s' "$response" | jq -r --arg name "$artifact_name" --arg run "${TARGET_RUN_ID}" '.artifacts[]? | select(.name==$name and .expired==false and (.workflow_run.id|tostring)!=$run) | [.id, .created_at] | @tsv')
+          if [ -z "$artifact_lines" ]; then
+            echo "[history] No prior artifact found"
+            exit 0
+          fi
+          latest=$(printf '%s\n' "$artifact_lines" | sort -k2 | tail -n1)
+          artifact_id=${latest%%$'\t'*}
+          tmpdir=$(mktemp -d)
+          echo "[history] Downloading artifact id ${artifact_id}"
+          if ! gh api repos/${TARGET_REPO}/actions/artifacts/${artifact_id}/zip > "$tmpdir/artifact.zip"; then
+            echo "[history] Failed to download artifact ${artifact_id}"
+            exit 0
+          fi
+          if unzip -p "$tmpdir/artifact.zip" ci/autofix/history.json > ci/autofix/history.json 2>/dev/null; then
+            echo "[history] Restored previous history.json"
+          else
+            echo "[history] Artifact ${artifact_id} did not contain ci/autofix/history.json"
+            rm -f ci/autofix/history.json
+          fi
+          rm -rf "$tmpdir"
+
       - name: Update residual history (same-repo)
         if: steps.same_repo.outputs.same == 'true'
         shell: bash


### PR DESCRIPTION
## Summary
- restore residual autofix history by downloading the latest prior artifact before appending the new snapshot and keep the JSON sanity checks
- expose the low coverage spotlight threshold as a workflow input and document the knob in the workflows README
- keep the low-coverage truncation row aligned with the table structure for consistent rendering

## Testing
- not run (yaml-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cf6fbbdb808331a2e13dc99ca3dff4