### PR TITLE
chore(codex): bootstrap PR for issue #1421

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -93,7 +93,9 @@ jobs:
       cov_min: 70
 ```
 Autofix commits use the configurable prefix (default `chore(autofix):`). The consolidated workflow guards against loops by
-detecting automation actors + existing prefix and only running after the CI workflow completes.
+detecting automation actors + existing prefix and only running after the CI workflow completes. Scheduled cleanup and reusable
+autofix helpers consume the same prefix so the guard behaviour is identical no matter which workflow authored the last automation
+commit.
 
 ```yaml
 name: Agents
@@ -158,7 +160,8 @@ Acceptance Criteria (Issue #1415) satisfied by: archival of legacy workflows, pr
 Loop prevention layers:
 1. The consolidated workflow only reacts to completed CI runs (no direct `push` trigger).
 2. Guard logic only fires when the workflow actor is `github-actions` (or `github-actions[bot]`) **and** the latest commit subject begins with the standardized prefix `chore(autofix):`.
-3. Style Gate runs independently and does not trigger autofix.
+3. Scheduled cleanup (`autofix-residual-cleanup.yml`) and reusable autofix consumers adopt the same prefix + actor guard, so automation commits short-circuit immediately instead of chaining runs.
+4. Style Gate runs independently and does not trigger autofix.
 
 Result: Each human push generates at most one autofix patch sequence; autofix commits do not recursively spawn new runs.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -92,9 +92,11 @@ jobs:
       python_matrix: '"3.11"'
       cov_min: 70
 ```
-Autofix commits use the configurable prefix (default `chore(autofix):`). The consolidated workflow guards against loops by
-detecting automation actors + existing prefix and only running after the CI workflow completes. Scheduled cleanup and reusable
-autofix helpers consume the same prefix so the guard behaviour is identical no matter which workflow authored the last automation
+Autofix commits use the configurable prefix (default `chore(autofix):`). Set the repository variable
+`AUTOFIX_COMMIT_PREFIX` to change the prefix once and every workflow picks up the new value. The
+consolidated workflow guards against loops by detecting automation actors + existing prefix and only
+running after the CI workflow completes. Scheduled cleanup and reusable autofix helpers consume the
+same prefix so the guard behaviour is identical no matter which workflow authored the last automation
 commit.
 
 ```yaml

--- a/.github/workflows/autofix-residual-cleanup.yml
+++ b/.github/workflows/autofix-residual-cleanup.yml
@@ -29,11 +29,39 @@ jobs:
           ref: ${{ github.event.repository.default_branch || 'phase-2-dev' }}
           fetch-depth: 0
 
+      - name: Guard against autofix loops
+        id: guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          skip=false
+          actor="${{ github.actor }}"
+          if [ "$actor" = "github-actions" ] || [ "$actor" = "github-actions[bot]" ]; then
+            head_msg="$(git log -1 --pretty=%s 2>/dev/null || echo '')"
+            prefix="${COMMIT_PREFIX}"
+            if [ -n "$prefix" ] && [ -n "$head_msg" ]; then
+              head_norm=$(printf '%s' "$head_msg" | tr '[:upper:]' '[:lower:]')
+              prefix_norm=$(printf '%s' "$prefix" | tr '[:upper:]' '[:lower:]')
+              case "$head_norm" in
+                "$prefix_norm"*)
+                  echo "[cleanup] Loop guard engaged for commit: $head_msg"
+                  skip=true
+                  ;;
+              esac
+            fi
+          fi
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
+          if [ "$skip" = "true" ]; then
+            echo "[cleanup] Skipping residual cleanup to avoid autofix loop."
+          fi
+
       - name: Run composite autofix (classification only)
+        if: steps.guard.outputs.skip != 'true'
         id: autofix
         uses: ./.github/actions/autofix
 
       - name: Evaluate residuals
+        if: steps.guard.outputs.skip != 'true'
         id: eval
         shell: bash
         run: |
