### PR TITLE
chore(codex): align autofix guard policy

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -93,7 +93,9 @@ jobs:
       cov_min: 70
 ```
 Autofix commits use the configurable prefix (default `chore(autofix):`). The consolidated workflow guards against loops by
-detecting automation actors + existing prefix and only running after the CI workflow completes.
+detecting automation actors + existing prefix and only running after the CI workflow completes. Scheduled cleanup and reusable
+autofix helpers consume the same prefix so the guard behaviour is identical no matter which workflow authored the last automation
+commit.
 
 ```yaml
 name: Agents
@@ -158,7 +160,8 @@ Acceptance Criteria (Issue #1415) satisfied by: archival of legacy workflows, pr
 Loop prevention layers:
 1. The consolidated workflow only reacts to completed CI runs (no direct `push` trigger).
 2. Guard logic only fires when the workflow actor is `github-actions` (or `github-actions[bot]`) **and** the latest commit subject begins with the standardized prefix `chore(autofix):`.
-3. Style Gate runs independently and does not trigger autofix.
+3. Scheduled cleanup (`autofix-residual-cleanup.yml`) and reusable autofix consumers adopt the same prefix + actor guard, so automation commits short-circuit immediately instead of chaining runs.
+4. Style Gate runs independently and does not trigger autofix.
 
 Result: Each human push generates at most one autofix patch sequence; autofix commits do not recursively spawn new runs.
 

--- a/.github/workflows/autofix-residual-cleanup.yml
+++ b/.github/workflows/autofix-residual-cleanup.yml
@@ -29,11 +29,39 @@ jobs:
           ref: ${{ github.event.repository.default_branch || 'phase-2-dev' }}
           fetch-depth: 0
 
+      - name: Guard against autofix loops
+        id: guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          skip=false
+          actor="${{ github.actor }}"
+          if [ "$actor" = "github-actions" ] || [ "$actor" = "github-actions[bot]" ]; then
+            head_msg="$(git log -1 --pretty=%s 2>/dev/null || echo '')"
+            prefix="${COMMIT_PREFIX}"
+            if [ -n "$prefix" ] && [ -n "$head_msg" ]; then
+              head_norm=$(printf '%s' "$head_msg" | tr '[:upper:]' '[:lower:]')
+              prefix_norm=$(printf '%s' "$prefix" | tr '[:upper:]' '[:lower:]')
+              case "$head_norm" in
+                "$prefix_norm"*)
+                  echo "[cleanup] Loop guard engaged for commit: $head_msg"
+                  skip=true
+                  ;;
+              esac
+            fi
+          fi
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
+          if [ "$skip" = "true" ]; then
+            echo "[cleanup] Skipping residual cleanup to avoid autofix loop."
+          fi
+
       - name: Run composite autofix (classification only)
+        if: steps.guard.outputs.skip != 'true'
         id: autofix
         uses: ./.github/actions/autofix
 
       - name: Evaluate residuals
+        if: steps.guard.outputs.skip != 'true'
         id: eval
         shell: bash
         run: |
@@ -43,6 +71,7 @@ jobs:
           echo "Remaining: ${{ steps.autofix.outputs.remaining_issues }} | New: ${{ steps.autofix.outputs.new_issues }}"
 
       - name: Generate residual report assets
+        if: steps.guard.outputs.skip != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -52,11 +81,13 @@ jobs:
             if [ -f scripts/generate_residual_report.py ]; then python scripts/generate_residual_report.py; fi
 
       - name: Placeholder targeted cleanup (non-destructive)
+        if: steps.guard.outputs.skip != 'true'
         shell: bash
         run: |
           if [ -f scripts/residual_cleanup.py ]; then python scripts/residual_cleanup.py || true; fi
 
       - name: Prune stale allowlist entries
+        if: steps.guard.outputs.skip != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -72,6 +103,7 @@ jobs:
           fi
 
       - name: Decide action
+        if: steps.guard.outputs.skip != 'true'
         id: decide
         shell: bash
         run: |
@@ -85,7 +117,7 @@ jobs:
           echo 'dry_run=false' >> $GITHUB_OUTPUT
 
       - name: Commit assets & open/update cleanup PR
-        if: steps.decide.outputs.dry_run != 'true'
+        if: steps.guard.outputs.skip != 'true' && steps.decide.outputs.dry_run != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -116,4 +148,5 @@ jobs:
             echo "Remaining: ${{ steps.autofix.outputs.remaining_issues }}"
             echo "New: ${{ steps.autofix.outputs.new_issues }}"
             echo "Dry run: ${{ github.event.inputs.dry_run || 'true' }}"
+            echo "Loop guard skip: ${{ steps.guard.outputs.skip || 'false' }}"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- add an actor + commit prefix guard to the scheduled residual cleanup workflow so it respects the standardized autofix loop protection
- document that all autofix lanes share the same `chore(autofix):` prefix and guard behaviour

## Testing
- not run (workflows and docs change only)


------
https://chatgpt.com/codex/tasks/task_e_68d1b5dbad988331b1a614bb1dd6aa27