### PR TITLE
chore(ci): finalize coverage soft gate retention (#1417)

### DIFF
--- a/.github/workflows/reuse-ci-python.yml
+++ b/.github/workflows/reuse-ci-python.yml
@@ -98,6 +98,7 @@ jobs:
             coverage-${{ matrix.py }}.json
             htmlcov-${{ matrix.py }}/**
             pytest-report-${{ matrix.py }}.xml
+          retention-days: 10
       - name: Summary
         if: always()
         run: |


### PR DESCRIPTION
Adds explicit `retention-days: 10` to coverage artifacts in the reusable CI workflow to complete the last outstanding acceptance criterion for Issue #1417.

## Context
Issue #1417 required:
- Matrix artifacts: coverage xml/json, htmlcov, JUnit (already in place)
- Soft gate job: aggregates coverage + hotspots, updates single tracking issue, injects PR comment (already in place)
- Non-blocking (no --cov-fail-under) (already in place)
- Artifact retention (missing) -> implemented here

## Change
Set `retention-days: 10` on the upload-artifact step (per example in issue body).

## Validation
No logic changes; only metadata for artifact lifecycle. Existing workflow semantics unchanged aside from retention duration.

## Follow-up
After merge, close #1417 with note that all acceptance criteria are satisfied.

---
Checklist:
- [x] Workflow updated
- [x] Branch naming policy (chore/ prefix) respected
- [x] Issue reference in commit & PR title

Fixes #1417
