### PR TITLE
PR summary: add authoritative table with per‑job log links - Source Issue #1418

### DIFF
--- a/.github/workflows/reuse-ci-python.yml
+++ b/.github/workflows/reuse-ci-python.yml
@@ -336,11 +336,20 @@ jobs:
             core.info('Injected coverage summary into unified PR comment');
       - name: Append run summary
         if: always()
+        env:
+          LOG_TABLE: ${{ steps.jobs.outputs.table }}
         run: |
           {
             echo "### Coverage Soft Gate"
             cat coverage_summary.md
             echo ""
+            if [ -n "$LOG_TABLE" ]; then
+              printf '%s\n' "$LOG_TABLE"
+              echo ""
+            else
+              echo "_No workflow jobs found to report._"
+              echo ""
+            fi
           } >> $GITHUB_STEP_SUMMARY
   remove-green-on-fail:
     name: strip ci:green on failure

--- a/.github/workflows/reuse-ci-python.yml
+++ b/.github/workflows/reuse-ci-python.yml
@@ -220,10 +220,70 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const run_id = context.runId;
-            const { data } = await github.rest.actions.listJobsForWorkflowRun({ owner, repo, run_id, per_page: 100 });
-            const rows = data.jobs.map(j => `| ${j.name} | ${j.conclusion || j.status} | [logs](${j.html_url}) |`);
-            const md = ["### Logs for this run","| Job | Result | Logs |","|---|---|---|",...rows].join("\n");
+            const jobs = [];
+            let page = 1;
+            while (true) {
+              const resp = await github.rest.actions.listJobsForWorkflowRun({ owner, repo, run_id, per_page: 100, page });
+              const pageJobs = resp.data.jobs || [];
+              jobs.push(...pageJobs);
+              const link = resp.headers.link || '';
+              if (!link.includes('rel="next"')) {
+                break;
+              }
+              page += 1;
+            }
+
+            const normalise = (value) => {
+              if (!value) return 'in_progress';
+              return String(value).toLowerCase();
+            };
+
+            const badge = (state) => {
+              switch (state) {
+                case 'success':
+                  return '✅';
+                case 'failure':
+                case 'timed_out':
+                case 'cancelled':
+                  return '❌';
+                case 'skipped':
+                  return '⏭️';
+                default:
+                  return '⏳';
+              }
+            };
+
+            const formatState = (state) => {
+              return state
+                .split('_')
+                .map(segment => segment ? segment.charAt(0).toUpperCase() + segment.slice(1) : segment)
+                .join(' ');
+            };
+
+            const rows = jobs
+              .slice()
+              .sort((a, b) => {
+                const aStart = a.started_at ? Date.parse(a.started_at) : 0;
+                const bStart = b.started_at ? Date.parse(b.started_at) : 0;
+                if (aStart !== bStart) return aStart - bStart;
+                return a.name.localeCompare(b.name);
+              })
+              .map(job => {
+                const state = normalise(job.conclusion || job.status);
+                const label = formatState(state);
+                const prefix = badge(state);
+                return `| ${job.name} | ${prefix} ${label} | [logs](${job.html_url}) |`;
+              });
+
+            const mdLines = [
+              '### Logs for this run',
+              '| Job | Result | Logs |',
+              '|-----|--------|------|',
+              ...(rows.length ? rows : ['| _No jobs found_ |  |  |'])
+            ];
+            const md = mdLines.join('\n');
             core.setOutput('table', md);
+
       - name: Create or update coverage issue
         id: issue
         uses: actions/github-script@v7
@@ -277,10 +337,11 @@ jobs:
       - name: Append run summary
         if: always()
         run: |
-          echo "### Coverage Soft Gate" >> $GITHUB_STEP_SUMMARY
-          cat coverage_summary.md >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.jobs.outputs.table }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### Coverage Soft Gate"
+            cat coverage_summary.md
+            echo ""
+          } >> $GITHUB_STEP_SUMMARY
   remove-green-on-fail:
     name: strip ci:green on failure
     runs-on: ubuntu-latest

--- a/agents/codex-1418.md
+++ b/agents/codex-1418.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1418 -->


### PR DESCRIPTION
### Source Issue #1418: PR summary: add authoritative table with per‑job log links

Source: https://github.com/stranske/Trend_Model_Project/issues/1418

> Topic GUID: f5ba1367-228b-52db-b29b-11ee75bf805f
> 
> ## Why
> Sometimes jobs are missing from your current summary. Use the Actions API for the current run and link each job’s logs directly.
> 
> Scope
> 
> In the CI (or gate) workflow, after dependencies complete, enumerate jobs for the current run and write: Job | Result | [logs].
> 
> ## Tasks
> Add a github-script step calling actions.listJobsForWorkflowRun and write a markdown table to $GITHUB_STEP_SUMMARY.
> 
>  Include matrix jobs as separate rows.
> 
> ## Acceptance criteria
> Every CI run shows a complete log table; failures deep‑link to the correct page.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/17889706220).

—
(After opening the PR, comment with `@codex start`.)