### PR TITLE
Extend autofix follower with status comment builder

### DIFF
--- a/.github/actions/build-pr-comment/action.yml
+++ b/.github/actions/build-pr-comment/action.yml
@@ -1,0 +1,175 @@
+name: "Build autofix PR comment"
+description: "Assemble the autofix status comment from residual reports and trend artifacts"
+inputs:
+  output:
+    description: "Path to write the markdown comment"
+    required: true
+  report:
+    description: "Path to the enriched autofix report JSON"
+    required: false
+    default: autofix_report_enriched.json
+  history:
+    description: "Path to the residual history JSON"
+    required: false
+    default: ci/autofix/history.json
+  trend:
+    description: "Path to the residual trend JSON"
+    required: false
+    default: ci/autofix/trend.json
+  pr-number:
+    description: "Pull request number (used for artifact names)"
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - name: Build comment body
+      shell: python
+      env:
+        OUTPUT: ${{ inputs.output }}
+        REPORT: ${{ inputs.report }}
+        HISTORY: ${{ inputs.history }}
+        TREND: ${{ inputs.trend }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+      run: |
+        import json
+        import os
+        import pathlib
+        from datetime import datetime, timezone
+
+        marker = "<!-- autofix-status: DO NOT EDIT -->"
+
+        def load_json(path: pathlib.Path):
+          try:
+            return json.loads(path.read_text())
+          except Exception:
+            return None
+
+        def coerce_bool(value) -> bool:
+          if isinstance(value, bool):
+            return value
+          if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+          return bool(value)
+
+        def coerce_int(value, default: int = 0) -> int:
+          try:
+            return int(value)
+          except (TypeError, ValueError):
+            return default
+
+        def format_timestamp(raw: str | None) -> str:
+          if not raw:
+            return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+          try:
+            normalized = raw.replace("Z", "+00:00") if raw.endswith("Z") else raw
+            stamp = datetime.fromisoformat(normalized)
+          except ValueError:
+            return raw
+          if stamp.tzinfo is None:
+            stamp = stamp.replace(tzinfo=timezone.utc)
+          return stamp.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+        def format_spark(series: str | None) -> str:
+          return series if series else "∅"
+
+        out_path = pathlib.Path(os.environ["OUTPUT"])
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+
+        report_path = pathlib.Path(os.environ.get("REPORT", ""))
+        history_path = pathlib.Path(os.environ.get("HISTORY", ""))
+        trend_path = pathlib.Path(os.environ.get("TREND", ""))
+
+        report = load_json(report_path) or {}
+        classification = report.get("classification")
+        if not isinstance(classification, dict):
+          classification = {}
+
+        changed = coerce_bool(report.get("changed"))
+        changed_text = "True" if changed else "False"
+        remaining = coerce_int(classification.get("total"))
+        new = coerce_int(classification.get("new"))
+        allowed = coerce_int(classification.get("allowed"))
+        history = load_json(history_path)
+        history_points = len(history) if isinstance(history, list) else 0
+        trend = load_json(trend_path) or {}
+
+        remaining_latest = coerce_int(trend.get("remaining_latest"), remaining)
+        new_latest = coerce_int(trend.get("new_latest"), new)
+        remaining_spark = format_spark(trend.get("remaining_spark"))
+        new_spark = format_spark(trend.get("new_spark"))
+
+        timestamp = classification.get("timestamp") or report.get("timestamp")
+        run_timestamp = format_timestamp(timestamp)
+
+        status_icon = "✅"
+        status_suffix = ""
+        if new_latest > 0:
+          status_icon = "⚠️"
+          status_suffix = " new diagnostics detected"
+        elif remaining_latest > 0:
+          status_icon = "⚠️"
+          status_suffix = " residual diagnostics remain"
+        elif changed:
+          status_suffix = " autofix updates applied"
+        status_value = f"{status_icon}{status_suffix}"
+
+        metrics_rows = [
+          "| Metric | Value |",
+          "|--------|-------|",
+          f"| Status | {status_value} |",
+          f"| Changed files | {changed_text} |",
+          f"| Remaining issues | {remaining} |",
+          f"| New issues | {new} |",
+          f"| Allowed (legacy) | {allowed} |",
+        ]
+        if history_points:
+          metrics_rows.append(f"| History points | {history_points} |")
+
+        trend_lines = [
+          f"Remaining: **{remaining_latest}**  `{remaining_spark}`",
+          f"New: **{new_latest}**  `{new_spark}`",
+        ]
+
+        codes = trend.get("codes")
+        code_lines: list[str] = []
+        if isinstance(codes, dict) and codes:
+          code_lines.append("")
+          code_lines.append("### Top residual codes")
+          code_lines.append("")
+          for code, payload in sorted(codes.items()):
+            latest = coerce_int(payload.get("latest"))
+            spark = format_spark(payload.get("spark"))
+            code_lines.append(f"- `{code}` latest: **{latest}**  `{spark}`")
+
+        artifacts: list[str] = []
+        pr_number = os.environ.get("PR_NUMBER") or ""
+        if pr_number:
+          artifacts.append(f"- JSON report: `autofix-report-pr-{pr_number}`")
+          if history_points:
+            artifacts.append(f"- Residual history: `autofix-history-pr-{pr_number}`")
+        if not artifacts:
+          artifacts.append("- No additional artifacts published for this run.")
+
+        lines = [
+          marker,
+          "# Autofix Status",
+          "",
+          f"*Run:* {run_timestamp}",
+          "",
+          *metrics_rows,
+          "",
+          "## Trend (last 40 runs)",
+          "",
+          *trend_lines,
+          *code_lines,
+          "",
+          "## Artifacts & Reports",
+          "",
+          *artifacts,
+          "",
+          "_This comment auto-updates; do not edit manually._",
+          marker,
+          "",
+        ]
+
+        out_path.write_text("\n".join(lines))

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -327,6 +327,7 @@ jobs:
         uses: ./.github/actions/build-pr-comment
         with:
           output: autofix_pr_comment.md
+          pr-number: ${{ needs.context.outputs.pr }}
       - name: Upsert consolidated PR comment (same-repo)
         if: needs.context.outputs.same_repo == 'true'
         uses: actions/github-script@v7
@@ -477,9 +478,10 @@ jobs:
 
       - name: Build consolidated PR comment (same-repo)
         if: needs.context.outputs.same_repo == 'true'
-        uses: ./.github/actions/build-consolidated-pr-comment
+        uses: ./.github/actions/build-pr-comment
         with:
           output: autofix_pr_comment.md
+          pr-number: ${{ needs.context.outputs.pr }}
 
       - name: Upsert consolidated PR comment (same-repo)
         if: needs.context.outputs.same_repo == 'true'


### PR DESCRIPTION
## Summary
- add a composite `build-pr-comment` action that assembles the autofix status comment from enriched reports, history, and trend artifacts
- update the consolidated autofix workflow to pass the PR number into the comment builder for both small-fixes and fix-failing-checks lanes

## Testing
- npx actionlint *(fails: npm could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_68d00d5538c08331b6e0eff6318f2b0b