### PR TITLE
Add guard-coverage tests for timefreq helpers

### DIFF
--- a/tests/test_timefreq.py
+++ b/tests/test_timefreq.py
@@ -56,3 +56,57 @@ def test_assert_no_invalid_period_aliases_in_source(tmp_path: Path) -> None:
     message = str(excinfo.value)
     assert "Invalid period_range frequency alias detected" in message
     assert str(bad_file) in message
+
+
+def test_assert_no_invalid_period_aliases_skips_known_false_positives(
+    tmp_path: Path,
+) -> None:
+    """Files under virtualenvs or this module itself are intentionally ignored."""
+
+    skipped_env = tmp_path / ".venv" / "lib" / "python.py"
+    skipped_env.parent.mkdir(parents=True)
+    skipped_env.write_text(
+        "pd.period_range('2024-01', periods=1, freq=\"ME\")\n",
+        encoding="utf-8",
+    )
+
+    skipped_module = tmp_path / "timefreq.py"
+    skipped_module.write_text(
+        "pd.period_range('2024-01', periods=1, freq=\"QE\")\n",
+        encoding="utf-8",
+    )
+
+    good_file = tmp_path / "good.py"
+    good_file.write_text(
+        "pd.period_range('2024-01', periods=1, freq=\"M\")\n",
+        encoding="utf-8",
+    )
+
+    # Even though the skipped files contain invalid aliases, they should be ignored.
+    timefreq.assert_no_invalid_period_aliases_in_source(
+        [str(skipped_env), str(skipped_module), str(good_file)]
+    )
+
+
+def test_assert_no_invalid_period_aliases_handles_unreadable_files(tmp_path: Path) -> None:
+    unreadable_file = tmp_path / "missing.py"
+    good_file = tmp_path / "good.py"
+    good_file.write_text(
+        "pd.period_range('2024-01', periods=1, freq=\"M\")\n",
+        encoding="utf-8",
+    )
+
+    # The helper should silently skip files that cannot be opened, relying on
+    # the caller to provide only project-controlled paths.
+    timefreq.assert_no_invalid_period_aliases_in_source(
+        [str(unreadable_file), str(good_file)]
+    )
+
+
+def test_validate_no_invalid_period_alias_includes_helpful_message() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        timefreq._validate_no_invalid_period_alias(timefreq.MONTHLY_DATE_FREQ)
+
+    message = str(excinfo.value)
+    assert timefreq.MONTHLY_PERIOD_FREQ in message
+    assert timefreq.QUARTERLY_PERIOD_FREQ in message


### PR DESCRIPTION
## Summary
- add regression tests that ensure invalid period aliases under virtualenv paths are ignored
- cover unreadable-path handling and error messaging for the invalid-alias guard

## Testing
- pytest tests/test_timefreq.py

------
https://chatgpt.com/codex/tasks/task_e_68d4e31f422483318fc993cd3a1b6c4f