### PR TITLE
feat: persist cached rolling metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "hypothesis",
     "matplotlib",
     "ipywidgets",
+    "joblib>=1.4",
     "scipy",
 ]
 

--- a/requirements.lock
+++ b/requirements.lock
@@ -30,6 +30,8 @@ ipywidgets==8.1.7
     # via trend-model (pyproject.toml)
 jedi==0.19.2
     # via ipython
+joblib==1.4.2
+    # via trend-model (pyproject.toml)
 jupyterlab-widgets==3.0.15
     # via ipywidgets
 kiwisolver==1.4.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ PyYAML
 hypothesis
 matplotlib
 ipywidgets
+joblib>=1.4
 nbformat
 streamlit>=1.30
 streamlit-sortables

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -19,6 +19,7 @@ from .api import run_simulation
 from .config import load_config
 from .constants import DEFAULT_OUTPUT_DIRECTORY, DEFAULT_OUTPUT_FORMATS
 from .data import load_csv
+from .perf.rolling_cache import set_cache_enabled
 
 APP_PATH = Path(__file__).resolve().parents[2] / "streamlit_app" / "app.py"
 LOCK_PATH = Path(__file__).resolve().parents[2] / "requirements.lock"
@@ -158,6 +159,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Disable structured JSONL logging for this run",
     )
+    run_p.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Disable persistent caching for rolling computations",
+    )
 
     # Handle --check flag before parsing subcommands
     # This allows --check to work without requiring a subcommand
@@ -183,6 +189,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "run":
         cfg = load_config(args.config)
+        set_cache_enabled(not args.no_cache)
         cli_seed = args.seed
         env_seed = os.getenv("TREND_SEED")
         # Precedence: CLI flag > TREND_SEED > config.seed > default 42

--- a/src/trend_analysis/metrics/rolling.py
+++ b/src/trend_analysis/metrics/rolling.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import pandas as pd
 
