### PR TITLE
fix: prevent local joblib stub from hijacking dependency

### DIFF
--- a/tests/test_sitecustomize_joblib_guard.py
+++ b/tests/test_sitecustomize_joblib_guard.py
@@ -1,0 +1,31 @@
+"""Tests for the joblib guard enforced during interpreter bootstrap."""
+
+from __future__ import annotations
+
+import importlib
+import types
+from pathlib import Path
+
+import pytest
+import sitecustomize
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_sitecustomize_raises_when_joblib_points_inside_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reloading with a repository-local joblib should raise ImportError."""
+
+    stub_spec = types.SimpleNamespace(origin=str(REPO_ROOT / "joblib.py"))
+    original_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name: str, *args, **kwargs):  # type: ignore[override]
+        if name == "joblib":
+            return stub_spec
+        return original_find_spec(name, *args, **kwargs)
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(importlib.util, "find_spec", fake_find_spec)
+        with pytest.raises(ImportError):
+            importlib.reload(sitecustomize)
+
+    importlib.reload(sitecustomize)

--- a/tests/test_sitecustomize_joblib_guard.py
+++ b/tests/test_sitecustomize_joblib_guard.py
@@ -7,12 +7,15 @@ import types
 from pathlib import Path
 
 import pytest
+
 import sitecustomize
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_sitecustomize_raises_when_joblib_points_inside_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sitecustomize_raises_when_joblib_points_inside_repo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Reloading with a repository-local joblib should raise ImportError."""
 
     stub_spec = types.SimpleNamespace(origin=str(REPO_ROOT / "joblib.py"))


### PR DESCRIPTION
## Summary
- relocate the legacy in-repo joblib stub into `trend_analysis.util.joblib_shim` so the third-party package is imported by default
- add interpreter-startup validation that raises if `joblib` resolves inside the repository instead of site/dist-packages
- cover the new behaviour with regression tests that confirm the real package is used and the guard trips when a repo stub would shadow it

## Testing
- pytest tests/test_joblib_import.py tests/test_sitecustomize_joblib_guard.py


------
https://chatgpt.com/codex/tasks/task_e_68dad7030e448331a4c712cf7185b8ed