### PR TITLE
Finish consolidated autofix workflow automation

### DIFF
--- a/.github/actions/apply-autofix/action.yml
+++ b/.github/actions/apply-autofix/action.yml
@@ -1,0 +1,124 @@
+name: "Apply autofix and deliver"
+description: "Run the composite autofix action and either push with the service bot PAT or upload a patch artifact"
+inputs:
+  head_ref:
+    description: "Branch ref for the pull request head"
+    required: true
+  same_repo:
+    description: "Whether the PR head resides in the same repository"
+    required: true
+  commit_prefix:
+    description: "Commit prefix for autofix commits"
+    required: false
+    default: "chore(autofix):"
+  pr:
+    description: "Pull request number"
+    required: true
+  service_bot_pat:
+    description: "Service bot PAT used for pushes"
+    required: false
+  github_token:
+    description: "Fallback GitHub token for checkout"
+    required: true
+outputs:
+  changed:
+    description: "Whether any files were modified"
+    value: ${{ steps.collect.outputs.changed }}
+  remaining_issues:
+    description: "Remaining ruff issues after autofix"
+    value: ${{ steps.collect.outputs.remaining }}
+  new_issues:
+    description: "New (non-allowlisted) ruff issues"
+    value: ${{ steps.collect.outputs.new }}
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout PR head
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.head_ref }}
+        fetch-depth: 0
+        token: ${{ inputs.same_repo == 'true' && inputs.service_bot_pat || inputs.github_token }}
+
+    - name: Run composite autofix
+      id: autofix
+      uses: ./.github/actions/autofix
+
+    - name: Collect autofix outputs
+      id: collect
+      shell: bash
+      run: |
+        echo "changed=${{ steps.autofix.outputs.changed }}" >> "$GITHUB_OUTPUT"
+        echo "remaining=${{ steps.autofix.outputs.remaining_issues }}" >> "$GITHUB_OUTPUT"
+        echo "new=${{ steps.autofix.outputs.new_issues }}" >> "$GITHUB_OUTPUT"
+
+    - name: Commit changes
+      if: ${{ inputs.same_repo == 'true' && steps.autofix.outputs.changed == 'true' }}
+      shell: bash
+      env:
+        COMMIT_PREFIX: ${{ inputs.commit_prefix }}
+      run: |
+        set -euo pipefail
+        git config user.name "trend-service-bot"
+        git config user.email "trend-service-bot@users.noreply.github.com"
+        git add -A
+        if git diff --cached --quiet; then
+          echo "No staged changes after autofix; skipping commit."
+          exit 0
+        fi
+        prefix=${COMMIT_PREFIX:-chore(autofix):}
+        git commit -m "${prefix% } formatting/lint"
+
+    - name: Push changes
+      if: ${{ inputs.same_repo == 'true' && steps.autofix.outputs.changed == 'true' }}
+      shell: bash
+      env:
+        HEAD_REF: ${{ inputs.head_ref }}
+        PAT: ${{ inputs.service_bot_pat }}
+      run: |
+        set -euo pipefail
+        if [ -z "${PAT}" ]; then
+          echo "::error::SERVICE_BOT_PAT is required to push autofix commits." >&2
+          exit 1
+        fi
+        git remote set-url origin "https://x-access-token:${PAT}@github.com/${GITHUB_REPOSITORY}.git"
+        for attempt in 1 2 3; do
+          echo "[autofix] Push attempt ${attempt}"
+          if git push origin HEAD:"${HEAD_REF}"; then
+            exit 0
+          fi
+          echo "[autofix] Push failed; attempting rebase." >&2
+          git fetch origin "${HEAD_REF}" --prune
+          if git rebase --autostash --strategy-option theirs origin/"${HEAD_REF}"; then
+            continue
+          fi
+          git rebase --abort || true
+        done
+        echo "::error::Failed to push autofix changes after 3 attempts." >&2
+        exit 1
+
+    - name: Prepare patch artifact
+      if: ${{ inputs.same_repo != 'true' && steps.autofix.outputs.changed == 'true' }}
+      shell: bash
+      env:
+        COMMIT_PREFIX: ${{ inputs.commit_prefix }}
+      run: |
+        set -euo pipefail
+        git config user.name "trend-service-bot"
+        git config user.email "trend-service-bot@users.noreply.github.com"
+        git add -A
+        if git diff --cached --quiet; then
+          exit 0
+        fi
+        prefix=${COMMIT_PREFIX:-chore(autofix):}
+        git commit -m "${prefix% } formatting/lint (patch)" || true
+        git format-patch -1 --stdout > autofix.patch
+
+    - name: Upload patch artifact
+      if: ${{ inputs.same_repo != 'true' && steps.autofix.outputs.changed == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: autofix-patch-pr-${{ inputs.pr }}
+        path: autofix.patch
+        if-no-files-found: ignore
+        retention-days: 7

--- a/.github/actions/autofix-commit-push/action.yml
+++ b/.github/actions/autofix-commit-push/action.yml
@@ -1,0 +1,118 @@
+name: "Autofix, commit, and deliver"
+description: "Run the composite autofix action, commit with the provided message, and push or upload a patch"
+inputs:
+  head_ref:
+    description: "Branch ref for the pull request head"
+    required: true
+  token:
+    description: "Authentication token (service bot PAT for same-repo pushes)"
+    required: true
+  same_repo:
+    description: "Whether the PR originates from the same repository"
+    required: true
+  commit_message:
+    description: "Commit message to use when changes are applied"
+    required: true
+  pr:
+    description: "Pull request number"
+    required: true
+outputs:
+  changed:
+    description: "Whether any files were modified"
+    value: ${{ steps.collect.outputs.changed }}
+  remaining_issues:
+    description: "Remaining ruff issues after autofix"
+    value: ${{ steps.collect.outputs.remaining }}
+  new_issues:
+    description: "New (non-allowlisted) ruff issues"
+    value: ${{ steps.collect.outputs.new }}
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout PR head
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.head_ref }}
+        fetch-depth: 0
+        token: ${{ inputs.token }}
+
+    - name: Run composite autofix
+      id: autofix
+      uses: ./.github/actions/autofix
+
+    - name: Collect autofix outputs
+      id: collect
+      shell: bash
+      run: |
+        echo "changed=${{ steps.autofix.outputs.changed }}" >> "$GITHUB_OUTPUT"
+        echo "remaining=${{ steps.autofix.outputs.remaining_issues }}" >> "$GITHUB_OUTPUT"
+        echo "new=${{ steps.autofix.outputs.new_issues }}" >> "$GITHUB_OUTPUT"
+
+    - name: Commit changes
+      if: ${{ inputs.same_repo == 'true' && steps.autofix.outputs.changed == 'true' }}
+      shell: bash
+      env:
+        COMMIT_MESSAGE: ${{ inputs.commit_message }}
+      run: |
+        set -euo pipefail
+        git config user.name "trend-service-bot"
+        git config user.email "trend-service-bot@users.noreply.github.com"
+        git add -A
+        if git diff --cached --quiet; then
+          echo "No staged changes after autofix; skipping commit."
+          exit 0
+        fi
+        git commit -m "$COMMIT_MESSAGE"
+
+    - name: Push changes
+      if: ${{ inputs.same_repo == 'true' && steps.autofix.outputs.changed == 'true' }}
+      shell: bash
+      env:
+        HEAD_REF: ${{ inputs.head_ref }}
+        TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        if [ -z "${TOKEN}" ]; then
+          echo "::error::Token is required to push autofix commits." >&2
+          exit 1
+        fi
+        git remote set-url origin "https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        for attempt in 1 2 3; do
+          echo "[autofix] Push attempt ${attempt}"
+          if git push origin HEAD:"${HEAD_REF}"; then
+            exit 0
+          fi
+          echo "[autofix] Push failed; attempting rebase." >&2
+          git fetch origin "${HEAD_REF}" --prune
+          if git rebase --autostash --strategy-option theirs origin/"${HEAD_REF}"; then
+            continue
+          fi
+          git rebase --abort || true
+        done
+        echo "::error::Failed to push autofix changes after 3 attempts." >&2
+        exit 1
+
+    - name: Prepare patch artifact
+      if: ${{ inputs.same_repo != 'true' && steps.autofix.outputs.changed == 'true' }}
+      shell: bash
+      env:
+        COMMIT_MESSAGE: ${{ inputs.commit_message }}
+      run: |
+        set -euo pipefail
+        git config user.name "trend-service-bot"
+        git config user.email "trend-service-bot@users.noreply.github.com"
+        git add -A
+        if git diff --cached --quiet; then
+          exit 0
+        fi
+        git commit -m "${COMMIT_MESSAGE} (patch)" || true
+        git format-patch -1 --stdout > autofix.patch
+
+    - name: Upload patch artifact
+      if: ${{ inputs.same_repo != 'true' && steps.autofix.outputs.changed == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: autofix-patch-pr-${{ inputs.pr }}
+        path: autofix.patch
+        if-no-files-found: ignore
+        retention-days: 7

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -12,7 +12,8 @@ permissions:
   actions: read
 
 concurrency:
-  group: autofix-pr-${{ needs.context.outputs.pr }}
+  group: >-
+    autofix-pr-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_branch || github.run_id }}
   cancel-in-progress: true
 
 env:
