### PR TITLE
Enforce shift-safe signal helpers and causal validation

### DIFF
--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -623,9 +623,9 @@ def load_config(cfg: Mapping[str, Any] | str | Path) -> ConfigProtocol:
     if isinstance(cfg, Mapping):
         cfg_dict = dict(cfg)
         config_obj = Config(**cfg_dict)
-        if _HAS_PYDANTIC:
-            validate_trend_config(cfg_dict, base_path=Path.cwd())
-        return config_obj
+    if _HAS_PYDANTIC:
+        validate_trend_config(cfg_dict, base_path=Path.cwd())
+    return config_obj
     raise TypeError("cfg must be a mapping or path")
 
 

--- a/tests/test_shift_safe_pipeline.py
+++ b/tests/test_shift_safe_pipeline.py
@@ -1,5 +1,3 @@
-import math
-
 import pandas as pd
 import pandas.testing as tm
 from hypothesis import given, settings


### PR DESCRIPTION
## Summary
- implement shift-safe signal generation and sequential positioning helpers in the pipeline
- add deterministic and property-based tests that fail if the helpers read future information
- adjust configuration fallback loader to import validation helpers robustly and skip Pydantic validation when unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d07f8751cc8331906382f2b3bb292a