### PR TITLE
feat: centralize market data validation metadata flow

### DIFF
--- a/README_APP.md
+++ b/README_APP.md
@@ -36,7 +36,10 @@ scripts/run_streamlit.sh
 Skeletons for multi-path generation and feature sweeps live under `src/trend_portfolio_app/monte_carlo/`.
 
 ## MVP Acceptance (Issue #367)
-- Load: CSV with `Date` column; basic validation via data schema.
+- Load: CSV with `Date` column; basic validation via data schema. See
+  [`docs/validation/market-data-contract.md`](docs/validation/market-data-contract.md)
+  for the full ingest contract and metadata propagation rules that the Streamlit
+  layer relies on.
 - Configure: YAML-like options exposed through UI; choose dates/freq/policy.
 - Run: Single and multi-period using existing modules where available.
 - View: Metrics tables and key charts (equity, drawdown, weights where applicable).

--- a/app/streamlit/state.py
+++ b/app/streamlit/state.py
@@ -39,7 +39,18 @@ def store_validated_data(df: pd.DataFrame, meta: dict):
     """Store validated data in session state."""
     st.session_state["returns_df"] = df
     st.session_state["schema_meta"] = meta
+    st.session_state["validation_report"] = meta.get("validation")
     st.session_state["upload_status"] = "success"
+
+
+def record_upload_error(message: str) -> None:
+    """Persist an upload failure and clear any stale data."""
+
+    st.session_state["returns_df"] = None
+    st.session_state["schema_meta"] = None
+    st.session_state["benchmark_candidates"] = []
+    st.session_state["validation_report"] = message
+    st.session_state["upload_status"] = "error"
 
 
 def get_uploaded_data() -> tuple[Optional[pd.DataFrame], Optional[dict]]:

--- a/streamlit_app/pages/1_Upload.py
+++ b/streamlit_app/pages/1_Upload.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 import uuid
 from functools import lru_cache
@@ -6,74 +5,84 @@ from pathlib import Path
 
 import streamlit as st
 
+from app.streamlit import state as app_state
 from trend_portfolio_app.data_schema import infer_benchmarks, load_and_validate_file
 
-st.title("Upload")
 
-uploaded = st.file_uploader(
-    "Upload returns (CSV or Excel). Requires a 'Date' column.",
-    type=["csv", "xlsx", "xls"],
-)
+def _persist_uploaded_copy(df) -> Path:
+    tmp_dir = Path(tempfile.gettempdir()) / "trend_app_uploads"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    tmp_path = tmp_dir / f"upload_{uuid.uuid4().hex}.csv"
+    reset = df.reset_index().rename(columns={df.index.name or "index": "Date"})
+    reset.to_csv(tmp_path, index=False)
+    return tmp_path
 
-demo_path_csv = "demo/demo_returns.csv"
-demo_path_xlsx = "demo/demo_returns.xlsx"
-if os.path.exists(demo_path_csv) or os.path.exists(demo_path_xlsx):
-    if st.button("Load demo data"):
-        path = demo_path_csv if os.path.exists(demo_path_csv) else demo_path_xlsx
-        try:
 
