### PR TITLE
Add tests to improve optimizer and export coverage

### DIFF
--- a/tests/test_autofix_samples.py
+++ b/tests/test_autofix_samples.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from trend_analysis import (
+    _autofix_trigger_sample,
+    _autofix_violation_case2,
+    _autofix_violation_case3,
+)
+
+
+def test_trigger_sample_functions_behave_as_documented() -> None:
+    assert _autofix_trigger_sample.badly_formatted_function(3, 7) == 10
+    assert _autofix_trigger_sample.another_func([1, 2], [3, 4]) == [4, 6]
+    assert _autofix_trigger_sample.Demo().method(1.5) == 3.0
+    assert "overly verbose" in _autofix_trigger_sample.long_line()
+
+
+def test_violation_case2_compute_and_helpers() -> None:
+    payload = _autofix_violation_case2.compute([2, 4, 6])
+    assert payload == {"total": 12, "mean": 4.0, "count": 3}
+
+    assert _autofix_violation_case2.Example().method(3.5, 0.5) == 4.0
+    assert "extravagantly" in _autofix_violation_case2.long_line_function()
+
+
+def test_violation_case3_exposes_expected_behaviour() -> None:
+    assert _autofix_violation_case3.compute_sum(5, 7) == 12
+    assert _autofix_violation_case3.list_builder([1, 2, 3]) == [1, 2, 3]
+    assert _autofix_violation_case3.ambiguous_types([1, 2], [4, 6]) == [5, 8]
+
+    container = _autofix_violation_case3.SomeContainer([2, 3, 5])
+    assert container.total() == 10

--- a/tests/test_optimizer_constraints_additional.py
+++ b/tests/test_optimizer_constraints_additional.py
@@ -48,7 +48,8 @@ def test_apply_constraints_requires_non_cash_assets_when_cash_weight_set() -> No
 
 
 def test_apply_constraints_rescales_weights_with_cash_and_cap() -> None:
-    """Cash allocation should be respected while the remainder obeys max weight."""
+    """Cash allocation should be respected while the remainder obeys max
+    weight."""
 
     weights = pd.Series({"Asset1": 2.0, "Asset2": 1.0, "CASH": 0.0})
     constraints = ConstraintSet(cash_weight=0.25, max_weight=0.6)

--- a/tests/test_optimizer_constraints_additional.py
+++ b/tests/test_optimizer_constraints_additional.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from trend_analysis.engine.optimizer import (
+    ConstraintSet,
+    ConstraintViolation,
+    _apply_cap,
+    _apply_group_caps,
+    apply_constraints,
+)
+
+
+def test_apply_cap_returns_early_when_total_is_zero() -> None:
+    """Guard against division-by-zero by exercising the early return branch."""
+
+    weights = pd.Series({"A": 0.0, "B": 0.0})
+
+    # ``total`` is explicitly provided as 0 so the function should return
+    # immediately without attempting to scale or redistribute.
+    result = _apply_cap(weights.copy(), cap=0.5, total=0.0)
+
+    pd.testing.assert_series_equal(result, weights)
+
+
+def test_apply_group_caps_missing_mapping_raises() -> None:
+    """Ensure a clear KeyError is raised when a group is unmapped."""
+
+    weights = pd.Series({"A": 0.6, "B": 0.4})
+    group_caps = {"Tech": 0.7}
+    groups = {"A": "Tech"}  # Asset ``B`` is intentionally left unmapped.
+
+    with pytest.raises(KeyError) as excinfo:
+        _apply_group_caps(weights, group_caps, groups)
+
+    assert "['B']" in str(excinfo.value)
+
+
+def test_apply_constraints_requires_non_cash_assets_when_cash_weight_set() -> None:
+    """Requesting a cash carve-out with no remaining assets should fail."""
+
+    weights = pd.Series({"CASH": 1.0})
+    constraints = ConstraintSet(cash_weight=0.3)
+
+    with pytest.raises(ConstraintViolation):
+        apply_constraints(weights, constraints)
+
+
+def test_apply_constraints_rescales_weights_with_cash_and_cap() -> None:
+    """Cash allocation should be respected while the remainder obeys max weight."""
+
+    weights = pd.Series({"Asset1": 2.0, "Asset2": 1.0, "CASH": 0.0})
+    constraints = ConstraintSet(cash_weight=0.25, max_weight=0.6)
+
+    result = apply_constraints(weights, constraints)
+
+    # All weights should sum to 1 and the CASH slice should equal the requested carve-out.
+    assert pytest.approx(result.sum(), rel=1e-9) == 1.0
+    assert pytest.approx(result.loc["CASH"], rel=1e-9) == 0.25
+
+    # The residual capital should respect the max_weight constraint and maintain order.
+    assert (result.drop("CASH") <= 0.6 + 1e-9).all()
+    pd.testing.assert_index_equal(result.index, pd.Index(["Asset1", "Asset2", "CASH"]))

--- a/tests/test_run_multi_analysis_additional.py
+++ b/tests/test_run_multi_analysis_additional.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
 from pathlib import Path
+from types import SimpleNamespace
 
 from trend_analysis import run_multi_analysis
 

--- a/tests/test_run_multi_analysis_additional.py
+++ b/tests/test_run_multi_analysis_additional.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from pathlib import Path
+
+from trend_analysis import run_multi_analysis
+
+
+def test_main_prints_message_when_no_results(monkeypatch, capsys):
+    stub_cfg = SimpleNamespace(export={})
+
+    monkeypatch.setattr(run_multi_analysis, "load", lambda path: stub_cfg)
+    monkeypatch.setattr(run_multi_analysis, "run_mp", lambda cfg: [])
+
+    exit_code = run_multi_analysis.main(["-c", "demo.yml"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "No results" in captured.out
+
+
+def test_main_uses_default_export_targets(monkeypatch):
+    stub_cfg = SimpleNamespace(export={})
+    results = [
+        {
+            "period": ("2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01"),
+            "metrics": {"Sharpe": 1.23},
+        }
+    ]
+
+    calls: dict[str, object] = {}
+
+    def fake_export(results_arg, path, *, formats, include_metrics):  # noqa: D401
+        calls["results"] = results_arg
+        calls["path"] = Path(path)
+        calls["formats"] = formats
+        calls["include_metrics"] = include_metrics
+
+    monkeypatch.setattr(run_multi_analysis, "load", lambda path: stub_cfg)
+    monkeypatch.setattr(run_multi_analysis, "run_mp", lambda cfg: results)
+    monkeypatch.setattr(
+        run_multi_analysis.export, "export_phase1_multi_metrics", fake_export
+    )
+
+    exit_code = run_multi_analysis.main(["-c", "demo.yml"])
+
+    assert exit_code == 0
+    assert calls["results"] == results
+    assert calls["path"] == Path("outputs") / "analysis"
+    assert calls["formats"] == ["excel"]
+    assert calls["include_metrics"] is True


### PR DESCRIPTION
## Summary
- exercise optimizer constraint edge cases including cash-weight handling and invalid group mappings
- add run-multi-analysis CLI coverage for no-result and default export scenarios
- extend portfolio app bundle cleanup tests and smoke-test autofix sample modules to drive coverage upward

## Testing
- pytest --maxfail=1 --disable-warnings --cov=src --cov-report=term-missing -k 'not lockfile'

------
https://chatgpt.com/codex/tasks/task_e_68cffaaeadc483319b488afcbc7b5d54