### PR TITLE
feat: gate sitecustomize bootstrap behind opt-in flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ If package installation fails due to network issues, the CLI is still available 
 PYTHONPATH="./src" python -m trend.cli run --help
 ```
 
+#### Optional interpreter bootstrap (development only)
+
+The legacy repository-level ``sitecustomize.py`` shim has been replaced with an
+opt-in module living under ``trend_model._sitecustomize``.  To restore the
+previous behaviour (ensuring ``src/`` is on ``sys.path`` and validating that the
+third-party ``joblib`` dependency is used) set the environment variable
+``TREND_MODEL_SITE_CUSTOMIZE=1`` **before** launching Python:
+
+```bash
+export TREND_MODEL_SITE_CUSTOMIZE=1
+python -m trend.cli run --help
+```
+
+Without this flag the interpreter starts without any Trend Model-specific side
+effects, making it safe to put the repository on ``PYTHONPATH`` during
+toolchain bootstrap.
+
 ### Docker (Zero-Setup)
 
 For the fastest setup with zero local dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ trend-model = "trend_analysis.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["trend_analysis*", "trend_portfolio_app*"]
+include = ["trend_analysis*", "trend_portfolio_app*", "trend_model*"]
 
 [project.optional-dependencies]
 app = [

--- a/src/trend_model/__init__.py
+++ b/src/trend_model/__init__.py
@@ -1,0 +1,7 @@
+"""Trend Model bootstrap utilities.
+
+This package currently exposes optional helpers for opt-in interpreter
+bootstrap behaviour used during development and testing.
+"""
+
+__all__ = []

--- a/src/trend_model/_sitecustomize.py
+++ b/src/trend_model/_sitecustomize.py
@@ -1,0 +1,68 @@
+"""Optional interpreter bootstrap hooks for Trend Model development.
+
+The helpers in this module replicate the legacy ``sitecustomize`` behaviour
+while allowing callers to opt-in explicitly by setting the
+``TREND_MODEL_SITE_CUSTOMIZE`` environment variable to ``"1"`` prior to
+interpreter start.  Importing the module has no side effects; consumers should
+call :func:`bootstrap` to execute the hooks.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+__all__ = ["bootstrap"]
+
+SITE_INDICATORS = {"site-packages", "dist-packages"}
+PACKAGE_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = PACKAGE_ROOT.parents[1]
+SRC_DIR = REPO_ROOT / "src"
+
+
+def _ensure_src_on_sys_path() -> None:
+    """Prepend ``src`` to ``sys.path`` if the directory exists."""
+
+    if SRC_DIR.exists():  # pragma: no branch - trivial guard
+        src = str(SRC_DIR)
+        if src not in sys.path:
+            sys.path.insert(0, src)
+
+
+def _ensure_joblib_external() -> None:
+    """Fail fast if :mod:`joblib` resolves to a repository-local module."""
+
+    spec = importlib.util.find_spec("joblib")
+    if spec is None or not spec.origin:
+        # Dependency not installed yet (e.g. during bootstrapping); defer to the
+        # actual import which will raise a clearer ModuleNotFoundError.
+        return
+
+    resolved = Path(spec.origin).resolve()
+    resolved_parts = resolved.parts
+
+    if any(part in SITE_INDICATORS for part in resolved_parts):
+        # Virtual environments often live inside the repository root (e.g.
+        # ``.venv/``). As long as the resolution path contains a recognised
+        # site-packages/dist-packages segment we accept it as the third-party
+        # dependency.
+        return
+
+    if REPO_ROOT in resolved.parents or resolved == REPO_ROOT:
+        raise ImportError(
+            "The third-party 'joblib' package is required; found repository "
+            f"stub at {resolved}."
+        )
+
+    raise ImportError(
+        "joblib should resolve from site-packages/dist-packages but instead "
+        f"resolved to {resolved}."
+    )
+
+
+def bootstrap() -> None:
+    """Execute the optional interpreter bootstrap hooks."""
+
+    _ensure_src_on_sys_path()
+    _ensure_joblib_external()


### PR DESCRIPTION
## Summary
- gate the interpreter bootstrap via TREND_MODEL_SITE_CUSTOMIZE by delegating to src/trend_model/_sitecustomize.py
- update docs and packaging metadata to reference the opt-in module
- adjust sitecustomize tests to use the opt-in flow and ensure imports are side-effect free when disabled

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbf89023e8833183ea7f1a608aab8c