@@ -242,18 +243,30 @@ jobs:
     env:
       APPLIED_LABEL: ${{ vars.AUTOFIX_APPLIED_LABEL || 'autofix:applied' }}
     steps:
-      - name: Apply autofix and commit/push/patch/label
+      - name: Apply autofix and deliver changes
+        id: apply
         uses: ./.github/actions/apply-autofix
         with:
           head_ref: ${{ needs.context.outputs.head_ref }}
           same_repo: ${{ needs.context.outputs.same_repo }}
-          pat_available: ${{ needs.context.outputs.pat_available }}
-          pr: ${{ needs.context.outputs.pr }}
           commit_prefix: ${{ env.COMMIT_PREFIX }}
-          applied_label: ${{ env.APPLIED_LABEL }}
-          changed: ${{ steps.autofix.outputs.changed }}
+          pr: ${{ needs.context.outputs.pr }}
           service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
           github_token: ${{ github.token }}
+
+      - name: Label PR (autofix applied)
+        if: steps.apply.outputs.changed == 'true' && needs.context.outputs.same_repo == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.SERVICE_BOT_PAT || github.token }}
+          script: |
+            const pr = Number('${{ needs.context.outputs.pr }}');
+            const label = process.env.APPLIED_LABEL || 'autofix:applied';
+            try {
+              await github.rest.issues.addLabels({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pr, labels: [label] });
+            } catch (error) {
+              core.warning(`Failed to add label: ${error.message}`);
+            }
       - name: Manage clean/debt labels
         if: needs.context.outputs.same_repo == 'true'
         uses: actions/github-script@v7
