### PR TITLE
feat(workflows): auto-sync ci status label in merge manager

### DIFF
--- a/.github/workflows/merge-manager.yml
+++ b/.github/workflows/merge-manager.yml
@@ -68,27 +68,17 @@ jobs:
           CI_LABEL_DESIRED: ${{ steps.evaluate.outputs.ci_label_desired }}
         with:
           script: |
-            const prNumber = parseInt(process.env.PR_NUMBER || '0', 10);
-            const labelName = process.env.CI_LABEL_NAME;
-            if (!prNumber || !labelName) {
-              return;
-            }
+            const { syncCiStatusLabel } = require('./.github/scripts/merge_manager.js');
             const { owner, repo } = context.repo;
-            const desired = process.env.CI_LABEL_DESIRED === 'true';
-            const present = process.env.CI_LABEL_PRESENT === 'true';
-            if (desired && !present) {
-              await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: [labelName] });
-              return;
-            }
-            if (!desired && present) {
-              try {
-                await github.rest.issues.removeLabel({ owner, repo, issue_number: prNumber, name: labelName });
-              } catch (error) {
-                if (error.status !== 404) {
-                  throw error;
-                }
-              }
-            }
+            await syncCiStatusLabel({
+              github,
+              owner,
+              repo,
+              prNumber: parseInt(process.env.PR_NUMBER || '0', 10),
+              labelName: process.env.CI_LABEL_NAME,
+              desired: process.env.CI_LABEL_DESIRED === 'true',
+              present: process.env.CI_LABEL_PRESENT === 'true',
+            });
 
       - name: Quiet & workflow gate
         if: steps.evaluate.outputs.should_run == 'true'

--- a/.github/workflows/merge-manager.yml
+++ b/.github/workflows/merge-manager.yml
@@ -58,6 +58,38 @@ jobs:
               },
             });
 
+      - name: Sync CI status label
+        if: steps.evaluate.outputs.pr_number != ''
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.evaluate.outputs.pr_number }}
+          CI_LABEL_NAME: ${{ vars.CI_LABEL || 'ci:green' }}
+          CI_LABEL_PRESENT: ${{ steps.evaluate.outputs.ci_label }}
+          CI_LABEL_DESIRED: ${{ steps.evaluate.outputs.ci_label_desired }}
+        with:
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER || '0', 10);
+            const labelName = process.env.CI_LABEL_NAME;
+            if (!prNumber || !labelName) {
+              return;
+            }
+            const { owner, repo } = context.repo;
+            const desired = process.env.CI_LABEL_DESIRED === 'true';
+            const present = process.env.CI_LABEL_PRESENT === 'true';
+            if (desired && !present) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: [labelName] });
+              return;
+            }
+            if (!desired && present) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: prNumber, name: labelName });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
       - name: Quiet & workflow gate
         if: steps.evaluate.outputs.should_run == 'true'
         id: quiet
@@ -149,6 +181,10 @@ jobs:
           FROM_LABEL: ${{ steps.evaluate.outputs.from_label }}
           RISK_LABEL: ${{ steps.evaluate.outputs.risk_label }}
           CI_LABEL: ${{ steps.evaluate.outputs.ci_label }}
+          CI_GREEN: ${{ steps.evaluate.outputs.ci_green }}
+          CI_PENDING: ${{ steps.evaluate.outputs.ci_pending }}
+          CI_FAILING: ${{ steps.evaluate.outputs.ci_failing }}
+          CI_SIGNAL: ${{ steps.evaluate.outputs.ci_signal }}
           QUIET_AVAILABLE: ${{ steps.quiet.outputs.proceed != '' }}
           QUIET_OK: ${{ steps.quiet.outputs.quiet_ok }}
           ACTIVE_OK: ${{ steps.quiet.outputs.active_ok }}
@@ -192,8 +228,16 @@ jobs:
               if (process.env.RISK_LABEL !== 'true') {
                 reasons.push('the `risk:low` label is missing');
               }
