### PR TITLE
fix: ensure third-party joblib is always imported

### DIFF
--- a/tests/test_joblib_shim.py
+++ b/tests/test_joblib_shim.py
@@ -1,0 +1,18 @@
+"""Unit tests for the lightweight joblib shim helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from trend_analysis.util.joblib_shim import dump, load
+
+
+def test_joblib_shim_roundtrip(tmp_path: Path) -> None:
+    payload = {"a": [1, 2, 3], "b": {"nested": True}}
+    target = tmp_path / "cache.joblib"
+
+    dump(payload, target)
+    assert target.exists()
+
+    restored = load(target)
+    assert restored == payload


### PR DESCRIPTION
## Summary
- rename the in-repo joblib stub and relocate the helpers under `trend_analysis.util.joblib_shim`
- guard interpreter startup with a sitecustomize check so `import joblib` resolves from site/dist-packages and add regression coverage
- exercise the shim directly with a round-trip unit test to ensure its dump/load helpers remain functional

## Testing
- pytest tests/test_joblib_import.py tests/test_sitecustomize_joblib_guard.py tests/test_joblib_shim.py

------
https://chatgpt.com/codex/tasks/task_e_68dafeda5d148331a8ac51d25cbf090d