### PR TITLE
Ensure validation errors expose structured issue lists

### DIFF
--- a/src/trend_analysis/io/market_data.py
+++ b/src/trend_analysis/io/market_data.py
@@ -115,14 +115,11 @@ def _resolve_datetime_index(df: pd.DataFrame, *, source: str | None) -> pd.DataF
                 date_col = column
                 break
         if date_col is None:
-            raise MarketDataValidationError(
-                _format_issues(
-                    [
-                        "Missing a 'Date' column or datetime index. "
-                        "Ensure the upload includes a timestamp column named 'Date'."
-                    ]
-                )
-            )
+            issues = [
+                "Missing a 'Date' column or datetime index. "
+                "Ensure the upload includes a timestamp column named 'Date'."
+            ]
+            raise MarketDataValidationError(_format_issues(issues), issues)
         try:
             parsed = pd.to_datetime(working[date_col], errors="coerce")
         except (TypeError, ValueError) as exc:
@@ -130,48 +127,36 @@ def _resolve_datetime_index(df: pd.DataFrame, *, source: str | None) -> pd.DataF
             preview = ", ".join(sample_values[:5])
             if len(sample_values) > 5:
                 preview += " …"
-            raise MarketDataValidationError(
-                _format_issues(
-                    [
-                        "Found dates that could not be parsed. "
-                        f"Examples: {preview or 'n/a'}."
-                    ]
-                )
-            ) from exc
+            issues = [
+                "Found dates that could not be parsed. "
+                f"Examples: {preview or 'n/a'}."
+            ]
+            raise MarketDataValidationError(_format_issues(issues), issues) from exc
         if parsed.isna().any():
             bad_values = working.loc[parsed.isna(), date_col].astype(str).tolist()
             preview = ", ".join(bad_values[:5])
             if len(bad_values) > 5:
                 preview += " …"
-            raise MarketDataValidationError(
-                _format_issues(
-                    ["Found dates that could not be parsed. " f"Examples: {preview}."]
-                )
-            )
+            issues = ["Found dates that could not be parsed. " f"Examples: {preview}."]
+            raise MarketDataValidationError(_format_issues(issues), issues)
         idx = pd.DatetimeIndex(parsed, name="Date")
         working = working.drop(columns=[date_col])
 
     if working.empty:
-        raise MarketDataValidationError(
-            _format_issues(
-                ["No data columns detected after extracting the Date index."]
-            )
-        )
+        issues = ["No data columns detected after extracting the Date index."]
+        raise MarketDataValidationError(_format_issues(issues), issues)
 
     duplicated = working.columns[working.columns.duplicated()].unique()
     if len(duplicated) > 0:
         preview = ", ".join(str(col) for col in duplicated[:5])
         if len(duplicated) > 5:  # pragma: no cover - defensive guard
             preview += " …"
-        raise MarketDataValidationError(
-            _format_issues(
-                [
-                    "Detected duplicate column names after removing the Date column: "
-                    + preview
-                    + ". Each column must be uniquely labelled."
-                ]
-            )
-        )
+        issues = [
+            "Detected duplicate column names after removing the Date column: "
+            + preview
+            + ". Each column must be uniquely labelled."
+        ]
+        raise MarketDataValidationError(_format_issues(issues), issues)
 
     idx = idx.tz_localize(None)
     working.index = idx
@@ -238,16 +223,13 @@ def _infer_frequency(index: pd.DatetimeIndex) -> Tuple[str, str]:
             preview = ", ".join(str(delta) for delta in unique_deltas[:3])
             if len(unique_deltas) > 3:
                 preview += " …"
-            raise MarketDataValidationError(
-                _format_issues(
-                    [
-                        "Mixed sampling cadence detected. Unable to infer the sampling frequency. "
-                        "Detected spacing values: "
-                        + preview
-                        + ". Ensure the Date index is evenly spaced."
-                    ]
-                )
-            )
+            issues = [
+                "Mixed sampling cadence detected. Unable to infer the sampling frequency. "
+                "Detected spacing values: "
+                + preview
+                + ". Ensure the Date index is evenly spaced."
+            ]
+            raise MarketDataValidationError(_format_issues(issues), issues)
 
     canonical = pd.tseries.frequencies.to_offset(freq).freqstr.upper()
     label = _HUMAN_FREQUENCY_LABELS.get(canonical, canonical)
@@ -258,15 +240,12 @@ def _infer_frequency(index: pd.DatetimeIndex) -> Tuple[str, str]:
         preview = ", ".join(ts.strftime("%Y-%m-%d") for ts in missing[:5])
         if len(missing) > 5:
             preview += " …"
-        raise MarketDataValidationError(
-            _format_issues(
-                [
-                    "Detected gaps in the Date index (missing timestamps: "
-                    + preview
-                    + ")."
-                ]
-            )
-        )
+        issues = [
+            "Detected gaps in the Date index (missing timestamps: "
+            + preview
+            + ")."
+        ]
+        raise MarketDataValidationError(_format_issues(issues), issues)
 
     return canonical, label
 
