### PR TITLE
Add smoke test coverage for API server entrypoint

### DIFF
--- a/tests/test_api_server_entrypoint.py
+++ b/tests/test_api_server_entrypoint.py
@@ -1,16 +1,27 @@
 from __future__ import annotations
 
 import runpy
+import sys
 
 
 def test_api_server_entrypoint_invokes_run(monkeypatch):
-    called = {}
+    """Executing the module as ``python -m`` should call ``run`` with the CLI defaults."""
+
+    called: dict[str, object] = {}
 
     def fake_run(*, host: str, port: int) -> None:
         called["host"] = host
         called["port"] = port
 
+    # Patch both the package-level reference and any cached attribute on the
+    # ``__main__`` module so the smoke test stays robust even if the module was
+    # imported earlier in the test session.
     monkeypatch.setattr("trend_analysis.api_server.run", fake_run)
+    monkeypatch.setattr("trend_analysis.api_server.__main__.run", fake_run, raising=False)
+
+    # Ensure ``run_module`` loads a fresh module instance so coverage captures
+    # the ``__main__`` guard without runtime warnings about cached modules.
+    sys.modules.pop("trend_analysis.api_server.__main__", None)
 
     runpy.run_module("trend_analysis.api_server.__main__", run_name="__main__")
 


### PR DESCRIPTION
## Summary
- harden the FastAPI entrypoint smoke test so it patches both the package and module level run hook
- reset any cached __main__ module before execution to exercise the CLI branch without warnings

## Testing
- pytest tests/test_api_server_entrypoint.py

------
https://chatgpt.com/codex/tasks/task_e_68d0b4ae978c8331bb0731f4141cab94