### PR TITLE
Tweak failure tracker cooldown and escalation thresholds

### DIFF
--- a/.github/workflows/maint-33-check-failure-tracker.yml
+++ b/.github/workflows/maint-33-check-failure-tracker.yml
@@ -21,12 +21,12 @@ jobs:
       STACK_TOKEN_MAX_LEN: 160              # Max characters kept from extracted stack/error line
       AUTO_HEAL_INACTIVITY_HOURS: 24        # Used by success job for auto-heal closure
       FAILURE_INACTIVITY_HEAL_HOURS: 0      # (Reserved) would auto-close during failure path if >0
-      NEW_ISSUE_COOLDOWN_HOURS: 24          # If >0, cooldown window for *new* failure issues (append instead)
+      NEW_ISSUE_COOLDOWN_HOURS: 12          # Tuned window to curb duplicate issues while remaining responsive
       DISABLE_FAILURE_ISSUES: 'false'       # If 'true', skip issue create/update (still summary)
       COOLDOWN_RETRY_MS: 3000               # Delay before second cooldown check (race mitigation)
       STACK_TOKEN_RAW: 'false'              # If 'true', disable normalization of stack tokens
       COOLDOWN_SCOPE: global                # global | workflow | signature (controls cooldown append scope)
-      OCCURRENCE_ESCALATE_THRESHOLD: 0      # If >0, add ESCALATE_LABEL when occurrences >= threshold
+      OCCURRENCE_ESCALATE_THRESHOLD: 3      # Escalate only after the third recorded occurrence
       ESCALATE_LABEL: 'priority: high'      # Label added on escalation when threshold met
       ESCALATE_COMMENT: ''                  # Optional custom escalation comment
     steps:
@@ -120,7 +120,7 @@ jobs:
             const workflowName = run.name;
             const signature = `${workflowName}|${sigHash}`;
             const title = `Workflow Failure (${signature})`;
-            const labels = ['ci-failure', 'workflows', 'devops', 'priority: medium'];
+            const labels = ['ci-failure', 'ci', 'devops', 'priority: medium'];
             const COOLDOWN_SCOPE = (process.env.COOLDOWN_SCOPE || 'global').toLowerCase();
             const ESC_THRESHOLD = parseInt(process.env.OCCURRENCE_ESCALATE_THRESHOLD || '0', 10);
             const ESC_LABEL = process.env.ESCALATE_LABEL || 'priority: high';

--- a/docs/ci-failure-tracker.md
+++ b/docs/ci-failure-tracker.md
@@ -8,7 +8,7 @@ This document summarises the behaviour and configuration of the enhanced failure
 1. Enumerates failed jobs and the first failing step.
 2. Optionally extracts a stack token (first exception or error line) per failed job.
 3. Builds a deterministic signature: `workflow|sha256(job::step::stackToken...)[:12]`.
-4. Opens or updates a single GitHub Issue per signature (labels: `ci-failure`, `workflows`, `devops`, `priority: medium`).
+4. Opens or updates a single GitHub Issue per signature (labels: `ci-failure`, `ci`, `devops`, `priority: medium`).
 5. Maintains metadata header: Occurrences, Last seen, Healing threshold.
 6. Appends a failure comment (rate-limited) with job + stack token tables.
 7. On successful runs, scans for inactive issues and auto-closes those with no reoccurrence for the configured inactivity window.
@@ -19,20 +19,33 @@ This document summarises the behaviour and configuration of the enhanced failure
 | `RATE_LIMIT_MINUTES` | Minimum minutes between new comments for same issue | 15 |
 | `STACK_TOKENS_ENABLED` | Toggle stack token hashing (`true`/`false`) | true |
 | `STACK_TOKEN_MAX_LEN` | Max chars retained from a stack/error line | 160 |
+| `STACK_TOKEN_RAW` | Skip stack token normalisation when `true` | false |
 | `AUTO_HEAL_INACTIVITY_HOURS` | Hours of stability before success path auto-heal closes issue | 24 |
 | `FAILURE_INACTIVITY_HEAL_HOURS` | (Reserved) Close during failure path if inactive for this many hours | 0 (disabled) |
+| `NEW_ISSUE_COOLDOWN_HOURS` | Cooldown window before creating *new* failure issues | 12 |
+| `COOLDOWN_SCOPE` | Which issue to target during cooldown (`global`, `workflow`, `signature`) | global |
+| `COOLDOWN_RETRY_MS` | Delay before retrying the cooldown append logic | 3000 |
+| `DISABLE_FAILURE_ISSUES` | If `true`, skip failure issue create/update (summary only) | false |
+| `OCCURRENCE_ESCALATE_THRESHOLD` | Escalation trigger once occurrences reach this count | 3 |
+| `ESCALATE_LABEL` | Label applied during escalation | `priority: high` |
+| `ESCALATE_COMMENT` | Custom escalation comment body | (empty) |
 
 ## Signature Evolution
 - Phase-1: job + first failing step.
 - Phase-2: adds first stack/error line token (or `no-stack` / `stacks-off`).
 
