### PR TITLE
Coverage soft-gate: file/update a single “Increase test coverage” issue instead of failing PRs - Source Issue #1417

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
       enable-history: 'false'
       enable-classification: 'false'
       enable-coverage-delta: 'false'
-      enable-soft-gate: 'false'
+      enable-soft-gate: 'true'
+      coverage-hard-fail: 'false'
   gate:
     name: gate / all-required-green
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-status-summary.yml
+++ b/.github/workflows/pr-status-summary.yml
@@ -20,6 +20,28 @@ jobs:
       github.event.workflow_run.pull_requests[0].number
     runs-on: ubuntu-latest
     steps:
+      - name: Download coverage summary artifact
+        id: dl_coverage
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: coverage-summary
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: coverage-summary
+      - name: Capture coverage summary content
+        id: coverage
+        shell: bash
+        run: |
+          set -euo pipefail
+          FILE="coverage-summary/coverage_summary.md"
+          if [ -f "$FILE" ]; then
+            {
+              echo 'body<<EOF'
+              cat "$FILE"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
       - name: Prepare summary body
         id: prep
         uses: actions/github-script@v7
@@ -77,6 +99,7 @@ jobs:
                 return `| ${jobName} | ${b} ${state} | [logs](${j.html_url}) |`;
               });
 
+            const coverageSection = (process.env.COVERAGE_SECTION || '').trim();
             const body = [
               '### Automated Status Summary',
               `**Workflow Run:** ${run.name} (#${run.id})`,
@@ -87,11 +110,14 @@ jobs:
               '|-----|--------|------|',
               ...rows,
               '',
+              ...(coverageSection ? ['### Coverage (soft gate)', coverageSection, ''] : []),
               '_Updated automatically; will refresh on subsequent CI/Docker completions._'
             ].join('\n');
 
             core.setOutput('body', body);
             core.setOutput('pr_number', pr.number);
+        env:
+          COVERAGE_SECTION: ${{ steps.coverage.outputs.body }}
       - name: Upsert summary comment
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/reusable-ci-python.yml
+++ b/.github/workflows/reusable-ci-python.yml
@@ -265,6 +265,12 @@ jobs:
           with open('coverage_summary.md','w') as w:
               w.write("\n".join(lines)+"\n")
           print('\n'.join(lines[:6])+'\n...')
+      - name: Upload coverage summary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-summary
+          retention-days: ${{ inputs.coverage-artifact-retention-days }}
+          path: coverage_summary.md
       - name: Build job log links table
         id: jobs
         uses: actions/github-script@v7
@@ -343,6 +349,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-trend
+          retention-days: ${{ inputs.coverage-artifact-retention-days }}
           path: coverage-trend.json
       - name: Download existing coverage trend history (if any)
         uses: actions/download-artifact@v4
@@ -367,6 +374,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-trend-history
+          retention-days: ${{ inputs.coverage-artifact-retention-days }}
           path: coverage-trend-history.ndjson
 
   # Universal logs summary (Issue #1344)


### PR DESCRIPTION
## Pull Request Overview

This PR creates a bootstrap file for implementing a coverage soft-gate system that will replace failing PRs with a single tracking issue for coverage improvements. The change addresses issue #1417 by creating a foundation for a new workflow that will analyze test coverage, identify hotspots, and maintain a single "Increase test coverage" issue instead of blocking PR merges.

- Creates initial bootstrap file for coverage soft-gate implementation
- Establishes foundation for issue #1417 tracking system
- Prepares for workflow implementation that will handle coverage reporting without blocking merges

### Follow-up updates
- Enables the soft-gate workflow in CI while disabling hard coverage failures so the gate remains advisory.
- Persists the generated coverage summary as an artifact and injects it into the automated PR status summary alongside hotspot details.


------
https://chatgpt.com/codex/tasks/task_e_68d0c02277b483319bae327e53448543