### PR TITLE
Enforce a data contract at ingest (CSV, Parquet, DataFrame) - Source Issue #1677

### DIFF
--- a/README_APP.md
+++ b/README_APP.md
@@ -36,7 +36,10 @@ scripts/run_streamlit.sh
 Skeletons for multi-path generation and feature sweeps live under `src/trend_portfolio_app/monte_carlo/`.
 
 ## MVP Acceptance (Issue #367)
-- Load: CSV with `Date` column; basic validation via data schema.
+- Load: CSV with `Date` column; basic validation via data schema. See
+  [`docs/validation/market-data-contract.md`](docs/validation/market-data-contract.md)
+  for the full ingest contract and metadata propagation rules that the Streamlit
+  layer relies on.
 - Configure: YAML-like options exposed through UI; choose dates/freq/policy.
 - Run: Single and multi-period using existing modules where available.
 - View: Metrics tables and key charts (equity, drawdown, weights where applicable).

--- a/app/streamlit/state.py
+++ b/app/streamlit/state.py
@@ -39,7 +39,18 @@ def store_validated_data(df: pd.DataFrame, meta: dict):
     """Store validated data in session state."""
     st.session_state["returns_df"] = df
     st.session_state["schema_meta"] = meta
+    st.session_state["validation_report"] = meta.get("validation")
     st.session_state["upload_status"] = "success"
+
+
+def record_upload_error(message: str) -> None:
+    """Persist an upload failure and clear any stale data."""
+
+    st.session_state["returns_df"] = None
+    st.session_state["schema_meta"] = None
+    st.session_state["benchmark_candidates"] = []
+    st.session_state["validation_report"] = message
+    st.session_state["upload_status"] = "error"
 
 
 def get_uploaded_data() -> tuple[Optional[pd.DataFrame], Optional[dict]]:

--- a/app/streamlit/state.py
+++ b/app/streamlit/state.py
@@ -1,6 +1,6 @@
 """Session state management for Streamlit app."""
 
-from typing import Optional
+from typing import Optional, Sequence
 
 import pandas as pd
 import streamlit as st
@@ -43,13 +43,16 @@ def store_validated_data(df: pd.DataFrame, meta: dict):
     st.session_state["upload_status"] = "success"
 
 
-def record_upload_error(message: str) -> None:
+def record_upload_error(message: str, issues: Sequence[str] | None = None) -> None:
     """Persist an upload failure and clear any stale data."""
 
     st.session_state["returns_df"] = None
     st.session_state["schema_meta"] = None
     st.session_state["benchmark_candidates"] = []
-    st.session_state["validation_report"] = message
+    st.session_state["validation_report"] = {
+        "message": message,
+        "issues": list(issues or []),
+    }
     st.session_state["upload_status"] = "error"
 
 

--- a/docs/validation/market-data-contract.md
+++ b/docs/validation/market-data-contract.md
@@ -43,7 +43,7 @@ via `df.attrs["market_data"]["metadata"]` for convenience.
   - `metadata`: the raw `MarketDataMetadata` Pydantic model.
   - `mode` / `mode_enum`: returns vs prices (string + enum).
   - `frequency` / `frequency_code`: human label and pandas offset alias.
-  - `columns`, `rows`, and the `start`/`end` ISO-8601 timestamps.
+  - `symbols`, `columns`, `rows`, and the `start`/`end` ISO-8601 timestamps.
 - The Streamlit helper (`trend_portfolio_app.data_schema.SchemaMeta`) mirrors
   those fields and stores them in `st.session_state["schema_meta"]` together
   with a lightweight validation report so downstream pages can surface mode and

--- a/docs/validation/market-data-contract.md
+++ b/docs/validation/market-data-contract.md
@@ -52,8 +52,10 @@ via `df.attrs["market_data"]["metadata"]` for convenience.
   builders to introspect the ingest metadata without recomputing it.
 
 Validation failures raise `MarketDataValidationError` with a single, bullet
-point formatted message.  This message is displayed verbatim in both the CLI
-and the Streamlit UI to satisfy the acceptance criteria.
+point formatted message alongside a populated `issues` list.  This message is
+displayed verbatim in both the CLI and the Streamlit UI, while callers that
+need structured details can read the `issues` attribute to satisfy the
+acceptance criteria.
 
 ## Integration points
 

--- a/src/trend_analysis/io/market_data.py
+++ b/src/trend_analysis/io/market_data.py
@@ -115,14 +115,11 @@ def _resolve_datetime_index(df: pd.DataFrame, *, source: str | None) -> pd.DataF
                 date_col = column
                 break
         if date_col is None:
-            raise MarketDataValidationError(
-                _format_issues(
-                    [
-                        "Missing a 'Date' column or datetime index. "
-                        "Ensure the upload includes a timestamp column named 'Date'."
-                    ]
-                )
-            )
+            issues = [
+                "Missing a 'Date' column or datetime index. "
+                "Ensure the upload includes a timestamp column named 'Date'."
+            ]
+            raise MarketDataValidationError(_format_issues(issues), issues)
         try:
             parsed = pd.to_datetime(working[date_col], errors="coerce")
         except (TypeError, ValueError) as exc:
