### PR TITLE
test: expand coverage for optimizer, pipeline, and config fallbacks

### DIFF
--- a/tests/test_multi_period_engine_price_frames_extra.py
+++ b/tests/test_multi_period_engine_price_frames_extra.py
@@ -41,6 +41,15 @@ def test_run_price_frames_requires_mapping() -> None:
         mp_engine.run(cfg, df=df, price_frames="not-a-mapping")
 
 
+def test_run_price_frames_enforces_dataframe_members() -> None:
+    cfg = DummyCfg()
+    df = pd.DataFrame({"Date": pd.to_datetime(["2020-01-31"])})
+    bad_frames = {"2020-01": [1, 2, 3]}
+
+    with pytest.raises(TypeError, match="must be a pandas DataFrame"):
+        mp_engine.run(cfg, df=df, price_frames=bad_frames)
+
+
 def test_run_price_frames_validate_columns() -> None:
     cfg = DummyCfg()
     df = pd.DataFrame({"Date": pd.to_datetime(["2020-01-31"])})
@@ -48,6 +57,13 @@ def test_run_price_frames_validate_columns() -> None:
 
     with pytest.raises(ValueError, match="missing required columns"):
         mp_engine.run(cfg, df=df, price_frames=bad_frames)
+
+
+def test_run_price_frames_rejects_empty_mapping() -> None:
+    cfg = DummyCfg()
+
+    with pytest.raises(ValueError, match="price_frames is empty"):
+        mp_engine.run(cfg, df=None, price_frames={})
 
 
 def test_run_price_frames_combines_and_sorts(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_optimizer_constraints_additional.py
+++ b/tests/test_optimizer_constraints_additional.py
@@ -63,3 +63,34 @@ def test_apply_constraints_rescales_weights_with_cash_and_cap() -> None:
     # The residual capital should respect the max_weight constraint and maintain order.
     assert (result.drop("CASH") <= 0.6 + 1e-9).all()
     pd.testing.assert_index_equal(result.index, pd.Index(["Asset1", "Asset2", "CASH"]))
+
+
+@pytest.mark.parametrize("cash_weight", [0.0, 1.0, -0.1, 1.5])
+def test_apply_constraints_rejects_invalid_cash_weight(cash_weight: float) -> None:
+    """Values outside ``(0, 1)`` should be rejected before any rescaling."""
+
+    weights = pd.Series({"A": 1.0, "B": 2.0})
+
+    with pytest.raises(
+        ConstraintViolation, match=r"cash_weight must be in \(0,1\) exclusive"
+    ):
+        apply_constraints(weights, ConstraintSet(cash_weight=cash_weight))
+
+
+def test_apply_constraints_reapplies_cap_after_group_redistribution() -> None:
+    """Redistribution from group caps should still honour the individual max weight."""
+
+    # Skewed starting weights force substantial redistribution after applying the
+    # group cap.  ``max_weight`` must be reapplied to keep the non-capped assets
+    # within bounds once they receive the excess allocation.
+    weights = pd.Series({"A": 9.0, "B": 0.5, "C": 0.5})
+    constraints = ConstraintSet(
+        max_weight=0.35,
+        group_caps={"G1": 0.15},
+        groups={"A": "G1", "B": "G2", "C": "G2"},
+    )
+
+    result = apply_constraints(weights, constraints)
+
+    assert pytest.approx(float(result.sum()), rel=1e-9) == 1.0
+    assert (result <= 0.35 + 1e-9).all()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -186,6 +186,12 @@ class TestLoadAndValidateUpload:
             load_and_validate_upload("no_such_file.csv")
         assert "File not found" in str(exc_info.value)
 
+    def test_nonexistent_excel_file_raises(self):
+        with pytest.raises(ValueError) as exc_info:
+            load_and_validate_upload("missing.xlsx")
+
+        assert "File not found" in str(exc_info.value)
+
     def test_permission_error_raises(self, monkeypatch):
         def fake_read_csv(*args, **kwargs):  # pragma: no cover - patched
             raise PermissionError
@@ -193,6 +199,20 @@ class TestLoadAndValidateUpload:
         monkeypatch.setattr(pd, "read_csv", fake_read_csv)
         with pytest.raises(ValueError) as exc_info:
             load_and_validate_upload("test.csv")
+        assert "Permission denied" in str(exc_info.value)
+
+    def test_excel_permission_error_raises(self, monkeypatch):
+        buf = io.BytesIO(b"dummy")
+        buf.name = "protected.xlsx"
+
+        def fake_read_excel(*args, **kwargs):  # pragma: no cover - patched
+            raise PermissionError
+
+        monkeypatch.setattr(pd, "read_excel", fake_read_excel)
+
+        with pytest.raises(ValueError) as exc_info:
+            load_and_validate_upload(buf)
+
         assert "Permission denied" in str(exc_info.value)
 
     def test_directory_path_error(self):


### PR DESCRIPTION
## Summary
- add defensive cash-weight and redistribution tests for the optimizer constraints guard rails
- extend multi-period engine coverage for price-frame validation and incremental covariance fallback behaviour
- exercise optional pipeline paths including AvgCorr metrics, NA gap policy, constraint fallback, and benchmark IR error handling while tightening config and upload validator checks

## Testing
- `PYTHONPATH=src pytest tests/test_optimizer_constraints_additional.py tests/test_multi_period_engine_price_frames_extra.py tests/test_multi_period_engine_incremental_extra.py tests/test_na_as_zero_policy.py tests/test_pipeline.py tests/test_trend_config_model_negative_paths.py tests/test_config_models_additional.py tests/test_validators.py`


------
https://chatgpt.com/codex/tasks/task_e_68d0d0e5917083318302eea183818253