### PR TITLE
Propagate validation issue details through Streamlit upload flow

### DIFF
--- a/app/streamlit/state.py
+++ b/app/streamlit/state.py
@@ -1,6 +1,6 @@
 """Session state management for Streamlit app."""
 
-from typing import Optional
+from typing import Optional, Sequence
 
 import pandas as pd
 import streamlit as st
@@ -43,13 +43,16 @@ def store_validated_data(df: pd.DataFrame, meta: dict):
     st.session_state["upload_status"] = "success"
 
 
-def record_upload_error(message: str) -> None:
+def record_upload_error(message: str, issues: Sequence[str] | None = None) -> None:
     """Persist an upload failure and clear any stale data."""
 
     st.session_state["returns_df"] = None
     st.session_state["schema_meta"] = None
     st.session_state["benchmark_candidates"] = []
-    st.session_state["validation_report"] = message
+    st.session_state["validation_report"] = {
+        "message": message,
+        "issues": list(issues or []),
+    }
     st.session_state["upload_status"] = "error"
 
 

--- a/src/trend_portfolio_app/data_schema.py
+++ b/src/trend_portfolio_app/data_schema.py
@@ -7,7 +7,6 @@ import pandas as pd
 
 from trend_analysis.io.market_data import (
     MarketDataMetadata,
-    MarketDataValidationError,
     ValidatedMarketData,
     validate_market_data,
 )
@@ -58,10 +57,7 @@ def _build_meta(validated: ValidatedMarketData) -> SchemaMeta:
 
 
 def _validate_df(df: pd.DataFrame) -> Tuple[pd.DataFrame, SchemaMeta]:
-    try:
-        validated = validate_market_data(df)
-    except MarketDataValidationError as exc:
-        raise ValueError(exc.user_message) from exc
+    validated = validate_market_data(df)
     meta = _build_meta(validated)
     return validated.frame, meta
 

--- a/tests/app/test_streamlit_state.py
+++ b/tests/app/test_streamlit_state.py
@@ -112,5 +112,8 @@ def test_record_upload_error_sets_error_state(session_state: dict) -> None:
     assert session_state["returns_df"] is None
     assert session_state["schema_meta"] is None
     assert session_state["benchmark_candidates"] == []
-    assert session_state["validation_report"] == "problem"
+    assert session_state["validation_report"] == {
+        "message": "problem",
+        "issues": [],
+    }
     assert session_state["upload_status"] == "error"

--- a/tests/test_data_schema.py
+++ b/tests/test_data_schema.py
@@ -3,7 +3,7 @@ import io
 import pandas as pd
 import pytest
 
-from trend_analysis.io.market_data import MarketDataMode
+from trend_analysis.io.market_data import MarketDataMode, MarketDataValidationError
 from trend_portfolio_app.data_schema import (
     DATE_COL,
     _validate_df,
@@ -30,18 +30,18 @@ def test_validate_df_basic():
 
 def test_validate_df_errors():
     # missing Date column
-    with pytest.raises(ValueError):
+    with pytest.raises(MarketDataValidationError):
         _validate_df(pd.DataFrame({"A": [1]}))
 
     # duplicate columns
     df = pd.DataFrame({"Date": ["2020-01-01"], "A": [1], "B": [2]})
     df.columns = ["Date", "A", "A"]
-    with pytest.raises(ValueError):
+    with pytest.raises(MarketDataValidationError):
         _validate_df(df)
 
     # all NA returns
     df = pd.DataFrame({"Date": ["2020-01-01"], "A": [float("nan")]})
-    with pytest.raises(ValueError):
+    with pytest.raises(MarketDataValidationError):
         _validate_df(df)
 
 


### PR DESCRIPTION
## Summary
- allow `trend_portfolio_app.data_schema._validate_df` to bubble up `MarketDataValidationError` instances so callers can inspect structured issue lists
- update the Streamlit session-state helper and upload page to capture both the user-facing message and issue details when validation fails
- refresh Streamlit UI tests and data schema tests to assert the structured failure payloads

## Testing
- pytest tests/test_market_data_validation.py tests/test_data.py tests/test_cli.py::test_cli_validation_error tests/test_validators.py tests/test_io_validators_additional.py tests/app/test_streamlit_state.py tests/app/test_upload_page.py tests/test_data_schema.py


------
https://chatgpt.com/codex/tasks/task_e_68dd701adc648331bfaf3e1c756bc55f