### PR TITLE
test: demonstrate autofix on lint failure

### DIFF
--- a/scripts/coverage_history_append.py
+++ b/scripts/coverage_history_append.py
@@ -14,7 +14,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 JsonRecord = dict[str, Any]
 
 

--- a/tests/test_autofix_pipeline.py
+++ b/tests/test_autofix_pipeline.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import os
 import pytest
 
 import scripts.auto_type_hygiene as auto_type_hygiene

--- a/tests/test_label_rules_assert.py
+++ b/tests/test_label_rules_assert.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import pytest
 
-
 SCRIPT_PATH = (
     Path(__file__).resolve().parents[1] / ".github/scripts/label_rules_assert.py"
 )

--- a/tests/test_metrics_rolling.py
+++ b/tests/test_metrics_rolling.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import pytest
-
 import pandas as pd
+import pytest
 
 from trend_analysis.metrics import rolling
 
@@ -104,7 +103,8 @@ def test_rolling_information_ratio_uses_cache_when_enabled(
 def test_rolling_information_ratio_cache_handles_unknown_frequency(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When frequency cannot be inferred the cache should fall back to ``unknown``."""
+    """When frequency cannot be inferred the cache should fall back to
+    ``unknown``."""
 
     returns = pd.Series(
         [0.02, -0.01, 0.015, -0.005],

--- a/tests/test_timefreq.py
+++ b/tests/test_timefreq.py
@@ -61,7 +61,8 @@ def test_assert_no_invalid_period_aliases_in_source(tmp_path: Path) -> None:
 def test_assert_no_invalid_period_aliases_skips_known_false_positives(
     tmp_path: Path,
 ) -> None:
-    """Files under virtualenvs or this module itself are intentionally ignored."""
+    """Files under virtualenvs or this module itself are intentionally
+    ignored."""
 
     skipped_env = tmp_path / ".venv" / "lib" / "python.py"
     skipped_env.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- intentionally add an unused import to trigger lint failure

## Testing
- SKIP=ruff git commit -am 'feat: add demo lint issue'