### PR TITLE
Increase test coverage - issue #1610

### DIFF
--- a/.github/scripts/label_rules_assert.py
+++ b/.github/scripts/label_rules_assert.py
@@ -1,0 +1,84 @@
+"""Validation helper for the label-agent workflow.
+
+This guard runs inside the Label agent PRs workflow after we fetch the
+trusted configuration via sparse checkout.  It ensures that the checkout
+contains exactly the files we whitelisted through the
+``TRUSTED_LABEL_RULE_PATHS`` environment variable so the workflow never
+accidentally evaluates untrusted content.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+def _parse_allowlist(raw: str) -> list[str]:
+    entries: list[str] = []
+    for line in raw.splitlines():
+        trimmed = line.strip()
+        if trimmed:
+            # Normalise to POSIX style for easier comparisons later on.
+            entries.append(trimmed.replace("\\", "/"))
+    return entries
+
+
+def _list_checkout_files(root: Path) -> Iterable[tuple[str, Path]]:
+    for path in root.rglob("*"):
+        if path.is_dir():
+            continue
+        # Skip Git metadata that checkout may leave behind.
+        if any(part == ".git" for part in path.parts):
+            continue
+        yield path.relative_to(root).as_posix(), path
+
+
+def main() -> int:
+    raw_allowlist = os.environ.get("TRUSTED_LABEL_RULE_PATHS", "")
+    allowlist = _parse_allowlist(raw_allowlist)
+    if not allowlist:
+        print(
+            "[label-rules-assert] TRUSTED_LABEL_RULE_PATHS must contain at least one entry",
+            file=sys.stderr,
+        )
+        return 1
+
+    checkout_root = Path("trusted-config")
+    if not checkout_root.exists():
+        print(
+            "[label-rules-assert] Expected checkout directory 'trusted-config' not found",
+            file=sys.stderr,
+        )
+        return 1
+
+    missing = [entry for entry in allowlist if not (checkout_root / entry).exists()]
+    if missing:
+        print(
+            "[label-rules-assert] Missing allowlisted paths:\n  - "
+            + "\n  - ".join(missing),
+            file=sys.stderr,
+        )
+        return 1
+
+    allowlist_set = set(allowlist)
+    extras = [
+        rel
+        for rel, _ in _list_checkout_files(checkout_root)
+        if rel not in allowlist_set
+    ]
+    if extras:
+        print(
+            "[label-rules-assert] Unexpected files present after sparse checkout:\n  - "
+            + "\n  - ".join(sorted(extras)),
+            file=sys.stderr,
+        )
+        return 1
+
+    print("[label-rules-assert] Sparse checkout contents verified.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agents/codex-1610.md
+++ b/agents/codex-1610.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1610 -->

--- a/tests/test_cli_cache_stats_extended.py
+++ b/tests/test_cli_cache_stats_extended.py
@@ -47,3 +47,26 @@ def test_extract_cache_stats_returns_none_when_missing() -> None:
     }
 
     assert cli._extract_cache_stats(payload) is None
+
+
+def test_extract_cache_stats_skips_invalid_candidates_but_keeps_prior() -> None:
+    payload = {
+        "snapshots": [
+            {"entries": 1, "hits": 2, "misses": 3, "incremental_updates": 4},
+            {
+                "entries": "oops",
+                "hits": 6,
+                "misses": 7,
+                "incremental_updates": 8,
+            },
+        ]
+    }
+
+    stats = cli._extract_cache_stats(payload)
+
+    assert stats == {
+        "entries": 1,
+        "hits": 2,
+        "misses": 3,
+        "incremental_updates": 4,
+    }

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -41,6 +41,18 @@ def test_check_environment_missing_file(tmp_path, capsys):
     assert f"Lock file not found: {lock}" in out
 
 
+def test_check_environment_skips_non_pinned_lines(tmp_path, capsys):
+    lock = tmp_path / "req.lock"
+    lock.write_text("# comment\nwheel>=0.0\n\n", encoding="utf-8")
+
+    ret = cli.check_environment(lock)
+    out = capsys.readouterr().out
+
+    assert ret == 0
+    assert "wheel" not in out
+    assert "All packages match" in out
+
+
 def test_main_check_flag_without_subcommand(monkeypatch):
     called: dict[str, bool] = {}
 

--- a/tests/test_metrics_rolling.py
+++ b/tests/test_metrics_rolling.py
@@ -1,11 +1,15 @@
-"""Tests for rolling metrics module."""
+"""Tests for the rolling metrics helpers."""
+
+from __future__ import annotations
+
+import pytest
 
 import pandas as pd
 
 from trend_analysis.metrics import rolling
 
 
-def test_rolling_information_ratio_basic():
+def test_rolling_information_ratio_basic() -> None:
     """Rolling IR matches manual calculation."""
 
     returns = pd.Series(
@@ -18,12 +22,10 @@ def test_rolling_information_ratio_basic():
 
     excess = returns - benchmark
     expected = excess.rolling(2).mean() / excess.rolling(2).std(ddof=1)
-    expected = expected.rename("rolling_ir")
-
-    pd.testing.assert_series_equal(result, expected)
+    pd.testing.assert_series_equal(result, expected.rename("rolling_ir"))
 
 
-def test_rolling_information_ratio_scalar_benchmark():
+def test_rolling_information_ratio_scalar_benchmark() -> None:
     """Scalar benchmark is broadcast correctly."""
 
     returns = pd.Series([0.01, -0.02, 0.015, 0.005])
@@ -34,7 +36,7 @@ def test_rolling_information_ratio_scalar_benchmark():
     assert len(result) == len(returns)
 
 
-def test_rolling_information_ratio_defaults_to_zero_benchmark():
+def test_rolling_information_ratio_defaults_to_zero_benchmark() -> None:
     """Passing ``None`` for the benchmark uses a zero baseline."""
 
     returns = pd.Series(
@@ -49,3 +51,78 @@ def test_rolling_information_ratio_defaults_to_zero_benchmark():
         (returns - zero_benchmark).rolling(2).std(ddof=1)
     )
     pd.testing.assert_series_equal(result, expected.rename("rolling_ir"))
+
+
+def test_rolling_information_ratio_uses_cache_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Caching path should delegate to ``get_or_compute`` with rich tags."""
+
+    returns = pd.Series(
+        [0.01, -0.02, 0.03, -0.01],
+        index=pd.date_range("2021-01-31", periods=4, freq="ME"),
+        name="returns",
+    )
+    benchmark = pd.Series(
+        [0.005, -0.01, 0.015, -0.002],
+        index=returns.index,
+        name="bench",
+    )
+
+    recorded: dict[str, object] = {}
+
+    class DummyCache:
+        def is_enabled(self) -> bool:
+            return True
+
+        def get_or_compute(self, dataset_hash, window, freq_tag, method_tag, compute_fn):
+            recorded["dataset_hash"] = dataset_hash
+            recorded["window"] = window
+            recorded["freq_tag"] = freq_tag
+            recorded["method_tag"] = method_tag
+            result = compute_fn()
+            recorded["result"] = result
+            return result
+
+    dummy = DummyCache()
+    monkeypatch.setattr(rolling, "get_cache", lambda: dummy)
+
+    result = rolling.rolling_information_ratio(returns, benchmark=benchmark, window=3)
+
+    expected_bench = benchmark.reindex_like(returns).fillna(0.0)
+    expected_hash = rolling.compute_dataset_hash([returns, expected_bench])
+
+    assert recorded["dataset_hash"] == expected_hash
+    assert recorded["window"] == 3
+    assert recorded["freq_tag"] == str(returns.index.freqstr)
+    assert recorded["method_tag"] == "rolling_information_ratio_ddof1"
+    pd.testing.assert_series_equal(result, recorded["result"])
+
+
+def test_rolling_information_ratio_cache_handles_unknown_frequency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When frequency cannot be inferred the cache should fall back to ``unknown``."""
+
+    returns = pd.Series(
+        [0.02, -0.01, 0.015, -0.005],
+        index=pd.to_datetime(["2021-01-31", "2021-02-02", "2021-03-15", "2021-03-29"]),
+    )
+
+    recorded: dict[str, object] = {}
+
+    class DummyCache:
+        def is_enabled(self) -> bool:
+            return True
+
+        def get_or_compute(self, dataset_hash, window, freq_tag, method_tag, compute_fn):
+            recorded["freq_tag"] = freq_tag
+            recorded["result"] = compute_fn()
+            return recorded["result"]
+
+    monkeypatch.setattr(rolling, "get_cache", lambda: DummyCache())
+
+    result = rolling.rolling_information_ratio(returns, benchmark=0.0, window=2)
+
+    assert recorded["freq_tag"] == "unknown"
+    pd.testing.assert_series_equal(result, recorded["result"])

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,98 @@
+"""Unit tests for :mod:`trend_analysis.engine.optimizer`."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from trend_analysis.engine import optimizer
+
+
+def test_apply_constraints_caps_and_normalises_weights() -> None:
+    weights = pd.Series({"A": 0.7, "B": 0.3})
+
+    result = optimizer.apply_constraints(
+        weights, optimizer.ConstraintSet(max_weight=0.6)
+    )
+
+    assert pytest.approx(1.0) == float(result.sum())
+    assert (result <= 0.6 + optimizer.NUMERICAL_TOLERANCE_HIGH).all()
+
+
+def test_apply_constraints_long_only_rejects_non_positive_portfolio() -> None:
+    weights = pd.Series({"A": -0.5, "B": -0.1})
+
+    with pytest.raises(optimizer.ConstraintViolation):
+        optimizer.apply_constraints(weights, optimizer.ConstraintSet())
+
+
+def test_apply_constraints_group_caps_require_group_mapping() -> None:
+    weights = pd.Series({"A": 0.5, "B": 0.5})
+
+    with pytest.raises(optimizer.ConstraintViolation):
+        optimizer.apply_constraints(
+            weights,
+            optimizer.ConstraintSet(
+                group_caps={"tech": 0.6},
+            ),
+        )
+
+
+def test_apply_constraints_group_caps_redistribute_excess_weight() -> None:
+    weights = pd.Series({"A": 0.6, "B": 0.2, "C": 0.2})
+    constraints = optimizer.ConstraintSet(
+        group_caps={"tech": 0.5, "health": 0.6},
+        groups={"A": "tech", "B": "tech", "C": "health"},
+    )
+
+    result = optimizer.apply_constraints(weights, constraints)
+
+    tech_total = result.loc[["A", "B"]].sum()
+    assert tech_total <= 0.5 + optimizer.NUMERICAL_TOLERANCE_HIGH
+    assert result.loc["C"] >= 0.2
+
+
+def test_apply_constraints_cash_weight_adds_cash_and_respects_cap() -> None:
+    weights = pd.Series({"A": 0.6, "B": 0.4})
+    constraints = optimizer.ConstraintSet(max_weight=0.45, cash_weight=0.4)
+
+    result = optimizer.apply_constraints(weights, constraints)
+
+    assert pytest.approx(1.0) == float(result.sum())
+    assert result.loc["CASH"] == pytest.approx(0.4)
+    assert (result.drop("CASH") <= 0.45 + optimizer.NUMERICAL_TOLERANCE_HIGH).all()
+
+
+def test_apply_constraints_cash_weight_infeasible_with_max_weight() -> None:
+    weights = pd.Series({"A": 0.5, "B": 0.5})
+    constraints = optimizer.ConstraintSet(max_weight=0.2, cash_weight=0.2)
+
+    with pytest.raises(optimizer.ConstraintViolation):
+        optimizer.apply_constraints(weights, constraints)
+
+
+def test_apply_cap_early_return_when_total_near_zero() -> None:
+    weights = pd.Series({"A": 1e-13, "B": 0.0})
+
+    capped = optimizer._apply_cap(weights, cap=0.5)
+
+    pd.testing.assert_series_equal(capped, weights)
+
+
+def test_redistribute_uniform_when_no_existing_weight() -> None:
+    weights = pd.Series({"A": 0.0, "B": 0.0, "C": 1.0})
+    mask = pd.Series([True, True, False], index=weights.index)
+
+    redistributed = optimizer._redistribute(weights.copy(), mask, amount=0.2)
+
+    assert redistributed.loc["A"] == pytest.approx(0.1)
+    assert redistributed.loc["B"] == pytest.approx(0.1)
+    assert redistributed.loc["C"] == pytest.approx(1.0)
+
+
+def test_redistribute_raises_when_no_capacity_available() -> None:
+    weights = pd.Series({"A": 0.4, "B": 0.6})
+    mask = pd.Series([False, False], index=weights.index)
+
+    with pytest.raises(optimizer.ConstraintViolation):
+        optimizer._redistribute(weights, mask, amount=0.1)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -136,6 +136,22 @@ def test_run_analysis_no_funds():
     assert res is None
 
 
