### PR TITLE
Add tests for util.hash normalisation paths

### DIFF
--- a/tests/test_util_hash.py
+++ b/tests/test_util_hash.py
@@ -10,6 +10,16 @@ import pytest
 from trend_analysis.util import hash as hash_utils
 
 
+class _ModelDumpable:
+    """Lightweight stand-in for a pydantic model implementing ``model_dump``."""
+
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = payload
+
+    def model_dump(self) -> dict[str, object]:
+        return self._payload
+
+
 def test_sha256_text_and_bytes_consistency() -> None:
     """Ensure text and byte helpers return the same digest."""
 
@@ -49,3 +59,43 @@ def test_sha256_bytes_matches_stdlib(value: bytes) -> None:
     """The raw byte helper should mirror ``hashlib.sha256``."""
 
     assert hash_utils.sha256_bytes(value) == hashlib.sha256(value).hexdigest()
+
+
+def test_normalise_for_json_handles_nested_structures(tmp_path: Path) -> None:
+    """The normaliser should coerce paths, tuples, and model dumps."""
+
+    nested_path = tmp_path / "resource" / "config.yml"
+    nested_path.parent.mkdir()
+    nested_model = _ModelDumpable({"path": nested_path, "values": (1, 2)})
+    payload = {
+        "mapping": {"path": nested_path, "model": nested_model},
+        "sequence": [nested_model, (nested_path, 3)],
+    }
+
+    normalised = hash_utils.normalise_for_json(payload)
+
+    assert normalised == {
+        "mapping": {"path": str(nested_path), "model": {"path": str(nested_path), "values": [1, 2]}},
+        "sequence": [
+            {"path": str(nested_path), "values": [1, 2]},
+            [str(nested_path), 3],
+        ],
+    }
+
+
+def test_sha256_config_supports_model_dump_payload(tmp_path: Path) -> None:
+    """Config hashing should honour ``model_dump`` normalisation."""
+
+    shared = tmp_path / "shared.json"
+    cfg = {
+        "model": _ModelDumpable({"path": shared, "values": (1, 2, 3)}),
+        "path": shared,
+    }
+    # Reorder the keys and wrap values in equivalent containers to ensure
+    # deterministic hashing despite structural differences.
+    reordered = {
+        "path": str(shared),
+        "model": {"values": [1, 2, 3], "path": str(shared)},
+    }
+
+    assert hash_utils.sha256_config(cfg) == hash_utils.sha256_config(reordered)


### PR DESCRIPTION
## Summary
- extend the util hash test module with a model_dump stub to cover nested normalisation paths
- assert normalise_for_json handles Path, tuple, and model_dump payloads consistently
- ensure sha256_config hashing stays deterministic for equivalent model_dump data

## Testing
- pytest tests/test_util_hash.py

------
https://chatgpt.com/codex/tasks/task_e_68d210a48a8c8331961a5566629d5fa0