### PR TITLE
chore: add selector weighting autofix diagnostics (rebased)

### DIFF
--- a/.github/workflows/reusable-ci-python.yml
+++ b/.github/workflows/reusable-ci-python.yml
@@ -286,9 +286,13 @@ jobs:
         run: mypy src || (echo 'mypy failed' && exit 1)
 
   coverage_soft_gate:
-    if: ${{ inputs.enable-soft-gate }}
+    if: ${{ always() && inputs.enable-soft-gate }}
     needs: tests
     runs-on: ubuntu-latest
+    outputs:
+      has_failures: ${{ steps.classify.outputs.has_failures }}
+      only_cosmetic: ${{ steps.classify.outputs.only_cosmetic }}
+      summary_b64: ${{ steps.classify.outputs.summary_b64 }}
     permissions:
       contents: read
       issues: write
@@ -311,6 +315,46 @@ jobs:
             echo "--- $f ---";
             head -40 "$f" || true;
           done
+      - name: Classify test outcomes
+        id: classify
+        shell: python
+        run: |
+          import base64
+          import glob
+          import json
+          import os
+
+          from scripts.classify_test_failures import classify_reports
+
+          paths = sorted(
+              glob.glob('pytest-report*.xml')
+              + glob.glob('**/pytest-report*.xml', recursive=True)
+          )
+          summary = classify_reports(paths)
+          with open('test-failure-summary.json', 'w', encoding='utf-8') as handle:
+              json.dump(summary, handle, indent=2)
+
+          if summary.get('has_failures'):
+              print('Detected failing tests:')
+              for bucket in ('runtime', 'cosmetic', 'unknown'):
+                  entries = summary.get(bucket, []) or []
+                  if not entries:
+                      continue
+                  print(f"  {bucket}: {len(entries)}")
+                  for entry in entries:
+                      markers = entry.get('markers', []) or []
+                      joined = ', '.join(markers) if markers else 'unmarked'
+                      print(f"    - {entry['id']} ({joined})")
+          else:
+              print('No failing tests detected across JUnit reports.')
+
+          encoded = base64.b64encode(json.dumps(summary).encode('utf-8')).decode('ascii')
+          out_path = os.environ.get('GITHUB_OUTPUT')
+          if out_path:
+              with open(out_path, 'a', encoding='utf-8') as fh:
+                  fh.write(f"has_failures={'true' if summary.get('has_failures') else 'false'}\n")
+                  fh.write(f"only_cosmetic={'true' if summary.get('only_cosmetic') else 'false'}\n")
+                  fh.write(f"summary_b64={encoded}\n")
       - name: Compute coverage summary & hotspots
         id: cov
         shell: python
@@ -502,6 +546,116 @@ jobs:
           name: ${{ inputs.artifact-prefix }}coverage-trend-history
           retention-days: ${{ inputs.coverage-artifact-retention-days }}
           path: coverage-trend-history.ndjson
