### PR TITLE
feat: validate mapping configs with minimal model

### DIFF
--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -617,7 +617,10 @@ def load_config(cfg: Mapping[str, Any] | str | Path) -> ConfigProtocol:
     if isinstance(cfg, (str, Path)):
         return load(cfg)
     if isinstance(cfg, Mapping):
-        return Config(**cfg)
+        cfg_dict = dict(cfg)
+        config_obj = Config(**cfg_dict)
+        validate_trend_config(cfg_dict, base_path=Path.cwd())
+        return config_obj
     raise TypeError("cfg must be a mapping or path")
 
 

--- a/tests/test_config_models_additional.py
+++ b/tests/test_config_models_additional.py
@@ -107,6 +107,22 @@ def test_load_config_rejects_invalid_type() -> None:
         models.load_config(123)  # type: ignore[arg-type]
 
 
+def test_load_config_validates_mapping_paths(tmp_path: Path) -> None:
+    """``load_config`` validates mapping inputs via the minimal model."""
+
+    csv_file = tmp_path / "returns.csv"
+    csv_file.write_text("Date,A\n2020-01-31,0.1\n", encoding="utf-8")
+    cfg = _base_config()
+    cfg["data"] = {
+        "csv_path": str(csv_file),
+        "date_column": "Date",
+        "frequency": "M",
+    }
+
+    loaded = models.load_config(cfg)
+    assert loaded.data["csv_path"] == str(csv_file)
+
+
 def test_list_available_presets_handles_missing_directory(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_trend_config_model.py
+++ b/tests/test_trend_config_model.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 import yaml
-from trend_analysis.config import TrendConfig, load_trend_config
+from trend_analysis.config import TrendConfig, load_config, load_trend_config
 
 
 def _write_config(tmp_path: Path, csv_path: Path, **overrides: object) -> Path:
@@ -76,3 +76,25 @@ def test_trend_config_requires_existing_paths(tmp_path: Path) -> None:
     with pytest.raises(ValueError) as exc:
         load_trend_config(cfg_path)
     assert "does not exist" in str(exc.value)
+
+
+def test_load_config_mapping_requires_source(tmp_path: Path) -> None:
+    cfg = {
+        "version": "1",
+        "data": {"date_column": "Date", "frequency": "M"},
+        "portfolio": {
+            "rebalance_calendar": "NYSE",
+            "max_turnover": 0.5,
+            "transaction_cost_bps": 10,
+        },
+        "vol_adjust": {"target_vol": 0.1},
+        "preprocessing": {},
+        "sample_split": {},
+        "metrics": {},
+        "export": {},
+        "run": {},
+    }
+
+    with pytest.raises(ValueError) as exc:
+        load_config(cfg)
+    assert "data.csv_path" in str(exc.value)


### PR DESCRIPTION
## Summary
- ensure config.load_config validates mapping inputs with the minimal TrendConfig schema
- cover mapping validation via new tests for load_config and direct config.load_config usage

## Testing
- pytest
- mypy src

------
https://chatgpt.com/codex/tasks/task_e_68d00bf5001c8331a18f11393554769f