### PR TITLE
feat: add minimal config validation at startup

### DIFF
--- a/config/demo.yml
+++ b/config/demo.yml
@@ -3,6 +3,7 @@ version: "1"                      # whatever your defaults.yml uses
 
 data:
   csv_path: demo/demo_returns.csv   # <– written by generate_demo.py
+  date_column: Date
   frequency: ME                 # monthly data
 
 preprocessing:
@@ -10,6 +11,7 @@ preprocessing:
 
 vol_adjust:
   enabled: false                # keep it off for speed
+  target_vol: 0.10              # default risk target when enabled
 
 sample_split:
   in_start: 2015-01
@@ -34,6 +36,9 @@ portfolio:
   weighting:
     name: equal
     params: {}
+  rebalance_calendar: NYSE
+  transaction_cost_bps: 0
+  max_turnover: 1.0
 
 benchmarks:
   spx: SPX

--- a/config/long_backtest.yml
+++ b/config/long_backtest.yml
@@ -3,6 +3,7 @@ version: "1"
 
 data:
   csv_path: hedge_fund_returns_with_indexes.csv
+  date_column: Date
   frequency: ME  # monthly data (month-end)
   na_as_zero:
     enabled: true
@@ -48,6 +49,9 @@ portfolio:
     soft_strikes: 2
     target_n: 8
     weighting: score_prop_bayes
+  transaction_cost_bps: 10     # Transaction cost of 10 basis points per trade
+  max_turnover: 0.50           # Limit monthly turnover to 50%
+  rebalance_calendar: NYSE
 
 # Leave benchmarks empty because the CSV does not include SPX/TSX columns
 benchmarks: {}

--- a/config/portfolio_test.yml
+++ b/config/portfolio_test.yml
@@ -3,6 +3,7 @@ version: "1"
 
 data:
   csv_path: demo/extended_returns.csv
+  date_column: Date
   frequency: ME  # monthly data
 
 preprocessing:
@@ -33,6 +34,9 @@ portfolio:
     name: score_prop_bayes  # Use Bayesian score-proportional weighting
     params:
       shrink_tau: 0.25
+  rebalance_calendar: NYSE
+  transaction_cost_bps: 0
+  max_turnover: 1.0
 
 benchmarks:
   spx: SPX

--- a/config/robust_demo.yml
+++ b/config/robust_demo.yml
@@ -9,7 +9,8 @@ version: "0.1.0"
 
 data:
   managers_glob: "demo/demo_returns.csv"
-  indices_glob: "data/raw/indices/*.csv"  
+  indices_glob: "data/raw/indices/*.csv"
+  csv_path: demo/demo_returns.csv
   date_column: "Date"
   price_column: "Adj_Close"
   frequency: "D"
@@ -31,6 +32,7 @@ preprocessing:
 
 vol_adjust:
   enabled: false  # Disable for cleaner robustness demonstration
+  target_vol: 0.10
 
 sample_split:
   method: "ratio"
@@ -44,6 +46,7 @@ portfolio:
   leverage_cap: 1.0
   transaction_cost_bps: 0
   max_turnover: 1.0
+  rebalance_calendar: NYSE
   
   # Enhanced robustness configuration
   robustness:

--- a/config/rolling_hold_bayes.yml
+++ b/config/rolling_hold_bayes.yml
@@ -2,6 +2,8 @@ version: "0.1.0"
 
 data:
   csv_path: "hedge_fund_returns_with_indexes.csv"
+  date_column: Date
+  frequency: ME
 
 preprocessing: {}
 vol_adjust:
@@ -32,6 +34,9 @@ portfolio:
     z_entry_hard: 1.5
     soft_strikes: 2
     weighting: score_prop_bayes
+  transaction_cost_bps: 0
+  max_turnover: 1.0
+  rebalance_calendar: NYSE
 
 benchmarks: {}
 

--- a/config/trend_concentrated_2004.yml
+++ b/config/trend_concentrated_2004.yml
@@ -3,6 +3,7 @@ version: "1"
 
 data:
   csv_path: "Trend Concentrated Universe Data.csv"  # path to Concentrated Universe dataset in repo root
+  date_column: Date
   frequency: ME  # monthly data (month-end)
   na_as_zero:
     enabled: true
@@ -56,6 +57,9 @@ portfolio:
     - Abrdn MOSERS Trend
     - HFRXSDV Base
     - SG Trend Index
