### PR TITLE
Follow-up: Agents: collapse to assign-to-agents.yml + agent-watchdog.yml; archive overlapping helpers

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -142,7 +142,7 @@ Result: Each human push generates at most one autofix patch sequence; autofix co
 End‑to‑end lifecycle for automation bootstrapped contributions:
 1. Maintainer opens Issue with label `codex-ready` (and optional spec details).
 2. Labeling with `agent:codex` triggers `assign-to-agents.yml`, which creates a bootstrap branch/PR, assigns Codex, and posts the kickoff command.
-3. `agent-watchdog.yml` (dispatched by the assigner) waits ~7 minutes for the cross-referenced PR and posts a success or timeout diagnostic comment.
+3. `agent-watchdog.yml` (dispatched by the assigner) waits ~7 minutes for the cross-referenced PR and posts a success comment with a direct link to the PR (plus the watchdog run URL) or a timeout diagnostic that calls out the expected PR number when known.
 4. When automation pushes commits, path labelers, CI, and autofix re-evaluate.
 Troubleshooting: If branch/PR not created, verify the label `codex-ready`, confirm `assign-to-agents.yml` completed successfully with write permissions, and ensure no conflicting bootstrap branch already exists.
 

--- a/.github/workflows/agent-watchdog.yml
+++ b/.github/workflows/agent-watchdog.yml
@@ -118,16 +118,24 @@ jobs:
             core.setOutput('pr', found ? String(found.number) : '');
             core.setOutput('elapsed_minutes', friendlyElapsed);
 
+            const runId = process.env.GITHUB_RUN_ID || '';
+            const runUrl = runId ? `https://github.com/${owner}/${repo}/actions/runs/${runId}` : '';
+
             const summary = core.summary.addHeading('Agent Watchdog Result');
             if (found) {
               summary.addTable([
                 [{ data: 'Status', header: true }, { data: 'Details', header: true }],
-                ['✅ PR detected', `#${found.number} (${found.url}) in ${friendlyElapsed} minutes`]
+                ['✅ PR detected', `#${found.number} (${found.url}) in ${friendlyElapsed} minutes`],
+                ['Workflow run', runUrl ? `[${runId}](${runUrl})` : 'Unavailable']
               ]);
             } else {
+              const timeoutDetail = expectedPr
+                ? `Expected PR #${expectedPr} but none detected within ${timeoutMinutes} minute window`
+                : `No PR detected within ${timeoutMinutes} minute window`;
               summary.addTable([
                 [{ data: 'Status', header: true }, { data: 'Details', header: true }],
-                ['⚠️ Timeout', `No PR detected within ${timeoutMinutes} minute window`]
+                ['⚠️ Timeout', timeoutDetail],
+                ['Workflow run', runUrl ? `[${runId}](${runUrl})` : 'Unavailable']
               ]);
             }
             await summary.write();
@@ -137,13 +145,16 @@ jobs:
             const alreadyCommented = (comments || []).some(c => (c.body || '').startsWith(commentPrefix));
 
             if (found) {
-              const body = `${commentPrefix}: Detected PR #${found.number} referencing this issue after ${friendlyElapsed} minute${elapsedMinutes === 1 ? '' : 's'}.\n\nLink: ${found.url}`;
+              const body = `${commentPrefix}: Detected PR #${found.number} referencing this issue after ${friendlyElapsed} minute${elapsedMinutes === 1 ? '' : 's'}.\n\nLink: ${found.url}${runUrl ? `\nWatchdog run: ${runUrl}` : ''}`;
               if (!alreadyCommented) {
                 await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
               }
             } else {
-              const body = `${commentPrefix}: No pull request cross-reference detected for **${agentLabel}** within `
-                + `${timeoutMinutes} minute${timeoutMinutes === 1 ? '' : 's'}.`;
+              let detail = `No pull request cross-reference detected for **${agentLabel}** within ${timeoutMinutes} minute${timeoutMinutes === 1 ? '' : 's'}.`;
+              if (expectedPr) {
+                detail += ` Expected PR #${expectedPr} never appeared.`;
+              }
+              const body = `${commentPrefix}: ${detail}${runUrl ? `\nWatchdog run: ${runUrl}` : ''}`;
               if (!alreadyCommented) {
                 await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
               }


### PR DESCRIPTION
## Summary
* Added `assign-to-agents.yml` to resolve agent labels, assign automation accounts, bootstrap Codex PRs, and dispatch the watchdog workflow when needed.
* Introduced `agent-watchdog.yml` to poll issue timelines for Codex PR cross-references and comment with success or timeout diagnostics.
* Refreshed workflow documentation to highlight the new assigner/watchdog pairing and updated operational guides for Codex automation.
* Enhanced watchdog diagnostics with workflow run links and expected-PR context so timeout comments are precise for maintainers.

## Testing
* ⚠️ `npx actionlint` *(environment issue: npm could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68d061e22f008331a61006a318f5c8b5