### PR TITLE
Unify PR CI: tests, lint, type check, and style gate in one workflow - Source Issue #1656

### DIFF
--- a/agents/codex-1656.md
+++ b/agents/codex-1656.md
@@ -1,14 +1,1 @@
 <!-- bootstrap for codex on issue #1656 -->
-
-## Iteration 1 Notes
-- Added unified CI style job to `pr-10-ci-python.yml` alongside tests and workflow automation.
-- Retired the standalone `pr-11-style-gate.yml` workflow and updated docs/scripts to point to the CI style job.
-- Ensured gate aggregation depends on the new style job and adjusted automation tests accordingly.
-
-## Iteration 2 Notes
-- Updated `requirements.lock` via `uv pip compile` so the lockfile consistency test passes with the refreshed dependency pins.
-- Fixed the local style gate script to call mypy against `src/trend_portfolio_app` (correct package path) using proper indentation.
-
-## Iteration 3 Notes
-- Synced contributor documentation so the unified CI style job is documented as running Black, Ruff, and pinned mypy locally and in CI.
-- Updated workflow guide tables to reference the `pr-10-ci-python.yml` style job instead of the removed standalone Style Gate workflow.


### PR DESCRIPTION
### Source Issue #1656: Unify PR CI: tests, lint, type check, and style gate in one workflow

Source: https://github.com/stranske/Trend_Model_Project/issues/1656

> Topic GUID: 5f3177ec-111b-5cec-81b0-4526e26af42e
> 
> ## Why
> Depends on: Issue 0 (rename scheme)
> Summary
> Fold the standalone Style Gate into the main CI workflow as a separate job so PRs get one place to look for red/green. Keep “CI” as the workflow name: for branch protections and existing integrations. Your current CI delegates to reusable-ci-python.yml and already runs unit tests and a workflow automation test job; add style/type jobs there so we don’t duplicate environment setup. 
> GitHub
> Scope
> Add jobs to pr-10-ci-python.yml:
> style: Black check, Ruff check, and Mypy. Mirror the current Style Gate behavior. 
> GitHub
> Make gate job depend on [main, workflow-automation, style] and keep it as a soft aggregator within the workflow.
> Emit artifacts coverage-summary, coverage-trend if available so “post‑CI” summaries still work. 
> GitHub
> 
> ## Tasks
> _Not provided._
> 
> ## Acceptance criteria
> One CI workflow with jobs: tests, style, workflow‑automation, gate.
> 
> Existing Style Gate file removed or marked deprecated (comment in YAML header).
> 
> PR Status Summary still collects and comments job results correctly. 
> GitHub
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18086613665).

—
(After opening the PR, comment with `@codex start`.)