-            @lru_cache(maxsize=2)
-            def _load_demo(p: str):
-                with open(p, "rb") as f:
-                    return load_and_validate_file(f)
-
-            df, meta = _load_demo(path)
-            st.session_state["returns_df"] = df
-            st.session_state["schema_meta"] = meta
-            st.session_state["uploaded_file_path"] = str(Path(path).resolve())
-            st.success(
-                f"Loaded demo: {df.shape[0]} rows × {df.shape[1]} cols. Range: "
-                f"{df.index.min().date()} → {df.index.max().date()}."
-            )
-            meta_info = meta.get("metadata")
-            if meta_info:
-                st.info(
-                    f"Detected {meta_info.mode.value} data at {meta_info.frequency_label} cadence."
-                )
-            st.dataframe(df.head(12))
-            candidates = infer_benchmarks(list(df.columns))
-            st.session_state["benchmark_candidates"] = candidates
-            if candidates:
-                st.info("Possible benchmark columns: " + ", ".join(candidates))
-        except Exception as e:
-            st.error(str(e))
-
-if uploaded is not None:
-    try:
-        df, meta = load_and_validate_file(uploaded)
-        st.session_state["returns_df"] = df
-        st.session_state["schema_meta"] = meta
-        tmp_dir = Path(tempfile.gettempdir()) / "trend_app_uploads"
-        tmp_dir.mkdir(parents=True, exist_ok=True)
-        tmp_path = tmp_dir / f"upload_{uuid.uuid4().hex}.csv"
-        reset = df.reset_index().rename(columns={df.index.name or "index": "Date"})
-        reset.to_csv(tmp_path, index=False)
-        st.session_state["uploaded_file_path"] = str(tmp_path)
-        st.success(
-            f"Loaded {df.shape[0]} rows × {df.shape[1]} columns. Range: "
-            f"{df.index.min().date()} to {df.index.max().date()}."
+def _handle_success(st_module, df, meta, source_path: Path | str) -> None:
+    app_state.store_validated_data(df, meta)
+    st_module.session_state["uploaded_file_path"] = str(source_path)
+    start = df.index.min().date() if hasattr(df.index.min(), "date") else df.index.min()
+    end = df.index.max().date() if hasattr(df.index.max(), "date") else df.index.max()
+    st_module.success(
+        f"Loaded {df.shape[0]} rows × {df.shape[1]} columns. Range: {start} to {end}."
+    )
+    meta_info = meta.get("metadata") if isinstance(meta, dict) else None
+    if meta_info:
+        st_module.info(
+            f"Detected {meta_info.mode.value} data at {meta_info.frequency_label} cadence."
         )
-        meta_info = meta.get("metadata")
-        if meta_info:
-            st.info(
-                f"Detected {meta_info.mode.value} data at {meta_info.frequency_label} cadence."
-            )
-        st.dataframe(df.head(12))
-        candidates = infer_benchmarks(list(df.columns))
-        st.session_state["benchmark_candidates"] = candidates
-        if candidates:
-            st.info("Possible benchmark columns: " + ", ".join(candidates))
-    except Exception as e:
-        st.error(str(e))
-else:
-    st.warning("No file uploaded yet.")
+    st_module.dataframe(df.head(12))
+    candidates = infer_benchmarks(list(df.columns))
+    st_module.session_state["benchmark_candidates"] = candidates
+    if candidates:
+        st_module.info("Possible benchmark columns: " + ", ".join(candidates))
+
+
+def _handle_failure(st_module, error: Exception) -> None:
+    message = str(error)
+    app_state.record_upload_error(message)
+    st_module.error(message)
+
+
+@lru_cache(maxsize=2)
+def _load_demo(path: str):
+    with open(path, "rb") as handle:
+        return load_and_validate_file(handle)
+
+
+def render_upload_page(st_module=st) -> None:
+    app_state.initialize_session_state()
+    st_module.title("Upload")
+
+    uploaded = st_module.file_uploader(
+        "Upload returns (CSV or Excel). Requires a 'Date' column.",
+        type=["csv", "xlsx", "xls"],
+    )
+
+    demo_path_csv = Path("demo/demo_returns.csv")
+    demo_path_xlsx = Path("demo/demo_returns.xlsx")
+    if demo_path_csv.exists() or demo_path_xlsx.exists():
+        if st_module.button("Load demo data"):
+            path = demo_path_csv if demo_path_csv.exists() else demo_path_xlsx
+            try:
+                df, meta = _load_demo(str(path))
+            except Exception as exc:  # pragma: no cover - defensive guard
+                _handle_failure(st_module, exc)
+            else:
+                _handle_success(st_module, df, meta, path.resolve())
+
+    if uploaded is not None:
+        try:
+            df, meta = load_and_validate_file(uploaded)
+        except ValueError as exc:
+            _handle_failure(st_module, exc)
+        except Exception as exc:  # pragma: no cover - unexpected parsing error
+            _handle_failure(st_module, exc)
+        else:
+            tmp_path = _persist_uploaded_copy(df)
+            _handle_success(st_module, df, meta, tmp_path)
+    elif not app_state.has_valid_upload():
+        st_module.warning("No file uploaded yet.")
+
+
+render_upload_page()

--- a/tests/app/test_streamlit_state.py
+++ b/tests/app/test_streamlit_state.py
@@ -68,7 +68,7 @@ def test_store_and_read_validated_data_updates_state(session_state: dict) -> Non
         {"value": [0.1, 0.2]},
         index=pd.to_datetime(["2024-01-31", "2024-02-29"]),
     )
-    meta = {"frequency": "Monthly"}
+    meta = {"frequency": "Monthly", "validation": {"issues": [], "warnings": []}}
 
     state.store_validated_data(df, meta)
 
@@ -76,6 +76,7 @@ def test_store_and_read_validated_data_updates_state(session_state: dict) -> Non
     assert stored_df is df
     assert stored_meta is meta
     assert state.has_valid_upload()
