### PR TITLE
ci: add failure tracker cooldown & disable flags

### DIFF
--- a/.github/workflows/check-failure-tracker.yml
+++ b/.github/workflows/check-failure-tracker.yml
@@ -21,6 +21,8 @@ jobs:
       STACK_TOKEN_MAX_LEN: 160              # Max characters kept from extracted stack/error line
       AUTO_HEAL_INACTIVITY_HOURS: 24        # Used by success job for auto-heal closure
       FAILURE_INACTIVITY_HEAL_HOURS: 0      # (Reserved) would auto-close during failure path if >0
+      NEW_ISSUE_COOLDOWN_HOURS: 24          # If >0, cooldown window for *new* failure issues (append instead)
+      DISABLE_FAILURE_ISSUES: 'false'       # If 'true', skip issue create/update (still summary)
     steps:
       - name: Derive failure signature & update tracking issue
         id: tracker
@@ -124,7 +126,16 @@ jobs:
               `> NOTE: ${stackTokenNote}`
             ].join('\n');
 
-            // Query for an existing open issue with this signature
+            // Optional global disable
+            if (/^true$/i.test(process.env.DISABLE_FAILURE_ISSUES || 'false')) {
+              core.info('Failure issue tracking disabled via DISABLE_FAILURE_ISSUES.');
+              core.summary.addHeading('Failure (tracking disabled)');
+              core.summary.addRaw('Issue creation disabled; diagnostics available in logs.');
+              await core.summary.write();
+              return;
+            }
+
+            // Query for existing signature issue
             const q = `repo:${owner}/${repo} is:issue is:open in:title "${signature}" label:ci-failure`;
             const search = await github.rest.search.issuesAndPullRequests({ q, per_page: 1 });
             if (search.data.items.length) {
@@ -196,7 +207,26 @@ jobs:
               }
               core.info(`Updated existing failure issue #${issue_number} (occurrence ${occ}).`);
             } else {
-              // New issue: seed header meta fields
+              // Cooldown path for new issues
+              const cooldownHours = parseFloat(process.env.NEW_ISSUE_COOLDOWN_HOURS || '0');
+              if (cooldownHours > 0) {
+                const recent = await github.rest.search.issuesAndPullRequests({
+                  q: `repo:${owner}/${repo} is:issue label:ci-failure`,
+                  sort: 'created', order: 'desc', per_page: 1
+                });
+                if (recent.data.items.length) {
+                  const latest = recent.data.items[0];
+                  const createdAt = Date.parse(latest.created_at);
+                  if (!isNaN(createdAt)) {
+                    const age = (Date.now() - createdAt) / 3_600_000;
+                    if (age < cooldownHours) {
+                      await github.rest.issues.createComment({ owner, repo, issue_number: latest.number, body: `Additional failure during cooldown (no new issue).\n\n${bodyBlock}` });
+                      core.info(`Cooldown active (${age.toFixed(2)}h < ${cooldownHours}h). Appended to #${latest.number}`);
+                      return;
+                    }
+                  }
+                }
+              }
               const nowIso = new Date().toISOString();
               const headerMeta = [
                 'Occurrences: 1',


### PR DESCRIPTION
### Summary\nAdds two controls to reduce CI failure issue noise.\n\n| Env Var | Default | Purpose |\n|---------|---------|---------|\n| `NEW_ISSUE_COOLDOWN_HOURS` | 24 | Prevent creation of a *new* failure issue if any ci-failure issue was created within the last N hours; appends comment instead. |\n| `DISABLE_FAILURE_ISSUES` | false | Hard switch to disable all create/update operations (logging + step summary only). |\n\n### Behaviour Details\n1. Existing signature issue: unchanged (occurrence count, history table, rate-limited comments).\n2. New signature: checks cooldown window; if active, comments on most recent ci-failure issue instead of creating a new one.\n3. Disable flag short-circuits logic, emits summary only.\n\n### Rationale\nLarge repos can accumulate many near-duplicate failure issues during an outage. Cooldown clusters them while preserving chronology; disable flag allows temporary suspension (e.g., planned infra maintenance).\n\n### Implementation Notes\n- Minimal diff: pure GitHub Script JS in existing workflow.\n- No dependency changes.\n- Backwards-compatible: defaults mimic previous behaviour except when multiple distinct failures happen within the same 24h window (now consolidated).\n\n### Follow Ups (Optional)\n- Separate cooldowns per signature (current is global).\n- Configurable label set for cooldown targeting.\n\nCloses: (follow-up to enhancements introduced in prior PR #1585 context).