### PR TITLE
Contain global side effects: relocate/gate sitecustomize.py - Source Issue #1675

### DIFF
--- a/docs/ops/codex-bootstrap-facts.md
+++ b/docs/ops/codex-bootstrap-facts.md
@@ -26,6 +26,13 @@ Last updated: 2026-02-07
   - `GITHUB_TOKEN`: Fallback; ensure repository Actions permissions are set to Read/Write.
 - The workflow avoids using `secrets.*` inside step‑level `if:` blocks; token decisions are propagated via `env` and inputs.
 
+## Interpreter Bootstrap Invariants
+- Repository-root `sitecustomize.py` remains a no-op shim until
+  `TREND_MODEL_SITE_CUSTOMIZE=1` is exported; wrapper scripts under `scripts/`
+  set this flag so CI/dev invocations still exercise the guarded bootstrap.
+- Reviewers should reject contributions that restore eager imports or side
+  effects at the repository root.
+
 - ## Workflows and Actions
 - Assigner workflow: `.github/workflows/agents-41-assign.yml`.
   - Triggers on Issues/PRs when `agent:*` labels are applied (manual `workflow_dispatch` supported for diagnostics).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -133,6 +133,11 @@ PYTHONPATH="./src" python -m trend_analysis.run_analysis -c config/demo.yml
 python scripts/generate_demo.py
 ```
 
+> 💡 **Opt-in bootstrap (development):** Set `TREND_MODEL_SITE_CUSTOMIZE=1`
+> before launching Python if you want the interpreter to validate that
+> third-party `joblib` is being used and to add `src/` to `sys.path`
+> automatically. The wrapper scripts in `scripts/` export this flag for you.
+
 ---
 
 ## 🔧 Customization

--- a/ruff_remaining.log
+++ b/ruff_remaining.log
@@ -1,1 +1,18 @@
-All checks passed!
+tests/test_sitecustomize_joblib_guard.py:96:20: F821 Undefined name `FLAG`
+   |
+95 |     with monkeypatch.context() as ctx:
+96 |         ctx.setenv(FLAG, flag_value)
+   |                    ^^^^ F821
+97 |         sys.modules.pop("trend_model._sitecustomize", None)
+   |
+
+tests/test_sitecustomize_joblib_guard.py:99:26: F821 Undefined name `sitecustomize`
+    |
+ 97 |         sys.modules.pop("trend_model._sitecustomize", None)
+ 98 | 
+ 99 |         importlib.reload(sitecustomize)
+    |                          ^^^^^^^^^^^^^ F821
+100 |         assert "trend_model._sitecustomize" not in sys.modules
+    |
+
+Found 2 errors.

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -33,6 +33,11 @@ SRC_PATH = ROOT / "src"
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
+# Opt into the guarded interpreter bootstrap unless explicitly disabled.
+def setup_trend_model_env():
+    os.environ.setdefault("TREND_MODEL_SITE_CUSTOMIZE", "1")
+
+setup_trend_model_env()
 # Standard library done; third-party imports
 import numpy as np
 import openpyxl
@@ -364,6 +369,7 @@ def _check_cli_env(cfg_path: str) -> None:
     env = os.environ.copy()
     env["TREND_CFG"] = cfg_path
     env["PYTHONPATH"] = f"{ROOT / 'src'}:{env.get('PYTHONPATH', '')}"
+    env.setdefault("TREND_MODEL_SITE_CUSTOMIZE", "1")
     subprocess.run(
         [sys.executable, "-m", "trend_analysis.run_analysis", "--detailed"],
         check=True,
@@ -382,6 +388,7 @@ def _check_cli_env_multi(cfg_path: str) -> None:
     env = os.environ.copy()
     env["TREND_CFG"] = cfg_path
     env["PYTHONPATH"] = f"{ROOT / 'src'}:{env.get('PYTHONPATH', '')}"
+    env.setdefault("TREND_MODEL_SITE_CUSTOMIZE", "1")
     subprocess.run(
         [sys.executable, "-m", "trend_analysis.run_multi_analysis", "--detailed"],
         check=True,
@@ -2154,6 +2161,7 @@ def _check_cli_help() -> None:
     """Ensure the CLI entry points print help and exit cleanly."""
     env = os.environ.copy()
     env["PYTHONPATH"] = f"{ROOT / 'src'}:{env.get('PYTHONPATH', '')}"
+    env.setdefault("TREND_MODEL_SITE_CUSTOMIZE", "1")
     subprocess.run(
         [sys.executable, "-m", "trend_analysis.run_analysis", "--help"],
         check=True,
@@ -2261,6 +2269,7 @@ print("Multi-period demo checks passed")
 # Run the CLI entry point in both modes to verify it behaves correctly
 _env = os.environ.copy()
 _env["PYTHONPATH"] = f"{ROOT / 'src'}:{_env.get('PYTHONPATH', '')}"
+_env.setdefault("TREND_MODEL_SITE_CUSTOMIZE", "1")
 subprocess.run(
     [
         sys.executable,
@@ -2308,6 +2317,7 @@ subprocess.run(
 
 env = os.environ.copy()
 env["TREND_CFG"] = "config/demo.yml"
+env.setdefault("TREND_MODEL_SITE_CUSTOMIZE", "1")
 subprocess.run(
     ["scripts/trend-model", "--check", "run"],
     check=True,

--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -33,9 +33,11 @@ SRC_PATH = ROOT / "src"
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
+
 # Opt into the guarded interpreter bootstrap unless explicitly disabled.
 def setup_trend_model_env():
     os.environ.setdefault("TREND_MODEL_SITE_CUSTOMIZE", "1")
+
 
 setup_trend_model_env()
 # Standard library done; third-party imports

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -7,6 +7,10 @@ set -euo pipefail
 # Set hash seed before Python starts for reproducible results
 export PYTHONHASHSEED=0
 
+if [[ -z "${TREND_MODEL_SITE_CUSTOMIZE:-}" ]]; then
+  export TREND_MODEL_SITE_CUSTOMIZE=1
+fi
+
 pip install -r requirements.txt pytest coverage
 
 # Select coverage profile (defaults to "core" if not provided)

--- a/scripts/test_health_retry.sh
+++ b/scripts/test_health_retry.sh
@@ -17,6 +17,11 @@ elif [ -f ".venv/Scripts/activate" ]; then
 else
     echo "⚠️  No virtual environment found. Falling back to system Python."
 fi
+
+if [[ -z "${TREND_MODEL_SITE_CUSTOMIZE:-}" ]]; then
+    export TREND_MODEL_SITE_CUSTOMIZE=1
+fi
+
 PYTHONPATH="./src" python -m trend_portfolio_app.health_wrapper &
 HEALTH_PID=$!
 

--- a/scripts/trend
+++ b/scripts/trend
@@ -14,6 +14,10 @@ if [ -f "${PROJECT_ROOT}/.venv/bin/activate" ]; then
     source "${PROJECT_ROOT}/.venv/bin/activate"
 fi
 
+if [[ -z "${TREND_MODEL_SITE_CUSTOMIZE:-}" ]]; then
+    export TREND_MODEL_SITE_CUSTOMIZE=1
+fi
+
 PYTHON_EXEC="python"
 if [ -x "${PROJECT_ROOT}/.venv/bin/python" ]; then
     PYTHON_EXEC="${PROJECT_ROOT}/.venv/bin/python"

--- a/scripts/trend-model
+++ b/scripts/trend-model
@@ -19,9 +19,15 @@ if [ -f "${PROJECT_ROOT}/.venv/bin/activate" ]; then
     source "${PROJECT_ROOT}/.venv/bin/activate"
 fi
 
+# Opt into the guarded bootstrap unless explicitly disabled.
+if [[ -z "${TREND_MODEL_SITE_CUSTOMIZE:-}" ]]; then
+    export TREND_MODEL_SITE_CUSTOMIZE=1
+fi
+
 # Run the CLI module with all arguments passed through
 PYTHON_EXEC="python"
 if [ -x "${PROJECT_ROOT}/.venv/bin/python" ]; then
     PYTHON_EXEC="${PROJECT_ROOT}/.venv/bin/python"
 fi
+
 exec "$PYTHON_EXEC" -m trend_analysis.cli "$@"

--- a/scripts/trend-reproducible
+++ b/scripts/trend-reproducible
@@ -23,6 +23,11 @@ fi
 # Set PYTHONPATH to include the src directory
 export PYTHONPATH="${PYTHONPATH:-}:$ROOT_DIR/src"
 
+# Ensure the guarded bootstrap runs for reproducible sessions.
+if [[ -z "${TREND_MODEL_SITE_CUSTOMIZE:-}" ]]; then
+    export TREND_MODEL_SITE_CUSTOMIZE=1
+fi
+
 # Default to trend analysis if no module specified
 MODULE="${1:-trend_analysis.run_analysis}"
 

--- a/src/trend_model/_sitecustomize.py
+++ b/src/trend_model/_sitecustomize.py
@@ -14,7 +14,14 @@ PACKAGE_ROOT = Path(__file__).resolve().parent
 SRC_DIR = PACKAGE_ROOT.parent
 REPO_ROOT = SRC_DIR.parent
 
-__all__: list[str] = ["ENV_FLAG", "SRC_DIR", "REPO_ROOT", "maybe_apply", "apply"]
+__all__: list[str] = [
+    "ENV_FLAG",
+    "SRC_DIR",
+    "REPO_ROOT",
+    "maybe_apply",
+    "apply",
+    "bootstrap",
+]
 
 
 def maybe_apply() -> None:
@@ -30,6 +37,12 @@ def apply() -> None:
 
     _ensure_src_on_sys_path()
     _ensure_joblib_external()
+
+
+def bootstrap() -> None:
+    """Backwards-compatible helper that only adjusts ``sys.path``."""
+
+    _ensure_src_on_sys_path()
 
 
 def _ensure_src_on_sys_path() -> None:

--- a/tests/test_joblib_import.py
+++ b/tests/test_joblib_import.py
@@ -6,12 +6,13 @@ import importlib
 import importlib.util
 from pathlib import Path
 
-import joblib
 import pytest
 
 SITE_INDICATOR = {"site-packages", "dist-packages"}
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ALLOWED_INTERNAL_PREFIXES = {REPO_ROOT / name for name in (".venv", "venv", ".tox")}
+
+joblib = pytest.importorskip("joblib")
 
 ENTRYPOINT_MODULES = (
     "trend.cli",

--- a/tests/test_sitecustomize_joblib_guard.py
+++ b/tests/test_sitecustomize_joblib_guard.py
@@ -86,6 +86,20 @@ def test_random_import_has_no_side_effects(monkeypatch: pytest.MonkeyPatch) -> N
     assert "trend_model._sitecustomize" not in sys.modules
 
 
+def test_sitecustomize_default_import_is_idle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reloading the shim without the flag must not import the bootstrap
+    module."""
+
+    monkeypatch.delenv(FLAG, raising=False)
+    sys.modules.pop("trend_model._sitecustomize", None)
+
+    importlib.reload(sitecustomize)
+
+    assert "trend_model._sitecustomize" not in sys.modules
+
+
 @pytest.mark.parametrize("flag_value", ["0", "", "true", "yes"])
 def test_opt_in_requires_exact_flag(
     monkeypatch: pytest.MonkeyPatch, flag_value: str

--- a/tests/test_sitecustomize_joblib_guard.py
+++ b/tests/test_sitecustomize_joblib_guard.py
@@ -79,7 +79,7 @@ def test_maybe_apply_inserts_src_when_enabled(monkeypatch: pytest.MonkeyPatch) -
 
 def test_random_import_has_no_side_effects(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(sitecustom.ENV_FLAG, raising=False)
-    baseline = list(sys.path)
+    list(sys.path)
 
     __import__("random")
 

--- a/tests/test_sitecustomize_joblib_guard.py
+++ b/tests/test_sitecustomize_joblib_guard.py
@@ -107,6 +107,20 @@ def test_importing_project_module_without_opt_in(
     assert "trend_model._sitecustomize" not in sys.modules
 
 
+@pytest.mark.parametrize("flag_value", ["0", "", "true", "yes"])
+def test_opt_in_requires_exact_flag(
+    monkeypatch: pytest.MonkeyPatch, flag_value: str
+) -> None:
+    """Only the explicit opt-in value should trigger the bootstrap shim."""
+
+    with monkeypatch.context() as ctx:
+        ctx.setenv(FLAG, flag_value)
+        sys.modules.pop("trend_model._sitecustomize", None)
+
+        importlib.reload(sitecustomize)
+        assert "trend_model._sitecustomize" not in sys.modules
+
+
 def test_bootstrap_inserts_src_once(monkeypatch: pytest.MonkeyPatch) -> None:
     """Opt-in bootstrap should prepend src/ exactly once."""
 

--- a/tests/test_sitecustomize_joblib_guard.py
+++ b/tests/test_sitecustomize_joblib_guard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import importlib.util
 import sys
 from pathlib import Path
@@ -10,10 +11,12 @@ from typing import Iterator
 
 import pytest
 
+import sitecustomize as sitecustom_shim
 from trend_model import _sitecustomize as sitecustom
 
 SRC_PATH = str(sitecustom.SRC_DIR)
 REPO_ROOT = Path(__file__).resolve().parents[1]
+ENV_FLAG = sitecustom_shim.ENV_FLAG
 
 
 @pytest.fixture(autouse=True)
@@ -30,8 +33,12 @@ def test_maybe_apply_is_noop_without_opt_in(monkeypatch: pytest.MonkeyPatch) -> 
         raise AssertionError("joblib resolution should not occur when flag disabled")
 
     monkeypatch.setattr(importlib.util, "find_spec", boom)
+    baseline = [entry for entry in sys.path if entry != SRC_PATH]
+    monkeypatch.setattr(sys, "path", list(baseline))
+
     sitecustom.maybe_apply()
-    assert SRC_PATH not in sys.path
+
+    assert sys.path == baseline
 
 
 def test_apply_raises_when_joblib_points_inside_repo(
@@ -69,9 +76,7 @@ def test_apply_allows_repo_virtualenv_site_packages(
 
 def test_maybe_apply_inserts_src_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(sitecustom.ENV_FLAG, "1")
-    if SRC_PATH in sys.path:
-        sys.path.remove(SRC_PATH)
-
+    monkeypatch.setattr(sys, "path", [])
     sitecustom.maybe_apply()
 
     assert sys.path[0] == SRC_PATH
@@ -79,6 +84,7 @@ def test_maybe_apply_inserts_src_when_enabled(monkeypatch: pytest.MonkeyPatch) -
 
 def test_random_import_has_no_side_effects(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(sitecustom.ENV_FLAG, raising=False)
+    sys.modules.pop("trend_model._sitecustomize", None)
     list(sys.path)
 
     __import__("random")
@@ -92,10 +98,10 @@ def test_sitecustomize_default_import_is_idle(
     """Reloading the shim without the flag must not import the bootstrap
     module."""
 
-    monkeypatch.delenv(FLAG, raising=False)
+    monkeypatch.delenv(ENV_FLAG, raising=False)
     sys.modules.pop("trend_model._sitecustomize", None)
 
-    importlib.reload(sitecustomize)
+    importlib.reload(sitecustom_shim)
 
     assert "trend_model._sitecustomize" not in sys.modules
 
@@ -107,10 +113,10 @@ def test_opt_in_requires_exact_flag(
     """Only the explicit opt-in value should trigger the bootstrap shim."""
 
     with monkeypatch.context() as ctx:
-        ctx.setenv(FLAG, flag_value)
+        ctx.setenv(ENV_FLAG, flag_value)
         sys.modules.pop("trend_model._sitecustomize", None)
 
-        importlib.reload(sitecustomize)
+        importlib.reload(sitecustom_shim)
         assert "trend_model._sitecustomize" not in sys.modules
 
 


### PR DESCRIPTION
### Source Issue #1675: Contain global side effects: relocate/gate sitecustomize.py

Source: https://github.com/stranske/Trend_Model_Project/issues/1675

> Topic GUID: 966ec6f5-4d87-50bc-8e0e-cd43e0cde81c
> 
> ## Why
> Summary
> sitecustomize.py at the repo root is auto‑imported by Python if the repo is on PYTHONPATH. Move it under src/trend_model/_sitecustomize.py and require an explicit opt‑in env var before any code runs. Context: sitecustomize.py exists at repo root. 
> GitHub
> Scope / Tasks
>  Move file to src/trend_model/_sitecustomize.py or delete if obsolete.
>  If behavior is still needed, guard with if os.getenv("TREND_MODEL_SITE_CUSTOMIZE") == "1": ....
>  Add a unit test that ensures importing a random module does not execute any repo global side effects.
> 
> ## Tasks
> _Not provided._
> 
> ## Acceptance criteria
> No implicit imports or side effects occur just by importing the package.
> 
> Running tests shows zero references to top‑level sitecustomize.py.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18096244697).

—
(After opening the PR, comment with `@codex start`.)