### PR TITLE
Normalize month-end frequency aliases to avoid pandas warnings

### DIFF
--- a/src/trend_analysis/io/market_data.py
+++ b/src/trend_analysis/io/market_data.py
@@ -29,6 +29,7 @@ _HUMAN_FREQUENCY_LABELS = {
     "Q": "quarterly",
     "QE": "quarterly",
     "Y": "annual",
+    "YE": "annual",
 }
 
 
@@ -220,15 +221,15 @@ def _infer_frequency(index: pd.DatetimeIndex) -> Tuple[str, str]:
         if len(unique_deltas) == 1:
             freq = pd.tseries.frequencies.to_offset(unique_deltas[0]).freqstr
         else:
-            # Attempt common calendar-based frequencies (monthly/quarterly) even when
-            # day deltas differ because of calendar length variations.
-            for candidate in ("ME", "M", "QE", "Q", "A", "Y"):
+            # Attempt common calendar-based frequencies (monthly/quarterly/yearly)
+            # even when day deltas differ because of calendar length variations.
+            for candidate in ("ME", "M", "QE", "Q", "YE", "Y"):
                 try:
                     reconstructed = index.to_period(candidate).to_timestamp(how="end")
                 except Exception:  # pragma: no cover - defensive guard
                     continue
                 if reconstructed.equals(index.sort_values()):
-                    freq = candidate
+                    freq = "YE" if candidate == "Y" else candidate
                     break
         if freq is None:
             preview = ", ".join(str(delta) for delta in unique_deltas[:3])

--- a/src/trend_analysis/io/validators.py
+++ b/src/trend_analysis/io/validators.py
@@ -258,7 +258,7 @@ def load_and_validate_upload(file_like: Any) -> Tuple[pd.DataFrame, Dict[str, An
 def create_sample_template() -> pd.DataFrame:
     """Create a sample returns template with realistic data."""
 
-    dates = pd.date_range(start="2023-01-31", periods=12, freq="M")
+    dates = pd.date_range(start="2023-01-31", periods=12, freq="ME")
     rng = np.random.default_rng(42)
     data: Dict[str, Any] = {"Date": dates}
     for idx in range(1, 6):

--- a/tests/app/test_upload_page.py
+++ b/tests/app/test_upload_page.py
@@ -141,7 +141,7 @@ def test_render_upload_page_success(monkeypatch: pytest.MonkeyPatch, upload_page
             "FundA": [0.01, 0.02, -0.01],
             "SPX Index": [0.03, -0.02, 0.01],
         },
-        index=pd.date_range("2024-01-31", periods=3, freq="M"),
+        index=pd.date_range("2024-01-31", periods=3, freq="ME"),
     )
     meta = _build_meta(df)
 

--- a/tests/test_io_validators_additional.py
+++ b/tests/test_io_validators_additional.py
@@ -21,7 +21,7 @@ def test_validation_result_failure_report() -> None:
 def test_price_mode_detection() -> None:
     frame = pd.DataFrame(
         {
-            "Date": pd.date_range("2023-01-31", periods=6, freq="M"),
+            "Date": pd.date_range("2023-01-31", periods=6, freq="ME"),
             "FundA": [100, 102, 101, 105, 107, 110],
             "FundB": [50, 51, 50.5, 52, 54, 55],
         }
@@ -34,7 +34,7 @@ def test_price_mode_detection() -> None:
 def test_ambiguous_mode_raises() -> None:
     frame = pd.DataFrame(
         {
-            "Date": pd.date_range("2023-01-31", periods=5, freq="M"),
+            "Date": pd.date_range("2023-01-31", periods=5, freq="ME"),
             "PriceFund": [100, 101, 102, 103, 104],
             "ReturnFund": [0.01, 0.02, -0.01, 0.03, 0.00],
         }
@@ -50,7 +50,7 @@ def test_load_and_validate_upload_parquet(tmp_path: Path) -> None:
     pytest.importorskip("pyarrow")
     frame = pd.DataFrame(
         {
-            "Date": pd.date_range("2023-01-31", periods=4, freq="M"),
+            "Date": pd.date_range("2023-01-31", periods=4, freq="ME"),
             "FundA": [0.01, -0.02, 0.03, 0.04],
         }
     )

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -95,7 +95,7 @@ class TestLoadAndValidateUpload:
     def _make_csv(self, tmp_path: Path) -> Path:
         frame = pd.DataFrame(
             {
-                "Date": pd.date_range("2023-01-31", periods=6, freq="M"),
+                "Date": pd.date_range("2023-01-31", periods=6, freq="ME"),
                 "FundA": [0.01, 0.02, -0.01, 0.03, 0.01, 0.005],
             }
         )
@@ -118,7 +118,7 @@ class TestLoadAndValidateUpload:
     def test_handles_excel_stream(self, tmp_path: Path) -> None:
         frame = pd.DataFrame(
             {
-                "Date": pd.date_range("2023-01-31", periods=3, freq="M"),
+                "Date": pd.date_range("2023-01-31", periods=3, freq="ME"),
                 "FundA": [0.01, -0.02, 0.03],
             }
         )


### PR DESCRIPTION
## Summary
- update the ingest frequency helper to recognise the YE alias and avoid deprecated pandas offsets when rebuilding expected timestamps
- switch validator utilities and app/upload tests to the ME month-end alias so the validation suite runs without noisy FutureWarnings

## Testing
- pytest tests/test_market_data_validation.py tests/test_validators.py tests/test_io_validators_additional.py tests/test_data.py tests/test_cli.py::test_cli_validation_error tests/app/test_streamlit_state.py tests/app/test_upload_page.py tests/test_data_schema.py

------
https://chatgpt.com/codex/tasks/task_e_68dd761fb1508331a9f2e79280f6dede