@@ -130,48 +127,36 @@ def _resolve_datetime_index(df: pd.DataFrame, *, source: str | None) -> pd.DataF
             preview = ", ".join(sample_values[:5])
             if len(sample_values) > 5:
                 preview += " …"
-            raise MarketDataValidationError(
-                _format_issues(
-                    [
-                        "Found dates that could not be parsed. "
-                        f"Examples: {preview or 'n/a'}."
-                    ]
-                )
-            ) from exc
+            issues = [
+                "Found dates that could not be parsed. "
+                f"Examples: {preview or 'n/a'}."
+            ]
+            raise MarketDataValidationError(_format_issues(issues), issues) from exc
         if parsed.isna().any():
             bad_values = working.loc[parsed.isna(), date_col].astype(str).tolist()
             preview = ", ".join(bad_values[:5])
             if len(bad_values) > 5:
                 preview += " …"
-            raise MarketDataValidationError(
-                _format_issues(
-                    ["Found dates that could not be parsed. " f"Examples: {preview}."]
-                )
-            )
+            issues = ["Found dates that could not be parsed. " f"Examples: {preview}."]
+            raise MarketDataValidationError(_format_issues(issues), issues)
         idx = pd.DatetimeIndex(parsed, name="Date")
         working = working.drop(columns=[date_col])
 
     if working.empty:
-        raise MarketDataValidationError(
-            _format_issues(
-                ["No data columns detected after extracting the Date index."]
-            )
-        )
+        issues = ["No data columns detected after extracting the Date index."]
+        raise MarketDataValidationError(_format_issues(issues), issues)
 
     duplicated = working.columns[working.columns.duplicated()].unique()
     if len(duplicated) > 0:
         preview = ", ".join(str(col) for col in duplicated[:5])
         if len(duplicated) > 5:  # pragma: no cover - defensive guard
             preview += " …"
-        raise MarketDataValidationError(
-            _format_issues(
-                [
-                    "Detected duplicate column names after removing the Date column: "
-                    + preview
-                    + ". Each column must be uniquely labelled."
-                ]
-            )
-        )
+        issues = [
+            "Detected duplicate column names after removing the Date column: "
+            + preview
+            + ". Each column must be uniquely labelled."
+        ]
+        raise MarketDataValidationError(_format_issues(issues), issues)
 
     idx = idx.tz_localize(None)
     working.index = idx
@@ -238,16 +223,13 @@ def _infer_frequency(index: pd.DatetimeIndex) -> Tuple[str, str]:
             preview = ", ".join(str(delta) for delta in unique_deltas[:3])
             if len(unique_deltas) > 3:
                 preview += " …"
-            raise MarketDataValidationError(
-                _format_issues(
-                    [
-                        "Mixed sampling cadence detected. Unable to infer the sampling frequency. "
-                        "Detected spacing values: "
-                        + preview
-                        + ". Ensure the Date index is evenly spaced."
-                    ]
-                )
-            )
+            issues = [
+                "Mixed sampling cadence detected. Unable to infer the sampling frequency. "
+                "Detected spacing values: "
+                + preview
+                + ". Ensure the Date index is evenly spaced."
+            ]
+            raise MarketDataValidationError(_format_issues(issues), issues)
 
     canonical = pd.tseries.frequencies.to_offset(freq).freqstr.upper()
     label = _HUMAN_FREQUENCY_LABELS.get(canonical, canonical)
@@ -258,15 +240,12 @@ def _infer_frequency(index: pd.DatetimeIndex) -> Tuple[str, str]:
         preview = ", ".join(ts.strftime("%Y-%m-%d") for ts in missing[:5])
         if len(missing) > 5:
             preview += " …"
-        raise MarketDataValidationError(
-            _format_issues(
-                [
-                    "Detected gaps in the Date index (missing timestamps: "
-                    + preview
-                    + ")."
-                ]
-            )
-        )
+        issues = [
+            "Detected gaps in the Date index (missing timestamps: "
+            + preview
+            + ")."
+        ]
+        raise MarketDataValidationError(_format_issues(issues), issues)
 
     return canonical, label
 
@@ -328,34 +307,25 @@ def _infer_mode(df: pd.DataFrame) -> MarketDataMode:
             modes.append(mode)
 
     if not modes:
-        raise MarketDataValidationError(
-            _format_issues(
-                [
-                    "Unable to determine whether the data are prices or returns. "
-                    "Ensure numeric columns contain representative values."
-                ]
-            )
-        )
+        issues = [
+            "Unable to determine whether the data are prices or returns. "
+            "Ensure numeric columns contain representative values."
+        ]
+        raise MarketDataValidationError(_format_issues(issues), issues)
 
     unique_modes = set(modes)
     if len(unique_modes) > 1:
