### PR TITLE
fix: enforce joblib site-packages check during startup

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -42,8 +42,11 @@ def _ensure_joblib_external() -> None:
             f"stub at {resolved}."
         )
 
-    # The previous check for 'site-packages'/'dist-packages' was too restrictive
-    # and has been removed to allow for flexible installation patterns (e.g., conda, virtualenv).
+    if not any(part in SITE_INDICATORS for part in resolved.parts):
+        raise ImportError(
+            "joblib should resolve from site-packages/dist-packages but instead "
+            f"resolved to {resolved}."
+        )
 
 
 _ensure_src_on_sys_path()


### PR DESCRIPTION
**Summary**
* Relocated the lightweight joblib shim into the packaged `trend_analysis.util` namespace and refreshed its documentation so the helpers ship with the library while keeping the third-party module unshadowed.
* Updated the rolling cache to import the shim explicitly, preventing regressions that could hijack `import joblib` away from the external dependency.
* Added a `sitecustomize` guard that asserts the resolved `joblib` module originates from site/dist-packages so interpreter startup fails fast when the dependency is shadowed.

**Testing**
* ✅ `pytest tests/test_joblib_import.py`


------
https://chatgpt.com/codex/tasks/task_e_68dad0b1aa948331ba5ace70ae949950