### PR TITLE
Codex bootstrap for #1436

### DIFF
--- a/src/trend_analysis/config/model.py
+++ b/src/trend_analysis/config/model.py
@@ -134,6 +134,13 @@ def _ensure_glob_matches(pattern: str, *, base_dir: Path | None) -> None:
             f"Update the glob '{pattern}' relative to '{base_hint}' or "
             "generate the manager inputs before running the analysis."
         )
+    csv_files = [path for path in files if path.suffix.lower() == ".csv"]
+    if not csv_files:
+        found = ", ".join(str(path.name) for path in files)
+        raise ValueError(
+            "data.managers_glob must resolve to CSV files. "
+            f"The pattern '{pattern}' matched non-CSV inputs: {found}."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_trend_config_model.py
+++ b/tests/test_trend_config_model.py
@@ -153,7 +153,7 @@ def test_trend_config_requires_matching_managers_glob(tmp_path: Path) -> None:
 def test_trend_config_managers_glob_requires_csv_extension(tmp_path: Path) -> None:
     data_dir = tmp_path / "inputs"
     data_dir.mkdir()
-    (data_dir / "fund_a.txt").write_text("Date,A\n2020-01-31,0.1\n", encoding="utf-8")
+    (data_dir / "fund_a.txt").write_text("This is not a CSV file.", encoding="utf-8")
 
     cfg = {
         "version": "1",

--- a/tests/test_trend_config_model.py
+++ b/tests/test_trend_config_model.py
@@ -148,3 +148,30 @@ def test_trend_config_requires_matching_managers_glob(tmp_path: Path) -> None:
     with pytest.raises(ValueError) as exc:
         validate_trend_config(cfg, base_path=tmp_path)
     assert "managers_glob" in str(exc.value)
+
+
+def test_trend_config_managers_glob_requires_csv_extension(tmp_path: Path) -> None:
+    data_dir = tmp_path / "inputs"
+    data_dir.mkdir()
+    (data_dir / "fund_a.txt").write_text("Date,A\n2020-01-31,0.1\n", encoding="utf-8")
+
+    cfg = {
+        "version": "1",
+        "data": {
+            "managers_glob": str(data_dir / "*"),
+            "date_column": "Date",
+            "frequency": "M",
+        },
+        "portfolio": {
+            "rebalance_calendar": "NYSE",
+            "max_turnover": 0.5,
+            "transaction_cost_bps": 10,
+        },
+        "vol_adjust": {"target_vol": 0.1},
+    }
+
+    with pytest.raises(ValueError) as exc:
+        validate_trend_config(cfg, base_path=tmp_path)
+    message = str(exc.value)
+    assert "CSV" in message
+    assert "fund_a.txt" in message


### PR DESCRIPTION
**Summary**
* Added glob-resolution helpers to the minimal TrendConfig validator so `data.managers_glob` must resolve to real CSV files, preventing ambiguous sources at startup.
* Checked in lightweight sample manager and index CSV inputs and updated `.gitignore` so repository defaults satisfy the stricter validation.
* Extended TrendConfig unit tests with positive and negative manager-glob scenarios to cover the new validation paths.
* Tightened manager glob validation to reject patterns that only match non-CSV files and added a regression test for the new failure mode.

**Testing**
* ✅ `pytest`
* ✅ `pytest tests/test_trend_config_model.py`
* ✅ `mypy src`


------
https://chatgpt.com/codex/tasks/task_e_68d04d50d6948331b98e2a88a1eb557a