### PR TITLE
Unify CI style gate and refresh dependencies

### DIFF
--- a/agents/codex-1656.md
+++ b/agents/codex-1656.md
@@ -4,3 +4,7 @@
 - Added unified CI style job to `pr-10-ci-python.yml` alongside tests and workflow automation.
 - Retired the standalone `pr-11-style-gate.yml` workflow and updated docs/scripts to point to the CI style job.
 - Ensured gate aggregation depends on the new style job and adjusted automation tests accordingly.
+
+## Iteration 2 Notes
+- Updated `requirements.lock` via `uv pip compile` so the lockfile consistency test passes with the refreshed dependency pins.
+- Fixed the local style gate script to call mypy against `src/trend_portfolio_app` (correct package path) using proper indentation.

--- a/requirements.lock
+++ b/requirements.lock
@@ -18,11 +18,11 @@ et-xmlfile==2.0.0
     # via openpyxl
 executing==2.2.1
     # via stack-data
-fonttools==4.60.0
+fonttools==4.60.1
     # via matplotlib
-hypothesis==6.140.1
+hypothesis==6.140.2
     # via trend-model (pyproject.toml)
-ipython==9.5.0
+ipython==9.6.0
     # via ipywidgets
 ipython-pygments-lexers==1.1.1
     # via ipython
@@ -30,7 +30,7 @@ ipywidgets==8.1.7
     # via trend-model (pyproject.toml)
 jedi==0.19.2
     # via ipython
-joblib==1.4.2
+joblib==1.5.2
     # via trend-model (pyproject.toml)
 jupyterlab-widgets==3.0.15
     # via ipywidgets
@@ -51,7 +51,7 @@ openpyxl==3.1.5
     # via trend-model (pyproject.toml)
 packaging==25.0
     # via matplotlib
-pandas==2.3.2
+pandas==2.3.3
     # via trend-model (pyproject.toml)
 parso==0.8.5
     # via jedi
@@ -81,7 +81,7 @@ python-dateutil==2.9.0.post0
     #   pandas
 pytz==2025.2
     # via pandas
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via trend-model (pyproject.toml)
 scipy==1.16.2
     # via trend-model (pyproject.toml)

--- a/scripts/style_gate_local.sh
+++ b/scripts/style_gate_local.sh
@@ -50,7 +50,7 @@ fi
 
 if command -v mypy >/dev/null 2>&1; then
   echo "Running mypy (core + app)" >&2
-  if ! mypy --config-file pyproject.toml src/trend_analysis src_trend_portfolio_app; then
+  if ! mypy --config-file pyproject.toml src/trend_analysis src/trend_portfolio_app; then
     echo "mypy type check failed." >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary
- add the CI `style` job to the unified workflow so Black, Ruff, and mypy run alongside the tests and workflow-automation jobs
- update documentation, helper scripts, and automation tests to reflect the consolidated style gate behaviour
- refresh `requirements.lock` with `uv pip compile` and fix the local style gate script to invoke mypy against `src/trend_portfolio_app`

## Testing
- `pytest tests/test_automation_workflows.py -q`
- `pytest tests/test_workflow_autofix_guard.py -q`
- `pytest tests/test_workflow_autofix_remote.py -q`
- `pytest tests/test_lockfile_consistency.py::test_lockfile_up_to_date -q`


------
https://chatgpt.com/codex/tasks/task_e_68db522d61988331821b38c9d162ec33