### PR TITLE
Fix config version validation failures and tighten autofix guard

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -157,7 +157,7 @@ Acceptance Criteria (Issue #1415) satisfied by: archival of legacy workflows, pr
 ### 7.1 Autofix Loop Guard (Issue #1347)
 Loop prevention layers:
 1. The consolidated workflow only reacts to completed CI runs (no direct `push` trigger).
-2. Guard logic inspects the latest commit subject for the configured prefix (default `chore(autofix):`) when the actor is `github-actions`.
+2. Guard logic only fires when the workflow actor is `github-actions` (or `github-actions[bot]`) **and** the latest commit subject begins with the standardized prefix `chore(autofix):`.
 3. Style Gate runs independently and does not trigger autofix.
 
 Result: Each human push generates at most one autofix patch sequence; autofix commits do not recursively spawn new runs.

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -129,8 +129,11 @@ jobs:
               const subject = (commit.data.commit.message || '').split('\n')[0];
               result.head_subject = subject;
               const actor = result.actor;
-              if (subject.toLowerCase().startsWith(prefix.toLowerCase())) {
-                core.info('Loop guard engaged: detected prior autofix commit.');
+              const isAutomation = actor === 'github-actions' || actor === 'github-actions[bot]';
+              const subjectLower = subject.toLowerCase();
+              const prefixLower = prefix.toLowerCase();
+              if (isAutomation && prefixLower && subjectLower.startsWith(prefixLower)) {
+                core.info(`Loop guard engaged for actor ${actor}: detected prior autofix commit.`);
                 result.loop_skip = 'true';
               }
             } catch (error) {

--- a/tests/test_app_coverage.py
+++ b/tests/test_app_coverage.py
@@ -939,7 +939,7 @@ def test_build_step0_datagrid_callbacks(monkeypatch, tmp_path):
 
     cfg_dir = tmp_path / "cfg"
     cfg_dir.mkdir()
-    (cfg_dir / "demo.yml").write_text("alpha: 1\n")
+    (cfg_dir / "demo.yml").write_text("version: '1'\nalpha: 1\n")
     monkeypatch.setattr(app_module, "_find_config_directory", lambda: cfg_dir)
 
     store = ParamStore()
@@ -996,7 +996,7 @@ def test_build_step0_datagrid_missing_on(monkeypatch, tmp_path):
 
     cfg_dir = tmp_path / "cfg"
     cfg_dir.mkdir()
-    (cfg_dir / "demo.yml").write_text("alpha: 1\n")
+    (cfg_dir / "demo.yml").write_text("version: '1'\nalpha: 1\n")
     monkeypatch.setattr(app_module, "_find_config_directory", lambda: cfg_dir)
 
     monkeypatch.setattr(app_module.widgets, "FileUpload", DummyFileUpload)

--- a/tests/test_gui_app_extended.py
+++ b/tests/test_gui_app_extended.py
@@ -243,7 +243,7 @@ def test_template_loader_handles_error_paths(monkeypatch, tmp_path):
 
     fake_dir = _FakeDir(
         {
-            "valid": _FakePath("valid.yml", "alpha: 1"),
+            "valid": _FakePath("valid.yml", "version: '1'\nalpha: 1"),
             "missing": _FakePath("missing.yml", FileNotFoundError("missing")),
             "permission": _FakePath("permission.yml", PermissionError("denied")),
             "invalid": _FakePath("invalid.yml", yaml.YAMLError("bad yaml")),
@@ -276,7 +276,7 @@ def test_template_loader_handles_error_paths(monkeypatch, tmp_path):
     callback = template._callbacks[0]
 
     callback({"new": "valid"})
-    assert store.cfg == {"alpha": 1}
+    assert store.cfg == {"version": "1", "alpha": 1}
     assert grid.data == [store.cfg]
     assert reset_calls == [store]
 


### PR DESCRIPTION
## Summary
- ensure GUI test fixtures write demo config files with the required `version` key
- tighten the workflow_run autofix guard so it only skips when github-actions pushes an autofix-prefixed commit
- document the standardized prefix + actor guard coupling in the workflows README

## Testing
- pytest tests/test_app_coverage.py tests/test_gui_app_extended.py *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68d1a1864fd08331a3f5b2c539e58613