### PR TITLE
Add shift-safe signal helpers and causal tests

### DIFF
--- a/tests/test_shift_safe_pipeline.py
+++ b/tests/test_shift_safe_pipeline.py
@@ -1,0 +1,53 @@
+import math
+
+import pandas as pd
+import pandas.testing as tm
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from trend_analysis.pipeline import compute_signal, position_from_signal
+
+
+def test_compute_signal_matches_shifted_trailing_mean():
+    df = pd.DataFrame({"returns": [0.01, 0.03, 0.02, -0.01, 0.05]})
+    signal = compute_signal(df, window=3)
+    expected = df["returns"].rolling(window=3, min_periods=3).mean().shift(1)
+    tm.assert_series_equal(signal, expected.rename(signal.name))
+
+
+def test_positions_ignore_future_data():
+    base = pd.DataFrame({"returns": [0.02, -0.01, 0.03, -0.02, 0.04, 0.01]})
+    original_positions = position_from_signal(compute_signal(base, window=3))
+
+    tweaked = base.copy()
+    tweaked.loc[tweaked.index[-1], "returns"] = 10.0
+    tweaked_positions = position_from_signal(compute_signal(tweaked, window=3))
+
+    tm.assert_series_equal(
+        original_positions.iloc[:-1],
+        tweaked_positions.iloc[:-1],
+        check_names=False,
+    )
+
+
+@given(
+    st.lists(
+        st.floats(min_value=-0.5, max_value=0.5, allow_nan=False, allow_infinity=False),
+        min_size=4,
+        max_size=32,
+    )
+)
+@settings(max_examples=50)
+def test_shift_safe_pipeline_is_causal(returns):
+    df = pd.DataFrame({"returns": returns})
+    global_positions = position_from_signal(compute_signal(df, window=3))
+
+    for idx in range(len(df)):
+        partial = df.iloc[: idx + 1]
+        partial_positions = position_from_signal(compute_signal(partial, window=3))
+        assert math.isclose(
+            float(global_positions.iloc[idx]),
+            float(partial_positions.iloc[-1]),
+            rel_tol=0,
+            abs_tol=0,
+        )


### PR DESCRIPTION
## Summary
- add shift-safe `compute_signal` helper to the pipeline module so signals always lag inputs by one period
- introduce `position_from_signal` to translate signals into positions sequentially without look-ahead
- cover the helpers with deterministic and property-based tests that fail if future data leaks into earlier decisions

## Testing
- pytest tests/test_shift_safe_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d05ed5f6188331919b7722f8021b13