### PR TITLE
Tame Check Failure Tracker signal and labels - Source Issue #1659

### DIFF
--- a/docs/ci-failure-tracker.md
+++ b/docs/ci-failure-tracker.md
@@ -83,6 +83,15 @@ You can manually validate behaviour:
 1. Dispatch `CI Selftest` (will create a failing issue).
 2. Rerun it but edit the `ci-selftest.yml` to succeed (or manually re-run jobs) to test auto-heal logic after adjusting `INACTIVITY_HOURS`.
 
+## Local Simulation Harness
+For a fast feedback loop without touching GitHub, run `node tools/simulate_failure_tracker.js`. The harness lifts the tracker script straight out of the workflow file and replays three sequential failures against an in-memory stub of the GitHub API. It asserts that:
+
+- The tuned defaults (12-hour cooldown, three-occurrence escalation) are honoured.
+- Issues aggregate signatures instead of spawning duplicates across the cooldown window.
+- The escalation label and comment appear only after the third occurrence while the base triage labels remain intact.
+
+Use this script whenever adjusting cooldown, label, or escalation logic to confirm the behaviour before pushing workflow changes.
+
 ## Future Extensions
 - Persist aggregated metrics (failure frequency) as JSON artifact.
 - Add PR comment summary for new signatures encountered in a PR context.


### PR DESCRIPTION
## Summary
* Tuned the failure tracker workflow to use a 12-hour new-issue cooldown, wait for three occurrences before escalation, and align its default labels with the repository’s taxonomy.
* Expanded the CI failure tracker documentation with the updated environment defaults, cooldown behaviour, escalation threshold, and label inventory to guide operators.
* Added a Node-based simulation harness that replays the workflow script to assert aggregation, cooldown, and escalation behaviour locally.

## Testing
* ✅ `node tools/simulate_failure_tracker.js`


------
https://chatgpt.com/codex/tasks/task_e_68ddf6fe85808331ab3442b46944a791