@@ -43,6 +71,7 @@ jobs:
           echo "Remaining: ${{ steps.autofix.outputs.remaining_issues }} | New: ${{ steps.autofix.outputs.new_issues }}"
 
       - name: Generate residual report assets
+        if: steps.guard.outputs.skip != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -52,11 +81,13 @@ jobs:
             if [ -f scripts/generate_residual_report.py ]; then python scripts/generate_residual_report.py; fi
 
       - name: Placeholder targeted cleanup (non-destructive)
+        if: steps.guard.outputs.skip != 'true'
         shell: bash
         run: |
           if [ -f scripts/residual_cleanup.py ]; then python scripts/residual_cleanup.py || true; fi
 
       - name: Prune stale allowlist entries
+        if: steps.guard.outputs.skip != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -72,6 +103,7 @@ jobs:
           fi
 
       - name: Decide action
+        if: steps.guard.outputs.skip != 'true'
         id: decide
         shell: bash
         run: |
@@ -85,7 +117,7 @@ jobs:
           echo 'dry_run=false' >> $GITHUB_OUTPUT
 
       - name: Commit assets & open/update cleanup PR
-        if: steps.decide.outputs.dry_run != 'true'
+        if: steps.guard.outputs.skip != 'true' && steps.decide.outputs.dry_run != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -116,4 +148,5 @@ jobs:
             echo "Remaining: ${{ steps.autofix.outputs.remaining_issues }}"
             echo "New: ${{ steps.autofix.outputs.new_issues }}"
             echo "Dry run: ${{ github.event.inputs.dry_run || 'true' }}"
+            echo "Loop guard skip: ${{ steps.guard.outputs.skip || 'false' }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/merge-manager.yml
+++ b/.github/workflows/merge-manager.yml
@@ -14,7 +14,7 @@ permissions:
   actions: read
 
 env:
-  COMMIT_PREFIX: "chore(autofix):"
+  COMMIT_PREFIX: ${{ vars.AUTOFIX_COMMIT_PREFIX || 'chore(autofix):' }}
   SAFE_LABEL_AUTOMERGE: ${{ vars.AUTOMERGE_LABEL || 'automerge' }}
   SAFE_LABEL_RISK: ${{ vars.RISK_LABEL || 'risk:low' }}
   SAFE_LABEL_CI: ${{ vars.CI_LABEL || 'ci:green' }}

--- a/.github/workflows/reuse-autofix.yml
+++ b/.github/workflows/reuse-autofix.yml
@@ -100,7 +100,7 @@ jobs:
           git commit -m "${AUTOFIX_COMMIT_PREFIX} formatting/lint"
 
       - name: Push changes (same-repo with rebase+retry)
-        if: steps.autofix.outputs.changed == 'true' && steps.same_repo.outputs.same == 'true'
+        if: steps.guard.outputs.skip != 'true' && steps.autofix.outputs.changed == 'true' && steps.same_repo.outputs.same == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -141,7 +141,7 @@ jobs:
 
 
       - name: Manage clean/debt labels (same-repo)
-        if: steps.same_repo.outputs.same == 'true'
+        if: steps.guard.outputs.skip != 'true' && steps.same_repo.outputs.same == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -159,7 +159,7 @@ jobs:
             }
 
       - name: Restore prior autofix history artifact (same-repo)
-        if: steps.same_repo.outputs.same == 'true'
+        if: steps.guard.outputs.skip != 'true' && steps.same_repo.outputs.same == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
@@ -203,7 +203,7 @@ jobs:
           rm -rf "$tmpdir"
 
       - name: Update residual history (same-repo)
-        if: steps.same_repo.outputs.same == 'true'
+        if: steps.guard.outputs.skip != 'true' && steps.same_repo.outputs.same == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -217,7 +217,7 @@ jobs:
           fi
 
       - name: Upload autofix history artifact (same-repo)
