### PR TITLE
Increase test coverage - issue #1610

### DIFF
--- a/tests/test_cli_cache_stats_extended.py
+++ b/tests/test_cli_cache_stats_extended.py
@@ -47,3 +47,26 @@ def test_extract_cache_stats_returns_none_when_missing() -> None:
     }
 
     assert cli._extract_cache_stats(payload) is None
+
+
+def test_extract_cache_stats_skips_invalid_candidates_but_keeps_prior() -> None:
+    payload = {
+        "snapshots": [
+            {"entries": 1, "hits": 2, "misses": 3, "incremental_updates": 4},
+            {
+                "entries": "oops",
+                "hits": 6,
+                "misses": 7,
+                "incremental_updates": 8,
+            },
+        ]
+    }
+
+    stats = cli._extract_cache_stats(payload)
+
+    assert stats == {
+        "entries": 1,
+        "hits": 2,
+        "misses": 3,
+        "incremental_updates": 4,
+    }

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -41,6 +41,18 @@ def test_check_environment_missing_file(tmp_path, capsys):
     assert f"Lock file not found: {lock}" in out
 
 
+def test_check_environment_skips_non_pinned_lines(tmp_path, capsys):
+    lock = tmp_path / "req.lock"
+    lock.write_text("# comment\nwheel>=0.0\n\n", encoding="utf-8")
+
+    ret = cli.check_environment(lock)
+    out = capsys.readouterr().out
+
+    assert ret == 0
+    assert "wheel" not in out
+    assert "All packages match" in out
+
+
 def test_main_check_flag_without_subcommand(monkeypatch):
     called: dict[str, bool] = {}
 


### PR DESCRIPTION
## Summary
- extend `trend_analysis.cli` coverage to retain the most recent valid cache statistics when invalid counters appear later in the payload
- ensure the environment check routine ignores comment and non-pinned lines so optional entries do not trigger mismatches

## Testing
- `pytest tests/test_cli_cache_stats_extended.py tests/test_cli_check.py`


------
https://chatgpt.com/codex/tasks/task_e_68d4f389ae4483319b07bd01d28fac1f