### PR TITLE
test: verify joblib resolves externally in subprocesses

### DIFF
--- a/tests/test_joblib_import.py
+++ b/tests/test_joblib_import.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
+import sys
 from pathlib import Path
 
 import joblib
@@ -35,3 +37,22 @@ def test_joblib_spec_origin_outside_repo() -> None:
     assert spec is not None, "joblib should be discoverable via importlib"
     assert spec.origin, "joblib should expose a filesystem origin"
     _assert_external(Path(spec.origin))
+
+
+def test_joblib_import_subprocess() -> None:
+    """A fresh interpreter should resolve :mod:`joblib` from site-packages."""
+
+    script = (
+        "import pathlib, joblib; "
+        "path = pathlib.Path(joblib.__file__).resolve(); "
+        "print(path)"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    resolved = Path(completed.stdout.strip())
+    _assert_external(resolved)


### PR DESCRIPTION
## Summary
- extend the joblib import safety suite with a subprocess-based check
- ensure a fresh interpreter launched from the repository also resolves the third-party joblib package

## Testing
- pytest tests/test_joblib_import.py tests/test_sitecustomize_joblib_guard.py tests/test_joblib_shim.py

------
https://chatgpt.com/codex/tasks/task_e_68db2cd6a6a4833192cc0bc1d49010d2