+  transaction_cost_bps: 10
+  max_turnover: 0.50
+  rebalance_calendar: NYSE
 
 benchmarks: {}
 

--- a/config/trend_universe_2004.yml
+++ b/config/trend_universe_2004.yml
@@ -3,6 +3,7 @@ version: "1"
 
 data:
   csv_path: Trend Universe Data.csv  # path to Trend Universe dataset in repo root
+  date_column: Date
   frequency: ME  # monthly data (month-end)
   na_as_zero:
     enabled: true
@@ -56,6 +57,9 @@ portfolio:
     - Abrdn MOSERS Trend
     - HFRXSDV Base
     - SG Trend Index
+  transaction_cost_bps: 10
+  max_turnover: 0.50
+  rebalance_calendar: NYSE
 
 benchmarks: {}
 

--- a/src/trend_analysis/config/__init__.py
+++ b/src/trend_analysis/config/__init__.py
@@ -1,6 +1,7 @@
 """Configuration package initialization."""
 
 # Re-export commonly used configuration models and helpers
+from .model import TrendConfig, load_trend_config, validate_trend_config
 from .models import (
     DEFAULTS,
     ColumnMapping,
@@ -24,7 +25,10 @@ __all__ = [
     "list_available_presets",
     "load",
     "load_config",
+    "load_trend_config",
+    "validate_trend_config",
     "Config",
     "ConfigType",
     "DEFAULTS",
+    "TrendConfig",
 ]

--- a/src/trend_analysis/config/model.py
+++ b/src/trend_analysis/config/model.py
@@ -82,9 +82,9 @@ def _resolve_path(value: str | os.PathLike[str], *, base_dir: Path | None) -> Pa
 class DataSettings(BaseModel):
     """Data input configuration validated at startup."""
 
-    csv_path: Path = Field(alias="csv_path")
-    date_column: str = Field(alias="date_column")
-    frequency: Literal["D", "W", "M", "ME"] = Field(alias="frequency")
+    csv_path: Path = Field()
+    date_column: str = Field()
+    frequency: Literal["D", "W", "M", "ME"] = Field()
 
     model_config = ConfigDict(extra="ignore")
 

--- a/src/trend_analysis/config/model.py
+++ b/src/trend_analysis/config/model.py
@@ -1,0 +1,265 @@
+"""Minimal configuration model used for startup validation.
+
+The production configuration model in :mod:`trend_analysis.config.models`
+remains the source of truth for the full schema.  This module defines a small
+subset that captures the fields required to safely start the application.  We
+leverage Pydantic so the same validation logic can run in both the command line
+entry points and the Streamlit UI before the heavy pipeline code is invoked.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CONFIG_DIR = Path(__file__).resolve().parents[3] / "config"
+_GLOB_CHARS = {"*", "?", "[", "]"}
+
+
+def _resolve_path(value: str | os.PathLike[str], *, base_dir: Path | None) -> Path:
+    """Resolve ``value`` relative to ``base_dir`` and ensure it exists.
+
+    Parameters
+    ----------
+    value:
+        Path-like value supplied by the configuration.  Strings are expanded to
+        user directories before resolution.
+    base_dir:
+        Directory that should be treated as the root for relative paths.  When
+        ``None`` the current working directory is used instead.
+    """
+
+    raw = Path(value).expanduser()
+    if raw.is_absolute():
+        path = raw.resolve()
+    else:
+        roots: list[Path] = []
+        if base_dir is not None:
+            roots.append(base_dir)
+            roots.append(base_dir.parent)
+        roots.append(Path.cwd())
+        for root in roots:
+            candidate = (root / raw).resolve()
+            if candidate.exists():
+                path = candidate
+                break
+        else:
+            path = (base_dir or Path.cwd()) / raw
+            path = path.resolve()
+    if any(ch in str(raw) for ch in _GLOB_CHARS):
+        # Globs are not supported because downstream readers expect a concrete
+        # CSV file.  Raising here keeps the failure actionable.
+        raise ValueError(
+            f"Input path '{value}' contains wildcard characters. Provide a "
+            "single CSV file instead of a glob pattern."
+        )
+    if not path.exists():
+        raise ValueError(
+            f"Input path '{value}' does not exist. Update the configuration or "
+            "generate the dataset before launching the analysis."
+        )
+    if path.is_dir():
+        raise ValueError(
+            f"Input path '{value}' points to a directory. Provide the full path "
+            "to the CSV file containing returns data."
+        )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models covering the minimal runtime contract
+# ---------------------------------------------------------------------------
+
+
+class DataSettings(BaseModel):
+    """Data input configuration validated at startup."""
+
+    csv_path: Path = Field(alias="csv_path")
+    date_column: str = Field(alias="date_column")
+    frequency: Literal["D", "W", "M", "ME"] = Field(alias="frequency")
+
+    model_config = ConfigDict(extra="ignore")
+
+    @field_validator("csv_path", mode="before")
+    @classmethod
+    def _validate_csv_path(cls, value: Any, info: Any) -> Path:
+        if value in (None, ""):
+            raise ValueError("data.csv_path must point to the returns CSV file.")
+        base_dir = None
+        if info.context:
+            base_dir = info.context.get("base_path")
+        return _resolve_path(value, base_dir=base_dir)
+
+    @field_validator("date_column")
+    @classmethod
+    def _validate_date_column(cls, value: str) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(
+                "data.date_column must be a non-empty string identifying the date column."
+            )
+        return value
+
+    @field_validator("frequency", mode="before")
+    @classmethod
+    def _normalize_frequency(cls, value: Any) -> str:
+        if value is None:
+            raise ValueError("data.frequency must be provided (D, W or M).")
+        freq = str(value).strip().upper()
+        if freq == "ME":
+            # Allow existing configs that still rely on the month-end alias.
+            return "ME"
+        allowed = {"D", "W", "M"}
+        if freq not in allowed:
+            allowed_list = ", ".join(sorted(allowed))
+            raise ValueError(
+                f"data.frequency '{value}' is not supported. Choose one of {allowed_list}."
+            )
+        return freq
+
+
+class PortfolioSettings(BaseModel):
+    """Portfolio controls validated before running analyses."""
+
+    rebalance_calendar: str = Field(alias="rebalance_calendar")
+    max_turnover: float = Field(alias="max_turnover")
+    transaction_cost_bps: float = Field(alias="transaction_cost_bps")
+
+    model_config = ConfigDict(extra="ignore")
+
+    @field_validator("rebalance_calendar")
+    @classmethod
+    def _validate_calendar(cls, value: str) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(
+                "portfolio.rebalance_calendar must name a valid trading calendar (e.g. 'NYSE')."
+            )
+        return value
+
+    @field_validator("max_turnover", mode="before")
+    @classmethod
+    def _validate_turnover(cls, value: Any) -> float:
+        try:
+            turnover = float(value)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError("portfolio.max_turnover must be numeric.") from exc
+        if turnover < 0:
+            raise ValueError("portfolio.max_turnover cannot be negative.")
+        if turnover > 1:
+            raise ValueError(
+                "portfolio.max_turnover must be between 0 and 1.0 inclusive to cap per-period turnover."
+            )
+        return turnover
+
+    @field_validator("transaction_cost_bps", mode="before")
+    @classmethod
+    def _validate_cost(cls, value: Any) -> float:
+        try:
+            cost = float(value)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError("portfolio.transaction_cost_bps must be numeric.") from exc
+        if cost < 0:
+            raise ValueError("portfolio.transaction_cost_bps cannot be negative.")
+        return cost
+
+
+class RiskSettings(BaseModel):
+    """Risk target configuration for volatility control."""
+
+    target_vol: float = Field(alias="target_vol")
+
+    model_config = ConfigDict(extra="ignore")
+
+    @field_validator("target_vol", mode="before")
+    @classmethod
+    def _validate_target(cls, value: Any) -> float:
+        try:
+            target = float(value)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError("vol_adjust.target_vol must be numeric.") from exc
+        if target <= 0:
+            raise ValueError("vol_adjust.target_vol must be greater than zero.")
+        return target
+
+
+class TrendConfig(BaseModel):
+    """Subset of configuration validated at application startup."""
+
+    data: DataSettings
+    portfolio: PortfolioSettings
+    vol_adjust: RiskSettings
+
+    model_config = ConfigDict(extra="ignore")
+
+
+# ---------------------------------------------------------------------------
+# Loading helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_config_path(candidate: str | os.PathLike[str] | None) -> Path:
+    if candidate in (None, ""):
+        env_override = os.environ.get("TREND_CONFIG") or os.environ.get("TREND_CFG")
+        if env_override:
+            candidate = env_override
+        else:
+            candidate = "demo.yml"
+    path = Path(candidate)
+    if not path.suffix:
+        path = path.with_suffix(".yml")
+    if not path.is_absolute():
+        within_repo = _CONFIG_DIR / path
+        if within_repo.exists():
+            return within_repo.resolve()
+    if path.exists():
+        return path.resolve()
+    raise FileNotFoundError(
+        f"Configuration file '{candidate}' was not found. Provide an absolute path "
+        f"or place the file inside '{_CONFIG_DIR}'."
+    )
+
+
+def validate_trend_config(data: dict[str, Any], *, base_path: Path) -> TrendConfig:
+    """Validate ``data`` against :class:`TrendConfig` with helpful errors."""
+
+    try:
+        return TrendConfig.model_validate(data, context={"base_path": base_path})
+    except ValidationError as exc:
+        first_error = exc.errors()[0] if exc.errors() else {}
+        message = first_error.get("msg") or str(exc)
+        loc = first_error.get("loc") or ()
+        if loc:
+            joined = ".".join(str(part) for part in loc)
+            if joined:
+                message = f"{joined}: {message}"
+        raise ValueError(message) from exc
+
+
+def load_trend_config(
+    candidate: str | os.PathLike[str] | None = None,
+) -> tuple[TrendConfig, Path]:
+    """Load and validate the minimal configuration model."""
+
+    cfg_path = _resolve_config_path(candidate)
+    raw = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise TypeError("Configuration files must contain a mapping at the root level.")
+    cfg = validate_trend_config(raw, base_path=cfg_path.parent)
+    return cfg, cfg_path
+
+
+__all__ = [
+    "TrendConfig",
+    "load_trend_config",
+    "validate_trend_config",
+    "DataSettings",
+    "PortfolioSettings",
+    "RiskSettings",
+]

--- a/src/trend_analysis/config/model.py
+++ b/src/trend_analysis/config/model.py
@@ -173,7 +173,7 @@ class PortfolioSettings(BaseModel):
 class RiskSettings(BaseModel):
     """Risk target configuration for volatility control."""
 
-    target_vol: float = Field(alias="target_vol")
+    target_vol: float = Field()
 
     model_config = ConfigDict(extra="ignore")
 

--- a/src/trend_analysis/config/model.py
+++ b/src/trend_analysis/config/model.py
@@ -128,9 +128,9 @@ class DataSettings(BaseModel):
 class PortfolioSettings(BaseModel):
     """Portfolio controls validated before running analyses."""
 
-    rebalance_calendar: str = Field(alias="rebalance_calendar")
-    max_turnover: float = Field(alias="max_turnover")
-    transaction_cost_bps: float = Field(alias="transaction_cost_bps")
+    rebalance_calendar: str
+    max_turnover: float
+    transaction_cost_bps: float
 
     model_config = ConfigDict(extra="ignore")
 

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -14,6 +14,8 @@ from typing import Any, ClassVar, Dict, List, Protocol, cast
 
 import yaml
 
+from .model import TrendConfig, validate_trend_config
+
 
 class ConfigProtocol(Protocol):
     """Type protocol for Config class that works in both Pydantic and fallback
@@ -626,17 +628,20 @@ def load(path: str | Path | None = None) -> ConfigProtocol:
     consulted before falling back to ``DEFAULTS``.
     If ``path`` is a dict, it is used directly as configuration data.
     """
+    base_dir = Path.cwd()
     if isinstance(path, dict):
         data = path.copy()
     elif path is None:
-        env = os.environ.get("TREND_CFG")
+        env = os.environ.get("TREND_CONFIG") or os.environ.get("TREND_CFG")
         cfg_path = Path(env) if env else DEFAULTS
+        base_dir = cfg_path.parent
         with cfg_path.open("r", encoding="utf-8") as fh:
             data = yaml.safe_load(fh)
             if not isinstance(data, dict):
                 raise TypeError("Config file must contain a mapping")
     else:
         cfg_path = Path(path)
+        base_dir = cfg_path.parent
         with cfg_path.open("r", encoding="utf-8") as fh:
             data = yaml.safe_load(fh)
             if not isinstance(data, dict):
@@ -668,6 +673,11 @@ def load(path: str | Path | None = None) -> ConfigProtocol:
             p = Path(path_val)
             export_cfg.setdefault("directory", str(p.parent) if p.parent else ".")
             export_cfg.setdefault("filename", p.name)
+
+    try:
+        validate_trend_config(data, base_path=base_dir)
+    except Exception as exc:  # pragma: no cover - surface helpful error
+        raise ValueError(str(exc)) from exc
 
     return Config(**data)
 

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -676,7 +676,7 @@ def load(path: str | Path | None = None) -> ConfigProtocol:
 
     try:
         validate_trend_config(data, base_path=base_dir)
-    except Exception as exc:  # pragma: no cover - surface helpful error
+    except (ValueError, TypeError) as exc:  # pragma: no cover - surface helpful error
         raise ValueError(str(exc)) from exc
 
     return Config(**data)

--- a/src/trend_portfolio_app/app.py
+++ b/src/trend_portfolio_app/app.py
@@ -11,7 +11,7 @@ import streamlit as st
 import yaml
 from trend_analysis import pipeline
 from trend_analysis.config import DEFAULTS as DEFAULT_CFG_PATH
-from trend_analysis.config import Config
+from trend_analysis.config import Config, validate_trend_config
 from trend_analysis.multi_period import run as run_multi
 
 if TYPE_CHECKING:  # pragma: no cover - type-only alias for static checkers
@@ -118,7 +118,7 @@ def _columns(spec: Any) -> List[Any]:
 
 def _build_cfg(d: Dict[str, Any]) -> ConfigType:
     """Instantiate the flexible ``Config`` object used by the pipeline."""
-
+    validate_trend_config(d, base_path=Path.cwd())
     return Config(**d)
 
 

--- a/tests/test_trend_config_model.py
+++ b/tests/test_trend_config_model.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from trend_analysis.config import TrendConfig, load_trend_config
+
+
+def _write_config(tmp_path: Path, csv_path: Path, **overrides: object) -> Path:
+    data = {
+        "version": "1",
+        "data": {
+            "csv_path": str(csv_path),
+            "date_column": "Date",
+            "frequency": "M",
+        },
+        "portfolio": {
+            "rebalance_calendar": "NYSE",
+            "max_turnover": 0.5,
+            "transaction_cost_bps": 10,
+        },
+        "vol_adjust": {"target_vol": 0.1},
+    }
+    for key, value in overrides.items():
+        if isinstance(value, dict):
+            data.setdefault(key, {}).update(value)
+        else:
+            data[key] = value
+    cfg_path = tmp_path / "test.yml"
+    cfg_path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return cfg_path
+
+
+def test_load_trend_config_defaults() -> None:
+    cfg, resolved = load_trend_config("demo")
+    assert resolved.name == "demo.yml"
+    # The demo dataset is checked into the repository so the path should exist.
+    assert cfg.data.csv_path.exists()
+    assert cfg.data.date_column == "Date"
+    assert isinstance(cfg, TrendConfig)
+
+
+def test_load_trend_config_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    csv_file = tmp_path / "returns.csv"
+    csv_file.write_text("Date,A\n2020-01-31,0.1\n", encoding="utf-8")
+    cfg_path = _write_config(tmp_path, csv_file)
+    monkeypatch.setenv("TREND_CONFIG", str(cfg_path))
+
+    cfg, resolved = load_trend_config()
+    assert resolved == cfg_path
+    assert cfg.data.csv_path == csv_file.resolve()
+
+
+def test_trend_config_rejects_invalid_frequency(tmp_path: Path) -> None:
+    csv_file = tmp_path / "returns.csv"
+    csv_file.write_text("Date,A\n2020-01-31,0.1\n", encoding="utf-8")
+    cfg_path = _write_config(
+        tmp_path,
+        csv_file,
+        data={"frequency": "dailyish"},
+    )
+
+    with pytest.raises(ValueError) as exc:
+        load_trend_config(cfg_path)
+    assert "frequency" in str(exc.value)
+
+
+def test_trend_config_requires_existing_paths(tmp_path: Path) -> None:
+    csv_file = tmp_path / "missing.csv"
+    cfg_path = _write_config(tmp_path, csv_file)
+
+    with pytest.raises(ValueError) as exc:
+        load_trend_config(cfg_path)
+    assert "does not exist" in str(exc.value)


### PR DESCRIPTION
## Summary
- add a pydantic-based TrendConfig model that validates required data paths, calendar, turnover and risk settings
- hook validation into config loading and the Streamlit UI, and update canned YAML configs with the required fields
- add focused tests covering config loading success, environment overrides, and common validation errors

## Testing
- pytest tests/test_trend_config_model.py tests/test_config_human_errors.py

------
https://chatgpt.com/codex/tasks/task_e_68cff8e56fb483318050ebb2e5f1c336