-## Rate Limiting
-A run comment is suppressed if:
+## Cooldown & Rate Limiting
+A newly-detected signature that would otherwise open a new issue first checks for recent failures within the `NEW_ISSUE_COOLDOWN_HOURS` window. When the cooldown is active, the run appends a comment to the selected issue instead of opening a duplicate. The default twelve-hour window balances duplicate suppression with timely visibility of unrelated failures.
+
+A run comment is additionally suppressed if:
 - The run URL already appears in an existing comment, OR
 - The last comment is younger than `RATE_LIMIT_MINUTES`.
 
 ## Auto-Heal (Success Path)
 On any successful monitored workflow run, open `ci-failure` issues are scanned. If `Last seen` is older than `AUTO_HEAL_INACTIVITY_HOURS`, the issue is commented on and closed.
+
+## Escalation Threshold
+Once an issue records its third occurrence (`OCCURRENCE_ESCALATE_THRESHOLD`), the workflow ensures the escalation label (`priority: high` by default) is applied and posts a single escalation comment. Earlier occurrences retain the medium-priority label so responders can distinguish first-time breakages from persistent regressions.
 
 ## JSON Snapshot Artifact
 Each successful run uploads `ci_failures_snapshot.json` containing an array of current open failure issues (number, occurrences, last_seen, timestamps). Use this for dashboards or external monitoring.