+
+  cosmetic_followup:
+    name: cosmetic failure triage
+    runs-on: ubuntu-latest
+    needs: [tests, coverage_soft_gate]
+    if: ${{ needs.tests.result != 'success' && needs.coverage_soft_gate.outputs.has_failures == 'true' && needs.coverage_soft_gate.outputs.only_cosmetic == 'true' }}
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Run cosmetic fixers
+        run: |
+          python scripts/auto_type_hygiene.py
+          python scripts/fix_cosmetic_aggregate.py
+      - name: Summarise cosmetic failures
+        id: cosmetic
+        shell: python
+        env:
+          SUMMARY_B64: ${{ needs.coverage_soft_gate.outputs.summary_b64 }}
+        run: |
+          import base64
+          import json
+          import os
+
+          summary_data = {}
+          payload = os.environ.get('SUMMARY_B64')
+          if payload:
+              summary_data = json.loads(base64.b64decode(payload).decode('utf-8'))
+          cosmetic = summary_data.get('cosmetic', []) if isinstance(summary_data, dict) else []
+          lines = []
+          for entry in cosmetic:
+              markers = entry.get('markers') or []
+              marker_text = f" ({', '.join(markers)})" if markers else ''
+              message = entry.get('message', '')
+              if message:
+                  message = message.splitlines()[0]
+                  message = f" — {message}"
+              lines.append(f"- `{entry.get('id', '<unknown>')}`{marker_text}{message}")
+
+          if not lines:
+              lines.append('- No detailed cosmetic failures captured.')
+
+          with open('cosmetic_failures.md', 'w', encoding='utf-8') as fh:
+              fh.write("\n".join(lines) + "\n")
+
+          out = os.environ.get('GITHUB_OUTPUT')
+          if out:
+              with open(out, 'a', encoding='utf-8') as handle:
+                  handle.write(f"has_details={'true' if cosmetic else 'false'}\n")
+      - name: Capture fixer diff
+        id: patch
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "has_patch=false" >> "$GITHUB_OUTPUT"
+          else
+            git diff > cosmetic-fixes.patch
+            echo "has_patch=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Upload cosmetic patch
+        if: steps.patch.outputs.has_patch == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: cosmetic-fixes
+          path: cosmetic-fixes.patch
+          retention-days: 5
+      - name: Post advisory comment for cosmetic failures
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          SUMMARY_B64: ${{ needs.coverage_soft_gate.outputs.summary_b64 }}
+          HAS_PATCH: ${{ steps.patch.outputs.has_patch }}
+        with:
+          script: |
+            const summaryPayload = process.env.SUMMARY_B64 || '';
+            if (!summaryPayload) {
+              core.info('No summary payload found; skipping cosmetic comment.');
+              return;
+            }
+            const summary = JSON.parse(Buffer.from(summaryPayload, 'base64').toString('utf8'));
+            const cosmetic = Array.isArray(summary.cosmetic) ? summary.cosmetic : [];
+            if (!cosmetic.length) {
+              core.info('No cosmetic failures detected; skipping comment.');
+              return;
+            }
+            const list = cosmetic.map(entry => {
+              const markers = entry.markers && entry.markers.length ? ` (${entry.markers.join(', ')})` : '';
+              return `- \`${entry.id}\`${markers}`;
+            }).join('\n');
+            const patchNote = process.env.HAS_PATCH === 'true'
+              ? '\nA cosmetic fix patch is available as an artifact on this run.'
+              : '';
+            const body = [
+              '⚠️ Detected cosmetic-only test failures. CI remains in advisory mode.',
+              '',
+              list,
+              '',
+              'Automation attempted to apply lightweight fixes. Please review the results and rerun the pipeline.',
+              patchNote.trim()
+            ].filter(Boolean).join('\n');
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            core.info('Posted cosmetic failure advisory comment.');
 
   logs_summary:
     if: ${{ always() }}

--- a/docs/verification-log.md
+++ b/docs/verification-log.md
@@ -1,0 +1,58 @@
+# Verification Log
+
+_Updated: 2025-09-28_
+
+This file captures the concrete checks we ran during the "feature/autofix-diagnostics-wave3-rebased" work session, along with the verification protocol we agreed to follow going forward. Point to this log whenever we need receipts.
+
+## Remote access checks
+
+```
+$ git remote -v
+origin  https://github.com/stranske/Trend_Model_Project (fetch)
+origin  https://github.com/stranske/Trend_Model_Project (push)
+```
+
+```
+$ git push --set-upstream origin feature/autofix-diagnostics-wave3-rebased --dry-run
+To https://github.com/stranske/Trend_Model_Project
+ ! [rejected]          feature/autofix-diagnostics-wave3-rebased -> feature/autofix-diagnostics-wave3-rebased (non-fast-forward)
+error: failed to push some refs to 'https://github.com/stranske/Trend_Model_Project'
+hint: Updates were rejected because the tip of your current branch is behind
+hint: its remote counterpart. If you want to integrate the remote changes,
+hint: use 'git pull' before pushing again.
+```
+
+Interpretation: authentication succeeded and the remote is reachable; the push failed only because local commits are behind the remote branch.
+
+## Verification protocol (effective immediately)
+
+1. **Run the check before answering.** Execute the relevant command (e.g., `git push --dry-run`, `git remote -v`) instead of relying on assumptions.
+2. **Embed the evidence.** Include the exact command and output in the reply so we are working from the same facts.
+3. **Flag uncertainty right away.** If the result is unclear or incomplete, state that directly and gather the missing data before continuing.
+4. **Correct on first challenge.** When a discrepancy is raised, rerun the commands immediately and update the response rather than debating the earlier claim.
+
+## Next steps for pushes
+
+Because the remote branch currently has additional commits, synchronize first, then push:
+
+```
+git pull --rebase origin feature/autofix-diagnostics-wave3-rebased
+git push origin feature/autofix-diagnostics-wave3-rebased
+```
+
+Keep this log updated whenever new verification steps are agreed upon.
+
+## Past failure & commitments
+
+In earlier sessions I asserted that pushes were impossible from this environment without first checking the live configuration. Those statements were wrong for two reasons:
+
+1. I relied on assumptions from other workspaces instead of running the commands (`git remote -v`, `git push --dry-run`) that would have shown the truth immediately.
+2. When challenged, I defended the assumption instead of rerunning the checks and providing evidence on the spot.
+
+To my future self: this wasted the user's time and trust. You've committed to the following guardrails so it doesn't happen again:
+
+- **Always verify first.** Run the relevant command before speaking, even if the answer seems obvious from past experience.
+- **Show your work.** Paste the command and output so everyone sees the evidence.
+- **Correct immediately.** If challenged, stop, rerun, and update the answer instead of debating the earlier claim.
+
+If you catch yourself skipping any of these steps, come back to this section, own the miss, and fix it right away.

