### PR TITLE
Align PR status summary with unified CI jobs

### DIFF
--- a/.github/workflows/maint-31-pr-status-summary.yml
+++ b/.github/workflows/maint-31-pr-status-summary.yml
@@ -67,12 +67,54 @@ jobs:
               return '⏳';
             };
 
-            // Determine required baseline heuristically (same logic as before using job names)
-            const nameSet = new Set(jobs.map(j => j.name));
-            const required = ['CI'];
-            if (nameSet.has('Docker')) required.push('Docker');
+            const combineStates = (states) => {
+              const normalized = states.map(s => (s || '').toLowerCase()).filter(Boolean);
+              if (!normalized.length) return 'missing';
+
+              const failureStates = ['failure', 'cancelled', 'timed_out', 'action_required'];
+              const pendingStates = ['in_progress', 'queued', 'waiting', 'pending'];
+
+              const failure = normalized.find(s => failureStates.includes(s));
+              if (failure) return failure;
+
+              const pending = normalized.find(s => pendingStates.includes(s));
+              if (pending) return pending;
+
+              if (normalized.every(s => s === 'skipped')) return 'skipped';
+              if (normalized.includes('success')) return 'success';
+
+              return normalized[0];
+            };
+
+            const formatRequirement = (label, predicate) => {
+              const matches = jobs.filter(job => predicate(job.name));
+              if (!matches.length) {
+                return `${label}: ${badge('missing')} missing`;
+              }
+
+              const combined = combineStates(matches.map(job => job.conclusion || job.status));
+              return `${label}: ${badge(combined)} ${combined}`;
+            };
+
             const conclusions = Object.fromEntries(jobs.map(j => [j.name, j.conclusion || j.status]));
-            const requiredStates = required.map(n => `${n}: ${conclusions[n] || 'missing'}`);
+            let requiredStates;
+
+            if ((run.name || '').toLowerCase() === 'ci') {
+              const ciGroups = [
+                { label: 'CI tests', predicate: (name) => name === 'main / tests' || name.startsWith('main / tests /') },
+                { label: 'CI workflow-automation', predicate: (name) => name.startsWith('workflow / automation-tests') },
+                { label: 'CI style', predicate: (name) => name === 'main / style' || name.startsWith('main / style /') },
+                { label: 'CI gate', predicate: (name) => name === 'gate / all-required-green' },
+              ];
+
+              requiredStates = ciGroups.map(group => formatRequirement(group.label, group.predicate));
+            } else {
+              const fallback = [run.name].filter(Boolean);
+              requiredStates = fallback.map(name => {
+                const state = conclusions[name] || 'missing';
+                return `${name}: ${badge(state)} ${state}`;
+              });
+            }
 
             // Build rows; highlight failed/cancelled at top (enhancement)
             const priorityOrder = (state) => {

--- a/scripts/generate_residual_report.py
+++ b/scripts/generate_residual_report.py
@@ -20,9 +20,9 @@ lines = [
     "",
     f"Generated: {datetime.datetime.utcnow():%Y-%m-%d %H:%M:%S} UTC",
     "",
-    f"Total diagnostics: {cls.get('total',0)}",
-    f"New diagnostics: {cls.get('new',0)}",
-    f"Allowed diagnostics: {cls.get('allowed',0)}",
+    f"Total diagnostics: {cls.get('total', 0)}",
+    f"New diagnostics: {cls.get('new', 0)}",
+    f"Allowed diagnostics: {cls.get('allowed', 0)}",
 ]
 
 # If trend file exists, show overall sparklines and top code trends
@@ -36,14 +36,14 @@ if trend:
         "",
         "## Trend (last 40 runs)",
         "",
-        f"Remaining: {trend.get('remaining_latest',0)}  {trend.get('remaining_spark','')}",
-        f"New: {trend.get('new_latest',0)}  {trend.get('new_spark','')}",
+        f"Remaining: {trend.get('remaining_latest', 0)}  {trend.get('remaining_spark', '')}",
+        f"New: {trend.get('new_latest', 0)}  {trend.get('new_spark', '')}",
     ]
     codes = trend.get("codes") or {}
     if codes:
         lines += ["", "### Top Codes Trend"]
         for code, data in codes.items():
-            lines.append(f"- {code}: {data.get('latest',0)}  {data.get('spark','')}")
+            lines.append(f"- {code}: {data.get('latest', 0)}  {data.get('spark', '')}")
 
 lines += ["", "## Per-Code Breakdown"]
 by_code = cls.get("by_code", {})

--- a/tests/test_automation_workflows.py
+++ b/tests/test_automation_workflows.py
@@ -85,7 +85,9 @@ class TestAutomationWorkflowCoverage(unittest.TestCase):
     def test_ci_workflow_invokes_reusable_stack(self) -> None:
         workflow = self._read_workflow("pr-10-ci-python.yml")
         jobs = workflow.get("jobs", {})
-        self.assertIn("tests", jobs, "CI workflow should delegate tests via reusable job")
+        self.assertIn(
+            "tests", jobs, "CI workflow should delegate tests via reusable job"
+        )
         tests_job = jobs["tests"]
         self.assertEqual(
             tests_job.get("uses"),


### PR DESCRIPTION
## Summary
- update the PR status summary workflow to aggregate the unified CI job states (tests, workflow-automation, style, gate)
- tidy spacing in the residual Ruff report helper to satisfy flake8
- accept the black reformat that keeps the automation workflow test in sync with repo style

## Testing
- ./scripts/dev_check.sh --changed --fix
- ./scripts/validate_fast.sh --changed --fix

------
https://chatgpt.com/codex/tasks/task_e_68db7f93475c8331a7fa5de672dfc589