### PR TITLE
Follow-up: align joblib import test with sitecustomize guard

### DIFF
--- a/tests/test_joblib_import.py
+++ b/tests/test_joblib_import.py
@@ -9,14 +9,16 @@ from pathlib import Path
 
 import joblib
 
-SITE_INDICATOR = {"site-packages", "dist-packages"}
-REPO_ROOT = Path(__file__).resolve().parents[1]
+import sitecustomize
+
+SITE_INDICATORS = sitecustomize.SITE_INDICATORS
+REPO_ROOT = sitecustomize.REPO_ROOT
 
 
 def _assert_external(path: Path) -> None:
     resolved = path.resolve()
     assert any(
-        part in resolved.parts for part in SITE_INDICATOR
+        part in resolved.parts for part in SITE_INDICATORS
     ), f"joblib resolved to unexpected location: {resolved!s}"
     assert (
         REPO_ROOT not in resolved.parents


### PR DESCRIPTION
## Summary
- update the joblib safety test to reuse SITE_INDICATORS and REPO_ROOT from sitecustomize so it stays in sync with the guard logic

## Testing
- pytest tests/test_joblib_import.py tests/test_sitecustomize_joblib_guard.py tests/test_joblib_shim.py

------
https://chatgpt.com/codex/tasks/task_e_68db306977c88331a0038d4394517dd2