@@ -261,7 +274,7 @@ jobs:
           github-token: ${{ secrets.SERVICE_BOT_PAT || github.token }}
           script: |
             const pr = Number('${{ needs.context.outputs.pr }}');
-            const remaining = Number("${{ steps.autofix.outputs.remaining_issues || '0' }}") || 0;
+            const remaining = Number("${{ steps.apply.outputs.remaining_issues || '0' }}") || 0;
             const cleanLabel = 'autofix:clean';
             const debtLabel = 'autofix:debt';
             const want = remaining === 0 ? cleanLabel : debtLabel;
@@ -279,8 +292,8 @@ jobs:
           echo "### Small fixes" >> "$GITHUB_STEP_SUMMARY"
           echo "PR: #${{ needs.context.outputs.pr }}" >> "$GITHUB_STEP_SUMMARY"
           echo "Files considered: ${{ needs.context.outputs.file_count }} (safe paths: ${{ needs.context.outputs.safe_paths }})" >> "$GITHUB_STEP_SUMMARY"
-          echo "Changes applied: ${{ steps.autofix.outputs.changed }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Remaining ruff issues: ${{ steps.autofix.outputs.remaining_issues }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Changes applied: ${{ steps.apply.outputs.changed }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Remaining ruff issues: ${{ steps.apply.outputs.remaining_issues }}" >> "$GITHUB_STEP_SUMMARY"
 
   fix-failing-checks:
     name: Fix failing checks


### PR DESCRIPTION
## Summary
- add composite actions to run the shared autofix routine, push via the service-bot PAT, or emit fork-friendly patches
- update the consolidated `autofix.yml` to use the new composites, label successful runs, and guard concurrency by PR or branch metadata

## Testing
- `./actionlint -color` *(fails: repository has pre-existing workflow issues outside the new autofix files)*

------
https://chatgpt.com/codex/tasks/task_e_68d005025fc4833185707d7948e9486b