### PR TITLE
Follow-up: Append workflow job table to run summary

### DIFF
--- a/.github/workflows/reuse-ci-python.yml
+++ b/.github/workflows/reuse-ci-python.yml
@@ -336,11 +336,20 @@ jobs:
             core.info('Injected coverage summary into unified PR comment');
       - name: Append run summary
         if: always()
+        env:
+          LOG_TABLE: ${{ steps.jobs.outputs.table }}
         run: |
           {
             echo "### Coverage Soft Gate"
             cat coverage_summary.md
             echo ""
+            if [ -n "$LOG_TABLE" ]; then
+              printf '%s\n' "$LOG_TABLE"
+              echo ""
+            else
+              echo "_No workflow jobs found to report._"
+              echo ""
+            fi
           } >> $GITHUB_STEP_SUMMARY
   remove-green-on-fail:
     name: strip ci:green on failure


### PR DESCRIPTION
## Summary
- export the generated per-job logs table from the github-script step to the run summary environment
- append the logs table (or a fallback message) alongside the coverage section in the workflow run summary so every CI run shows the authoritative log links

## Testing
- pytest tests/test_workflow_codex_issue_bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68d0f578a6d48331b12c64b345ae2ae4