### PR TITLE
feat(pipeline): causal compute_signal and regression tests (#1438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog (https://keepachangelog.com/) and this project adheres to Semantic Versioning.
+
+## [Unreleased]
+### Added
+- Regression tests (`test_shift_safe_pipeline.py`, `test_shift_safe_regression.py`) enforcing causal, no look‑ahead behavior in signal/position pipeline (Issue #1438).
+
+### Changed
+- `compute_signal` now returns a strictly causal rolling mean shifted by one period (previously included the current row). Prevents subtle look‑ahead bias in downstream position construction (Issue #1438).
+
+### Deprecated
+- Legacy root scripts (`portfolio_analysis_report.py`, `manager_attribution_analysis.py`, `demo_turnover_cap.py`) now emit `DeprecationWarning` and delegate to unified `trend` CLI (Issue #1437).
+
+### Migration Notes
+- If external code depended on the previous inclusive rolling mean, apply `.shift(-1)` to approximate prior behavior, or compute the unshifted rolling mean directly via `df[column].rolling(window).mean()`.
+
+---

--- a/src/trend_analysis/metrics/rolling.py
+++ b/src/trend_analysis/metrics/rolling.py
@@ -59,7 +59,9 @@ def rolling_information_ratio(
                 freq = None
         freq_tag = freq or "unknown"
         method_tag = "rolling_information_ratio_ddof1"
-        return cache.get_or_compute(dataset_hash, int(window), freq_tag, method_tag, _compute)
+        return cache.get_or_compute(
+            dataset_hash, int(window), freq_tag, method_tag, _compute
+        )
 
     return _compute()
 

--- a/src/trend_analysis/perf/rolling_cache.py
+++ b/src/trend_analysis/perf/rolling_cache.py
@@ -12,6 +12,7 @@ import pandas as pd
 from joblib import dump, load
 from pandas.util import hash_pandas_object
 
+
 def _get_default_cache_dir() -> Path:
     env_path = os.getenv("TREND_ROLLING_CACHE")
     if env_path:
@@ -29,7 +30,10 @@ def _get_default_cache_dir() -> Path:
     else:
         return Path.home() / ".cache/trend_model/rolling"
 
+
 _DEFAULT_CACHE_DIR = _get_default_cache_dir()
+
+
 def _normalise_component(component: str) -> str:
     """Return a filesystem-safe version of ``component``."""
 
@@ -75,7 +79,9 @@ class RollingCache:
     def is_enabled(self) -> bool:
         return self._enabled
 
-    def _build_path(self, dataset_hash: str, window: int, freq: str, method: str) -> Path:
+    def _build_path(
+        self, dataset_hash: str, window: int, freq: str, method: str
+    ) -> Path:
         safe_method = _normalise_component(method)
         safe_freq = _normalise_component(freq)
         file_name = f"{dataset_hash}_{safe_method}_{safe_freq}_{window}.joblib"

--- a/tests/test_cli_no_cache_flag.py
+++ b/tests/test_cli_no_cache_flag.py
@@ -35,7 +35,9 @@ def test_cli_respects_no_cache_flag(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "load_csv", lambda path: df.copy())
 
     toggles: list[bool] = []
-    monkeypatch.setattr(cli, "set_cache_enabled", lambda enabled: toggles.append(enabled))
+    monkeypatch.setattr(
+        cli, "set_cache_enabled", lambda enabled: toggles.append(enabled)
+    )
 
     run_result = RunResult(
         metrics=pd.DataFrame({"metric": [1.0]}),

--- a/tests/test_shift_safe_pipeline.py
+++ b/tests/test_shift_safe_pipeline.py
@@ -12,9 +12,10 @@ from trend_analysis.pipeline import compute_signal, position_from_signal
 def test_compute_signal_matches_trailing_mean_without_current_row():
     df = pd.DataFrame({"returns": [0.01, 0.03, 0.02, -0.01, 0.05]})
     signal = compute_signal(df, window=3)
-    # Updated spec: signal equals trailing mean shifted by one period (no look-ahead)
+    # Causal spec: signal equals trailing mean excluding current row (rolling mean then shift)
     expected = df["returns"].rolling(window=3, min_periods=3).mean().shift(1)
-    tm.assert_series_equal(signal, expected.rename(signal.name))
+    expected.name = signal.name
+    tm.assert_series_equal(signal, expected)
 
 
 def test_positions_ignore_future_data():

--- a/tests/test_shift_safe_regression.py
+++ b/tests/test_shift_safe_regression.py
@@ -1,0 +1,40 @@
+import math
+import pandas as pd
+
+from trend_analysis.pipeline import compute_signal
+
+
+def test_regression_compute_signal_causal_nan_warmup():
+    df = pd.DataFrame({"returns": [0.1, -0.2, 0.05, 0.03, -0.01, 0.04]})
+    window = 3
+    sig = compute_signal(df, window=window)
+
+    # Warmup: with shift applied after rolling mean, first valid value appears at index == window (0-based)
+    # for an implementation that shifts by one AND requires full window. Actual current behavior shows first
+    # valid at index 3 for window=3 (so indices 0..2 NaN, index 3 valid). Assert that pattern.
+    assert sig.iloc[0:window].isna().all(), sig  # indices 0,1,2
+    assert not pd.isna(sig.iloc[window]), sig  # index 3 is first non-NaN
+
+    # Validate each subsequent point uses strictly prior observations
+    for i in range(4, len(sig)):
+        history = df["returns"].iloc[i - window : i]  # strictly prior window
+        expected = history.mean()
+        assert math.isclose(sig.iloc[i], expected, rel_tol=1e-12, abs_tol=1e-12)
+
+
+def test_regression_compute_signal_no_current_row_dependency():
+    df = pd.DataFrame({"returns": [0.05, 0.07, -0.02, 0.04, 0.09]})
+    sig = compute_signal(df, window=3)
+
+    # Perturb current-row value and assert previously computed signals unchanged
+    for i in range(len(df)):
+        if i < 3:  # warmup region (NaNs)
+            continue
+        df_alt = df.copy()
+        orig_scalar = df_alt.loc[df_alt.index[i], "returns"]
+        orig_val = float(pd.Series([orig_scalar]).astype(float).iloc[0])
+        df_alt.loc[df_alt.index[i], "returns"] = (
+            orig_val + 10.0
+        )  # large shock at current row
+        sig_alt = compute_signal(df_alt, window=3)
+        pd.testing.assert_series_equal(sig.iloc[:i], sig_alt.iloc[:i])


### PR DESCRIPTION
### Summary
Implements Issue #1438 by enforcing a strictly causal (no look‑ahead) rolling signal and adding regression/property tests.

### Changes
- Updated  to shift the rolling mean by one period (uses only prior rows).
- Added regression test  for warmup NaN and no current-row dependency.
- Updated existing shift-safe pipeline tests to align with causal spec.
- Added  with Unreleased notes (documents change & migration tip).

### Rationale
Prevents subtle look‑ahead bias: previous implementation included current observation in the rolling mean, conflicting with stated intent.

### Tests
Targeted tests:
......                                                                   [100%]
6 passed in 2.93s
Ultra-fast validation ([0;36m=== Ultra-Fast Development Check ===[0m
[0;34mChecking only changed files (excluding old folders):[0m
  src/trend_analysis/metrics/rolling.py
  src/trend_analysis/perf/rolling_cache.py
  src/trend_analysis/pipeline.py
  tests/test_cli_no_cache_flag.py
  tests/test_shift_safe_pipeline.py
  tests/test_shift_safe_regression.py

[0;34m1. Syntax check...[0m
[0;32m✓ Syntax check[0m
[0;34m2. Import test...[0m
[0;32m✓ Import test[0m
[0;34m3. Formatting...[0m
[0;32m✓ Black formatting[0m
[0;34m4. Critical linting...[0m
[0;32m✓ Critical lint errors[0m
[0;34m5. Basic type check...[0m
[0;32m✓ Basic type check[0m

[0;36m=== Quick Check Complete ===[0m
[0;34mFor comprehensive validation, run: ./scripts/check_branch.sh[0m
[0;34mFor auto-fixes, run with: --fix[0m
[0;34mFor changed files only: --changed[0m) passed (syntax, lint, type, formatting).

### Backwards Compatibility
External code relying on inclusive (current-row) behavior should replace  with:

or shift the new causal series forward by one if needed.

### Follow-ups (Optional)
- Consider documenting signal semantics in .
- Add performance benchmark for cache hits under causal mode if needed.

---
Closes #1438.
