### PR TITLE
Add regression test for strict sitecustomize opt-in flag

### DIFF
--- a/scripts/run_multi_demo.py
+++ b/scripts/run_multi_demo.py
@@ -33,9 +33,11 @@ SRC_PATH = ROOT / "src"
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
+
 # Opt into the guarded interpreter bootstrap unless explicitly disabled.
 def setup_trend_model_env():
     os.environ.setdefault("TREND_MODEL_SITE_CUSTOMIZE", "1")
+
 
 setup_trend_model_env()
 # Standard library done; third-party imports

--- a/tests/test_sitecustomize_joblib_guard.py
+++ b/tests/test_sitecustomize_joblib_guard.py
@@ -108,7 +108,9 @@ def test_importing_project_module_without_opt_in(
 
 
 @pytest.mark.parametrize("flag_value", ["0", "", "true", "yes"])
-def test_opt_in_requires_exact_flag(monkeypatch: pytest.MonkeyPatch, flag_value: str) -> None:
+def test_opt_in_requires_exact_flag(
+    monkeypatch: pytest.MonkeyPatch, flag_value: str
+) -> None:
     """Only the explicit opt-in value should trigger the bootstrap shim."""
 
     with monkeypatch.context() as ctx:
@@ -117,6 +119,8 @@ def test_opt_in_requires_exact_flag(monkeypatch: pytest.MonkeyPatch, flag_value:
 
         importlib.reload(sitecustomize)
         assert "trend_model._sitecustomize" not in sys.modules
+
+
 def test_bootstrap_inserts_src_once(monkeypatch: pytest.MonkeyPatch) -> None:
     """Opt-in bootstrap should prepend src/ exactly once."""
 

--- a/tests/test_sitecustomize_joblib_guard.py
+++ b/tests/test_sitecustomize_joblib_guard.py
@@ -107,6 +107,21 @@ def test_importing_project_module_without_opt_in(
     assert "trend_model._sitecustomize" not in sys.modules
 
 
+@pytest.mark.parametrize("flag_value", ["0", "", "true", "yes"])
+def test_opt_in_requires_exact_flag(monkeypatch: pytest.MonkeyPatch, flag_value: str) -> None:
+    """Only the explicit opt-in value should trigger the bootstrap shim."""
+
+    with monkeypatch.context() as ctx:
+        ctx.setenv(FLAG, flag_value)
+        sys.modules.pop("trend_model._sitecustomize", None)
+
+        importlib.reload(sitecustomize)
+
+        assert "trend_model._sitecustomize" not in sys.modules
+
+    importlib.reload(sitecustomize)
+
+
 def test_bootstrap_inserts_src_once(monkeypatch: pytest.MonkeyPatch) -> None:
     """Opt-in bootstrap should prepend src/ exactly once."""
 

--- a/tests/test_sitecustomize_joblib_guard.py
+++ b/tests/test_sitecustomize_joblib_guard.py
@@ -116,12 +116,7 @@ def test_opt_in_requires_exact_flag(monkeypatch: pytest.MonkeyPatch, flag_value:
         sys.modules.pop("trend_model._sitecustomize", None)
 
         importlib.reload(sitecustomize)
-
         assert "trend_model._sitecustomize" not in sys.modules
-
-    importlib.reload(sitecustomize)
-
-
 def test_bootstrap_inserts_src_once(monkeypatch: pytest.MonkeyPatch) -> None:
     """Opt-in bootstrap should prepend src/ exactly once."""
 


### PR DESCRIPTION
## Summary
- add coverage ensuring the sitecustomize shim only boots when TREND_MODEL_SITE_CUSTOMIZE is exactly "1"

## Testing
- pytest -k sitecustomize -q

------
https://chatgpt.com/codex/tasks/task_e_68dc5da9771483319d9d85c4fdab4f12