### PR TITLE
Add explicit symbols metadata to validated market data

### DIFF
--- a/docs/validation/market-data-contract.md
+++ b/docs/validation/market-data-contract.md
@@ -43,7 +43,7 @@ via `df.attrs["market_data"]["metadata"]` for convenience.
   - `metadata`: the raw `MarketDataMetadata` Pydantic model.
   - `mode` / `mode_enum`: returns vs prices (string + enum).
   - `frequency` / `frequency_code`: human label and pandas offset alias.
-  - `columns`, `rows`, and the `start`/`end` ISO-8601 timestamps.
+  - `symbols`, `columns`, `rows`, and the `start`/`end` ISO-8601 timestamps.
 - The Streamlit helper (`trend_portfolio_app.data_schema.SchemaMeta`) mirrors
   those fields and stores them in `st.session_state["schema_meta"]` together
   with a lightweight validation report so downstream pages can surface mode and

--- a/src/trend_portfolio_app/data_schema.py
+++ b/src/trend_portfolio_app/data_schema.py
@@ -46,7 +46,7 @@ def _build_meta(validated: ValidatedMarketData) -> SchemaMeta:
     meta["metadata"] = metadata
     meta["validation"] = _build_validation_report(validated)
     meta["original_columns"] = list(metadata.columns or metadata.symbols)
-    meta["symbols"] = list(metadata.symbols or metadata.columns)
+    meta["symbols"] = list(metadata.symbols)
     meta["n_rows"] = metadata.rows
     meta["mode"] = metadata.mode.value
     meta["frequency"] = metadata.frequency_label

--- a/src/trend_portfolio_app/data_schema.py
+++ b/src/trend_portfolio_app/data_schema.py
@@ -45,8 +45,8 @@ def _build_meta(validated: ValidatedMarketData) -> SchemaMeta:
     meta = SchemaMeta()
     meta["metadata"] = metadata
     meta["validation"] = _build_validation_report(validated)
-    meta["original_columns"] = list(metadata.columns)
-    meta["symbols"] = list(metadata.columns)
+    meta["original_columns"] = list(metadata.columns or metadata.symbols)
+    meta["symbols"] = list(metadata.symbols or metadata.columns)
     meta["n_rows"] = metadata.rows
     meta["mode"] = metadata.mode.value
     meta["frequency"] = metadata.frequency_label

--- a/tests/test_market_data_validation.py
+++ b/tests/test_market_data_validation.py
@@ -29,6 +29,7 @@ def test_validate_market_data_happy_path_returns() -> None:
     assert meta["frequency"] == "monthly"
     assert pd.Timestamp(meta["start"]) == validated.index.min()
     assert pd.Timestamp(meta["end"]) == validated.index.max()
+    assert meta["symbols"] == ["FundA", "FundB"]
 
 
 def test_validate_market_data_duplicate_dates() -> None:
@@ -71,6 +72,7 @@ def test_validate_market_data_price_mode_detection() -> None:
     meta = validated.attrs.get("market_data", {})
     assert meta["mode"] == "prices"
     assert meta["frequency"] in {"daily", "business-daily"}
+    assert meta["symbols"] == ["Asset"]
 
 
 def test_validate_market_data_mixed_modes_detected() -> None:


### PR DESCRIPTION
## Summary
- add a dedicated `symbols` field to `MarketDataMetadata`, ensure it mirrors the column list, and propagate it into the DataFrame attrs
- expose the inferred symbols through `SchemaMeta` so the Streamlit app and downstream consumers receive both symbols and original columns
- document the new metadata entry and extend validation tests to assert the symbols payload is present

## Testing
- pytest tests/test_market_data_validation.py tests/test_validators.py tests/test_io_validators_additional.py tests/test_data.py tests/test_cli.py::test_cli_validation_error tests/app/test_streamlit_state.py tests/app/test_upload_page.py


------
https://chatgpt.com/codex/tasks/task_e_68dd5ddff1888331a736ac38e44e51d1