### PR TITLE
Add regression test to ensure sitecustomize shim stays idle by default

### DIFF
--- a/tests/test_sitecustomize_joblib_guard.py
+++ b/tests/test_sitecustomize_joblib_guard.py
@@ -107,6 +107,19 @@ def test_importing_project_module_without_opt_in(
     assert "trend_model._sitecustomize" not in sys.modules
 
 
+def test_sitecustomize_default_import_is_idle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reloading the shim without the flag must not import the bootstrap module."""
+
+    monkeypatch.delenv(FLAG, raising=False)
+    sys.modules.pop("trend_model._sitecustomize", None)
+
+    importlib.reload(sitecustomize)
+
+    assert "trend_model._sitecustomize" not in sys.modules
+
+
 @pytest.mark.parametrize("flag_value", ["0", "", "true", "yes"])
 def test_opt_in_requires_exact_flag(
     monkeypatch: pytest.MonkeyPatch, flag_value: str


### PR DESCRIPTION
## Summary
- add a regression test that reloads the repository root sitecustomize shim without the opt-in flag and asserts the guarded bootstrap module is not imported

## Testing
- pytest -k sitecustomize -q

------
https://chatgpt.com/codex/tasks/task_e_68dc64d875708331be8f87d60630b99c