### PR TITLE
chore(codex): bootstrap PR for issue #1674

### DIFF
--- a/tests/test_sitecustomize_joblib_guard.py
+++ b/tests/test_sitecustomize_joblib_guard.py
@@ -32,3 +32,22 @@ def test_sitecustomize_raises_when_joblib_points_inside_repo(
             importlib.reload(sitecustomize)
 
     importlib.reload(sitecustomize)
+
+
+def test_sitecustomize_allows_missing_joblib(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The guard should defer to import-time error when joblib is absent."""
+
+    original_find_spec = importlib.util.find_spec
+
+    def missing_find_spec(name: str, *args, **kwargs):  # type: ignore[override]
+        if name == "joblib":
+            return None
+        return original_find_spec(name, *args, **kwargs)
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(importlib.util, "find_spec", missing_find_spec)
+        # No exception is expected because the guard should defer to the
+        # subsequent import-time ModuleNotFoundError.
+        importlib.reload(sitecustomize)
+
+    importlib.reload(sitecustomize)


### PR DESCRIPTION
### Source Issue #1674: Fix import shadowing: rename joblib.py to avoid hijacking third-party joblib

Source: https://github.com/stranske/Trend_Model_Project/issues/1674

> Topic GUID: d38ce795-623c-5014-bcf7-7b21aa3848aa
> 
> ## Why
> Summary
> The repository includes a top-level joblib.py. Any import joblib will import this local file rather than the package, causing hard-to-diagnose failures. Rename the file and fix local imports. Context: joblib.py exists at repo root. 
> GitHub
> Why it matters
> Shadowing a core dependency breaks caching/parallelization quietly and inconsistently across environments.
> Scope / Tasks
>  Rename joblib.py to joblib_shim.py (or remove if unused).
>  Grep for import joblib and ensure they import the real package. If the local code is needed, update to from .joblib_shim import ... or relocate into src/....
>  Add a safety test: assert "site-packages" appears in joblib.__file__ at runtime.
> 
> ## Tasks
> _Not provided._
> 
> ## Acceptance criteria
> Importing joblib resolves to the third-party package across app, CLI, tests.
> 
> CI tests (local) confirm joblib.__file__ path is outside the repo.
> 
> Out of scope
> Performance tuning or swapping joblib for alternatives.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18096244697).

—
(After opening the PR, comment with `@codex start`.)

------
https://chatgpt.com/codex/tasks/task_e_68dafc29653c8331be297a3b19cccbfe