### PR TITLE
Docker smoke reliability: buildx cache + timeout - Source Issue #1422

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           dockerfile: Dockerfile
 
-  build:
+  smoke:
     needs: lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -62,17 +62,28 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: buildx-${{ hashFiles('Dockerfile', 'requirements.lock') }}-${{ github.sha }}
+          key: ${{ format('buildx-{0}-{1}', runner.os, hashFiles('Dockerfile', 'requirements.lock')) }}
           restore-keys: |
-            buildx-${{ hashFiles('Dockerfile', 'requirements.lock') }}
+            ${{ format('buildx-{0}-', runner.os) }}
 
-      - name: Note cache presence
+      - name: Summarize buildx cache
+        env:
+          CACHE_HIT: ${{ steps.buildx-cache.outputs.cache-hit }}
+          CACHE_KEY: ${{ format('buildx-{0}-{1}', runner.os, hashFiles('Dockerfile', 'requirements.lock')) }}
         run: |
-          if [ -d /tmp/.buildx-cache ]; then
-            echo "::notice title=BuildxCache::Cache restored (Issue #1153)"
+          if [ "$CACHE_HIT" = "true" ]; then
+            echo "::notice title=BuildxCache::Cache hit for ${CACHE_KEY}"
+            SUMMARY="✅ Cache hit for \`${CACHE_KEY}\`"
           else
-            echo "::notice title=BuildxCache::No existing cache (Issue #1153)"
+            echo "::notice title=BuildxCache::Cache miss for ${CACHE_KEY}"
+            SUMMARY="⚠️ Cache miss – priming \`${CACHE_KEY}\`"
           fi
+
+          {
+            echo "### Docker buildx cache"
+            echo ""
+            echo "$SUMMARY"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build image (cached)
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -96,6 +96,13 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Save buildx cache
+        if: steps.buildx-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ format('buildx-{0}-{1}', runner.os, hashFiles('Dockerfile', 'requirements.lock')) }}
       - name: Run test suite
         run: |
           # Use verbose output only for debug builds, quiet mode for production

--- a/agents/codex-1422.md
+++ b/agents/codex-1422.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1422 -->


### PR DESCRIPTION
### Source Issue #1422: Docker smoke reliability: buildx cache + timeout

Source: https://github.com/stranske/Trend_Model_Project/issues/1422

> Topic GUID: 0bee8b57-d57c-5af7-a530-493f5d9215e4
> 
> ## Why
> Pulls and cache misses cause flaky timeouts. Buildx caching and a cap keeps the lane predictable.
> 
> Scope
> 
> Use buildx with cache keyed on Dockerfile + requirements.lock.
> 
> Always --pull and add timeout-minutes: 10 to the smoke job.
> 
> ## Tasks
> Set up actions/cache for the buildx cache dir.
> 
>  Log cache hits/misses to the summary.
> 
> ## Acceptance criteria
> Smoke job completes under 10 minutes on repeat runs with visible cache hits.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/17889706220).

—
(After opening the PR, comment with `@codex start`.)