### PR TITLE
Frequency detection and missing‑data policy - Source Issue #1678

### DIFF
--- a/agents/codex-1678.md
+++ b/agents/codex-1678.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1678 -->

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -14,6 +14,8 @@ data:
   timezone: "UTC" # for parsing
   currency: "USD"
   nan_policy: "ffill" # drop | ffill | bfill | both
+  missing_policy: "drop" # drop | ffill | zero
+  missing_fill_limit: null # optional forward-fill limit per asset
   lookback_required: 756 # minimum obs (≈3 yrs daily)
 # ----------------------------------------------------------------------
 # 2. PRE-PROCESSING OPTIONS

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -31,6 +31,11 @@ preprocessing:
     target: "D" # keep None to skip
     method: "last" # last | mean | sum | pad
     business_only: true
+  missing_data:
+    policy: drop           # drop | ffill | zero
+    limit: null            # max consecutive periods to forward-fill (None = unlimited)
+    per_asset: {}          # optional overrides, e.g. {RF: zero}
+    per_asset_limit: {}    # optional forward-fill window overrides per asset
 # ----------------------------------------------------------------------
 # 3. VOLATILITY ADJUSTMENT
 # ----------------------------------------------------------------------

--- a/config/demo.yml
+++ b/config/demo.yml
@@ -10,6 +10,9 @@ data:
 
 preprocessing:
   steps: []                     # none for a synthetic demo
+  missing_data:
+    policy: ffill
+    limit: 2
 
 vol_adjust:
   enabled: false                # keep it off for speed

--- a/config/demo.yml
+++ b/config/demo.yml
@@ -5,6 +5,8 @@ data:
   csv_path: demo/demo_returns.csv   # <– written by generate_demo.py
   date_column: Date
   frequency: ME                 # monthly data
+  missing_policy: drop
+  missing_fill_limit: null
 
 preprocessing:
   steps: []                     # none for a synthetic demo

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -24,6 +24,12 @@ If `-c` is omitted, the tool loads `config/defaults.yml` or the file specified b
 
 The metrics output is printed to the console and can also be written to Excel, CSV or JSON depending on `output.format` in the config.
 
+### 2.1 Input frequency and missing-data handling
+
+- The ingestion layer inspects the `Date` column and automatically classifies the cadence as daily, weekly or monthly. Holiday gaps and February shortfalls are tolerated and the series is resampled to month-end returns before modelling begins.
+- Missing-data behaviour is configured per asset via `data.missing_policy` (`drop`, `ffill` or `zero`). When forward-fill is selected the optional `data.missing_fill_limit` caps the length of consecutive gaps that will be filled.
+- Every report—console text, Excel summary and the JSON bundle—prints a one-line status showing the detected frequency and the applied missing-data policy so runs remain auditable.
+
 ## 3. Interactive GUI
 
 A graphical interface is available in Jupyter. Launch it by running:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -54,6 +54,24 @@ python -m trend_analysis.run_analysis -c config/presets/balanced.yml
 Replace `balanced` with `conservative` or `aggressive` as needed. See
 [PresetStrategies.md](PresetStrategies.md) for a summary of each option.
 
+### 4.1 Frequency detection & missing-data policies
+
+The pipeline now inspects the `Date` column and automatically detects whether
+the input returns are daily, weekly or monthly. Daily and weekly data are
+compounded to month-end returns before the in/out-sample windows are sliced, so
+backtests remain comparable regardless of the original cadence.
+
+Missing observations are handled according to `preprocessing.missing_data` in
+the YAML configuration. The section supports:
+
+- `policy`: `drop`, `ffill` or `zero` (default is `drop`).
+- `limit`: maximum length of a forward-fill run (use `null` for unlimited).
+- `per_asset` / `per_asset_limit`: optional overrides per column, e.g.
+  `per_asset: {RF: zero}`.
+
+The effective cadence and policy are recorded in the results under
+`preprocessing.summary` and appear as a one-line note on Excel/TXT exports.
+
 ## 5. Selection modes and ranking
 
 `portfolio.selection_mode` supports `all`, `random`, `manual` and `rank` values. In rank mode you can keep the top funds by score or apply a threshold. Scores come from metrics defined under `metrics.registry` and may be combined with z‑scored weights.

--- a/src/trend_analysis/api.py
+++ b/src/trend_analysis/api.py
@@ -87,6 +87,10 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
     split = config.sample_split
     metrics_list = config.metrics.get("registry")
     stats_cfg = None
+    data_cfg = getattr(config, "data", {})
+    missing_policy = str(data_cfg.get("missing_policy", "drop"))
+    missing_limit_raw = data_cfg.get("missing_fill_limit")
+    missing_limit = None if missing_limit_raw in (None, "") else int(missing_limit_raw)
     if metrics_list:
         from .core.rank_selection import RiskStatsConfig, canonical_metric_list
 
@@ -117,6 +121,8 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
         weighting_scheme=config.portfolio.get("weighting_scheme", "equal"),
         constraints=config.portfolio.get("constraints"),
         stats_cfg=stats_cfg,
+        missing_policy=missing_policy,
+        missing_limit=missing_limit,
     )
     if res is None:
         logger.warning("run_simulation produced no result")

--- a/src/trend_analysis/api.py
+++ b/src/trend_analysis/api.py
@@ -16,7 +16,7 @@ else:  # Runtime: avoid importing typing-only names
     from typing import Any as ConfigType
 
 from .logging import log_step as _log_step  # lightweight import
-from .pipeline import _run_analysis
+from .pipeline import _policy_from_config, _run_analysis
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +99,16 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
             risk_free=0.0,
         )
 
