### PR TITLE
Add guardrails for retired gate workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -29,6 +29,8 @@ The CI stack now runs in distinct lanes so each concern can evolve independently
 
 Temporary state: `pr-10-ci-python.yml` (formerly `ci.yml`) exists solely to preserve the historic required check name ("CI") while maintainers transition branch protection to the gate job. Once maintainers flip protection, delete `pr-10-ci-python.yml` and mark the gate job required.
 
+> ℹ️ **Gate wrapper retired (Issue #1657).** The invalid standalone `gate.yml` workflow was deleted; the `gate / all-required-green` job within `pr-10-ci-python.yml` is now the sole aggregation point. Do not recreate the wrapper—tests assert the file remains absent.
+
 Flow:
 1. PR opened → labelers apply path + agent labels.
 2. Labels / branch rules trigger CI, autofix, readiness.

--- a/ARCHIVE_WORKFLOWS.md
+++ b/ARCHIVE_WORKFLOWS.md
@@ -16,6 +16,7 @@ All deprecated agent automation workflows were deleted from `.github/workflows/`
 ## Additional Archived Workflows
 - `guard-no-reuse-pr-branches.yml` – Archived in place (no functional replacement required; governance policy only). Removal candidate after 2025-10-20.
 - (2026-02-07) `codex-issue-bridge.yml`, `reuse-agents.yml`, and `agents-consumer.yml` moved to `Old/.github/workflows/` after assigner/watchdog consolidation. In 2026-09 the agent utilities were renumbered under WFv1: `agents-40-consumer.yml`, `agents-41-assign.yml`, `agents-42-watchdog.yml`, and `reusable-90-agents.yml` now live in `.github/workflows/`.
+- (2026-09-30) Standalone `gate.yml` wrapper deleted (Issue #1657). Aggregation now lives exclusively in the `gate / all-required-green` job inside `pr-10-ci-python.yml`; no archived copy retained because the YAML was invalid.
 
 ## Retired Autofix Wrapper
 - Legacy `autofix.yml` (pre-2025) was deleted during the earlier cleanup. As of 2026-02-15 a new consolidated `autofix.yml` now drives both small fixes and trivial failure remediation; the former consumer wrappers have been removed.

--- a/tests/test_automation_workflows.py
+++ b/tests/test_automation_workflows.py
@@ -98,6 +98,30 @@ class TestAutomationWorkflowCoverage(unittest.TestCase):
             inputs.get("enable-soft-gate"), "CI should enable coverage soft gate"
         )
 
+        self.assertIn("gate", jobs, "CI workflow should expose aggregate gate job")
+        gate_job = jobs["gate"]
+        self.assertEqual(
+            gate_job.get("name"),
+            "gate / all-required-green",
+            "Gate job name should match required check label",
+        )
+        self.assertEqual(
+            set(gate_job.get("needs", [])),
+            {"tests", "workflow-automation", "style"},
+            "Gate job must aggregate core CI jobs",
+        )
+        self.assertTrue(
+            gate_job.get("steps"),
+            "Gate job should include at least one confirmation step",
+        )
+
+    def test_gate_workflow_file_is_absent(self) -> None:
+        gate_path = self.workflows_dir / "gate.yml"
+        self.assertFalse(
+            gate_path.exists(),
+            "Legacy gate.yml workflow should remain deleted; rely on pr-10 gate job",
+        )
+
     def test_reusable_ci_runs_tests_and_mypy(self) -> None:
         workflow = self._read_workflow("reusable-ci-python.yml")
         jobs = workflow.get("jobs", {})


### PR DESCRIPTION
## Summary
- document that the legacy gate.yml workflow has been retired in the workflow guide and archive log
- extend workflow coverage tests to assert the pr-10 gate job is authoritative and the standalone gate.yml file stays deleted

## Testing
- pytest tests/test_automation_workflows.py

------
https://chatgpt.com/codex/tasks/task_e_68db7cd980308331ac9c2f9e8948ab2f