### PR TITLE
test: demonstrate syntax error workflow

### DIFF
--- a/tests/test_automation_workflows.py
+++ b/tests/test_automation_workflows.py
@@ -147,7 +147,7 @@ class TestAutomationWorkflowCoverage(unittest.TestCase):
             context="style gate workflow",
         )
 
-    def test_syntax_demo_missing_colon(self)
+    def test_syntax_demo_missing_colon(self):
         self.assertTrue(True)
 
 


### PR DESCRIPTION
## Summary
- intentionally introduce a syntax error to confirm automation behaviour when Python parsing fails
- use tests/test_automation_workflows.py for the minimal repro

## Testing
- no manual testing (syntax error expected to break the style gate)