--- a/docs/failure_tracker_env.md
+++ b/docs/failure_tracker_env.md
@@ -10,13 +10,23 @@ Central reference for all environment variables used by `.github/workflows/maint
 | `STACK_TOKEN_RAW` | `false` | bool | Stack token normalization | If `true`, skips normalization (only truncation) | Raw mode may fragment signatures across similar failures |
 | `AUTO_HEAL_INACTIVITY_HOURS` | 24 | int/float | Success path (healer job) | Hours of no recurrence before closing failure issue | Applied only in `success` job – separates detection from healing |
 | `FAILURE_INACTIVITY_HEAL_HOURS` | 0 | int/float | (Reserved) failure path | Would allow healing during failure workflow if >0 | Currently unused placeholder for future inline healing |
-| `NEW_ISSUE_COOLDOWN_HOURS` | 24 | int/float | New issue creation path | If >0, within window try to append to an existing issue instead of creating a new one | Combats duplicate bursts from concurrent failing runs |
+| `NEW_ISSUE_COOLDOWN_HOURS` | 12 | int/float | New issue creation path | If >0, within window try to append to an existing issue instead of creating a new one | Tuned lower to curb duplicate issues while staying responsive |
 | `COOLDOWN_SCOPE` | `global` | enum (`global`,`workflow`,`signature`) | Cooldown selection | Controls which existing issue is eligible for append under cooldown | `global` → most recent; `workflow` → same workflow name; `signature` → only exact signature |
 | `COOLDOWN_RETRY_MS` | 3000 | int (ms) | Race mitigation | Wait then re-check candidate issues before creating a new one | Reduces TOCTOU window between parallel runs |
 | `DISABLE_FAILURE_ISSUES` | `false` | bool | All failure tracking | If `true` skips create/update (summary still written) | Use for dry-runs or temporary silence |
-| `OCCURRENCE_ESCALATE_THRESHOLD` | 0 | int | Existing issue update | If >0 and occurrences ≥ threshold → escalation branch | 0 disables escalation logic |
+| `OCCURRENCE_ESCALATE_THRESHOLD` | 3 | int | Existing issue update | If >0 and occurrences ≥ threshold → escalation branch | Escalate on the third occurrence |
 | `ESCALATE_LABEL` | `priority: high` | string | Escalation | Label added once threshold crossed | Auto-created if missing |
 | `ESCALATE_COMMENT` | (empty) | string | Escalation | Optional custom escalation comment body | Falls back to auto-generated message |
+
+## Default Labels
+The workflow seeds each failure issue with the following labels to aid triage:
+
+- `ci-failure`
+- `ci`
+- `devops`
+- `priority: medium`
+
+All labels are created on-demand if they are missing from the repository so the automation remains resilient across new forks.
 
 ## Signature Construction
 Signature hash = SHA-256( sorted failed jobs mapped to `jobName::firstFailingStep::stackToken`) truncated to 12 hex chars. Workflow name + hash produce the issue title: `Workflow Failure (<workflow>|<hash>)`.

--- a/tools/simulate_failure_tracker.js
+++ b/tools/simulate_failure_tracker.js
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function extractTrackerScript() {
+  const workflowPath = path.join(__dirname, '..', '.github', 'workflows', 'maint-33-check-failure-tracker.yml');
+  const content = fs.readFileSync(workflowPath, 'utf8');
+  const lines = content.split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim() === 'script: |');
+  if (start === -1) {
+    throw new Error('Unable to locate tracker script block.');
+  }
+  const scriptLines = [];
+  if (start + 1 >= lines.length) {
+    return '';
+  }
+  const firstLine = lines[start + 1];
+  const indentMatch = firstLine.match(/^(\s*)/);
+  const indent = indentMatch ? indentMatch[1].length : 0;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() === '') {
+      scriptLines.push('');
+      continue;
+    }
+    const leading = line.match(/^(\s*)/);
+    const leadingSpaces = leading ? leading[1].length : 0;
+    if (leadingSpaces < indent) {
+      break;
+    }
+    scriptLines.push(line.slice(indent));
+  }
+  return scriptLines.join('\n');
+}
+
+function createCore(state) {
+  const summary = {
+    addHeading() {
+      return this;
+    },
+    addRaw() {
+      return this;
+    },
+    async write() {
+      return undefined;
+    },
+  };
+  return {
+    info(message) {
+      state.log.push(String(message));
+    },
+    summary,
+  };
+}
+
+function extractOccurrences(body) {
+  const match = body.match(/Occurrences:\s*(\d+)/i);
+  return match ? parseInt(match[1], 10) : 0;
+}
+
+function createGithub(state, options) {
+  const { searchHasIssue } = options;
+  const failedJobs = [
+    {
+      id: 9001,
+      name: 'Tests',
+      conclusion: 'failure',
+      html_url: `https://ci.example/jobs/${state.runIndex + 1}`,
+      steps: [
+        { name: 'pytest', conclusion: 'failure' },
+      ],
+    },
+  ];
+
+  return {
+    rest: {
+      actions: {
+        async listJobsForWorkflowRun() {
+          return { data: { jobs: failedJobs } };
+        },
+      },
+      issues: {
+        async getLabel({ name }) {
+          if (!state.availableLabels.has(name)) {
+            throw Object.assign(new Error('Not Found'), { status: 404 });
+          }
+          return { data: { name } };
+        },
+        async createLabel({ name }) {
+          state.availableLabels.add(name);
+          state.log.push(`label created: ${name}`);
+          return { data: { name } };
+        },
+        async get({ issue_number }) {
+          if (!state.issue || state.issue.number !== issue_number) {
+            throw new Error(`Issue ${issue_number} not found in simulation.`);
+          }
+          return {
+            data: {
+              number: state.issue.number,
+              title: state.issue.title,
+              body: state.issue.body,
+              labels: Array.from(state.issue.labels).map((name) => ({ name })),
+            },
+          };
+        },
+        async update({ issue_number, body, title }) {
+          if (!state.issue || state.issue.number !== issue_number) {
+            throw new Error(`Update called for unexpected issue ${issue_number}.`);
+          }
+          state.issue.body = body;
+          state.issue.title = title;
+          state.issue.updated_at = new Date(state.now).toISOString();
+          return { data: state.issue };
+        },
+        async listComments({ issue_number }) {
+          const comments = state.comments.filter((c) => c.issue_number === issue_number);
+          return {
+            data: comments.map((c) => ({ body: c.body, created_at: c.created_at })),
+          };
+        },
+        async createComment({ issue_number, body }) {
+          const created = {
+            issue_number,
+            body,
+            created_at: new Date(state.now).toISOString(),
+          };
+          state.comments.push(created);
+          state.log.push(`comment appended to #${issue_number}`);
+          return { data: created };
+        },
+        async addLabels({ issue_number, labels }) {
+          if (!state.issue || state.issue.number !== issue_number) {
+            throw new Error(`addLabels called for unexpected issue ${issue_number}.`);
+          }
+          labels.forEach((label) => state.issue.labels.add(label));
+          state.log.push(`labels added to #${issue_number}: ${labels.join(', ')}`);
+          return { data: { labels: Array.from(state.issue.labels) } };
+        },
+        async listForRepo() {
+          if (!state.issue) {
+            return { data: [] };
+          }
+          return {
+            data: [
+              {
+                number: state.issue.number,
+                title: state.issue.title,
+                created_at: state.issue.created_at,
+                pull_request: null,
+              },
+            ],
+          };
+        },
+        async create({ title, body, labels }) {
+          const number = state.issue ? state.issue.number : state.nextIssueNumber;
+          state.issue = {
+            number,
+            title,
+            body,
+            labels: new Set(labels),
+            created_at: new Date(state.now).toISOString(),
+            updated_at: new Date(state.now).toISOString(),
+          };
+          state.log.push(`issue #${number} created`);
+          return { data: state.issue };
+        },
+      },
+      search: {
+        async issuesAndPullRequests() {
+          if (searchHasIssue && state.issue) {
+            return {
+              data: {
+                items: [
+                  {
+                    number: state.issue.number,
+                    title: state.issue.title,
+                  },
+                ],
+              },
+            };
+          }
+          return { data: { items: [] } };
+        },
+      },
+    },
+    async request() {
+      return { data: Buffer.from('') };
+    },
+  };
+}
+
+async function main() {
+  const script = extractTrackerScript();
+  const wrapped = `(async () => {\n${script}\n})()`;
+
+  const state = {
+    availableLabels: new Set(['ci-failure', 'ci', 'devops', 'priority: medium', 'priority: high']),
+    baseTime: new Date('2025-01-01T00:00:00Z'),
+    comments: [],
+    issue: null,
+    log: [],
+    nextIssueNumber: 321,
+    now: new Date('2025-01-01T00:00:00Z'),
+    runIndex: 0,
+  };
+
+  const runs = [
+    { label: 'First failure', offsetHours: 0, searchHasIssue: false },
+    { label: 'Second failure', offsetHours: 2, searchHasIssue: true },
+    { label: 'Third failure', offsetHours: 4, searchHasIssue: true },
+  ];
+
+  const realDateNow = Date.now;
+
+  try {
+    for (let i = 0; i < runs.length; i += 1) {
+      const run = runs[i];
+      state.runIndex = i;
+      state.now = new Date(state.baseTime.getTime() + run.offsetHours * 3600 * 1000);
+      Date.now = () => state.now.getTime();
+
+      const core = createCore(state);
+      const github = createGithub(state, run);
+      const context = {
+        repo: { owner: 'stranske', repo: 'Trend_Model_Project' },
+        payload: {
+          workflow_run: {
+            id: 5000 + i,
+            name: 'CI',
+            html_url: `https://ci.example/runs/${i + 1}`,
+          },
+        },
+      };
+
+      // ensure script reads the tuned defaults
+      process.env.RATE_LIMIT_MINUTES = '15';
+      process.env.STACK_TOKENS_ENABLED = 'false';
+      process.env.STACK_TOKEN_MAX_LEN = '160';
+      process.env.NEW_ISSUE_COOLDOWN_HOURS = '12';
+      process.env.COOLDOWN_SCOPE = 'global';
+      process.env.COOLDOWN_RETRY_MS = '0';
+      process.env.OCCURRENCE_ESCALATE_THRESHOLD = '3';
+      process.env.AUTO_HEAL_INACTIVITY_HOURS = '24';
+
+      await vm.runInNewContext(wrapped, {
+        Buffer,
+        console,
+        context,
+        core,
+        github,
+        process,
+        require,
+        setTimeout,
+        clearTimeout,
+      });
+
+      if (!state.issue) {
+        throw new Error('Tracker did not create or update an issue.');
+      }
+
+      const occurrences = extractOccurrences(state.issue.body);
+      assert.strictEqual(occurrences, i + 1, `Unexpected occurrence count after ${run.label.toLowerCase()}`);
+      const labels = Array.from(state.issue.labels).sort();
+      console.log(`${run.label}: occurrences=${occurrences}, labels=${labels.join(', ')}`);
+    }
+  } finally {
+    Date.now = realDateNow;
+  }
+
+  const escalationComments = state.comments.filter((c) => c.body.includes('Escalation: occurrences reached threshold'));
+  assert.strictEqual(escalationComments.length, 1, 'Escalation comment should be posted exactly once.');
+  assert.ok(state.issue.labels.has('priority: high'), 'Escalation label was not applied at the threshold.');
+  assert.ok(state.issue.labels.has('priority: medium'), 'Base priority label should remain alongside escalation label.');
+
+  console.log('Escalation comment posted:', escalationComments[0].body.trim());
+  console.log('Simulation completed successfully.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tools/simulate_failure_tracker.js
+++ b/tools/simulate_failure_tracker.js
@@ -15,7 +15,7 @@ function extractTrackerScript() {
   }
   const scriptLines = [];
   if (start + 1 >= lines.length) {
-    return '';
+    throw new Error('Tracker script block is empty or malformed.');
   }
   const firstLine = lines[start + 1];
   const indentMatch = firstLine.match(/^(\s*)/);


### PR DESCRIPTION
## Summary
- lower the failure tracker cooldown window to 12h, require 3 occurrences before escalating, and align the base label set with repo labels
- document the tuned defaults and label usage in the CI failure tracker guides
- add a local simulation harness to exercise the workflow script’s aggregation and escalation paths

## Testing
- node tools/simulate_failure_tracker.js

------
https://chatgpt.com/codex/tasks/task_e_68ddedc961ec833198f479f7475d6330