### PR TITLE
Docker smoke reliability: buildx cache summary logging

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           dockerfile: Dockerfile
 
-  build:
+  smoke:
     needs: lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -62,17 +62,28 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: buildx-${{ hashFiles('Dockerfile', 'requirements.lock') }}-${{ github.sha }}
+          key: ${{ format('buildx-{0}-{1}', runner.os, hashFiles('Dockerfile', 'requirements.lock')) }}
           restore-keys: |
-            buildx-${{ hashFiles('Dockerfile', 'requirements.lock') }}
+            ${{ format('buildx-{0}-', runner.os) }}
 
-      - name: Note cache presence
+      - name: Summarize buildx cache
+        env:
+          CACHE_HIT: ${{ steps.buildx-cache.outputs.cache-hit }}
+          CACHE_KEY: ${{ format('buildx-{0}-{1}', runner.os, hashFiles('Dockerfile', 'requirements.lock')) }}
         run: |
-          if [ -d /tmp/.buildx-cache ]; then
-            echo "::notice title=BuildxCache::Cache restored (Issue #1153)"
+          if [ "$CACHE_HIT" = "true" ]; then
+            echo "::notice title=BuildxCache::Cache hit for ${CACHE_KEY}"
+            SUMMARY="✅ Cache hit for \`${CACHE_KEY}\`"
           else
-            echo "::notice title=BuildxCache::No existing cache (Issue #1153)"
+            echo "::notice title=BuildxCache::Cache miss for ${CACHE_KEY}"
+            SUMMARY="⚠️ Cache miss – priming \`${CACHE_KEY}\`"
           fi
+
+          {
+            echo "### Docker buildx cache"
+            echo ""
+            echo "$SUMMARY"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build image (cached)
         run: |


### PR DESCRIPTION
## Summary
- rename the Docker workflow's build job to `smoke` and keep the 10 minute timeout
- key the buildx cache strictly on the runner OS plus Dockerfile and requirements.lock hashes
- write the buildx cache hit or miss status to both workflow notices and the job summary

## Testing
- ./actionlint -color .github/workflows/docker.yml

------
https://chatgpt.com/codex/tasks/task_e_68d1b7691f0c83319bccf6a9e4b3aeed