### PR TITLE
Tame Check Failure Tracker signal and labels - Source Issue #1659

### DIFF
--- a/docs/ci-failure-tracker.md
+++ b/docs/ci-failure-tracker.md
@@ -83,6 +83,19 @@ You can manually validate behaviour:
 1. Dispatch `CI Selftest` (will create a failing issue).
 2. Rerun it but edit the `ci-selftest.yml` to succeed (or manually re-run jobs) to test auto-heal logic after adjusting `INACTIVITY_HOURS`.
 
+## Local Simulation Harness
+For deterministic verification without exercising GitHub Actions, run the bundled Node.js simulation harness. It executes the workflow script inside a mocked Actions runtime and asserts key behaviours such as:
+
+- Cooldown aggregation that appends to an existing failure issue during the configured `NEW_ISSUE_COOLDOWN_HOURS` window.
+- Occurrence counter updates and capped history table maintenance.
+- Escalation flow that adds the priority label only after `OCCURRENCE_ESCALATE_THRESHOLD` occurrences and emits a single escalation comment.
+
+```bash
+node tools/simulate_failure_tracker.js
+```
+
+The script replays three sequential failures and prints each occurrence state, making it easy to confirm configuration changes before shipping them.
+
 ## Future Extensions
 - Persist aggregated metrics (failure frequency) as JSON artifact.
 - Add PR comment summary for new signatures encountered in a PR context.


### PR DESCRIPTION
### Source Issue #1659: Tame Check Failure Tracker signal and labels

Source: https://github.com/stranske/Trend_Model_Project/issues/1659

> Topic GUID: c4c9255f-7cbe-51c2-afcf-804e36201790
> 
> ## Why
> Depends on: Issue 3
> Summary
> Tune maint-33-check-failure-tracker.yml to reduce duplicate Issue churn and escalate only when failures repeat. The current tracker hashes failure “signatures” and attaches labels like ci-failure, devops, workflows, and a priority label. Adjust environment variables for your desired thresholds and ensure labels used exist in the repo. 
> GitHub
> Changes
> Set NEW_ISSUE_COOLDOWN_HOURS to reduce duplicate tracking Issues.
> Set OCCURRENCE_ESCALATE_THRESHOLD to a non-zero number before applying priority: high.
> Confirm the label set used by the workflow exists (e.g., ci-failure, devops, workflows). Your labels page shows ci-failure, ci, devops present. 
> GitHub
> Document the local simulation harness for verifying cooldown aggregation and escalation behaviour.
> 
> ## Tasks
> _Not provided._
> 
> ## Acceptance criteria
> Failure tracker creates or appends to a single Issue per signature across the cooldown window.
> 
> Escalation label adds only after the configured threshold.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18086613665).


------
https://chatgpt.com/codex/tasks/task_e_68ddf64f8be48331a8c37ab40204734b