-        raise MarketDataValidationError(
-            _format_issues(
-                [
-                    "Detected a mix of returns-like and price-like columns. "
-                    "Uploads must use a single representation."
-                ]
-            )
-        )
+        issues = [
+            "Detected a mix of returns-like and price-like columns. "
+            "Uploads must use a single representation."
+        ]
+        raise MarketDataValidationError(_format_issues(issues), issues)
 
     mode = modes[0]
     if ambiguous:
         preview = ", ".join(ambiguous[:5])
-        raise MarketDataValidationError(
-            _format_issues(
-                ["Could not classify columns as price or return series: " + preview]
-            )
-        )
+        issues = ["Could not classify columns as price or return series: " + preview]
+        raise MarketDataValidationError(_format_issues(issues), issues)
 
     return mode
 
@@ -401,21 +371,17 @@ def load_market_data_csv(path: str) -> ValidatedMarketData:
     try:
         frame = pd.read_csv(path)
     except FileNotFoundError as exc:  # pragma: no cover - defensive guard
-        raise MarketDataValidationError(
-            _format_issues([f"File not found: {path}"])
-        ) from exc
+        issues = [f"File not found: {path}"]
+        raise MarketDataValidationError(_format_issues(issues), issues) from exc
     except PermissionError as exc:  # pragma: no cover - defensive guard
-        raise MarketDataValidationError(
-            _format_issues([f"Permission denied when reading: {path}"])
-        ) from exc
+        issues = [f"Permission denied when reading: {path}"]
+        raise MarketDataValidationError(_format_issues(issues), issues) from exc
     except pd.errors.EmptyDataError as exc:
-        raise MarketDataValidationError(
-            _format_issues([f"File contains no data: {path}"])
-        ) from exc
+        issues = [f"File contains no data: {path}"]
+        raise MarketDataValidationError(_format_issues(issues), issues) from exc
     except pd.errors.ParserError as exc:
-        raise MarketDataValidationError(
-            _format_issues([f"Failed to parse file '{path}'"])
-        ) from exc
+        issues = [f"Failed to parse file '{path}'"]
+        raise MarketDataValidationError(_format_issues(issues), issues) from exc
 
     return validate_market_data(frame, source=path)
 
@@ -426,13 +392,11 @@ def load_market_data_parquet(path: str) -> ValidatedMarketData:
     try:
         frame = pd.read_parquet(path)
     except FileNotFoundError as exc:  # pragma: no cover - defensive guard
-        raise MarketDataValidationError(
-            _format_issues([f"File not found: {path}"])
-        ) from exc
+        issues = [f"File not found: {path}"]
+        raise MarketDataValidationError(_format_issues(issues), issues) from exc
     except PermissionError as exc:  # pragma: no cover - defensive guard
-        raise MarketDataValidationError(
-            _format_issues([f"Permission denied when reading: {path}"])
-        ) from exc
+        issues = [f"Permission denied when reading: {path}"]
+        raise MarketDataValidationError(_format_issues(issues), issues) from exc
 
     return validate_market_data(frame, source=path)
 

--- a/src/trend_analysis/io/market_data.py
+++ b/src/trend_analysis/io/market_data.py
@@ -29,6 +29,7 @@ _HUMAN_FREQUENCY_LABELS = {
     "Q": "quarterly",
     "QE": "quarterly",
     "Y": "annual",
+    "YE": "annual",
 }
 
 
@@ -220,15 +221,15 @@ def _infer_frequency(index: pd.DatetimeIndex) -> Tuple[str, str]:
         if len(unique_deltas) == 1:
             freq = pd.tseries.frequencies.to_offset(unique_deltas[0]).freqstr
         else:
-            # Attempt common calendar-based frequencies (monthly/quarterly) even when
-            # day deltas differ because of calendar length variations.
-            for candidate in ("ME", "M", "QE", "Q", "A", "Y"):
+            # Attempt common calendar-based frequencies (monthly/quarterly/yearly)
+            # even when day deltas differ because of calendar length variations.
+            for candidate in ("ME", "M", "QE", "Q", "YE", "Y"):
                 try:
                     reconstructed = index.to_period(candidate).to_timestamp(how="end")
                 except Exception:  # pragma: no cover - defensive guard
                     continue
                 if reconstructed.equals(index.sort_values()):
-                    freq = candidate
+                    freq = "YE" if candidate == "Y" else candidate
                     break
         if freq is None:
             preview = ", ".join(str(delta) for delta in unique_deltas[:3])

