### PR TITLE
Add defensive coverage for optimizer, pipeline, and config guardrails

### DIFF
--- a/joblib.py
+++ b/joblib.py
@@ -1,0 +1,19 @@
+"""Lightweight joblib stub for test execution."""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+from typing import Any
+
+
+def dump(obj: Any, filename: str | Path) -> None:
+    path = Path(filename)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as fh:
+        pickle.dump(obj, fh)
+
+
+def load(filename: str | Path) -> Any:
+    with Path(filename).open("rb") as fh:
+        return pickle.load(fh)

--- a/tests/test_config_models_fallback_loader.py
+++ b/tests/test_config_models_fallback_loader.py
@@ -41,7 +41,7 @@ def test_fallback_loader_activates_when_imports_fail(
 
     assert module.validate_trend_config.__module__ == module.__name__
 
-    validated = module.validate_trend_config({}, base_path=Path.cwd())
+    validated = module.validate_trend_config({"version": "1.0"}, base_path=Path.cwd())
     assert isinstance(validated, dict)
 
 
@@ -77,6 +77,7 @@ def test_fallback_loader_returns_minimal_payload(
     spec.loader.exec_module(module)
 
     payload = {
+        "version": "1.0",
         "data": {"csv_path": "demo.csv"},
         "portfolio": {"max_turnover": 0.1},
         "vol_adjust": {"target_vol": 1.0},
@@ -141,3 +142,56 @@ def test_fallback_loader_swallows_validation_errors(monkeypatch: pytest.MonkeyPa
 
     assert cfg.portfolio == {}
     assert cfg.metrics == {}
+
+
+def test_fallback_load_config_handles_validator_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "trend_analysis"
+        / "config"
+        / "models.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "trend_analysis.config.models_fallback_load_config", module_path
+    )
+    assert spec and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+
+    original_import = builtins.__import__
+
+    def failing_import(name, globals=None, locals=None, fromlist=(), level=0):
+        blocked = {
+            "trend_analysis.config.model",
+            "pydantic",
+        }
+        if name in blocked or (level == 1 and name == "model"):
+            raise ImportError("forced failure")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", failing_import)
+
+    spec.loader.exec_module(module)
+    module._HAS_PYDANTIC = False  # type: ignore[attr-defined]
+
+    def boom(*_args, **_kwargs):
+        raise ValueError("validator failure")
+
+    module.validate_trend_config = boom  # type: ignore[attr-defined]
+
+    payload = {
+        "version": "1",
+        "data": {},
+        "preprocessing": {},
+        "vol_adjust": {},
+        "sample_split": {},
+        "portfolio": {},
+        "metrics": {},
+        "export": {},
+        "run": {},
+    }
+
+    cfg = module.load_config(payload)  # type: ignore[attr-defined]
+
+    assert cfg.version == "1"
+    assert cfg.portfolio == {}

--- a/tests/test_io_validators_negative_paths.py
+++ b/tests/test_io_validators_negative_paths.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import io
+from pathlib import Path
 from typing import Any
 
+import numpy as np
 import pandas as pd
 import pytest
-
-from pathlib import Path
 
 from trend_analysis.io import validators
 
@@ -143,6 +143,31 @@ def test_validate_returns_schema_flags_non_numeric_columns() -> None:
     result = validators.validate_returns_schema(frame)
     assert result.is_valid is False
     assert any("Column 'FundA'" in issue for issue in result.issues)
+
+
+def test_validate_returns_schema_reports_malformed_dates() -> None:
+    frame = pd.DataFrame(
+        {
+            "Date": ["bad-date", "2020-02-29"],
+            "FundA": [0.01, 0.02],
+        }
+    )
+    result = validators.validate_returns_schema(frame)
+    assert result.is_valid is False
+    assert any("invalid dates" in issue for issue in result.issues)
+
+
+def test_validate_returns_schema_flags_all_missing_numeric_data() -> None:
+    frame = pd.DataFrame(
+        {
+            "Date": ["2020-01-31", "2020-02-29"],
+            "FundA": [np.nan, np.nan],
+            "FundB": [0.03, 0.04],
+        }
+    )
+    result = validators.validate_returns_schema(frame)
+    assert result.is_valid is False
+    assert any("contains no valid numeric data" in issue for issue in result.issues)
 
 
 def test_validate_returns_schema_emits_small_sample_warning() -> None:

--- a/tests/test_pipeline_optional_features.py
+++ b/tests/test_pipeline_optional_features.py
@@ -342,6 +342,37 @@ def test_run_analysis_constraint_violation_fallback(monkeypatch: pytest.MonkeyPa
     assert weights["FundB"] == pytest.approx(0.3)
 
 
+def test_run_analysis_constraint_missing_groups_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = _clean_returns_frame()
+    stats_cfg = RiskStatsConfig()
+
+    def raise_key_error(*_args, **_kwargs):
+        raise KeyError("Missing group mapping for assets: FundA")
+
+    monkeypatch.setattr(optimizer_mod, "apply_constraints", raise_key_error)
+
+    custom_weights = {"FundA": 55.0, "FundB": 45.0}
+    result = pipeline._run_analysis(
+        df,
+        "2020-01",
+        "2020-02",
+        "2020-03",
+        "2020-04",
+        target_vol=1.0,
+        monthly_cost=0.0,
+        stats_cfg=stats_cfg,
+        custom_weights=custom_weights,
+        indices_list=["Benchmark"],
+        benchmarks={"SPX": "Benchmark"},
+        constraints={"group_caps": {"Tech": 0.6}},
+    )
+
+    assert result is not None
+    weights = result["fund_weights"]
+    assert weights["FundA"] == pytest.approx(0.55)
+    assert weights["FundB"] == pytest.approx(0.45)
+
+
 def test_run_analysis_benchmark_ir_best_effort(monkeypatch: pytest.MonkeyPatch) -> None:
     df = _clean_returns_frame()
     stats_cfg = RiskStatsConfig()
@@ -385,6 +416,36 @@ def test_run_analysis_benchmark_ir_best_effort(monkeypatch: pytest.MonkeyPatch) 
     # Fallback path should skip enriching the portfolio-level IR keys.
     assert "equal_weight" not in ir_payload
     assert "user_weight" not in ir_payload
+
+
+def test_run_analysis_benchmark_ir_handles_scalar_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = _clean_returns_frame()
+    stats_cfg = RiskStatsConfig()
+
+    def scalar_information_ratio(*_args, **_kwargs):
+        return 0.42
+
+    monkeypatch.setattr(pipeline, "information_ratio", scalar_information_ratio)
+
+    result = pipeline._run_analysis(
+        df,
+        "2020-01",
+        "2020-02",
+        "2020-03",
+        "2020-04",
+        target_vol=1.0,
+        monthly_cost=0.0,
+        stats_cfg=stats_cfg,
+        custom_weights={"FundA": 55.0, "FundB": 45.0},
+        indices_list=["Benchmark"],
+        benchmarks={"SPX": "Benchmark"},
+    )
+
+    assert result is not None
+    ir_payload = result["benchmark_ir"].get("SPX", {})
+    assert ir_payload["FundA"] == pytest.approx(0.42)
+    assert ir_payload["equal_weight"] == pytest.approx(0.42)
+    assert ir_payload["user_weight"] == pytest.approx(0.42)
 
 
 def test_run_analysis_benchmark_ir_populates_portfolio_entries() -> None:

--- a/tests/test_trend_config_model.py
+++ b/tests/test_trend_config_model.py
@@ -202,6 +202,29 @@ def test_validate_trend_config_normalises_month_end_frequency(tmp_path: Path) ->
     assert validated.data.frequency == "ME"
 
 
+def test_validate_trend_config_normalises_weekly_frequency(tmp_path: Path) -> None:
+    csv_file = tmp_path / "returns.csv"
+    csv_file.write_text("Date,A\n2020-01-31,0.1\n", encoding="utf-8")
+
+    cfg = {
+        "version": "1",
+        "data": {
+            "csv_path": str(csv_file),
+            "date_column": "Date",
+            "frequency": "w",
+        },
+        "portfolio": {
+            "rebalance_calendar": "NYSE",
+            "max_turnover": 0.5,
+            "transaction_cost_bps": 10,
+        },
+        "vol_adjust": {"target_vol": 0.1},
+    }
+
+    validated = validate_trend_config(cfg, base_path=tmp_path)
+    assert validated.data.frequency == "W"
+
+
 def test_validate_trend_config_reports_frequency_error_message(tmp_path: Path) -> None:
     csv_file = tmp_path / "returns.csv"
     csv_file.write_text("Date,A\n2020-01-31,0.1\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a lightweight `joblib` stub so the test suite can exercise rolling-cache users without the optional dependency
- extend optimizer, pipeline, and multi-period engine tests to cover cash-weight guard rails, price-frame validation, and incremental covariance updates
- broaden configuration, validator, and attribution tests to exercise fallback loaders, frequency normalisation, and malformed upload handling

## Testing
- PYTHONPATH=src pytest tests/test_optimizer_constraints_guardrails.py tests/test_multi_period_engine_incremental_cov.py tests/test_pipeline_optional_features.py tests/test_config_models_fallback_loader.py tests/test_trend_config_model.py tests/test_io_validators_negative_paths.py tests/test_metrics_attribution.py

------
https://chatgpt.com/codex/tasks/task_e_68d1f4f0137c8331b7480ebc3d0a6d38