-              if (process.env.CI_LABEL !== 'true') {
-                reasons.push('the `ci:green` label is missing');
+              if (process.env.CI_GREEN !== 'true') {
+                if (process.env.CI_PENDING === 'true') {
+                  reasons.push('required CI checks are still running');
+                } else if (process.env.CI_FAILING === 'true') {
+                  reasons.push('one or more required CI checks have failed');
+                } else if (process.env.CI_SIGNAL !== 'true') {
+                  reasons.push('required CI checks have not reported results yet');
+                } else {
+                  reasons.push('required CI checks have not completed successfully');
+                }
               }
               if (process.env.QUIET_AVAILABLE === 'true') {
                 if (process.env.QUIET_OK !== 'true') {
@@ -279,6 +323,38 @@ jobs:
               },
             });
 
+      - name: Sync CI status label
+        if: steps.evaluate_post.outputs.pr_number != ''
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.evaluate_post.outputs.pr_number }}
+          CI_LABEL_NAME: ${{ vars.CI_LABEL || 'ci:green' }}
+          CI_LABEL_PRESENT: ${{ steps.evaluate_post.outputs.ci_label }}
+          CI_LABEL_DESIRED: ${{ steps.evaluate_post.outputs.ci_label_desired }}
+        with:
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER || '0', 10);
+            const labelName = process.env.CI_LABEL_NAME;
+            if (!prNumber || !labelName) {
+              return;
+            }
+            const { owner, repo } = context.repo;
+            const desired = process.env.CI_LABEL_DESIRED === 'true';
+            const present = process.env.CI_LABEL_PRESENT === 'true';
+            if (desired && !present) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: [labelName] });
+              return;
+            }
+            if (!desired && present) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: prNumber, name: labelName });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
       - name: Quiet & workflow gate
         if: steps.evaluate_post.outputs.should_run == 'true'
         id: quiet_post
@@ -348,6 +424,10 @@ jobs:
           FROM_LABEL: ${{ steps.evaluate_post.outputs.from_label }}
           RISK_LABEL: ${{ steps.evaluate_post.outputs.risk_label }}
           CI_LABEL: ${{ steps.evaluate_post.outputs.ci_label }}
+          CI_GREEN: ${{ steps.evaluate_post.outputs.ci_green }}
+          CI_PENDING: ${{ steps.evaluate_post.outputs.ci_pending }}
+          CI_FAILING: ${{ steps.evaluate_post.outputs.ci_failing }}
+          CI_SIGNAL: ${{ steps.evaluate_post.outputs.ci_signal }}
           QUIET_AVAILABLE: ${{ steps.quiet_post.outputs.proceed != '' }}
           QUIET_OK: ${{ steps.quiet_post.outputs.quiet_ok }}
           ACTIVE_OK: ${{ steps.quiet_post.outputs.active_ok }}
@@ -391,8 +471,16 @@ jobs:
               if (process.env.RISK_LABEL !== 'true') {
                 reasons.push('the `risk:low` label is missing');
               }