@@ -328,34 +307,25 @@ def _infer_mode(df: pd.DataFrame) -> MarketDataMode:
             modes.append(mode)
 
     if not modes:
-        raise MarketDataValidationError(
-            _format_issues(
-                [
-                    "Unable to determine whether the data are prices or returns. "
-                    "Ensure numeric columns contain representative values."
-                ]
-            )
-        )
+        issues = [
+            "Unable to determine whether the data are prices or returns. "
+            "Ensure numeric columns contain representative values."
+        ]
+        raise MarketDataValidationError(_format_issues(issues), issues)
 
     unique_modes = set(modes)
     if len(unique_modes) > 1:
-        raise MarketDataValidationError(
-            _format_issues(
-                [
-                    "Detected a mix of returns-like and price-like columns. "
-                    "Uploads must use a single representation."
-                ]
-            )
-        )
+        issues = [
+            "Detected a mix of returns-like and price-like columns. "
+            "Uploads must use a single representation."
+        ]
+        raise MarketDataValidationError(_format_issues(issues), issues)
 
     mode = modes[0]
     if ambiguous:
         preview = ", ".join(ambiguous[:5])
-        raise MarketDataValidationError(
-            _format_issues(
-                ["Could not classify columns as price or return series: " + preview]
-            )
-        )
+        issues = ["Could not classify columns as price or return series: " + preview]
+        raise MarketDataValidationError(_format_issues(issues), issues)
 
     return mode
 
@@ -401,21 +371,17 @@ def load_market_data_csv(path: str) -> ValidatedMarketData:
     try:
         frame = pd.read_csv(path)
     except FileNotFoundError as exc:  # pragma: no cover - defensive guard
-        raise MarketDataValidationError(
-            _format_issues([f"File not found: {path}"])
-        ) from exc
+        issues = [f"File not found: {path}"]
+        raise MarketDataValidationError(_format_issues(issues), issues) from exc
     except PermissionError as exc:  # pragma: no cover - defensive guard
-        raise MarketDataValidationError(
-            _format_issues([f"Permission denied when reading: {path}"])
-        ) from exc
+        issues = [f"Permission denied when reading: {path}"]
+        raise MarketDataValidationError(_format_issues(issues), issues) from exc
     except pd.errors.EmptyDataError as exc:
-        raise MarketDataValidationError(
-            _format_issues([f"File contains no data: {path}"])
-        ) from exc
+        issues = [f"File contains no data: {path}"]
+        raise MarketDataValidationError(_format_issues(issues), issues) from exc
     except pd.errors.ParserError as exc:
-        raise MarketDataValidationError(
-            _format_issues([f"Failed to parse file '{path}'"])
-        ) from exc
+        issues = [f"Failed to parse file '{path}'"]
+        raise MarketDataValidationError(_format_issues(issues), issues) from exc
 
     return validate_market_data(frame, source=path)
 
@@ -426,13 +392,11 @@ def load_market_data_parquet(path: str) -> ValidatedMarketData:
     try:
         frame = pd.read_parquet(path)
     except FileNotFoundError as exc:  # pragma: no cover - defensive guard
-        raise MarketDataValidationError(
-            _format_issues([f"File not found: {path}"])
-        ) from exc
+        issues = [f"File not found: {path}"]
+        raise MarketDataValidationError(_format_issues(issues), issues) from exc
     except PermissionError as exc:  # pragma: no cover - defensive guard
-        raise MarketDataValidationError(
-            _format_issues([f"Permission denied when reading: {path}"])
-        ) from exc
+        issues = [f"Permission denied when reading: {path}"]
+        raise MarketDataValidationError(_format_issues(issues), issues) from exc
 
     return validate_market_data(frame, source=path)
 


### PR DESCRIPTION
**Summary**
* Extended `SchemaMeta` to surface full validation metadata and warnings for downstream consumers, ensuring callers receive inferred mode, cadence, date range, and symbol details straight from `validate_market_data`.
* Updated the Streamlit state helpers and upload page to persist validation reports, reuse the shared validator, and emit a single error banner; added component and state tests to lock in the new contract.
* Documented the ingest metadata contract, including propagation expectations, and linked the guidance from the app README for quick discovery.
* Ensured `MarketDataValidationError` consistently populates structured issue lists for every failure path so downstream surfaces can render precise messaging.

**Testing**
* ✅ `pytest tests/test_market_data_validation.py tests/test_validators.py tests/test_io_validators_additional.py tests/test_data.py tests/test_cli.py::test_cli_validation_error tests/app/test_streamlit_state.py tests/app/test_upload_page.py`

------
https://chatgpt.com/codex/tasks/task_e_68dd50e787b88331b470b4ccaa814afc