### PR TITLE
test: extend coverage for optimizer and multi-period guard rails

### DIFF
--- a/tests/test_multi_period_engine_price_frames.py
+++ b/tests/test_multi_period_engine_price_frames.py
@@ -77,6 +77,18 @@ def test_run_rejects_empty_price_frames_collection() -> None:
         mp_engine.run(cfg, price_frames={})
 
 
+def test_run_reports_available_columns_when_date_missing() -> None:
+    cfg = DummyConfig()
+    bad_frame = pd.DataFrame({"Close": [1.0], "Open": [0.9]})
+
+    with pytest.raises(ValueError) as excinfo:
+        mp_engine.run(cfg, price_frames={"2020-01-31": bad_frame})
+
+    message = str(excinfo.value)
+    assert "Available columns" in message
+    assert "Close" in message and "Open" in message
+
+
 def test_run_combines_price_frames_and_invokes_analysis(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_pipeline_optional_features.py
+++ b/tests/test_pipeline_optional_features.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from trend_analysis.core import rank_selection as rank_selection_mod
 from trend_analysis.core.rank_selection import RiskStatsConfig
 from trend_analysis.engine import optimizer as optimizer_mod
 from trend_analysis import pipeline
@@ -56,6 +57,35 @@ def test_single_period_run_injects_avg_corr_metric() -> None:
     assert score_frame["AvgCorr"].notna().all()
 
 
+def test_single_period_run_swallows_avg_corr_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2020-01-31", "2020-02-29", "2020-03-31"]),
+            "FundA": [0.02, 0.01, 0.015],
+            "FundB": [0.01, 0.012, 0.011],
+        }
+    )
+
+    class StatsCfg(RiskStatsConfig):
+        def __init__(self) -> None:
+            super().__init__()
+            self.extra_metrics = ["AvgCorr"]
+
+    stats_cfg = StatsCfg()
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("avg corr failure")
+
+    monkeypatch.setattr(rank_selection_mod, "compute_metric_series_with_cache", boom)
+
+    score_frame = pipeline.single_period_run(
+        df, "2020-01", "2020-03", stats_cfg=stats_cfg
+    )
+
+    # Failure of the optional metric should not prevent the base metrics from materialising.
+    assert set(score_frame.columns) == set(stats_cfg.metrics_to_run)
+
+
 def test_run_analysis_na_tolerant_filtering_preserves_funds() -> None:
     df = _base_returns_frame()
     stats_cfg = RiskStatsConfig()
@@ -84,6 +114,35 @@ def test_run_analysis_na_tolerant_filtering_preserves_funds() -> None:
 
     assert result is not None
     assert "FundA" in result["selected_funds"]
+
+
+def test_run_analysis_na_tolerant_filtering_drops_excessive_gaps() -> None:
+    df = _base_returns_frame()
+    stats_cfg = RiskStatsConfig()
+    setattr(
+        stats_cfg,
+        "na_as_zero_cfg",
+        {
+            "enabled": True,
+            "max_missing_per_window": 0,
+            "max_consecutive_gap": 0,
+        },
+    )
+
+    result = pipeline._run_analysis(
+        df,
+        "2020-01",
+        "2020-02",
+        "2020-03",
+        "2020-04",
+        target_vol=1.0,
+        monthly_cost=0.0,
+        stats_cfg=stats_cfg,
+        indices_list=["Benchmark"],
+        benchmarks={"SPX": "Benchmark"},
+    )
+
+    assert result is None or "FundA" not in (result or {}).get("selected_funds", [])
 
 
 def test_run_analysis_constraint_failure_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -160,3 +219,42 @@ def test_run_analysis_benchmark_ir_best_effort(monkeypatch: pytest.MonkeyPatch) 
     # Fallback path should skip enriching the portfolio-level IR keys.
     assert "equal_weight" not in ir_payload
     assert "user_weight" not in ir_payload
+
+
+def test_run_analysis_benchmark_ir_handles_scalar_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = _clean_returns_frame()
+    stats_cfg = RiskStatsConfig()
+
+    calls: list[str] = []
+
+    original_ir = pipeline.information_ratio
+
+    def scalar_information_ratio(a, b):
+        calls.append(type(a).__name__)
+        if isinstance(a, pd.DataFrame):
+            return 0.42
+        return original_ir(a, b)
+
+    monkeypatch.setattr(pipeline, "information_ratio", scalar_information_ratio)
+
+    result = pipeline._run_analysis(
+        df,
+        "2020-01",
+        "2020-02",
+        "2020-03",
+        "2020-04",
+        target_vol=1.0,
+        monthly_cost=0.0,
+        stats_cfg=stats_cfg,
+        custom_weights={"FundA": 60.0, "FundB": 40.0},
+        indices_list=["Benchmark"],
+        benchmarks={"SPX": "Benchmark"},
+    )
+
+    assert result is not None
+    ir_payload = result["benchmark_ir"].get("SPX", {})
+    # Scalar response should yield a mapping entry for at least the first selected fund.
+    assert "FundA" in ir_payload
+    assert "FundB" not in ir_payload
+    # Ensure follow-up portfolio enrichment ran (calls include Series for eq/user paths).
+    assert "Series" in calls


### PR DESCRIPTION
## Summary
- add optimizer cash-weight guard rail scenarios covering mapping inputs and post-redistribution caps
- extend multi-period engine price-frame validation and incremental covariance fallback coverage
- exercise pipeline optional paths for AvgCorr failures, NA-tolerant filtering dropouts, and scalar benchmark IR enrichment

## Testing
- pytest tests/test_optimizer_constraints_additional.py tests/test_multi_period_engine_price_frames.py tests/test_multi_period_engine_incremental_cov.py tests/test_pipeline_optional_features.py

------
https://chatgpt.com/codex/tasks/task_e_68d0f250c3d88331b5fe9e09b0d6bdef