### PR TITLE
Add regression coverage for validation issue details

### DIFF
--- a/docs/validation/market-data-contract.md
+++ b/docs/validation/market-data-contract.md
@@ -52,8 +52,10 @@ via `df.attrs["market_data"]["metadata"]` for convenience.
   builders to introspect the ingest metadata without recomputing it.
 
 Validation failures raise `MarketDataValidationError` with a single, bullet
-point formatted message.  This message is displayed verbatim in both the CLI
-and the Streamlit UI to satisfy the acceptance criteria.
+point formatted message alongside a populated `issues` list.  This message is
+displayed verbatim in both the CLI and the Streamlit UI, while callers that
+need structured details can read the `issues` attribute to satisfy the
+acceptance criteria.
 
 ## Integration points
 

--- a/tests/test_market_data_validation.py
+++ b/tests/test_market_data_validation.py
@@ -46,6 +46,8 @@ def test_validate_market_data_unsorted_dates() -> None:
     with pytest.raises(MarketDataValidationError) as exc:
         validate_market_data(df)
     assert "sorted in ascending order" in str(exc.value)
+    assert exc.value.issues
+    assert any("sorted" in issue for issue in exc.value.issues)
 
 
 def test_validate_market_data_mixed_frequency() -> None:
@@ -97,6 +99,18 @@ def test_validate_market_data_ambiguous_mode() -> None:
     with pytest.raises(MarketDataValidationError) as exc:
         validate_market_data(df)
     assert "Unable to determine" in str(exc.value)
+    assert exc.value.issues
+    assert any("Unable to determine" in issue for issue in exc.value.issues)
+
+
+def test_validate_market_data_missing_date_column_reports_issue() -> None:
+    df = pd.DataFrame({"FundA": [0.01, 0.02, 0.03]})
+
+    with pytest.raises(MarketDataValidationError) as exc:
+        validate_market_data(df)
+
+    assert exc.value.issues
+    assert any("Missing a 'Date'" in issue for issue in exc.value.issues)
 
 
 def test_validate_market_data_accepts_datetime_index() -> None:


### PR DESCRIPTION
## Summary
- ensure market data validation failures expose populated `MarketDataValidationError.issues` entries in the test suite
- clarify ingest contract documentation to note the availability of structured issue details for callers

## Testing
- pytest tests/test_market_data_validation.py tests/test_validators.py tests/test_io_validators_additional.py tests/test_data.py tests/test_cli.py::test_cli_validation_error tests/app/test_streamlit_state.py tests/app/test_upload_page.py

------
https://chatgpt.com/codex/tasks/task_e_68dd56dfe40083319748f7a39919c585