-        if: steps.same_repo.outputs.same == 'true'
+        if: steps.guard.outputs.skip != 'true' && steps.same_repo.outputs.same == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: autofix-history-pr-${{ github.event.pull_request.number }}
@@ -225,21 +225,21 @@ jobs:
           if-no-files-found: ignore
 
       - name: Generate trend sparkline (same-repo)
-        if: steps.same_repo.outputs.same == 'true'
+        if: steps.guard.outputs.skip != 'true' && steps.same_repo.outputs.same == 'true'
         shell: bash
         run: |
           if [ -f scripts/generate_residual_trend.py ]; then python scripts/generate_residual_trend.py || true; fi
           if [ -f ci/autofix/trend.json ]; then echo "Trend:"; cat ci/autofix/trend.json; fi
 
       - name: Build consolidated PR comment (same-repo)
-        if: steps.same_repo.outputs.same == 'true'
+        if: steps.guard.outputs.skip != 'true' && steps.same_repo.outputs.same == 'true'
         uses: ./.github/actions/build-pr-comment
         with:
           output: autofix_pr_comment.md
           pr-number: ${{ github.event.pull_request.number }}
 
       - name: Upsert consolidated PR comment (same-repo)
-        if: steps.same_repo.outputs.same == 'true'
+        if: steps.guard.outputs.skip != 'true' && steps.same_repo.outputs.same == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -259,7 +259,7 @@ jobs:
             }
 
       - name: Regression detector (same-repo)
-        if: steps.same_repo.outputs.same == 'true'
+        if: steps.guard.outputs.skip != 'true' && steps.same_repo.outputs.same == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -291,6 +291,7 @@ jobs:
             await github.rest.issues.create({ owner: context.repo.owner, repo: context.repo.repo, title: issueTitle, body, labels:['autofix:regression'] });
 
       - name: Emit JSON report
+        if: steps.guard.outputs.skip != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -310,6 +311,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Upload JSON report
+        if: steps.guard.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: autofix-report-pr-${{ github.event.pull_request.number }}

--- a/agents/codex-1421.md
+++ b/agents/codex-1421.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1421 -->

--- a/tests/test_workflow_merge_manager.py
+++ b/tests/test_workflow_merge_manager.py
@@ -53,6 +53,6 @@ def test_commit_prefix_is_quoted():
     data = _load_yaml(WORKFLOWS / "merge-manager.yml")
     env = data.get("env", {})
     prefix = env.get("COMMIT_PREFIX")
-    assert isinstance(prefix, str) and prefix.startswith(
-        "chore("
-    ), "COMMIT_PREFIX must be a quoted string starting with 'chore('"
+    assert isinstance(prefix, str), "COMMIT_PREFIX must be configured as a string"
+    assert "AUTOFIX_COMMIT_PREFIX" in prefix, "COMMIT_PREFIX should defer to vars.AUTOFIX_COMMIT_PREFIX"
+    assert "chore(autofix):" in prefix, "COMMIT_PREFIX must fall back to 'chore(autofix):'"


### PR DESCRIPTION
### Source Issue #1420: Single autofix guard and policy

Source: https://github.com/stranske/Trend_Model_Project/issues/1420

> Topic GUID: 6462a5ef-681a-5fee-8e36-f1be55594b42
> 
> ## Why
> Autofix loops happen when bots edit and re‑trigger themselves.
> 
> Scope
> 
> Standardize on a commit prefix and guard logic across all autofix steps.
> 
> ## Tasks
> Ensure current autofix processes function and kick off as designed
> 
> Prefix: chore(autofix):.
> 
>  Guard: if github.actor == 'github-actions' and last commit starts with that prefix, skip.
> 
>  Document in .github/workflows/README.md.
> 
> ## Acceptance criteria
> No self‑trigger storms; audit logs show the guard firing when expected.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/17889706220).

—
(After opening the PR, comment with `@codex start`.)