+    assert session_state["validation_report"] == meta["validation"]
 
 
 def test_has_valid_upload_requires_success_status(session_state: dict) -> None:
@@ -103,3 +104,13 @@ def test_get_upload_summary_formats_output(
     summary = state.get_upload_summary()
     base = "3 rows × 1 columns | Range: 2024-01-31 to 2024-03-31"
     assert summary == f"{base}{expected_suffix}"
+
+
+def test_record_upload_error_sets_error_state(session_state: dict) -> None:
+    state.record_upload_error("problem")
+
+    assert session_state["returns_df"] is None
+    assert session_state["schema_meta"] is None
+    assert session_state["benchmark_candidates"] == []
+    assert session_state["validation_report"] == "problem"
+    assert session_state["upload_status"] == "error"

--- a/tests/app/test_upload_page.py
+++ b/tests/app/test_upload_page.py
@@ -1,0 +1,182 @@
+import importlib
+import sys
+from types import ModuleType
+from typing import Any, Callable
+
+import pandas as pd
+import pytest
+
+from trend_analysis.io.market_data import MarketDataMetadata, MarketDataMode
+
+
+class DummyStreamlit:
+    def __init__(self) -> None:
+        self.session_state: dict[str, Any] = {}
+        self.uploaded: Any = None
+        self.button_clicked = False
+        self.title_calls: list[str] = []
+        self.file_uploader_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        self.button_calls: list[str] = []
+        self.success_messages: list[str] = []
+        self.error_messages: list[str] = []
+        self.info_messages: list[str] = []
+        self.warning_messages: list[str] = []
+        self.dataframes: list[pd.DataFrame] = []
+
+    def title(self, text: str) -> None:
+        self.title_calls.append(text)
+
+    def file_uploader(self, *args: Any, **kwargs: Any) -> Any:
+        self.file_uploader_calls.append((args, kwargs))
+        return self.uploaded
+
+    def button(self, label: str) -> bool:
+        self.button_calls.append(label)
+        return self.button_clicked
+
+    def success(self, message: str) -> None:
+        self.success_messages.append(message)
+
+    def error(self, message: str) -> None:
+        self.error_messages.append(message)
+
+    def info(self, message: str) -> None:
+        self.info_messages.append(message)
+
+    def warning(self, message: str) -> None:
+        self.warning_messages.append(message)
+
+    def dataframe(self, df: pd.DataFrame) -> None:
+        self.dataframes.append(df)
+
+
+@pytest.fixture
+def upload_page(monkeypatch: pytest.MonkeyPatch):
+    stub = DummyStreamlit()
+    module = ModuleType("streamlit")
+
+    def bind(name: str) -> Callable[..., Any]:
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            return getattr(stub, name)(*args, **kwargs)
+
+        return wrapper
+
+    for attr in [
+        "title",
+        "file_uploader",
+        "button",
+        "success",
+        "error",
+        "info",
+        "warning",
+        "dataframe",
+    ]:
+        setattr(module, attr, bind(attr))
+    module.session_state = stub.session_state
+
+    monkeypatch.setitem(sys.modules, "streamlit", module)
+
+    from app.streamlit import state as app_state
+
+    monkeypatch.setattr(app_state, "st", module)
+
+    page = importlib.reload(importlib.import_module("streamlit_app.pages.1_Upload"))
+    page.st = module
+
+    stub.session_state.clear()
+    stub.uploaded = None
+    stub.button_clicked = False
+    stub.title_calls.clear()
+    stub.file_uploader_calls.clear()
+    stub.button_calls.clear()
+    stub.success_messages.clear()
+    stub.error_messages.clear()
+    stub.info_messages.clear()
+    stub.warning_messages.clear()
+    stub.dataframes.clear()
+    module.session_state = stub.session_state
+
+    return page, stub, module
+
+
+def _build_meta(df: pd.DataFrame) -> dict[str, Any]:
+    metadata = MarketDataMetadata(
+        mode=MarketDataMode.RETURNS,
+        frequency="M",
+        frequency_label="monthly",
+        start=df.index.min().to_pydatetime(),
+        end=df.index.max().to_pydatetime(),
+        rows=len(df),
+        columns=list(df.columns),
+    )
+    warnings = []
+    if len(df) < 12:
+        warnings.append(
+            f"Dataset is quite small ({len(df)} periods) – consider a longer history."
+        )
+    return {
+        "metadata": metadata,
+        "validation": {"issues": [], "warnings": warnings},
+        "original_columns": list(df.columns),
+        "symbols": list(df.columns),
+        "n_rows": len(df),
+        "mode": metadata.mode.value,
+        "frequency": metadata.frequency_label,
+        "frequency_code": metadata.frequency,
+        "date_range": metadata.date_range,
+        "start": metadata.start,
+        "end": metadata.end,
+    }
+
+
+def test_render_upload_page_success(monkeypatch: pytest.MonkeyPatch, upload_page) -> None:
+    page, stub, st_module = upload_page
+
+    df = pd.DataFrame(
+        {
+            "FundA": [0.01, 0.02, -0.01],
+            "SPX Index": [0.03, -0.02, 0.01],
+        },
+        index=pd.date_range("2024-01-31", periods=3, freq="M"),
+    )
+    meta = _build_meta(df)
+
+    stub.uploaded = object()
+    monkeypatch.setattr(page, "load_and_validate_file", lambda handle: (df, meta))
+
+    page.render_upload_page(st_module)
+
+    assert stub.error_messages == []
+    assert stub.success_messages
+    assert "Loaded" in stub.success_messages[-1]
+    assert any("Detected" in msg for msg in stub.info_messages)
+    assert stub.dataframes and stub.dataframes[0].equals(df.head(12))
+    assert st_module.session_state["upload_status"] == "success"
+    assert st_module.session_state["schema_meta"] is meta
+    assert st_module.session_state["returns_df"] is df
+    assert (
+        st_module.session_state["validation_report"] == meta["validation"]
+    )
+    assert st_module.session_state["benchmark_candidates"] == ["SPX Index"]
+
+
+def test_render_upload_page_failure(monkeypatch: pytest.MonkeyPatch, upload_page) -> None:
+    page, stub, st_module = upload_page
+
+    stub.uploaded = object()
+
+    def raise_validation(_: Any) -> tuple[Any, Any]:
+        raise ValueError("Data validation failed:\n• unsorted index")
+
+    monkeypatch.setattr(page, "load_and_validate_file", raise_validation)
+
+    page.render_upload_page(st_module)
+
+    assert len(stub.error_messages) == 1
+    assert "unsorted index" in stub.error_messages[0]
+    assert not stub.success_messages
+    assert st_module.session_state["upload_status"] == "error"
+    assert st_module.session_state["returns_df"] is None
+    assert st_module.session_state["schema_meta"] is None
+    assert st_module.session_state["validation_report"] == "Data validation failed:\n• unsorted index"
+    assert st_module.session_state["benchmark_candidates"] == []

--- a/tests/test_data_schema.py
+++ b/tests/test_data_schema.py
@@ -3,6 +3,7 @@ import io
 import pandas as pd
 import pytest
 
+from trend_analysis.io.market_data import MarketDataMode
 from trend_portfolio_app.data_schema import (
     DATE_COL,
     _validate_df,
@@ -19,6 +20,12 @@ def test_validate_df_basic():
     assert list(df.index) == expected
     assert meta["original_columns"] == ["A", "B"]
     assert meta["n_rows"] == 2
+    assert meta["metadata"].mode == MarketDataMode.RETURNS
+    assert meta["frequency"] in {"monthly", "31D"}
+    assert meta["frequency_code"] in {"M", "31D"}
+    assert meta["symbols"] == ["A", "B"]
+    assert meta["validation"]["issues"] == []
+    assert any("Dataset is quite small" in w for w in meta["validation"]["warnings"])
 
 
 def test_validate_df_errors():
@@ -47,6 +54,8 @@ def test_load_and_validate_file_excel(tmp_path):
     df2, meta = load_and_validate_file(buf)
     assert DATE_COL not in df2.columns
     assert meta["n_rows"] == 2
+    assert meta["metadata"].mode == MarketDataMode.RETURNS
+    assert meta["validation"]["issues"] == []
 
 
 def test_load_and_validate_file_seek_error():


### PR DESCRIPTION
## Summary
- expose structured metadata and validation warnings from trend_portfolio_app.data_schema so the UI can surface mode/frequency details
- update the Streamlit upload page and shared state helpers to persist validation metadata, show a single banner on failure, and reuse the CLI validator
- document the ingest metadata contract and add component-level tests covering the Streamlit upload banner behaviour

## Testing
- pytest tests/test_data_schema.py tests/app/test_streamlit_state.py tests/app/test_upload_page.py tests/test_market_data_validation.py tests/test_cli.py::test_cli_validation_error

------
https://chatgpt.com/codex/tasks/task_e_68dd3b2c26b88331815d677ca0882323