### PR TITLE
Strengthen guards against resurrecting gate.yml workflow

### DIFF
--- a/agents/codex-1657.md
+++ b/agents/codex-1657.md
@@ -1,1 +1,0 @@
-<!-- bootstrap for codex on issue #1657 -->


### PR DESCRIPTION
**Summary**
* Documented that the legacy `gate.yml` wrapper remains retired and pointed maintainers at the `gate / all-required-green` job as the sole CI aggregation point.
* Logged the gate workflow removal in the archival ledger for future auditing.
* Strengthened workflow coverage tests to verify the gate job wiring and ensure the standalone `gate.yml` file stays absent.
* Added a regression test that fails if any workflow reintroduces the bare `not quarantine and not slow` marker filter and removed the bootstrap marker file now that the retirement work is complete.

**Testing**
* ✅ `pytest tests/test_automation_workflows.py`


------
https://chatgpt.com/codex/tasks/task_e_68db82272f888331b25233712a8e2e7f