+def test_run_analysis_returns_none_when_window_missing():
+    df = make_df()
+
+    # In-sample window entirely before available data.
+    res_in_empty = pipeline.run_analysis(
+        df, "2019-01", "2019-03", "2020-04", "2020-06", 1.0, 0.0
+    )
+    assert res_in_empty is None
+
+    # Out-of-sample window after available data.
+    res_out_empty = pipeline.run_analysis(
+        df, "2020-01", "2020-03", "2021-01", "2021-03", 1.0, 0.0
+    )
+    assert res_out_empty is None
+
+
 def test_run_missing_csv_key(tmp_path):
     cfg = Config(
         version="1",

--- a/tests/test_proxy_cli.py
+++ b/tests/test_proxy_cli.py
@@ -1,0 +1,89 @@
+"""Tests for :mod:`trend_analysis.proxy.cli`."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from trend_analysis.proxy import cli
+
+
+def _run_with_argv(monkeypatch: pytest.MonkeyPatch, argv: list[str]) -> int:
+    """Execute ``cli.main`` with ``argv`` patched in ``sys.argv``."""
+
+    monkeypatch.setattr(sys, "argv", argv)
+    return cli.main()
+
+
+def test_proxy_cli_invokes_run_proxy_with_parsed_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = SimpleNamespace(called=False, kwargs={})
+
+    def fake_run_proxy(**kwargs: object) -> None:
+        captured.called = True
+        captured.kwargs = kwargs
+
+    monkeypatch.setattr(cli, "run_proxy", fake_run_proxy)
+    monkeypatch.setattr(cli.logging, "basicConfig", lambda **_: None)
+
+    exit_code = _run_with_argv(
+        monkeypatch,
+        [
+            "proxy-cli",
+            "--streamlit-host",
+            "streamlit.internal",
+            "--streamlit-port",
+            "8601",
+            "--proxy-host",
+            "127.0.0.1",
+            "--proxy-port",
+            "9000",
+            "--log-level",
+            "DEBUG",
+        ],
+    )
+
+    assert exit_code == 0
+    assert captured.called is True
+    assert captured.kwargs == {
+        "streamlit_host": "streamlit.internal",
+        "streamlit_port": 8601,
+        "proxy_host": "127.0.0.1",
+        "proxy_port": 9000,
+    }
+
+
+def test_proxy_cli_handles_keyboard_interrupt(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fake_run_proxy(**_: object) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli, "run_proxy", fake_run_proxy)
+    monkeypatch.setattr(cli.logging, "basicConfig", lambda **_: None)
+
+    exit_code = _run_with_argv(monkeypatch, ["proxy-cli"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Proxy server stopped by user" in captured.out
+
+
+def test_proxy_cli_reports_generic_exception(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fake_run_proxy(**_: object) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cli, "run_proxy", fake_run_proxy)
+    monkeypatch.setattr(cli.logging, "basicConfig", lambda **_: None)
+
+    exit_code = _run_with_argv(monkeypatch, ["proxy-cli"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Error starting proxy" in captured.err
+    assert "boom" in captured.err

--- a/tests/test_timefreq.py
+++ b/tests/test_timefreq.py
@@ -56,3 +56,57 @@ def test_assert_no_invalid_period_aliases_in_source(tmp_path: Path) -> None:
     message = str(excinfo.value)
     assert "Invalid period_range frequency alias detected" in message
     assert str(bad_file) in message
+
+
+def test_assert_no_invalid_period_aliases_skips_known_false_positives(
+    tmp_path: Path,
+) -> None:
+    """Files under virtualenvs or this module itself are intentionally ignored."""
+
+    skipped_env = tmp_path / ".venv" / "lib" / "python.py"
+    skipped_env.parent.mkdir(parents=True)
+    skipped_env.write_text(
+        "pd.period_range('2024-01', periods=1, freq=\"ME\")\n",
+        encoding="utf-8",
+    )
+
+    skipped_module = tmp_path / "timefreq.py"
+    skipped_module.write_text(
+        "pd.period_range('2024-01', periods=1, freq=\"QE\")\n",
+        encoding="utf-8",
+    )
+
+    good_file = tmp_path / "good.py"
+    good_file.write_text(
+        "pd.period_range('2024-01', periods=1, freq=\"M\")\n",
+        encoding="utf-8",
+    )
+
+    # Even though the skipped files contain invalid aliases, they should be ignored.
+    timefreq.assert_no_invalid_period_aliases_in_source(
+        [str(skipped_env), str(skipped_module), str(good_file)]
+    )
+
+
+def test_assert_no_invalid_period_aliases_handles_unreadable_files(tmp_path: Path) -> None:
+    unreadable_file = tmp_path / "missing.py"
+    good_file = tmp_path / "good.py"
+    good_file.write_text(
+        "pd.period_range('2024-01', periods=1, freq=\"M\")\n",
+        encoding="utf-8",
+    )
+
+    # The helper should silently skip files that cannot be opened, relying on
+    # the caller to provide only project-controlled paths.
+    timefreq.assert_no_invalid_period_aliases_in_source(
+        [str(unreadable_file), str(good_file)]
+    )
+
+
+def test_validate_no_invalid_period_alias_includes_helpful_message() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        timefreq._validate_no_invalid_period_alias(timefreq.MONTHLY_DATE_FREQ)
+
+    message = str(excinfo.value)
+    assert timefreq.MONTHLY_PERIOD_FREQ in message
+    assert timefreq.QUARTERLY_PERIOD_FREQ in message

--- a/tests/test_timefreq.py
+++ b/tests/test_timefreq.py
@@ -1,0 +1,58 @@
+"""Unit tests for :mod:`trend_analysis.timefreq`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from trend_analysis import timefreq
+
+
+def test_monthly_date_range_uses_policy_frequency() -> None:
+    idx = timefreq.monthly_date_range("2024-01-31", periods=3)
+    assert isinstance(idx, pd.DatetimeIndex)
+    assert idx.freqstr == timefreq.MONTHLY_DATE_FREQ
+    assert list(idx) == list(
+        pd.date_range("2024-01-31", periods=3, freq=timefreq.MONTHLY_DATE_FREQ)
+    )
+
+
+def test_monthly_period_range_uses_policy_frequency() -> None:
+    idx = timefreq.monthly_period_range("2024-01", periods=2)
+    assert isinstance(idx, pd.PeriodIndex)
+    assert idx.freqstr == timefreq.MONTHLY_PERIOD_FREQ
+    assert list(idx.astype(str)) == ["2024-01", "2024-02"]
+
+
+def test_validate_no_invalid_period_alias_rejects_timestamp_aliases() -> None:
+    timefreq._validate_no_invalid_period_alias(timefreq.MONTHLY_PERIOD_FREQ)
+    timefreq._validate_no_invalid_period_alias(timefreq.QUARTERLY_PERIOD_FREQ)
+    with pytest.raises(ValueError):
+        timefreq._validate_no_invalid_period_alias(timefreq.MONTHLY_DATE_FREQ)
+    with pytest.raises(ValueError):
+        timefreq._validate_no_invalid_period_alias(timefreq.QUARTERLY_DATE_FREQ)
+
+
+def test_assert_no_invalid_period_aliases_in_source(tmp_path: Path) -> None:
+    good_file = tmp_path / "good.py"
+    good_file.write_text(
+        "pd.period_range('2024-01', periods=1, freq=\"M\")\n",
+        encoding="utf-8",
+    )
+
+    bad_file = tmp_path / "bad.py"
+    bad_file.write_text(
+        "pd.period_range('2024-01', periods=1, freq=\"ME\")\n",
+        encoding="utf-8",
+    )
+
+    timefreq.assert_no_invalid_period_aliases_in_source([str(good_file)])
+
+    with pytest.raises(AssertionError) as excinfo:
+        timefreq.assert_no_invalid_period_aliases_in_source([str(bad_file)])
+
+    message = str(excinfo.value)
+    assert "Invalid period_range frequency alias detected" in message
+    assert str(bad_file) in message


### PR DESCRIPTION
Continue to work on extending test coverage beginning with the modules that have the lowest coverage as shown by the data below
### Source Issue #1610: Increase test coverage (soft gate)

Source: https://github.com/stranske/Trend_Model_Project/issues/1610

> CI run: https://github.com/stranske/Trend_Model_Project/actions/runs/17937371782
> 
> **Coverage (avg across jobs): 97.03% | worst job: 97.03%**
> 
> | File | % covered |
> |---|---:|
> | `src/trend_analysis/timefreq.py` | 67.4% |
> | `src/trend_analysis/engine/optimizer.py` | 92.3% |
> | `src/trend_analysis/proxy/cli.py` | 92.3% |
> | `src/trend_analysis/config/model.py` | 92.7% |
> | `src/trend_analysis/__init__.py` | 93.5% |
> | `src/trend_analysis/multi_period/engine.py` | 93.7% |
> | `src/trend_analysis/cli.py` | 93.7% |
> | `src/trend_analysis/config/legacy.py` | 94.4% |
> | `src/trend_analysis/metrics/rolling.py` | 94.9% |
> | `src/trend_analysis/pipeline.py` | 95.0% |
> | `src/trend_analysis/metrics/__init__.py` | 95.1% |
> | `src/trend_analysis/weights/hierarchical_risk_parity.py` | 95.1% |
> | `src/trend_portfolio_app/monte_carlo/engine.py` | 95.3% |
> | `src/trend/cli.py` | 95.6% |
> | `src/trend_portfolio_app/io_utils.py` | 96.1% |
> 
> 
> #### Job logs
> ### Logs for this run
> | Job | Result | Logs |
> |---|---|---|
> | main / tests (3.11) | success | [logs](https://github.com/stranske/Trend_Model_Project/actions/runs/17937371782/job/51005991074) |
> | main / mypy | failure | [logs](https://github.com/stranske/Trend_Model_Project/actions/runs/17937371782/job/51005991078) |
> | main / logs_summary | in_progress | [logs](https://github.com/stranske/Trend_Model_Project/actions/runs/17937371782/job/51006107178) |
> | main / coverage_soft_gate | in_progress | [logs](https://github.com/stranske/Trend_Model_Project/actions/runs/17937371782/job/51006107180) |

—
(After opening the PR, comment with `@codex start`.)