### PR TITLE
Add tests for config fallback behaviour

### DIFF
--- a/tests/test_config_models_fallback_unit.py
+++ b/tests/test_config_models_fallback_unit.py
@@ -95,8 +95,8 @@ def test_fallback_config_coerces_portfolio_controls(fallback_models: ModuleType)
             }
         )
     )
-    assert pytest.approx(cfg.portfolio["transaction_cost_bps"]) == 2.5
-    assert pytest.approx(cfg.portfolio["max_turnover"]) == 1.25
+    assert cfg.portfolio["transaction_cost_bps"] == pytest.approx(2.5)
+    assert cfg.portfolio["max_turnover"] == pytest.approx(1.25)
     assert cfg.output is None
     assert cfg.multi_period is None
 


### PR DESCRIPTION
## Summary
- add a dedicated test module that reloads `trend_analysis.config.models` without pydantic installed
- exercise the fallback `Config`, preset helpers, column mapping, and `load`/`load_config` flows including export merging
- stub `validate_trend_config` to capture validation calls and assert base path handling to raise coverage across the module

## Testing
- pytest tests/test_config_models_fallback_unit.py
- coverage run -m pytest tests/test_config_models_additional.py
- coverage run --append -m pytest tests/test_config_models_fallback_unit.py

------
https://chatgpt.com/codex/tasks/task_e_68d07a46872483318939b00af94b80ee