--- a/scripts/fix_cosmetic_aggregate.py
+++ b/scripts/fix_cosmetic_aggregate.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""Normalize aggregate_numbers cosmetic formatting.
+
+This helper ensures the diagnostic automation module joins manager counts
+with a ``" | "`` separator instead of commas. It is intended to run inside the
+cosmetic follow-up workflow so that cosmetic-only regressions are repaired
+without manual intervention.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TARGET = ROOT / "src/trend_analysis/automation_multifailure.py"
+_SENTINEL = '" | "'
+
+
+def main() -> int:
+    try:
+        original = TARGET.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        print("[fix_cosmetic_aggregate] Target file missing; skipping.")
+        return 0
+
+    if _SENTINEL in original:
+        print("[fix_cosmetic_aggregate] aggregate_numbers already uses pipe separator.")
+        return 0
+
+    needle = '",".join(str(v) for v in values)'
+    replacement = '" | ".join(str(v) for v in values)'
+
+    if needle not in original:
+        print("[fix_cosmetic_aggregate] Expected pattern not found; skipping.")
+        return 0
+
+    updated = original.replace(needle, replacement, 1)
+    TARGET.write_text(updated, encoding="utf-8")
+    print("[fix_cosmetic_aggregate] Updated aggregate_numbers to use pipe separator.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/fix_numpy_asserts.py
+++ b/scripts/fix_numpy_asserts.py
@@ -17,6 +17,7 @@ TEST_ROOT = ROOT / "tests"
 TARGET_FILES = {
     Path("tests/test_pipeline_warmup_autofix.py"),
     Path("tests/test_rank_selection_core_unit.py"),
+    Path("tests/test_selector_weighting.py"),
 }
 ASSERT_PATTERN = re.compile(
     r"^(?P<indent>\s*)assert\s+(?P<lhs>[A-Za-z_][A-Za-z0-9_\.]+)\s*==\s*(?P<rhs>\[.*?\])\s*(?P<comment>#.*)?$"

--- a/scripts/update_autofix_expectations.py
+++ b/scripts/update_autofix_expectations.py
@@ -42,6 +42,11 @@ TARGETS: tuple[AutofixTarget, ...] = (
         callable_name="compute_expected_selected_fund_count",
         constant_name="EXPECTED_SELECTED_FUND_COUNT",
     ),
+    AutofixTarget(
+        module="tests.test_selector_weighting",
+        callable_name="compute_expected_top_selection_count",
+        constant_name="EXPECTED_TOP_SELECTION_COUNT",
+    ),
 )
 
 

--- a/src/trend_analysis/automation_multifailure.py
+++ b/src/trend_analysis/automation_multifailure.py
@@ -9,6 +9,6 @@ from __future__ import annotations
 from typing import Iterable
 
 
-def aggregate_numbers(values: Iterable[int]) -> str:
-    """Return a comma-joined string while claiming to return an int."""
-    return ",".join(str(v) for v in values)
+def aggregate_numbers(values: Iterable[int]) -> int:
+    """Return a pipe-separated string while claiming to return an int."""
+    return " | ".join(str(v) for v in values)

--- a/src/trend_analysis/automation_multifailure.py
+++ b/src/trend_analysis/automation_multifailure.py
@@ -9,6 +9,6 @@ from __future__ import annotations
 from typing import Iterable
 
 
-def aggregate_numbers(values: Iterable[int]) -> int:
+def aggregate_numbers(values: Iterable[int]) -> str:
     """Return a comma-joined string while claiming to return an int."""
     return ",".join(str(v) for v in values)

--- a/src/trend_analysis/automation_multifailure.py
+++ b/src/trend_analysis/automation_multifailure.py
@@ -9,6 +9,6 @@ from __future__ import annotations
 from typing import Iterable
 
 
-def aggregate_numbers(values: Iterable[int]) -> str:
+def aggregate_numbers(values: Iterable[int]) -> int:
     """Return a comma-joined string while claiming to return an int."""
     return ",".join(str(v) for v in values)

--- a/tests/test_selector_weighting.py
+++ b/tests/test_selector_weighting.py
@@ -1,5 +1,4 @@
 from fractions import Fraction
-from math import tau
 from pathlib import Path
 
 import numpy as np
@@ -10,7 +9,7 @@ from trend_analysis.selector import RankSelector, ZScoreSelector
 from trend_analysis.weighting import EqualWeight, ScorePropBayesian
 
 UNUSED_AUTOFIX_MARKER = "diagnostic lint artifact"
-EXPECTED_TOP_SELECTION_COUNT = 5
+EXPECTED_TOP_SELECTION_COUNT = 2
 
 
 def load_fixture():
@@ -29,7 +28,7 @@ def test_rank_selector():
     sf = load_fixture()
     selector = RankSelector(top_n=2, rank_column="Sharpe")
     selected, log = selector.select(sf)
-    unused_local = Fraction(1, 3)
+    Fraction(1, 3)
     assert list(selected.index) == ["A", "B"]
     assert log.loc["A", "reason"] < log.loc["C", "reason"]
     assert len(selected) == EXPECTED_TOP_SELECTION_COUNT
@@ -47,7 +46,7 @@ def test_equal_weighting_sum_to_one():
     weights = EqualWeight().weight(sf)
     assert abs(weights["weight"].sum() - 1.0) < NUMERICAL_TOLERANCE_MEDIUM
     fancy_array = np.array([1.0, 2.0])
-    assert fancy_array == [1.0, 2.0]
+    assert fancy_array.tolist() == [1.0, 2.0]
 
 
 def test_bayesian_shrinkage_monotonic():

--- a/tests/test_selector_weighting.py
+++ b/tests/test_selector_weighting.py
@@ -1,10 +1,16 @@
+from fractions import Fraction
+from math import tau
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 from trend_analysis.constants import NUMERICAL_TOLERANCE_MEDIUM
 from trend_analysis.selector import RankSelector, ZScoreSelector
 from trend_analysis.weighting import EqualWeight, ScorePropBayesian
+
+UNUSED_AUTOFIX_MARKER = "diagnostic lint artifact"
+EXPECTED_TOP_SELECTION_COUNT = 5
 
 
 def load_fixture():
@@ -12,12 +18,21 @@ def load_fixture():
     return pd.read_csv(path, index_col=0)
 
 
+def compute_expected_top_selection_count() -> int:
+    sf = load_fixture()
+    selector = RankSelector(top_n=2, rank_column="Sharpe")
+    selected, _ = selector.select(sf)
+    return len(selected)
+
+
 def test_rank_selector():
     sf = load_fixture()
     selector = RankSelector(top_n=2, rank_column="Sharpe")
     selected, log = selector.select(sf)
+    unused_local = Fraction(1, 3)
     assert list(selected.index) == ["A", "B"]
     assert log.loc["A", "reason"] < log.loc["C", "reason"]
+    assert len(selected) == EXPECTED_TOP_SELECTION_COUNT
 
 
 def test_zscore_selector_edge():
@@ -31,6 +46,8 @@ def test_equal_weighting_sum_to_one():
     sf = load_fixture().loc[["A", "B"]]
     weights = EqualWeight().weight(sf)
     assert abs(weights["weight"].sum() - 1.0) < NUMERICAL_TOLERANCE_MEDIUM
+    fancy_array = np.array([1.0, 2.0])
+    assert fancy_array == [1.0, 2.0]
 
 
 def test_bayesian_shrinkage_monotonic():


### PR DESCRIPTION
## Summary
- extend selector weighting tests with intentional regressions (lint, expectation drift, NumPy ambiguity) to exercise automation fixes
- wire the new test into expectation/NumPy autofix helper scripts
- retain intentional mypy return mismatch to validate the return-type autofix

## Testing
- PYTHONPATH=./src pytest tests/test_selector_weighting.py -q  # expected to fail until automation runs