+from ..perf.rolling_cache import compute_dataset_hash, get_cache
+
 
 def rolling_information_ratio(
     returns: pd.Series,
@@ -28,18 +30,38 @@ def rolling_information_ratio(
         Rolling information ratio named ``rolling_ir``.
     """
 
+    base_returns = returns.astype(float)
     if benchmark is None:
-        bench = pd.Series(0.0, index=returns.index)
+        bench = pd.Series(0.0, index=base_returns.index)
     elif isinstance(benchmark, pd.Series):
-        bench = benchmark.reindex_like(returns).fillna(0.0)
+        bench = benchmark.reindex_like(base_returns).fillna(0.0)
     else:
-        bench = pd.Series(float(benchmark), index=returns.index)
+        bench = pd.Series(float(benchmark), index=base_returns.index)
 
-    excess = returns - bench
-    mean = excess.rolling(window).mean()
-    std = excess.rolling(window).std(ddof=1)
-    ir = mean / std.replace(0.0, pd.NA)
-    return ir.rename("rolling_ir")
+    cache = get_cache()
+
+    def _compute() -> pd.Series:
+        excess = base_returns - bench
+        mean = excess.rolling(window).mean()
+        std = excess.rolling(window).std(ddof=1)
+        ir = mean / std.replace(0.0, pd.NA)
+        return ir.rename("rolling_ir")
+
+    if cache.is_enabled():
+        dataset_hash = compute_dataset_hash([base_returns, bench])
+        idx = base_returns.index
+        if hasattr(idx, "freqstr") and idx.freqstr:
+            freq = str(idx.freqstr)
+        else:
+            try:
+                freq = pd.infer_freq(idx)
+            except (ValueError, TypeError):
+                freq = None
+        freq_tag = freq or "unknown"
+        method_tag = "rolling_information_ratio_ddof1"
+        return cache.get_or_compute(dataset_hash, int(window), freq_tag, method_tag, _compute)
+
+    return _compute()
 
 
 __all__ = ["rolling_information_ratio"]

--- a/src/trend_analysis/metrics/rolling.py
+++ b/src/trend_analysis/metrics/rolling.py
@@ -30,7 +30,7 @@ def rolling_information_ratio(
         Rolling information ratio named ``rolling_ir``.
     """
 
-    base_returns = returns.astype(float)
+    base_returns = returns
     if benchmark is None:
         bench = pd.Series(0.0, index=base_returns.index)
     elif isinstance(benchmark, pd.Series):

--- a/src/trend_analysis/perf/rolling_cache.py
+++ b/src/trend_analysis/perf/rolling_cache.py
@@ -12,9 +12,24 @@ import pandas as pd
 from joblib import dump, load
 from pandas.util import hash_pandas_object
 
-_DEFAULT_CACHE_DIR = Path(os.getenv("TREND_ROLLING_CACHE", "~/.cache/trend_model/rolling"))
+def _get_default_cache_dir() -> Path:
+    env_path = os.getenv("TREND_ROLLING_CACHE")
+    if env_path:
+        # Expand user and resolve to absolute path
+        cache_path = Path(env_path).expanduser().resolve()
+        # Optionally, ensure cache_path is within the user's home directory
+        try:
+            home = Path.home().resolve()
+            if not str(cache_path).startswith(str(home)):
+                # Fallback to safe default if outside home
+                cache_path = home / ".cache/trend_model/rolling"
+        except Exception:
+            cache_path = Path.home() / ".cache/trend_model/rolling"
+        return cache_path
+    else:
+        return Path.home() / ".cache/trend_model/rolling"
 
-
+_DEFAULT_CACHE_DIR = _get_default_cache_dir()
 def _normalise_component(component: str) -> str:
     """Return a filesystem-safe version of ``component``."""
 

--- a/src/trend_analysis/pipeline.py
+++ b/src/trend_analysis/pipeline.py
@@ -23,6 +23,7 @@ from .metrics import (
     sortino_ratio,
     volatility,
 )
+from .perf.rolling_cache import compute_dataset_hash, get_cache
 
 logger = logging.getLogger(__name__)
 
@@ -750,13 +751,29 @@ def compute_signal(
     if effective_min_periods <= 0:
         raise ValueError("min_periods must be positive")
 
-    # Unshifted trailing rolling mean (option 2): value at index i (for i >= window-1)
-    # is the mean of the last ``window`` observations INCLUDING the current row.
-    # Earlier indices produce NaN until ``window`` observations are available.
-    rolling = base.rolling(window=window, min_periods=effective_min_periods).mean()
-    signal = rolling
-    signal.name = f"{column}_signal"
-    return signal
+    cache = get_cache()
+
+    def _compute() -> pd.Series:
+        rolling = base.rolling(window=window, min_periods=effective_min_periods).mean()
+        signal = rolling
+        signal.name = f"{column}_signal"
+        return signal
+
+    if cache.is_enabled():
+        dataset_hash = compute_dataset_hash([base])
+        idx = base.index
+        if hasattr(idx, "freqstr") and idx.freqstr:
+            freq = str(idx.freqstr)
+        else:
+            try:
+                freq = pd.infer_freq(idx)
+            except (ValueError, TypeError):
+                freq = None
+        freq_tag = freq or "unknown"
+        method_tag = f"rolling_mean_min{effective_min_periods}"
+        return cache.get_or_compute(dataset_hash, int(window), freq_tag, method_tag, _compute)
+
+    return _compute()
 
 
 def position_from_signal(

--- a/tests/test_cli_no_cache_flag.py
+++ b/tests/test_cli_no_cache_flag.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+import pandas as pd
+
+from trend_analysis import cli
+from trend_analysis.api import RunResult
+
+
+def test_cli_respects_no_cache_flag(monkeypatch, tmp_path):
+    csv_path = tmp_path / "data.csv"
+    df = pd.DataFrame(
+        {
+            "Date": pd.date_range("2020-01-31", periods=3, freq="ME"),
+            "Fund": [0.01, 0.02, 0.03],
+        }
+    )
+    df.to_csv(csv_path, index=False)
+
+    cfg = SimpleNamespace(
+        sample_split={
+            "in_start": "2020-01",
+            "in_end": "2020-02",
+            "out_start": "2020-03",
+            "out_end": "2020-03",
+        },
+        export={"directory": "ignored", "formats": []},
+        vol_adjust={},
+        portfolio={},
+        benchmarks={},
+        metrics={},
+        run={},
+    )
+
+    monkeypatch.setattr(cli, "load_config", lambda path: cfg)
+    monkeypatch.setattr(cli, "load_csv", lambda path: df.copy())
+
+    toggles: list[bool] = []
+    monkeypatch.setattr(cli, "set_cache_enabled", lambda enabled: toggles.append(enabled))
+
+    run_result = RunResult(
+        metrics=pd.DataFrame({"metric": [1.0]}),
+        details={"periods": []},
+        seed=7,
+        environment={"python": "3.11"},
+    )
+    monkeypatch.setattr(cli, "run_simulation", lambda *a, **k: run_result)
+    monkeypatch.setattr(cli.export, "format_summary_text", lambda *a, **k: "summary")
+    monkeypatch.setattr(cli.export, "export_to_excel", lambda *a, **k: None)
+    monkeypatch.setattr(cli.export, "export_data", lambda *a, **k: None)
+
+    rc = cli.main(
+        [
+            "run",
+            "-c",
+            str(tmp_path / "cfg.yml"),
+            "-i",
+            str(csv_path),
+            "--no-cache",
+        ]
+    )
+
+    assert rc == 0
+    assert toggles and toggles[0] is False

--- a/tests/test_rolling_cache.py
+++ b/tests/test_rolling_cache.py
@@ -1,0 +1,51 @@
+import pandas as pd
+import pandas.testing as tm
+
+from trend_analysis.perf.rolling_cache import RollingCache, compute_dataset_hash
+
+
+def test_compute_dataset_hash_reflects_data_changes():
+    series_a = pd.Series([1.0, 2.0, 3.0], name="value")
+    series_b = pd.Series([1.0, 2.0, 4.0], name="value")
+
+    hash_a = compute_dataset_hash([series_a])
+    hash_b = compute_dataset_hash([series_b])
+
+    assert hash_a != hash_b
+
+
+def test_rolling_cache_persists_results(tmp_path):
+    cache = RollingCache(cache_dir=tmp_path)
+    dataset_series = pd.Series([0.1, 0.2, 0.3], name="signal")
+    dataset_hash = compute_dataset_hash([dataset_series])
+
+    calls: list[pd.Series] = []
+
+    def compute() -> pd.Series:
+        result = pd.Series([0.1, 0.2, 0.3], name="signal")
+        calls.append(result)
+        return result
+
+    first = cache.get_or_compute(dataset_hash, 3, "M", "rolling_mean", compute)
+    second = cache.get_or_compute(dataset_hash, 3, "M", "rolling_mean", compute)
+
+    assert len(calls) == 1
+    tm.assert_series_equal(first, second)
+
+
+def test_rolling_cache_respects_disable(tmp_path):
+    cache = RollingCache(cache_dir=tmp_path)
+    cache.set_enabled(False)
+    dataset_series = pd.Series([5.0, 6.0, 7.0], name="value")
+    dataset_hash = compute_dataset_hash([dataset_series])
+
+    counter = {"calls": 0}
+
+    def compute() -> pd.Series:
+        counter["calls"] += 1
+        return pd.Series([5.0, 6.0, 7.0], name="value")
+
+    cache.get_or_compute(dataset_hash, 2, "unknown", "rolling_mean", compute)
+    cache.get_or_compute(dataset_hash, 2, "unknown", "rolling_mean", compute)
+
+    assert counter["calls"] == 2


### PR DESCRIPTION
## Summary
- add a joblib-backed rolling cache utility that fingerprints pandas inputs
- reuse cached results in compute_signal and rolling_information_ratio with opt-out flag in the CLI
- cover the caching layer and new CLI switch with unit tests and document the joblib dependency

## Testing
- `pytest` *(fails: NameError raised inside trend_analysis.config.models while loading configs during CLI smoke tests; also existing hypothesis check for compute_signal assumes shifted semantics)*
- `pytest tests/test_rolling_cache.py tests/test_cli_no_cache_flag.py`


------
https://chatgpt.com/codex/tasks/task_e_68d0f4104b988331aa6a89e0002c6f61