+    preprocessing_section = getattr(config, "preprocessing", {}) or {}
+    missing_section = (
+        preprocessing_section.get("missing_data")
+        if isinstance(preprocessing_section, Mapping)
+        else None
+    )
+    policy_spec, limit_spec = _policy_from_config(
+        missing_section if isinstance(missing_section, Mapping) else None
+    )
+
     _log_step(run_id, "analysis_start", "_run_analysis dispatch")
     res = _run_analysis(
         returns,
@@ -120,9 +130,8 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
         seed=seed,
         weighting_scheme=config.portfolio.get("weighting_scheme", "equal"),
         constraints=config.portfolio.get("constraints"),
-        stats_cfg=stats_cfg,
-        missing_policy=missing_policy,
-        missing_limit=missing_limit,
+        missing_policy=policy_spec,
+        missing_limit=limit_spec,
     )
     if res is None:
         logger.warning("run_simulation produced no result")

--- a/src/trend_analysis/export/__init__.py
+++ b/src/trend_analysis/export/__init__.py
@@ -363,8 +363,15 @@ def _build_summary_formatter(
         ws.write_row(0, 0, ["Vol-Adj Trend Analysis"], bold)
         ws.write_row(1, 0, [f"In:  {in_start} → {in_end}"], bold)
         ws.write_row(2, 0, [f"Out: {out_start} → {out_end}"], bold)
-        meta_line = _format_frequency_policy_line(res)
-        ws.write_row(3, 0, [meta_line], bold)
+        summary_text = cast(
+            str,
+            res.get("preprocessing_summary")
+            or cast(Mapping[str, Any], res.get("preprocessing", {})).get("summary"),
+        )
+        if summary_text:
+            ws.write_row(3, 0, [summary_text])
+        else:
+            ws.write_row(3, 0, [""])
         bench_labels = list(res.get("benchmark_ir", {}))
         headers = [
             "Name",
@@ -629,10 +636,18 @@ def format_summary_text(
         "Vol-Adj Trend Analysis",
         f"In:  {in_start} → {in_end}",
         f"Out: {out_start} → {out_end}",
-        meta_line,
+    ]
+    summary_text = cast(
+        str,
+        res.get("preprocessing_summary")
+        or cast(Mapping[str, Any], res.get("preprocessing", {})).get("summary"),
+    )
+    if summary_text:
+        header.append(summary_text)
+    header.extend([
         "",
         df_formatted.to_string(index=False),
-    ]
+    ])
     return "\n".join(header)
 
 

--- a/src/trend_analysis/export/__init__.py
+++ b/src/trend_analysis/export/__init__.py
@@ -270,6 +270,52 @@ def reset_formatters_excel() -> None:
     FORMATTERS_EXCEL.clear()
 
 
+def _format_frequency_policy_line(res: Mapping[str, Any]) -> str:
+    freq = cast(Mapping[str, Any], res.get("input_frequency", {}))
+    policy = cast(Mapping[str, Any], res.get("missing_data_policy", {}))
+
+    freq_label = cast(str | None, freq.get("label"))
+    target_label = cast(str | None, freq.get("target_label")) or freq_label
+    resampled = bool(freq.get("resampled"))
+    if freq_label:
+        if resampled and target_label and target_label != freq_label:
+            freq_part = f"{freq_label} → {target_label}"
+        else:
+            freq_part = freq_label
+    else:
+        freq_part = "Unknown"
+
+    policy_name = str(policy.get("policy", "drop")).lower()
+    policy_labels = {
+        "drop": "Drop",
+        "ffill": "Forward-fill",
+        "zero": "Zero-fill",
+    }
+    policy_part = policy_labels.get(policy_name, policy_name.title())
+    extras: list[str] = []
+    limit = policy.get("limit")
+    if policy_name == "ffill" and limit is not None:
+        extras.append(f"limit={limit}")
+    total_filled = policy.get("total_filled")
+    try:
+        filled_int = int(total_filled)
+    except (TypeError, ValueError):
+        filled_int = 0
+    if filled_int:
+        extras.append(
+            f"filled {filled_int} cell{'s' if filled_int != 1 else ''}"
+        )
+    dropped_assets = policy.get("dropped_assets")
+    dropped_count = len(dropped_assets) if isinstance(dropped_assets, list) else 0
+    if dropped_count:
+        extras.append(
+            f"dropped {dropped_count} asset{'s' if dropped_count != 1 else ''}"
+        )
+    if extras:
+        policy_part = f"{policy_part} ({', '.join(extras)})"
+    return f"Frequency: {freq_part}; NA policy: {policy_part}"
+
+
 def _build_summary_formatter(
     res: Mapping[str, Any],
     in_start: str,
@@ -317,6 +363,8 @@ def _build_summary_formatter(
         ws.write_row(0, 0, ["Vol-Adj Trend Analysis"], bold)
         ws.write_row(1, 0, [f"In:  {in_start} → {in_end}"], bold)
         ws.write_row(2, 0, [f"Out: {out_start} → {out_end}"], bold)
+        meta_line = _format_frequency_policy_line(res)
+        ws.write_row(3, 0, [meta_line], bold)
         bench_labels = list(res.get("benchmark_ir", {}))
         headers = [
             "Name",
@@ -576,10 +624,12 @@ def format_summary_text(
 
     df = pd.DataFrame(rows, columns=columns)
     df_formatted = df.map(safe)
+    meta_line = _format_frequency_policy_line(res)
     header = [
         "Vol-Adj Trend Analysis",
         f"In:  {in_start} → {in_end}",
         f"Out: {out_start} → {out_end}",
+        meta_line,
         "",
         df_formatted.to_string(index=False),
     ]

--- a/src/trend_analysis/util/frequency.py
+++ b/src/trend_analysis/util/frequency.py
@@ -1,137 +1,83 @@
+"""Frequency-detection helpers used by the analysis pipeline."""
+
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Iterable
+from typing import Iterable as TypingIterable
 from typing import Literal
 
 import numpy as np
 import pandas as pd
-from pandas.tseries import offsets
 
-__all__ = ["FrequencySummary", "FREQUENCY_LABELS", "detect_frequency"]
+__all__ = ["detect_frequency", "FrequencyCode"]
 
 FrequencyCode = Literal["D", "W", "M"]
 
-FREQUENCY_LABELS: dict[FrequencyCode, str] = {
-    "D": "Daily",
-    "W": "Weekly",
-    "M": "Monthly",
-}
 
+def _as_datetime_index(index: Iterable[object]) -> pd.DatetimeIndex:
+    """Return a normalised :class:`~pandas.DatetimeIndex` from ``index``."""
 
-@dataclass(frozen=True)
-class FrequencySummary:
-    """Summary of detected sampling cadence."""
-
-    code: FrequencyCode
-    label: str
-    target: FrequencyCode
-    resampled: bool
-
-    @property
-    def target_label(self) -> str:
-        return FREQUENCY_LABELS[self.target]
-
-
-def detect_frequency(index: pd.Index) -> FrequencySummary:
-    """Return the sampling cadence for ``index``.
-
-    Parameters
-    ----------
-    index:
-        Datetime index describing the observations.
-
-    Returns
-    -------
-    FrequencySummary
-        Structured summary describing the detected frequency and whether the
-        series needs to be resampled to the monthly cadence expected by the
-        modelling pipeline.
-
-    Raises
-    ------
-    TypeError
-        If ``index`` is not a :class:`~pandas.DatetimeIndex`.
-    ValueError
-        When the frequency cannot be inferred with reasonable confidence.
-    """
-
-    if not isinstance(index, pd.DatetimeIndex):
-        raise TypeError("detect_frequency expects a DatetimeIndex")
-
-    if len(index) < 2:
-        raise ValueError("At least two timestamps are required to infer frequency")
-
-    idx = index.sort_values().unique()
-
-    inferred = pd.infer_freq(idx)
-    if inferred:
-        code = _map_offset_to_code(inferred)
-        if code is not None:
-            return FrequencySummary(code=code, label=FREQUENCY_LABELS[code], target="M", resampled=code != "M")
-
-    code = _fallback_frequency_detection(idx)
-    return FrequencySummary(code=code, label=FREQUENCY_LABELS[code], target="M", resampled=code != "M")
-
-
-def _map_offset_to_code(freq: str) -> FrequencyCode | None:
+    if isinstance(index, pd.DatetimeIndex):
+        return index.sort_values()
     try:
-        offset = pd.tseries.frequencies.to_offset(freq)
-    except (ValueError, TypeError):
-        return None
+        idx = pd.DatetimeIndex(index)
+    except (TypeError, ValueError):
+        idx = pd.to_datetime(list(index), errors="coerce")
+        if getattr(idx, "isna", lambda: True)().any():
+            raise ValueError("detect_frequency requires datetime-like inputs")
+        idx = pd.DatetimeIndex(idx)
+    return idx.sort_values()
 
-    if isinstance(offset, (offsets.Day, offsets.BusinessDay, offsets.CDay, offsets.CustomBusinessDay)):
-        return "D"
-    if isinstance(offset, offsets.Week):
+
+def _map_inferred(freq: str | None) -> FrequencyCode | None:
+    if not freq:
+        return None
+    freq = freq.upper()
+    if freq.startswith("W"):
         return "W"
-    if isinstance(
-        offset,
-        (
-            offsets.MonthBegin,
-            offsets.MonthEnd,
-            offsets.BMonthBegin,
-            offsets.BMonthEnd,
-            offsets.SemiMonthBegin,
-            offsets.SemiMonthEnd,
-        ),
-    ):
+    if freq.endswith("D") or freq in {"B", "C", "BD"}:
+        return "D"
+    if any(freq.startswith(prefix) for prefix in ("M", "SM", "BM")):
+        return "M"
+    if any(freq.startswith(prefix) for prefix in ("Q", "A", "Y")):
         return "M"
     return None
 
 
-def _fallback_frequency_detection(index: pd.DatetimeIndex) -> FrequencyCode:
-    if _looks_monthly(index):
+def detect_frequency(index: TypingIterable[object]) -> FrequencyCode:
+    """Classify a date index as daily, weekly or monthly.
+
+    Parameters
+    ----------
+    index:
+        Iterable of datetime-like values.  The iterable is converted to a
+        :class:`~pandas.DatetimeIndex` internally; duplicates are ignored.
+
+    Returns
+    -------
+    Literal["D", "W", "M"]
+        Canonicalised frequency code representing daily, weekly or monthly
+        cadence.  The detector tolerates gaps introduced by market holidays and
+        short calendar months by relying on the median interval once
+        :func:`pandas.infer_freq` cannot produce a definitive answer.
+    """
+
+    idx = _as_datetime_index(index).drop_duplicates()
+    if len(idx) < 2:
         return "M"
-    if _looks_weekly(index):
-        return "W"
-    if _looks_daily(index):
+
+    detected = _map_inferred(pd.infer_freq(idx))
+    if detected is not None:
+        return detected
+
+    diffs = np.diff(idx.view("i8"))  # nanoseconds
+    if diffs.size == 0:
+        return "M"
+    diffs_days = diffs / 86_400_000_000_000  # ns -> days
+    median = float(np.median(diffs_days))
+    if median <= 3.5:
         return "D"
-    raise ValueError("Unable to determine sampling frequency from index gaps")
+    if median <= 12:
+        return "W"
+    return "M"
 
-
-def _looks_monthly(index: pd.DatetimeIndex) -> bool:
-    months = index.to_period("M")
-    if months.nunique() != len(index):
-        return False
-    deltas = np.diff(index.values.astype("datetime64[D]").astype(np.int64))
-    if len(deltas) == 0:
-        return True
-    return float(np.mean((deltas >= 25) & (deltas <= 35))) >= 0.6
-
-
-def _looks_weekly(index: pd.DatetimeIndex) -> bool:
-    weeks = index.to_period("W")
-    if weeks.nunique() != len(index):
-        return False
-    deltas = np.diff(index.values.astype("datetime64[D]").astype(np.int64))
-    if len(deltas) == 0:
-        return True
-    ratio = float(np.mean((deltas >= 5) & (deltas <= 9)))
-    return ratio >= 0.6
-
-
-def _looks_daily(index: pd.DatetimeIndex) -> bool:
-    deltas = np.diff(index.values.astype("datetime64[D]").astype(np.int64))
-    if len(deltas) == 0:
-        return True
-    ratio = float(np.mean(deltas <= 4))
-    return ratio >= 0.75

--- a/src/trend_analysis/util/frequency.py
+++ b/src/trend_analysis/util/frequency.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+from pandas.tseries import offsets
+
+__all__ = ["FrequencySummary", "FREQUENCY_LABELS", "detect_frequency"]
+
+FrequencyCode = Literal["D", "W", "M"]
+
+FREQUENCY_LABELS: dict[FrequencyCode, str] = {
+    "D": "Daily",
+    "W": "Weekly",
+    "M": "Monthly",
+}
+
+
+@dataclass(frozen=True)
+class FrequencySummary:
+    """Summary of detected sampling cadence."""
+
+    code: FrequencyCode
+    label: str
+    target: FrequencyCode
+    resampled: bool
+
+    @property
+    def target_label(self) -> str:
+        return FREQUENCY_LABELS[self.target]
+
+
+def detect_frequency(index: pd.Index) -> FrequencySummary:
+    """Return the sampling cadence for ``index``.
+
+    Parameters
+    ----------
+    index:
+        Datetime index describing the observations.
+
+    Returns
+    -------
+    FrequencySummary
+        Structured summary describing the detected frequency and whether the
+        series needs to be resampled to the monthly cadence expected by the
+        modelling pipeline.
+
+    Raises
+    ------
+    TypeError
+        If ``index`` is not a :class:`~pandas.DatetimeIndex`.
+    ValueError
+        When the frequency cannot be inferred with reasonable confidence.
+    """
+
+    if not isinstance(index, pd.DatetimeIndex):
+        raise TypeError("detect_frequency expects a DatetimeIndex")
+
+    if len(index) < 2:
+        raise ValueError("At least two timestamps are required to infer frequency")
+
+    idx = index.sort_values().unique()
+
+    inferred = pd.infer_freq(idx)
+    if inferred:
+        code = _map_offset_to_code(inferred)
+        if code is not None:
+            return FrequencySummary(code=code, label=FREQUENCY_LABELS[code], target="M", resampled=code != "M")
+
+    code = _fallback_frequency_detection(idx)
+    return FrequencySummary(code=code, label=FREQUENCY_LABELS[code], target="M", resampled=code != "M")
+
+
+def _map_offset_to_code(freq: str) -> FrequencyCode | None:
+    try:
+        offset = pd.tseries.frequencies.to_offset(freq)
+    except (ValueError, TypeError):
+        return None
+
+    if isinstance(offset, (offsets.Day, offsets.BusinessDay, offsets.CDay, offsets.CustomBusinessDay)):
+        return "D"
+    if isinstance(offset, offsets.Week):
+        return "W"
+    if isinstance(
+        offset,
+        (
+            offsets.MonthBegin,
+            offsets.MonthEnd,
+            offsets.BMonthBegin,
+            offsets.BMonthEnd,
+            offsets.SemiMonthBegin,
+            offsets.SemiMonthEnd,
+        ),
+    ):
+        return "M"
+    return None
+
+
+def _fallback_frequency_detection(index: pd.DatetimeIndex) -> FrequencyCode:
+    if _looks_monthly(index):
+        return "M"
+    if _looks_weekly(index):
+        return "W"
+    if _looks_daily(index):
+        return "D"
+    raise ValueError("Unable to determine sampling frequency from index gaps")
+
+
+def _looks_monthly(index: pd.DatetimeIndex) -> bool:
+    months = index.to_period("M")
+    if months.nunique() != len(index):
+        return False
+    deltas = np.diff(index.values.astype("datetime64[D]").astype(np.int64))
+    if len(deltas) == 0:
+        return True
+    return float(np.mean((deltas >= 25) & (deltas <= 35))) >= 0.6
+
+
+def _looks_weekly(index: pd.DatetimeIndex) -> bool:
+    weeks = index.to_period("W")
+    if weeks.nunique() != len(index):
+        return False
+    deltas = np.diff(index.values.astype("datetime64[D]").astype(np.int64))
+    if len(deltas) == 0:
+        return True
+    ratio = float(np.mean((deltas >= 5) & (deltas <= 9)))
+    return ratio >= 0.6
+
+
+def _looks_daily(index: pd.DatetimeIndex) -> bool:
+    deltas = np.diff(index.values.astype("datetime64[D]").astype(np.int64))
+    if len(deltas) == 0:
+        return True
+    ratio = float(np.mean(deltas <= 4))
+    return ratio >= 0.75

--- a/src/trend_analysis/util/missing.py
+++ b/src/trend_analysis/util/missing.py
@@ -1,105 +1,169 @@
+"""Utilities for enforcing missing-data policies on return frames."""
+
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Mapping
+from typing import Any, Iterable
 
 import pandas as pd
 
-__all__ = ["MissingPolicyResult", "apply_missing_policy"]
+__all__ = ["apply_missing_policy"]
 
 
-@dataclass(frozen=True)
-class MissingPolicyResult:
-    """Result metadata produced when applying a missing-data policy."""
+def _coerce_policy(policy: str | None) -> str:
+    value = (policy or "drop").strip().lower()
+    if value not in {"drop", "ffill", "zero"}:
+        raise ValueError(f"Unsupported missing-data policy: {policy!r}")
+    return value
 
-    policy: str
-    limit: int | None
-    dropped_assets: tuple[str, ...]
-    filled_cells: tuple[tuple[str, int], ...]
 
-    @property
-    def total_filled(self) -> int:
-        return sum(count for _, count in self.filled_cells)
+def _coerce_limit(limit: Any) -> int | None:
+    if limit is None:
+        return None
+    try:
+        value = int(limit)
+    except (TypeError, ValueError):  # pragma: no cover - defensive guard
+        raise ValueError(f"Invalid forward-fill limit: {limit!r}") from None
+    if value < 0:
+        raise ValueError("Forward-fill limit must be non-negative")
+    return value
+
+
+def _resolve_mapping(
+    spec: str | Mapping[str, str] | None, default: str
+) -> tuple[str, dict[str, str]]:
+    if spec is None or isinstance(spec, str):
+        return _coerce_policy(spec or default), {}
+    overrides = {k: _coerce_policy(v) for k, v in spec.items() if k != "default"}
+    default_policy = _coerce_policy(spec.get("default", default))
+    return default_policy, overrides
+
+
+def _resolve_limits(
+    limit: int | Mapping[str, int | None] | None
+) -> tuple[int | None, dict[str, int | None]]:
+    if isinstance(limit, Mapping):
+        resolved = {k: _coerce_limit(v) for k, v in limit.items() if k != "default"}
+        default_limit = _coerce_limit(limit.get("default"))
+        return default_limit, resolved
+    return _coerce_limit(limit), {}
+
+
+def _policy_display(
+    default_policy: str,
+    overrides: Mapping[str, str],
+    default_limit: int | None,
+    limit_overrides: Mapping[str, int | None],
+) -> str:
+    limit_part = (
+        f"limit={default_limit}" if default_limit is not None else "unbounded"
+    )
+    text = [f"default={default_policy}({limit_part})"]
+    if overrides:
+        over = ", ".join(
+            f"{asset}={policy}"
+            + (
+                f"(limit={limit_overrides.get(asset)})"
+                if policy == "ffill" and asset in limit_overrides
+                else ""
+            )
+            for asset, policy in sorted(overrides.items())
+        )
+        text.append(f"overrides: {over}")
+    return "; ".join(text)
 
 
 def apply_missing_policy(
-    df: pd.DataFrame, policy: str, limit: int | None = None
-) -> tuple[pd.DataFrame, MissingPolicyResult]:
-    """Apply the missing-data policy to ``df`` column by column.
+    df: pd.DataFrame,
+    policy: str | Mapping[str, str] | None,
+    limit: int | Mapping[str, int | None] | None,
+    *,
+    columns: Iterable[str] | None = None,
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    """Apply a missing-data policy column by column.
 
     Parameters
     ----------
     df:
-        DataFrame indexed by ``Date`` with asset returns in the remaining columns.
+        DataFrame of asset returns indexed by date.
     policy:
-        One of ``"drop"``, ``"ffill"`` or ``"zero"``. Comparison is case-insensitive.
+        Either a single policy name (``"drop"``, ``"ffill"``, ``"zero"``), or a
+        mapping of column names to policies.  The special key ``"default"`` sets
+        the default policy when a mapping is provided.
     limit:
-        Maximum consecutive observations to fill when ``policy='ffill'``.
+        Global forward-fill limit, or a mapping of column names to limits.
+    columns:
+        Optional iterable restricting which columns participate.  Columns not in
+        ``columns`` are returned unchanged.
 
     Returns
     -------
-    tuple[pd.DataFrame, MissingPolicyResult]
-        The cleaned DataFrame and structured metadata describing the outcome.
-
-    Raises
-    ------
-    ValueError
-        If ``policy`` is unknown or ``limit`` is negative.
+    tuple
+        ``(frame, metadata)`` where ``frame`` is the transformed DataFrame and
+        ``metadata`` captures the effective policy plus bookkeeping such as the
+        number of fills performed and which columns were dropped.
     """
 
-    if limit is not None:
-        try:
-            limit_value = int(limit)
-        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
-            raise ValueError("limit must be an integer when provided") from exc
-        if limit_value < 0:
-            raise ValueError("limit cannot be negative")
-        limit = limit_value
+    cols = list(columns) if columns is not None else list(df.columns)
+    work = df.copy()
 
-    policy_normalised = policy.lower().strip()
-    if policy_normalised not in {"drop", "ffill", "zero"}:
-        raise ValueError("policy must be one of {'drop', 'ffill', 'zero'}")
+    default_policy, per_column_policy = _resolve_mapping(policy, "drop")
+    default_limit, per_column_limit = _resolve_limits(limit)
 
-    cleaned = pd.DataFrame(index=df.index)
+    filled_counts: dict[str, int] = {}
     dropped: list[str] = []
-    filled: list[tuple[str, int]] = []
+    applied_policy: dict[str, str] = {}
+    limit_used: dict[str, int | None] = {}
 
-    for column in df.columns:
-        series = df[column]
-        if policy_normalised == "drop":
+    result_columns: dict[str, pd.Series] = {
+        col: work[col] for col in df.columns if col not in cols
+    }
+    for col in cols:
+        series = work[col]
+        col_policy = per_column_policy.get(col, default_policy)
+        applied_policy[col] = col_policy
+        col_limit = per_column_limit.get(col, default_limit)
+        if col_policy == "drop":
             if series.isna().any():
-                dropped.append(column)
+                dropped.append(col)
                 continue
-            cleaned[column] = series
+            result_columns[col] = series
+            limit_used[col] = None
             continue
-
-        if policy_normalised == "ffill":
-            kwargs: dict[str, int] = {}
-            if limit is not None:
-                kwargs["limit"] = limit
-            filled_series = series.ffill(**kwargs)
-            filled_count = int(series.isna().sum() - filled_series.isna().sum())
-            if filled_count:
-                filled.append((column, filled_count))
-            if filled_series.isna().all():
-                dropped.append(column)
+        if col_policy == "ffill":
+            filled_before = int(series.isna().sum())
+            series = series.ffill(limit=col_limit)
+            filled_after = int(series.isna().sum())
+            filled_counts[col] = filled_before - filled_after
+            limit_used[col] = col_limit
+            if series.isna().any():
+                dropped.append(col)
                 continue
-            cleaned[column] = filled_series
+            result_columns[col] = series
             continue
-
-        # zero policy
-        filled_series = series.fillna(0.0)
-        filled_count = int(series.isna().sum())
-        if filled_count:
-            filled.append((column, filled_count))
-        if filled_series.isna().all():
-            dropped.append(column)
+        if col_policy == "zero":
+            filled_before = int(series.isna().sum())
+            if filled_before:
+                series = series.fillna(0.0)
+            filled_counts[col] = filled_before
+            limit_used[col] = None
+            result_columns[col] = series
             continue
-        cleaned[column] = filled_series
+        raise AssertionError(f"Unhandled policy: {col_policy}")
 
-    result = MissingPolicyResult(
-        policy=policy_normalised,
-        limit=limit,
-        dropped_assets=tuple(dropped),
-        filled_cells=tuple((col, count) for col, count in filled),
+    out = pd.DataFrame(result_columns, index=work.index)
+
+    metadata = {
+        "policy": applied_policy,
+        "default_policy": default_policy,
+        "limit": limit_used,
+        "filled": filled_counts,
+        "dropped": dropped,
+    }
+    metadata["summary"] = _policy_display(
+        default_policy,
+        per_column_policy,
+        default_limit,
+        per_column_limit,
     )
-    return cleaned, result
+    return out, metadata

--- a/src/trend_analysis/util/missing.py
+++ b/src/trend_analysis/util/missing.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+__all__ = ["MissingPolicyResult", "apply_missing_policy"]
+
+
+@dataclass(frozen=True)
+class MissingPolicyResult:
+    """Result metadata produced when applying a missing-data policy."""
+
+    policy: str
+    limit: int | None
+    dropped_assets: tuple[str, ...]
+    filled_cells: tuple[tuple[str, int], ...]
+
+    @property
+    def total_filled(self) -> int:
+        return sum(count for _, count in self.filled_cells)
+
+
+def apply_missing_policy(
+    df: pd.DataFrame, policy: str, limit: int | None = None
+) -> tuple[pd.DataFrame, MissingPolicyResult]:
+    """Apply the missing-data policy to ``df`` column by column.
+
+    Parameters
+    ----------
+    df:
+        DataFrame indexed by ``Date`` with asset returns in the remaining columns.
+    policy:
+        One of ``"drop"``, ``"ffill"`` or ``"zero"``. Comparison is case-insensitive.
+    limit:
+        Maximum consecutive observations to fill when ``policy='ffill'``.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, MissingPolicyResult]
+        The cleaned DataFrame and structured metadata describing the outcome.
+
+    Raises
+    ------
+    ValueError
+        If ``policy`` is unknown or ``limit`` is negative.
+    """
+
+    if limit is not None:
+        try:
+            limit_value = int(limit)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
+            raise ValueError("limit must be an integer when provided") from exc
+        if limit_value < 0:
+            raise ValueError("limit cannot be negative")
+        limit = limit_value
+
+    policy_normalised = policy.lower().strip()
+    if policy_normalised not in {"drop", "ffill", "zero"}:
+        raise ValueError("policy must be one of {'drop', 'ffill', 'zero'}")
+
+    cleaned = pd.DataFrame(index=df.index)
+    dropped: list[str] = []
+    filled: list[tuple[str, int]] = []
+
+    for column in df.columns:
+        series = df[column]
+        if policy_normalised == "drop":
+            if series.isna().any():
+                dropped.append(column)
+                continue
+            cleaned[column] = series
+            continue
+
+        if policy_normalised == "ffill":
+            kwargs: dict[str, int] = {}
+            if limit is not None:
+                kwargs["limit"] = limit
+            filled_series = series.ffill(**kwargs)
+            filled_count = int(series.isna().sum() - filled_series.isna().sum())
+            if filled_count:
+                filled.append((column, filled_count))
+            if filled_series.isna().all():
+                dropped.append(column)
+                continue
+            cleaned[column] = filled_series
+            continue
+
+        # zero policy
+        filled_series = series.fillna(0.0)
+        filled_count = int(series.isna().sum())
+        if filled_count:
+            filled.append((column, filled_count))
+        if filled_series.isna().all():
+            dropped.append(column)
+            continue
+        cleaned[column] = filled_series
+
+    result = MissingPolicyResult(
+        policy=policy_normalised,
+        limit=limit,
+        dropped_assets=tuple(dropped),
+        filled_cells=tuple((col, count) for col, count in filled),
+    )
+    return cleaned, result

--- a/tests/test_export_formatter.py
+++ b/tests/test_export_formatter.py
@@ -128,6 +128,8 @@ def test_make_summary_formatter_registers_and_runs(formatters_excel_registry):
     wb = DummyWB()
     fmt(ws, wb)
     assert ws.rows[0][2][0] == "Vol-Adj Trend Analysis"
+    meta_rows = [row for row in ws.rows if row[0] == 3]
+    assert meta_rows and meta_rows[0][2][0].startswith("Frequency:")
 
 
 @pytest.mark.parametrize("as_dataframe", [False, True])

--- a/tests/test_frequency_missing.py
+++ b/tests/test_frequency_missing.py
@@ -1,0 +1,62 @@
+import pandas as pd
+
+from trend_analysis.util.frequency import detect_frequency
+from trend_analysis.util.missing import apply_missing_policy
+
+
+def test_detect_frequency_daily_with_gaps():
+    idx = pd.date_range("2024-01-01", periods=10, freq="B")
+    idx = idx.delete([2, 5])  # simulate holidays
+    assert detect_frequency(idx) == "D"
+
+
+def test_detect_frequency_weekly():
+    idx = pd.date_range("2024-01-05", periods=6, freq="W-FRI")
+    assert detect_frequency(idx) == "W"
+
+
+def test_detect_frequency_monthly():
+    idx = pd.to_datetime(["2024-01-31", "2024-02-29", "2024-03-29", "2024-04-30"])
+    assert detect_frequency(idx) == "M"
+
+
+def test_apply_missing_policy_drop():
+    df = pd.DataFrame(
+        {
+            "A": [1.0, float("nan"), 3.0],
+            "B": [1.0, 2.0, 3.0],
+        },
+        index=pd.date_range("2024-01-01", periods=3, freq="D"),
+    )
+    out, meta = apply_missing_policy(df, "drop", None)
+    assert list(out.columns) == ["B"]
+    assert meta["dropped"] == ["A"]
+
+
+def test_apply_missing_policy_ffill_limit():
+    df = pd.DataFrame(
+        {
+            "A": [1.0, float("nan"), float("nan"), 4.0],
+            "B": [0.5, 0.6, 0.7, 0.8],
+        },
+        index=pd.date_range("2024-01-01", periods=4, freq="D"),
+    )
+    out, meta = apply_missing_policy(df, "ffill", limit=1)
+    assert "A" not in out.columns  # two consecutive NaNs exceed limit
+    assert meta["dropped"] == ["A"]
+
+
+def test_apply_missing_policy_zero_override():
+    df = pd.DataFrame(
+        {
+            "A": [1.0, float("nan"), 3.0],
+            "B": [0.5, float("nan"), 0.7],
+        },
+        index=pd.date_range("2024-01-01", periods=3, freq="D"),
+    )
+    policy = {"default": "drop", "B": "zero"}
+    out, meta = apply_missing_policy(df, policy, limit=None)
+    assert "A" not in out.columns
+    assert "B" in out.columns
+    assert meta["filled"]["B"] == 1
+    assert meta["policy"]["B"] == "zero"

--- a/tests/test_run_analysis.py
+++ b/tests/test_run_analysis.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from trend_analysis.core.rank_selection import RiskStatsConfig
 from trend_analysis.metrics import (
@@ -21,6 +22,29 @@ def make_df():
         "B": [0.01, 0.02, -0.02, 0.03, 0.02, 0.0],
     }
     return pd.DataFrame(data)
+
+
+def make_daily_df(monthly_df: pd.DataFrame) -> pd.DataFrame:
+    records: list[dict[str, float | pd.Timestamp]] = []
+    for _, row in monthly_df.iterrows():
+        period = row["Date"].to_period("M")
+        days = pd.date_range(period.to_timestamp(), period.to_timestamp("M"), freq="B")
+        count = len(days)
+        for day in days:
+            record: dict[str, float | pd.Timestamp] = {"Date": day}
+            for column in monthly_df.columns:
+                if column == "Date":
+                    continue
+                value = row[column]
+                if pd.isna(value):
+                    record[column] = float("nan")
+                    continue
+                if column == "RF":
+                    record[column] = float(value) / count
+                else:
+                    record[column] = float((1.0 + value) ** (1.0 / count) - 1.0)
+            records.append(record)
+    return pd.DataFrame(records)
 
 
 def test_metrics_roundtrip():
@@ -73,3 +97,76 @@ def test_run_analysis_returns_score_frame():
     cfg = RiskStatsConfig()
     assert sf.columns.tolist() == cfg.metrics_to_run
     assert sf.attrs["insample_len"] == 3
+
+
+def test_run_analysis_normalises_daily_inputs():
+    monthly_df = make_df()
+    daily_df = make_daily_df(monthly_df)
+
+    res_monthly = run_analysis(
+        monthly_df,
+        "2020-01",
+        "2020-03",
+        "2020-04",
+        "2020-06",
+        0.1,
+        0.0,
+    )
+    res_daily = run_analysis(
+        daily_df,
+        "2020-01",
+        "2020-03",
+        "2020-04",
+        "2020-06",
+        0.1,
+        0.0,
+        missing_policy="drop",
+    )
+
+    assert res_monthly["input_frequency"]["code"] == "M"
+    assert res_daily["input_frequency"]["code"] == "D"
+    assert set(res_monthly["selected_funds"]) == set(res_daily["selected_funds"])
+
+    for key in ("in_sample_stats", "out_sample_stats"):
+            for fund, monthly_stats in res_monthly[key].items():
+                daily_stats = res_daily[key][fund]
+                for attr in ("cagr", "vol", "sharpe", "sortino", "information_ratio", "max_drawdown"):
+                    expected = getattr(monthly_stats, attr)
+                    actual = getattr(daily_stats, attr)
+                    if pd.isna(expected) and pd.isna(actual):
+                        continue
+                    assert actual == pytest.approx(expected, rel=1e-6)
+
+
+def test_run_analysis_missing_policy_summary_zero_fill():
+    df = make_df()
+    df.loc[2, "A"] = pd.NA
+
+    res_drop = run_analysis(
+        df,
+        "2020-01",
+        "2020-03",
+        "2020-04",
+        "2020-06",
+        0.1,
+        0.0,
+        missing_policy="drop",
+    )
+    res_zero = run_analysis(
+        df,
+        "2020-01",
+        "2020-03",
+        "2020-04",
+        "2020-06",
+        0.1,
+        0.0,
+        missing_policy="zero",
+    )
+
+    assert res_drop["missing_data_policy"]["policy"] == "drop"
+    assert "A" not in res_drop["selected_funds"]
+
+    zero_policy = res_zero["missing_data_policy"]
+    assert zero_policy["policy"] == "zero"
+    assert zero_policy["total_filled"] >= 1
+    assert "A" in res_zero["selected_funds"]

--- a/tests/test_util_frequency_missing.py
+++ b/tests/test_util_frequency_missing.py
@@ -1,0 +1,86 @@
+import pandas as pd
+import pytest
+
+from trend_analysis.util.frequency import FREQUENCY_LABELS, detect_frequency
+from trend_analysis.util.missing import MissingPolicyResult, apply_missing_policy
+
+
+def test_detect_frequency_daily_with_holiday_gap():
+    dates = pd.to_datetime(
+        [
+            "2024-01-02",
+            "2024-01-03",
+            "2024-01-04",
+            "2024-01-05",
+            "2024-01-08",  # weekend gap
+            "2024-01-09",
+            "2024-01-11",  # simulate market holiday on the 10th
+        ]
+    )
+    summary = detect_frequency(pd.DatetimeIndex(dates))
+    assert summary.code == "D"
+    assert summary.label == FREQUENCY_LABELS["D"]
+    assert summary.resampled is True
+
+
+def test_detect_frequency_weekly_series():
+    dates = pd.date_range("2024-01-05", periods=6, freq="W-FRI")
+    summary = detect_frequency(pd.DatetimeIndex(dates))
+    assert summary.code == "W"
+    assert summary.label == FREQUENCY_LABELS["W"]
+    assert summary.resampled is True
+
+
+def test_detect_frequency_monthly_series():
+    dates = pd.date_range("2023-01-31", periods=6, freq="ME")
+    summary = detect_frequency(pd.DatetimeIndex(dates))
+    assert summary.code == "M"
+    assert summary.label == FREQUENCY_LABELS["M"]
+    assert summary.resampled is False
+
+
+def test_detect_frequency_irregular_raises():
+    dates = pd.to_datetime(["2024-01-01", "2024-01-10", "2024-02-01", "2024-02-05"])
+    with pytest.raises(ValueError):
+        detect_frequency(pd.DatetimeIndex(dates))
+
+
+def test_apply_missing_policy_drop_removes_assets():
+    frame = pd.DataFrame(
+        {
+            "A": [0.01, 0.02, None, 0.03],
+            "B": [0.01, 0.01, 0.01, 0.01],
+        },
+        index=pd.date_range("2024-01-31", periods=4, freq="ME"),
+    )
+    cleaned, result = apply_missing_policy(frame, "drop")
+    assert list(cleaned.columns) == ["B"]
+    assert isinstance(result, MissingPolicyResult)
+    assert result.dropped_assets == ("A",)
+    assert result.total_filled == 0
+
+
+def test_apply_missing_policy_ffill_with_limit():
+    frame = pd.DataFrame(
+        {
+            "A": [0.01, None, None, 0.02],
+        },
+        index=pd.date_range("2024-01-31", periods=4, freq="ME"),
+    )
+    cleaned, result = apply_missing_policy(frame, "ffill", limit=1)
+    assert cleaned.iloc[1, 0] == pytest.approx(0.01)
+    # limit prevents the second consecutive NaN from filling
+    assert pd.isna(cleaned.iloc[2, 0])
+    assert result.filled_cells == (("A", 1),)
+
+
+def test_apply_missing_policy_zero_fill():
+    frame = pd.DataFrame(
+        {
+            "A": [0.01, None, 0.03],
+        },
+        index=pd.date_range("2024-01-31", periods=3, freq="ME"),
+    )
+    cleaned, result = apply_missing_policy(frame, "zero")
+    assert cleaned.iloc[1, 0] == 0.0
+    assert result.total_filled == 1


### PR DESCRIPTION
### Source Issue #1678: Frequency detection and missing‑data policy

Source: https://github.com/stranske/Trend_Model_Project/issues/1678

> Topic GUID: 54b3b31c-4739-52f5-b68e-ae73018367ac
> 
> ## Why
> Summary
> Detect daily/weekly/monthly automatically. Force a policy for missing data per asset (drop, FFILL with max window, or zero return). Show the choice in the final report.
> Scope / Tasks
>  Implement detect_frequency(index) -> Literal["D","W","M"] with tolerance for holidays and short months.
>  Implement apply_missing_policy(df, policy, limit) with per‑asset option.
>  Add a one‑liner summary to the report of frequency and NA policy.
> 
> ## Tasks
> _Not provided._
> 
> ## Acceptance criteria
> Backtests are consistent no matter the input frequency, with a visible record of the policy applied.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18096244697).

—
(After opening the PR, comment with `@codex start`.)