### PR TITLE
test: ensure repo no longer ships joblib stub

### DIFF
--- a/tests/test_joblib_import.py
+++ b/tests/test_joblib_import.py
@@ -58,3 +58,12 @@ def test_joblib_import_subprocess() -> None:
     )
     resolved = Path(completed.stdout.strip())
     _assert_external(resolved)
+
+
+def test_repository_does_not_ship_joblib_stub() -> None:
+    """The legacy ``joblib.py`` shim should not exist at the repository root."""
+
+    assert not (REPO_ROOT / "joblib.py").exists(), (
+        "A legacy joblib.py stub was found in the repository root; "
+        "rename or remove it to avoid shadowing the third-party dependency."
+    )


### PR DESCRIPTION
## Summary
- add a regression test that asserts the legacy joblib.py shim is absent from the repository root
- keep the new test alongside the existing joblib import safety checks

## Testing
- python -m pytest tests/test_joblib_import.py tests/test_sitecustomize_joblib_guard.py tests/test_joblib_shim.py

------
https://chatgpt.com/codex/tasks/task_e_68db38346a408331a500981ce3c8effb