### PR TITLE
Fix config fallback import and extend coverage

### DIFF
--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -21,22 +21,22 @@ import yaml
 # ``tests.config_models_fallback``) which breaks the relative ``.model`` import.
 # Falling back to the absolute import keeps both the production import path and
 # the isolated test harness working.
+def _fallback_validate_trend_config(_data: Mapping[str, Any], *, base_path: Path) -> None:  # type: ignore[override]
+    return None
+
 try:  # pragma: no cover - exercised indirectly via tests
     from .model import validate_trend_config
 except ImportError:  # pragma: no cover - defensive fallback for test harness
     if sys.modules.get("pydantic") is None:
 
-        def validate_trend_config(_data: Mapping[str, Any], *, base_path: Path) -> dict[str, Any]:  # type: ignore[override]
-            return {}
+        validate_trend_config = _fallback_validate_trend_config
+
 
     else:
         try:
             from trend_analysis.config.model import validate_trend_config
         except ImportError:
-            def validate_trend_config(_data: Mapping[str, Any], *, base_path: Path) -> dict[str, Any]:  # type: ignore[override]
-                return {}
-
-
+            validate_trend_config = _fallback_validate_trend_config
 class ConfigProtocol(Protocol):
     """Type protocol for Config class that works in both Pydantic and fallback
     modes."""

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -26,15 +26,15 @@ try:  # pragma: no cover - exercised indirectly via tests
 except ImportError:  # pragma: no cover - defensive fallback for test harness
     if sys.modules.get("pydantic") is None:
 
-        def validate_trend_config(_data: Mapping[str, Any], *, base_path: Path) -> None:  # type: ignore[override]
-            return None
+        def validate_trend_config(_data: Mapping[str, Any], *, base_path: Path) -> dict[str, Any]:  # type: ignore[override]
+            return {}
 
     else:
         try:
             from trend_analysis.config.model import validate_trend_config
         except ImportError:
-            def validate_trend_config(_data: Mapping[str, Any], *, base_path: Path) -> None:  # type: ignore[override]
-                return None
+            def validate_trend_config(_data: Mapping[str, Any], *, base_path: Path) -> dict[str, Any]:  # type: ignore[override]
+                return {}
 
 
 class ConfigProtocol(Protocol):

--- a/tests/test_config_fallback_additional.py
+++ b/tests/test_config_fallback_additional.py
@@ -199,6 +199,36 @@ def test_load_merges_output_settings(monkeypatch: pytest.MonkeyPatch) -> None:
         sys.modules.pop("tests.config_models_fallback_load", None)
 
 
+def test_load_without_pydantic_when_model_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fallback load should succeed even if the real model module is cached."""
+
+    import trend_analysis.config.model  # noqa: F401 - populate sys.modules
+
+    module = _load_config_module_without_pydantic(
+        monkeypatch, module_name="tests.config_models_fallback_preloaded"
+    )
+    try:
+        payload = {
+            "version": "1.0",
+            "data": {},
+            "preprocessing": {},
+            "vol_adjust": {},
+            "sample_split": {},
+            "portfolio": {},
+            "benchmarks": {},
+            "metrics": {},
+            "export": {},
+            "performance": {},
+            "run": {},
+        }
+
+        cfg = module.load(payload)
+        assert cfg.version == "1.0"
+        assert cfg.export == {}
+    finally:
+        sys.modules.pop("tests.config_models_fallback_preloaded", None)
+
+
 def test_load_preset_missing_file_raises(
     fallback_models: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- guard the configuration fallback import to avoid package resolution errors when tests simulate missing pydantic and ensure a safe shim is provided
- add regression coverage that exercises the fallback loader after the production module has already been imported so the shim is executed in CI

## Testing
- pytest --maxfail=1 --disable-warnings -q

------
https://chatgpt.com/codex/tasks/task_e_68d08222bce08331a02d326a6f773ed5