### PR TITLE
test: verify autofix trivial keywords cover quality gates

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -202,7 +202,7 @@ jobs:
               return;
             }
 
-            const keywords = (process.env.TRIVIAL_KEYWORDS || 'lint,format,style,doc,ruff,mypy,type,black,isort,label').split(',')
+            const keywords = (process.env.TRIVIAL_KEYWORDS || 'lint,format,style,doc,ruff,mypy,type,black,isort,label,test').split(',')
               .map(str => str.trim().toLowerCase())
               .filter(Boolean);
 

--- a/tests/test_workflow_autofix_guard.py
+++ b/tests/test_workflow_autofix_guard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pathlib
+import re
 from typing import Any, Dict, List
 
 import yaml
@@ -61,3 +62,25 @@ def test_reusable_autofix_guard_applies_to_all_steps() -> None:
     steps = data["jobs"]["autofix"]["steps"]
     missing = _guarded_follow_up_steps(steps)
     assert not missing, f"Reusable autofix steps missing guard condition: {missing}"
+
+
+def _extract_trivial_keywords(script: str) -> set[str]:
+    match = re.search(r"TRIVIAL_KEYWORDS\s*\|\|\s*'([^']+)'", script)
+    if not match:
+        raise AssertionError(
+            "Default TRIVIAL_KEYWORDS clause missing from autofix workflow"
+        )
+    return {token.strip() for token in match.group(1).split(",") if token.strip()}
+
+
+def test_autofix_trivial_keywords_cover_lint_type_and_tests() -> None:
+    data = _load_yaml("autofix.yml")
+    failure_step = next(
+        step for step in data["jobs"]["context"]["steps"] if step.get("id") == "failure"
+    )
+    script = failure_step["with"]["script"]
+    keywords = _extract_trivial_keywords(script)
+    expected = {"lint", "mypy", "test"}
+    missing = expected.difference(keywords)
+    assert not missing, f"Autofix trivial keywords missing expected tokens: {missing}"
+    assert "label" in keywords, "Label failures should remain autofix-eligible"


### PR DESCRIPTION
## Summary
- keep CI autofix workflow aligned with new smoke scenario by classifying test failures as trivial
- add workflow regression test ensuring lint/type/test/label keywords stay present in TRIVIAL_KEYWORDS
i> validates automation will run autofix passes when style gate, mypy, or tests fail

## Testing
- pytest tests/test_workflow_autofix_guard.py