### PR TITLE
test: expand coverage for optional and fallback paths

### DIFF
--- a/tests/test_io_validators_negative_paths.py
+++ b/tests/test_io_validators_negative_paths.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import io
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from pathlib import Path
+
+from trend_analysis.io import validators
+
+
+def test_load_and_validate_upload_missing_file() -> None:
+    missing = Path("missing.csv")
+
+    with pytest.raises(ValueError, match="File not found: 'missing.csv'"):
+        validators.load_and_validate_upload(missing)
+
+
+def test_load_and_validate_upload_parser_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyFile:
+        name = "broken.csv"
+
+    def boom(*_args: Any, **_kwargs: Any) -> pd.DataFrame:
+        raise pd.errors.ParserError("bad format")
+
+    monkeypatch.setattr(validators.pd, "read_csv", boom)
+
+    with pytest.raises(ValueError, match="Failed to parse file"):
+        validators.load_and_validate_upload(DummyFile())
+
+
+def test_load_and_validate_upload_schema_failure() -> None:
+    buffer = io.StringIO("Foo,Bar\n1,2\n")
+    buffer.name = "invalid.csv"  # type: ignore[attr-defined]
+
+    with pytest.raises(ValueError, match="Schema validation failed"):
+        validators.load_and_validate_upload(buffer)

--- a/tests/test_multi_period_engine_price_frames_extra.py
+++ b/tests/test_multi_period_engine_price_frames_extra.py
@@ -59,6 +59,21 @@ def test_run_price_frames_validate_columns() -> None:
         mp_engine.run(cfg, df=df, price_frames=bad_frames)
 
 
+def test_run_price_frames_error_mentions_available_columns() -> None:
+    cfg = DummyCfg()
+    df = pd.DataFrame({"Date": pd.to_datetime(["2020-01-31"])})
+    bad_frames = {
+        "2020-01": pd.DataFrame({"Foo": [1.0], "Bar": [2.0]})
+    }
+
+    with pytest.raises(ValueError) as exc:
+        mp_engine.run(cfg, df=df, price_frames=bad_frames)
+
+    message = str(exc.value)
+    assert "Available columns" in message
+    assert "['Foo', 'Bar']" in message
+
+
 def test_run_price_frames_rejects_empty_mapping() -> None:
     cfg = DummyCfg()
 

--- a/tests/test_trend_config_model.py
+++ b/tests/test_trend_config_model.py
@@ -177,3 +177,51 @@ def test_trend_config_managers_glob_requires_csv_extension(tmp_path: Path) -> No
     message = str(exc.value)
     assert "CSV" in message
     assert "fund_a.txt" in message
+
+
+def test_validate_trend_config_normalises_month_end_frequency(tmp_path: Path) -> None:
+    csv_file = tmp_path / "returns.csv"
+    csv_file.write_text("Date,A\n2020-01-31,0.1\n", encoding="utf-8")
+
+    cfg = {
+        "version": "1",
+        "data": {
+            "csv_path": str(csv_file),
+            "date_column": "Date",
+            "frequency": "me",
+        },
+        "portfolio": {
+            "rebalance_calendar": "NYSE",
+            "max_turnover": 0.5,
+            "transaction_cost_bps": 10,
+        },
+        "vol_adjust": {"target_vol": 0.1},
+    }
+
+    validated = validate_trend_config(cfg, base_path=tmp_path)
+    assert validated.data.frequency == "ME"
+
+
+def test_validate_trend_config_reports_frequency_error_message(tmp_path: Path) -> None:
+    csv_file = tmp_path / "returns.csv"
+    csv_file.write_text("Date,A\n2020-01-31,0.1\n", encoding="utf-8")
+
+    cfg = {
+        "version": "1",
+        "data": {
+            "csv_path": str(csv_file),
+            "date_column": "Date",
+            "frequency": "quarterlyish",
+        },
+        "portfolio": {
+            "rebalance_calendar": "NYSE",
+            "max_turnover": 0.5,
+            "transaction_cost_bps": 10,
+        },
+        "vol_adjust": {"target_vol": 0.1},
+    }
+
+    with pytest.raises(ValueError) as exc:
+        validate_trend_config(cfg, base_path=tmp_path)
+
+    assert "data.frequency 'quarterlyish'" in str(exc.value)


### PR DESCRIPTION
## Summary
- cover the optional AvgCorr enrichment path in the pipeline results payload
- exercise price frame validation messaging and data ingest error handling
- ensure configuration frequency normalisation and fallback loader recovery paths are tested

## Testing
- pytest tests/test_pipeline_optional_features.py::test_run_analysis_avg_corr_metrics_populate_stats
- pytest tests/test_trend_config_model.py::test_validate_trend_config_normalises_month_end_frequency tests/test_trend_config_model.py::test_validate_trend_config_reports_frequency_error_message
- pytest tests/test_config_models_fallback_unit.py::test_load_config_fallback_handles_validation_failure
- pytest tests/test_io_validators_negative_paths.py
- pytest tests/test_multi_period_engine_price_frames_extra.py::test_run_price_frames_error_mentions_available_columns

------
https://chatgpt.com/codex/tasks/task_e_68d1745c29a083319cb51a6a4523fcb9