### PR TITLE
Ensure dev_check finds flake8 automatically

### DIFF
--- a/scripts/dev_check.sh
+++ b/scripts/dev_check.sh
@@ -41,7 +41,7 @@ if [[ -z "$VIRTUAL_ENV" && -f ".venv/bin/activate" ]]; then
     source .venv/bin/activate > /dev/null 2>&1
 fi
 
-# Ensure formatter tooling is available (black, isort, docformatter)
+# Ensure formatter tooling is available (black, isort, docformatter) and include lint tooling.
 ensure_python_packages() {
     local missing=()
     for package in "$@"; do
@@ -68,7 +68,20 @@ PY
     fi
 }
 
-ensure_python_packages black isort docformatter
+# Ensure lint tooling (flake8) is also available for critical error checks.
+ensure_python_packages black isort docformatter flake8
+
+# Guarantee the Python scripts directory (where flake8 entry point lives) is on PATH.
+if ! command -v flake8 >/dev/null 2>&1; then
+    FLK_BIN=$(python - <<'PY'
+import sysconfig
+print(sysconfig.get_path('scripts') or '')
+PY
+)
+    if [[ -n "$FLK_BIN" ]]; then
+        export PATH="${FLK_BIN}:${PATH}"
+    fi
+fi
 
 # Determine files to check
 if [[ "$CHANGED_ONLY" == true ]]; then


### PR DESCRIPTION
## Summary
- make the fast dev_check script install flake8 alongside existing formatter tooling
- append the Python scripts directory to PATH when needed so the flake8 entrypoint is discoverable

## Testing
- ./scripts/dev_check.sh --changed --fix
- ./scripts/validate_fast.sh --changed --fix

------
https://chatgpt.com/codex/tasks/task_e_68db8489f92c8331b1bcac9d165237bd