-              if (process.env.CI_LABEL !== 'true') {
-                reasons.push('the `ci:green` label is missing');
+              if (process.env.CI_GREEN !== 'true') {
+                if (process.env.CI_PENDING === 'true') {
+                  reasons.push('required CI checks are still running');
+                } else if (process.env.CI_FAILING === 'true') {
+                  reasons.push('one or more required CI checks have failed');
+                } else if (process.env.CI_SIGNAL !== 'true') {
+                  reasons.push('required CI checks have not reported results yet');
+                } else {
+                  reasons.push('required CI checks have not completed successfully');
+                }
               }
               if (process.env.QUIET_AVAILABLE === 'true') {
                 if (process.env.QUIET_OK !== 'true') {

--- a/WORKFLOW_AUDIT_TEMP.md
+++ b/WORKFLOW_AUDIT_TEMP.md
@@ -55,7 +55,7 @@ Update: `cleanup-codex-bootstrap.yml` confirmed – prunes stale `agents/codex-i
 - `reuse-autofix.yml` – (Already listed; cross-category usage as building block.)
 
 ### 8. Governance / Policy Enforcement
-- `merge-manager.yml` – Approves and enables auto-merge when allowlist, label, and quiet-period gates pass.
+- `merge-manager.yml` – Approves and enables auto-merge when allowlist, label, quiet-period, and CI status gates pass (auto-syncs the `ci:green` label).
 - `label-agent-prs.yml` – Applies standardized agent labels (pull_request_target hardened).
 - `guard-no-reuse-pr-branches.yml` (ARCHIVED 2025-09-20) – Former branch reuse enforcement; policy-only now.
 - `pr-path-labeler.yml` – Path‑based labeling for PR taxonomy.

--- a/docs/ops/codex-bootstrap-facts.md
+++ b/docs/ops/codex-bootstrap-facts.md
@@ -93,6 +93,7 @@ This catalog explains what each active workflow does, how it’s triggered, the 
    - Jobs: `manage-on-pr-event`, `manage-post-status`
      - Validates allowlist patterns and change size before auto-approving eligible PRs.
      - Enforces label, quiet-period, and active-workflow gates before enabling squash auto-merge.
+     - Synchronizes the `ci:green` label with actual check status so pending/failing runs pause automation with a single status comment.
      - Posts (and updates) a single status comment when automation is paused, explaining the blocking condition.
 
 <a id="wf-guard-no-reuse"></a>

--- a/docs/ops/smoke-automerge-2.md
+++ b/docs/ops/smoke-automerge-2.md
@@ -5,4 +5,4 @@ This second smoke test file validates that labeler → merge-manager (approve + 
 Expectations:
 - Branch naming (agents/codex-*) triggers from:codex + agent:codex + automerge + risk:low labels.
 - Merge manager approves this docs-only PR.
-- Merge manager enables squash merging and merges once checks pass.
+- Merge manager enables squash merging and merges once checks pass, updating the `ci:green` label automatically when gates clear.

--- a/docs/ops/smoke-automerge.md
+++ b/docs/ops/smoke-automerge.md
@@ -8,4 +8,4 @@ This file exists solely to exercise the labeler and the unified merge-manager wo
 Runbook:
 - Labeler should add `from:codex`, `agent:codex`, `automerge`, and `risk:low` based on branch naming.
 - Merge manager should approve this PR if patterns and size are within thresholds.
-- Merge manager should enable squash auto-merge and merge after checks pass.
+- Merge manager should enable squash auto-merge and merge after checks pass, auto-syncing the `ci:green` label once runs finish.

--- a/docs/ops/template-setup.md
+++ b/docs/ops/template-setup.md
@@ -54,6 +54,7 @@ Security posture: The `pull_request_target` workflows in this template do not ch
 
 - The merge-manager workflow evaluates labels, file-change constraints, and quiet-period rules before approving and enabling auto-merge.
 - Customize labels via variables above. Adjust approvable file patterns and size cap via `APPROVE_PATTERNS` and `MAX_LINES_CHANGED`.
+- The workflow now toggles the `ci:green` label automatically to mirror real check status; no manual relabeling is needed after CI reruns.
 - Auto-merge uses squash by default; change the merge method in the workflow if desired.
 
 ## 6. Docker Workflow


### PR DESCRIPTION
## Summary
* Consolidated the legacy approval and auto-merge flows into a single `merge-manager` workflow that evaluates allowlists, enforces quiet-period gates, and maintains status comments while auto-approving and enabling merges for eligible PRs.
* Added a reusable helper module to load the approval allowlist, compute merge eligibility, and manage merge-manager status comments.
* Updated operational documentation and smoke tests to reference the merge-manager workflow and its behavior across setup guides, catalogs, and verification files.
* Synced the CI gate with actual check status by deriving readiness from check runs, auto-toggling the `ci:green` label, and extending rationale comments when runs are pending or failing.

## Testing
* not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d0962eb03883318a117efb4e42669c