--- a/src/trend_analysis/io/validators.py
+++ b/src/trend_analysis/io/validators.py
@@ -258,7 +258,7 @@ def load_and_validate_upload(file_like: Any) -> Tuple[pd.DataFrame, Dict[str, An
 def create_sample_template() -> pd.DataFrame:
     """Create a sample returns template with realistic data."""
 
-    dates = pd.date_range(start="2023-01-31", periods=12, freq="M")
+    dates = pd.date_range(start="2023-01-31", periods=12, freq="ME")
     rng = np.random.default_rng(42)
     data: Dict[str, Any] = {"Date": dates}
     for idx in range(1, 6):

--- a/src/trend_portfolio_app/data_schema.py
+++ b/src/trend_portfolio_app/data_schema.py
@@ -7,7 +7,6 @@ import pandas as pd
 
 from trend_analysis.io.market_data import (
     MarketDataMetadata,
-    MarketDataValidationError,
     ValidatedMarketData,
     validate_market_data,
 )
@@ -58,10 +57,7 @@ def _build_meta(validated: ValidatedMarketData) -> SchemaMeta:
 
 
 def _validate_df(df: pd.DataFrame) -> Tuple[pd.DataFrame, SchemaMeta]:
-    try:
-        validated = validate_market_data(df)
-    except MarketDataValidationError as exc:
-        raise ValueError(exc.user_message) from exc
+    validated = validate_market_data(df)
     meta = _build_meta(validated)
     return validated.frame, meta
 

--- a/src/trend_portfolio_app/data_schema.py
+++ b/src/trend_portfolio_app/data_schema.py
@@ -45,8 +45,8 @@ def _build_meta(validated: ValidatedMarketData) -> SchemaMeta:
     meta = SchemaMeta()
     meta["metadata"] = metadata
     meta["validation"] = _build_validation_report(validated)
-    meta["original_columns"] = list(metadata.columns)
-    meta["symbols"] = list(metadata.columns)
+    meta["original_columns"] = list(metadata.columns or metadata.symbols)
+    meta["symbols"] = list(metadata.symbols)
     meta["n_rows"] = metadata.rows
     meta["mode"] = metadata.mode.value
     meta["frequency"] = metadata.frequency_label

--- a/streamlit_app/pages/1_Upload.py
+++ b/streamlit_app/pages/1_Upload.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 import uuid
 from functools import lru_cache
@@ -6,74 +5,84 @@ from pathlib import Path
 
 import streamlit as st
 
+from app.streamlit import state as app_state
 from trend_portfolio_app.data_schema import infer_benchmarks, load_and_validate_file
 
-st.title("Upload")
 
-uploaded = st.file_uploader(
-    "Upload returns (CSV or Excel). Requires a 'Date' column.",
-    type=["csv", "xlsx", "xls"],
-)
+def _persist_uploaded_copy(df) -> Path:
+    tmp_dir = Path(tempfile.gettempdir()) / "trend_app_uploads"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    tmp_path = tmp_dir / f"upload_{uuid.uuid4().hex}.csv"
+    reset = df.reset_index().rename(columns={df.index.name or "index": "Date"})
+    reset.to_csv(tmp_path, index=False)
+    return tmp_path
 
-demo_path_csv = "demo/demo_returns.csv"
-demo_path_xlsx = "demo/demo_returns.xlsx"
-if os.path.exists(demo_path_csv) or os.path.exists(demo_path_xlsx):
-    if st.button("Load demo data"):
-        path = demo_path_csv if os.path.exists(demo_path_csv) else demo_path_xlsx
-        try:
 
-            @lru_cache(maxsize=2)
-            def _load_demo(p: str):
-                with open(p, "rb") as f:
-                    return load_and_validate_file(f)
-
-            df, meta = _load_demo(path)
-            st.session_state["returns_df"] = df
-            st.session_state["schema_meta"] = meta
-            st.session_state["uploaded_file_path"] = str(Path(path).resolve())
-            st.success(
-                f"Loaded demo: {df.shape[0]} rows × {df.shape[1]} cols. Range: "
-                f"{df.index.min().date()} → {df.index.max().date()}."
-            )
-            meta_info = meta.get("metadata")
-            if meta_info:
-                st.info(
-                    f"Detected {meta_info.mode.value} data at {meta_info.frequency_label} cadence."
-                )
-            st.dataframe(df.head(12))
-            candidates = infer_benchmarks(list(df.columns))
-            st.session_state["benchmark_candidates"] = candidates
-            if candidates:
-                st.info("Possible benchmark columns: " + ", ".join(candidates))
-        except Exception as e:
-            st.error(str(e))
-
-if uploaded is not None:
-    try:
-        df, meta = load_and_validate_file(uploaded)
-        st.session_state["returns_df"] = df
-        st.session_state["schema_meta"] = meta
-        tmp_dir = Path(tempfile.gettempdir()) / "trend_app_uploads"
-        tmp_dir.mkdir(parents=True, exist_ok=True)
-        tmp_path = tmp_dir / f"upload_{uuid.uuid4().hex}.csv"
-        reset = df.reset_index().rename(columns={df.index.name or "index": "Date"})
-        reset.to_csv(tmp_path, index=False)
-        st.session_state["uploaded_file_path"] = str(tmp_path)
-        st.success(
-            f"Loaded {df.shape[0]} rows × {df.shape[1]} columns. Range: "
-            f"{df.index.min().date()} to {df.index.max().date()}."
+def _handle_success(st_module, df, meta, source_path: Path | str) -> None:
+    app_state.store_validated_data(df, meta)
+    st_module.session_state["uploaded_file_path"] = str(source_path)
+    start = df.index.min().date() if hasattr(df.index.min(), "date") else df.index.min()
+    end = df.index.max().date() if hasattr(df.index.max(), "date") else df.index.max()
+    st_module.success(
+        f"Loaded {df.shape[0]} rows × {df.shape[1]} columns. Range: {start} to {end}."
+    )
+    meta_info = meta.get("metadata") if isinstance(meta, dict) else None
+    if meta_info:
+        st_module.info(
+            f"Detected {meta_info.mode.value} data at {meta_info.frequency_label} cadence."
         )
-        meta_info = meta.get("metadata")
-        if meta_info:
-            st.info(
-                f"Detected {meta_info.mode.value} data at {meta_info.frequency_label} cadence."
-            )
-        st.dataframe(df.head(12))
-        candidates = infer_benchmarks(list(df.columns))
-        st.session_state["benchmark_candidates"] = candidates
-        if candidates:
-            st.info("Possible benchmark columns: " + ", ".join(candidates))
-    except Exception as e:
-        st.error(str(e))
-else:
-    st.warning("No file uploaded yet.")
+    st_module.dataframe(df.head(12))
+    candidates = infer_benchmarks(list(df.columns))
+    st_module.session_state["benchmark_candidates"] = candidates
+    if candidates:
+        st_module.info("Possible benchmark columns: " + ", ".join(candidates))
+
+
+def _handle_failure(st_module, error: Exception) -> None:
+    message = str(error)
+    app_state.record_upload_error(message)
+    st_module.error(message)
+
+
+@lru_cache(maxsize=2)
+def _load_demo(path: str):
+    with open(path, "rb") as handle:
+        return load_and_validate_file(handle)
+
+
+def render_upload_page(st_module=st) -> None:
+    app_state.initialize_session_state()
+    st_module.title("Upload")
+
+    uploaded = st_module.file_uploader(
+        "Upload returns (CSV or Excel). Requires a 'Date' column.",
+        type=["csv", "xlsx", "xls"],
+    )
+
+    demo_path_csv = Path("demo/demo_returns.csv")
+    demo_path_xlsx = Path("demo/demo_returns.xlsx")
+    if demo_path_csv.exists() or demo_path_xlsx.exists():
+        if st_module.button("Load demo data"):
+            path = demo_path_csv if demo_path_csv.exists() else demo_path_xlsx
+            try:
+                df, meta = _load_demo(str(path))
+            except Exception as exc:  # pragma: no cover - defensive guard
+                _handle_failure(st_module, exc)
+            else:
+                _handle_success(st_module, df, meta, path.resolve())
+
+    if uploaded is not None:
+        try:
+            df, meta = load_and_validate_file(uploaded)
+        except ValueError as exc:
+            _handle_failure(st_module, exc)
+        except Exception as exc:  # pragma: no cover - unexpected parsing error
+            _handle_failure(st_module, exc)
+        else:
+            tmp_path = _persist_uploaded_copy(df)
+            _handle_success(st_module, df, meta, tmp_path)
+    elif not app_state.has_valid_upload():
+        st_module.warning("No file uploaded yet.")
+
+
+render_upload_page()

--- a/tests/app/test_streamlit_state.py
+++ b/tests/app/test_streamlit_state.py
@@ -112,5 +112,8 @@ def test_record_upload_error_sets_error_state(session_state: dict) -> None:
     assert session_state["returns_df"] is None
     assert session_state["schema_meta"] is None
     assert session_state["benchmark_candidates"] == []
-    assert session_state["validation_report"] == "problem"
+    assert session_state["validation_report"] == {
+        "message": "problem",
+        "issues": [],
+    }
     assert session_state["upload_status"] == "error"

--- a/tests/app/test_streamlit_state.py
+++ b/tests/app/test_streamlit_state.py
@@ -68,7 +68,7 @@ def test_store_and_read_validated_data_updates_state(session_state: dict) -> Non
         {"value": [0.1, 0.2]},
         index=pd.to_datetime(["2024-01-31", "2024-02-29"]),
     )
-    meta = {"frequency": "Monthly"}
+    meta = {"frequency": "Monthly", "validation": {"issues": [], "warnings": []}}
 
     state.store_validated_data(df, meta)
 
@@ -76,6 +76,7 @@ def test_store_and_read_validated_data_updates_state(session_state: dict) -> Non
     assert stored_df is df
     assert stored_meta is meta
     assert state.has_valid_upload()
+    assert session_state["validation_report"] == meta["validation"]
 
 
 def test_has_valid_upload_requires_success_status(session_state: dict) -> None:
@@ -103,3 +104,13 @@ def test_get_upload_summary_formats_output(
     summary = state.get_upload_summary()
     base = "3 rows × 1 columns | Range: 2024-01-31 to 2024-03-31"
     assert summary == f"{base}{expected_suffix}"
+
+
+def test_record_upload_error_sets_error_state(session_state: dict) -> None:
+    state.record_upload_error("problem")
+
+    assert session_state["returns_df"] is None
+    assert session_state["schema_meta"] is None
+    assert session_state["benchmark_candidates"] == []
+    assert session_state["validation_report"] == "problem"
+    assert session_state["upload_status"] == "error"

--- a/tests/app/test_upload_page.py
+++ b/tests/app/test_upload_page.py
@@ -1,0 +1,182 @@
+import importlib
+import sys
+from types import ModuleType
+from typing import Any, Callable
+
+import pandas as pd
+import pytest
+
+from trend_analysis.io.market_data import MarketDataMetadata, MarketDataMode
+
+
+class DummyStreamlit:
+    def __init__(self) -> None:
+        self.session_state: dict[str, Any] = {}
+        self.uploaded: Any = None
+        self.button_clicked = False
+        self.title_calls: list[str] = []
+        self.file_uploader_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        self.button_calls: list[str] = []
+        self.success_messages: list[str] = []
+        self.error_messages: list[str] = []
+        self.info_messages: list[str] = []
+        self.warning_messages: list[str] = []
+        self.dataframes: list[pd.DataFrame] = []
+
+    def title(self, text: str) -> None:
+        self.title_calls.append(text)
+
+    def file_uploader(self, *args: Any, **kwargs: Any) -> Any:
+        self.file_uploader_calls.append((args, kwargs))
+        return self.uploaded
+
+    def button(self, label: str) -> bool:
+        self.button_calls.append(label)
+        return self.button_clicked
+
+    def success(self, message: str) -> None:
+        self.success_messages.append(message)
+
+    def error(self, message: str) -> None:
+        self.error_messages.append(message)
+
+    def info(self, message: str) -> None:
+        self.info_messages.append(message)
+
+    def warning(self, message: str) -> None:
+        self.warning_messages.append(message)
+
+    def dataframe(self, df: pd.DataFrame) -> None:
+        self.dataframes.append(df)
+
+
+@pytest.fixture
+def upload_page(monkeypatch: pytest.MonkeyPatch):
+    stub = DummyStreamlit()
+    module = ModuleType("streamlit")
+
+    def bind(name: str) -> Callable[..., Any]:
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            return getattr(stub, name)(*args, **kwargs)
+
+        return wrapper
+
+    for attr in [
+        "title",
+        "file_uploader",
+        "button",
+        "success",
+        "error",
+        "info",
+        "warning",
+        "dataframe",
+    ]:
+        setattr(module, attr, bind(attr))
+    module.session_state = stub.session_state
+
+    monkeypatch.setitem(sys.modules, "streamlit", module)
+
+    from app.streamlit import state as app_state
+
+    monkeypatch.setattr(app_state, "st", module)
+
+    page = importlib.reload(importlib.import_module("streamlit_app.pages.1_Upload"))
+    page.st = module
+
+    stub.session_state.clear()
+    stub.uploaded = None
+    stub.button_clicked = False
+    stub.title_calls.clear()
+    stub.file_uploader_calls.clear()
+    stub.button_calls.clear()
+    stub.success_messages.clear()
+    stub.error_messages.clear()
+    stub.info_messages.clear()
+    stub.warning_messages.clear()
+    stub.dataframes.clear()
+    module.session_state = stub.session_state
+
+    return page, stub, module
+
+
+def _build_meta(df: pd.DataFrame) -> dict[str, Any]:
+    metadata = MarketDataMetadata(
+        mode=MarketDataMode.RETURNS,
+        frequency="M",
+        frequency_label="monthly",
+        start=df.index.min().to_pydatetime(),
+        end=df.index.max().to_pydatetime(),
+        rows=len(df),
+        columns=list(df.columns),
+    )
+    warnings = []
+    if len(df) < 12:
+        warnings.append(
+            f"Dataset is quite small ({len(df)} periods) – consider a longer history."
+        )
+    return {
+        "metadata": metadata,
+        "validation": {"issues": [], "warnings": warnings},
+        "original_columns": list(df.columns),
+        "symbols": list(df.columns),
+        "n_rows": len(df),
+        "mode": metadata.mode.value,
+        "frequency": metadata.frequency_label,
+        "frequency_code": metadata.frequency,
+        "date_range": metadata.date_range,
+        "start": metadata.start,
+        "end": metadata.end,
+    }
+
+
+def test_render_upload_page_success(monkeypatch: pytest.MonkeyPatch, upload_page) -> None:
+    page, stub, st_module = upload_page
+
+    df = pd.DataFrame(
+        {
+            "FundA": [0.01, 0.02, -0.01],
+            "SPX Index": [0.03, -0.02, 0.01],
+        },
+        index=pd.date_range("2024-01-31", periods=3, freq="M"),
+    )
+    meta = _build_meta(df)
+
+    stub.uploaded = object()
+    monkeypatch.setattr(page, "load_and_validate_file", lambda handle: (df, meta))
+
+    page.render_upload_page(st_module)
+
+    assert stub.error_messages == []
+    assert stub.success_messages
+    assert "Loaded" in stub.success_messages[-1]
+    assert any("Detected" in msg for msg in stub.info_messages)
+    assert stub.dataframes and stub.dataframes[0].equals(df.head(12))
+    assert st_module.session_state["upload_status"] == "success"
+    assert st_module.session_state["schema_meta"] is meta
+    assert st_module.session_state["returns_df"] is df
+    assert (
+        st_module.session_state["validation_report"] == meta["validation"]
+    )
+    assert st_module.session_state["benchmark_candidates"] == ["SPX Index"]
+
+
+def test_render_upload_page_failure(monkeypatch: pytest.MonkeyPatch, upload_page) -> None:
+    page, stub, st_module = upload_page
+
+    stub.uploaded = object()
+
+    def raise_validation(_: Any) -> tuple[Any, Any]:
+        raise ValueError("Data validation failed:\n• unsorted index")
+
+    monkeypatch.setattr(page, "load_and_validate_file", raise_validation)
+
+    page.render_upload_page(st_module)
+
+    assert len(stub.error_messages) == 1
+    assert "unsorted index" in stub.error_messages[0]
+    assert not stub.success_messages
+    assert st_module.session_state["upload_status"] == "error"
+    assert st_module.session_state["returns_df"] is None
+    assert st_module.session_state["schema_meta"] is None
+    assert st_module.session_state["validation_report"] == "Data validation failed:\n• unsorted index"
+    assert st_module.session_state["benchmark_candidates"] == []

--- a/tests/app/test_upload_page.py
+++ b/tests/app/test_upload_page.py
@@ -141,7 +141,7 @@ def test_render_upload_page_success(monkeypatch: pytest.MonkeyPatch, upload_page
             "FundA": [0.01, 0.02, -0.01],
             "SPX Index": [0.03, -0.02, 0.01],
         },
-        index=pd.date_range("2024-01-31", periods=3, freq="M"),
+        index=pd.date_range("2024-01-31", periods=3, freq="ME"),
     )
     meta = _build_meta(df)
 

--- a/tests/test_data_schema.py
+++ b/tests/test_data_schema.py
@@ -3,6 +3,7 @@ import io
 import pandas as pd
 import pytest
 
+from trend_analysis.io.market_data import MarketDataMode
 from trend_portfolio_app.data_schema import (
     DATE_COL,
     _validate_df,
@@ -19,6 +20,12 @@ def test_validate_df_basic():
     assert list(df.index) == expected
     assert meta["original_columns"] == ["A", "B"]
     assert meta["n_rows"] == 2
+    assert meta["metadata"].mode == MarketDataMode.RETURNS
+    assert meta["frequency"] in {"monthly", "31D"}
+    assert meta["frequency_code"] in {"M", "31D"}
+    assert meta["symbols"] == ["A", "B"]
+    assert meta["validation"]["issues"] == []
+    assert any("Dataset is quite small" in w for w in meta["validation"]["warnings"])
 
 
 def test_validate_df_errors():
@@ -47,6 +54,8 @@ def test_load_and_validate_file_excel(tmp_path):
     df2, meta = load_and_validate_file(buf)
     assert DATE_COL not in df2.columns
     assert meta["n_rows"] == 2
+    assert meta["metadata"].mode == MarketDataMode.RETURNS
+    assert meta["validation"]["issues"] == []
 
 
 def test_load_and_validate_file_seek_error():

--- a/tests/test_data_schema.py
+++ b/tests/test_data_schema.py
@@ -3,7 +3,7 @@ import io
 import pandas as pd
 import pytest
 
-from trend_analysis.io.market_data import MarketDataMode
+from trend_analysis.io.market_data import MarketDataMode, MarketDataValidationError
 from trend_portfolio_app.data_schema import (
     DATE_COL,
     _validate_df,
@@ -30,18 +30,18 @@ def test_validate_df_basic():
 
 def test_validate_df_errors():
     # missing Date column
-    with pytest.raises(ValueError):
+    with pytest.raises(MarketDataValidationError):
         _validate_df(pd.DataFrame({"A": [1]}))
 
     # duplicate columns
     df = pd.DataFrame({"Date": ["2020-01-01"], "A": [1], "B": [2]})
     df.columns = ["Date", "A", "A"]
-    with pytest.raises(ValueError):
+    with pytest.raises(MarketDataValidationError):
         _validate_df(df)
 
     # all NA returns
     df = pd.DataFrame({"Date": ["2020-01-01"], "A": [float("nan")]})
-    with pytest.raises(ValueError):
+    with pytest.raises(MarketDataValidationError):
         _validate_df(df)
 
 

--- a/tests/test_io_validators_additional.py
+++ b/tests/test_io_validators_additional.py
@@ -21,7 +21,7 @@ def test_validation_result_failure_report() -> None:
 def test_price_mode_detection() -> None:
     frame = pd.DataFrame(
         {
-            "Date": pd.date_range("2023-01-31", periods=6, freq="M"),
+            "Date": pd.date_range("2023-01-31", periods=6, freq="ME"),
             "FundA": [100, 102, 101, 105, 107, 110],
             "FundB": [50, 51, 50.5, 52, 54, 55],
         }
@@ -34,7 +34,7 @@ def test_price_mode_detection() -> None:
 def test_ambiguous_mode_raises() -> None:
     frame = pd.DataFrame(
         {
-            "Date": pd.date_range("2023-01-31", periods=5, freq="M"),
+            "Date": pd.date_range("2023-01-31", periods=5, freq="ME"),
             "PriceFund": [100, 101, 102, 103, 104],
             "ReturnFund": [0.01, 0.02, -0.01, 0.03, 0.00],
         }
@@ -50,7 +50,7 @@ def test_load_and_validate_upload_parquet(tmp_path: Path) -> None:
     pytest.importorskip("pyarrow")
     frame = pd.DataFrame(
         {
-            "Date": pd.date_range("2023-01-31", periods=4, freq="M"),
+            "Date": pd.date_range("2023-01-31", periods=4, freq="ME"),
             "FundA": [0.01, -0.02, 0.03, 0.04],
         }
     )

--- a/tests/test_market_data_validation.py
+++ b/tests/test_market_data_validation.py
@@ -46,6 +46,8 @@ def test_validate_market_data_unsorted_dates() -> None:
     with pytest.raises(MarketDataValidationError) as exc:
         validate_market_data(df)
     assert "sorted in ascending order" in str(exc.value)
+    assert exc.value.issues
+    assert any("sorted" in issue for issue in exc.value.issues)
 
 
 def test_validate_market_data_mixed_frequency() -> None:
@@ -97,6 +99,18 @@ def test_validate_market_data_ambiguous_mode() -> None:
     with pytest.raises(MarketDataValidationError) as exc:
         validate_market_data(df)
     assert "Unable to determine" in str(exc.value)
+    assert exc.value.issues
+    assert any("Unable to determine" in issue for issue in exc.value.issues)
+
+
+def test_validate_market_data_missing_date_column_reports_issue() -> None:
+    df = pd.DataFrame({"FundA": [0.01, 0.02, 0.03]})
+
+    with pytest.raises(MarketDataValidationError) as exc:
+        validate_market_data(df)
+
+    assert exc.value.issues
+    assert any("Missing a 'Date'" in issue for issue in exc.value.issues)
 
 
 def test_validate_market_data_accepts_datetime_index() -> None:

--- a/tests/test_market_data_validation.py
+++ b/tests/test_market_data_validation.py
@@ -29,6 +29,7 @@ def test_validate_market_data_happy_path_returns() -> None:
     assert meta["frequency"] == "monthly"
     assert pd.Timestamp(meta["start"]) == validated.index.min()
     assert pd.Timestamp(meta["end"]) == validated.index.max()
+    assert meta["symbols"] == ["FundA", "FundB"]
 
 
 def test_validate_market_data_duplicate_dates() -> None:
@@ -71,6 +72,7 @@ def test_validate_market_data_price_mode_detection() -> None:
     meta = validated.attrs.get("market_data", {})
     assert meta["mode"] == "prices"
     assert meta["frequency"] in {"daily", "business-daily"}
+    assert meta["symbols"] == ["Asset"]
 
 
 def test_validate_market_data_mixed_modes_detected() -> None:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -95,7 +95,7 @@ class TestLoadAndValidateUpload:
     def _make_csv(self, tmp_path: Path) -> Path:
         frame = pd.DataFrame(
             {
-                "Date": pd.date_range("2023-01-31", periods=6, freq="M"),
+                "Date": pd.date_range("2023-01-31", periods=6, freq="ME"),
                 "FundA": [0.01, 0.02, -0.01, 0.03, 0.01, 0.005],
             }
         )
@@ -118,7 +118,7 @@ class TestLoadAndValidateUpload:
     def test_handles_excel_stream(self, tmp_path: Path) -> None:
         frame = pd.DataFrame(
             {
-                "Date": pd.date_range("2023-01-31", periods=3, freq="M"),
+                "Date": pd.date_range("2023-01-31", periods=3, freq="ME"),
                 "FundA": [0.01, -0.02, 0.03],
             }
         )


### PR DESCRIPTION
### Source Issue #1677: Enforce a data contract at ingest (CSV, Parquet, DataFrame)

Source: https://github.com/stranske/Trend_Model_Project/issues/1677

> Topic GUID: 299e639b-27eb-5a7f-bbc4-9533c9a3c1d0
> 
> ## Why
> Summary
> Hard‑fail early on schema problems: index monotonicity, duplicate timestamps, return vs price mode, symbol presence, and frequency.
> Scope / Tasks
>  Implement validate_market_data(data: DataFrame) -> DataFrame with checks: sorted Date index, no dupes, consistent frequency, and either price or return mode clearly inferred.
>  Decide simple dependency: pandera for DataFrame schema or pydantic for record‑level schema; document the choice.
>  Integrate into app upload flow and CLI input path with clear error messages.
> 
> ## Tasks
> _Not provided._
> 
> ## Acceptance criteria
> Invalid uploads surface a single, descriptive error banner in the app; CLI exits non‑zero with the same message.
> 
> Validation runs automatically before any modeling.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18096244697).

—
(After opening the PR, comment with `@codex start`.)