### PR TITLE
Scope the reusable‑CI selftest to manual + nightly and fix current failure - Source Issue #1660

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -216,7 +216,8 @@ Retention Guidance: Use 7–14 days. Shorter (<7 days) risks losing comparison c
 
 - **Trigger scope:** Manual dispatch plus a nightly cron (`02:30 UTC`). This keeps reusable pipeline coverage fresh without
   consuming PR minutes. Dispatch from the Actions tab under **Self-Test Reusable CI** when validating changes to
-  `.github/workflows/reusable-ci-python.yml` or its helper scripts.
+  `.github/workflows/reusable-ci-python.yml` or its helper scripts. The legacy PR-comment notifier was removed because the
+  workflow no longer runs on pull_request events.
 - **Latest remediation:** The October 2025 failure stemmed from `typing-inspection` drifting from `0.4.1` to `0.4.2`, causing
   `tests/test_lockfile_consistency.py` to fail during the reusable matrix runs. Refresh `requirements.lock` with
   `uv pip compile --upgrade pyproject.toml -o requirements.lock` before re-running the workflow. The matrix now completes when

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -215,7 +215,7 @@ Retention Guidance: Use 7–14 days. Shorter (<7 days) risks losing comparison c
 ## 7.4 Self-Test Reusable CI (Issue #1660)
 
 - **Trigger scope:** Manual dispatch plus a nightly cron (`02:30 UTC`). This keeps reusable pipeline coverage fresh without
-  consuming PR minutes. Dispatch from the Actions tab under **Self-Test Reusable CI** when validating changes to
+  consuming PR minutes. Dispatch from the Actions tab under **Self-Test Reusable CI** or via CLI when validating changes to
   `.github/workflows/reusable-ci-python.yml` or its helper scripts. The legacy PR-comment notifier was removed because the
   workflow no longer runs on pull_request events. After shipping a change, monitor the next two nightly runs and confirm
   their success in the self-test health issue before considering the work complete.
@@ -235,6 +235,19 @@ Retention Guidance: Use 7–14 days. Shorter (<7 days) risks losing comparison c
 
   Inspect `selftest-artifacts/selftest-report/selftest-report.json` for mismatched artifacts and reproduce dependency drift
   issues locally or to validate lockfile drift fixes with `pytest tests/test_lockfile_consistency.py -k "up_to_date" -q`.
+
+- **CLI helpers:**
+
+  ```bash
+  # Manual dispatch (requires `gh auth login` with workflow scope)
+  gh workflow run "Self-Test Reusable CI"
+
+  # Monitor most recent nightly outcomes
+  gh run list --workflow "Self-Test Reusable CI" --limit 2 --json conclusion,headBranch,runNumber,startedAt
+  ```
+
+  Use the `gh run list` output to confirm two consecutive nightly runs have concluded with `success` before closing out
+  Issue #1660 follow-up tasks.
 ## 7.5 Universal Logs Summary (Issue #1351)
 Source: `logs_summary` job inside `reusable-ci-python.yml` enumerates all jobs via the Actions API and writes a Markdown table to the run summary. Columns include Job, Status (emoji), Duration, and Log link.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -225,9 +225,16 @@ Retention Guidance: Use 7–14 days. Shorter (<7 days) risks losing comparison c
   invoked manually or on schedule.
 - **Diagnostics:** Each run uploads a `selftest-report` artifact summarising scenario coverage and any unexpected or missing
   artifacts. Use it alongside the job logs to validate new reusable features before promoting changes.
-- **Local reproduction:** To validate the lockfile drift fix locally, execute `pytest tests/test_lockfile_consistency.py -k
-  "up_to_date" -q`. This mirrors the failure that blocked the latest nightly run.
+- **Failure triage workflow:** When a nightly run fails, open the run in the Actions tab and download diagnostics with the
+  GitHub CLI:
 
+  ```bash
+  gh run download <run-id> --dir selftest-artifacts
+  gh run view <run-id> --log
+  ```
+
+  Inspect `selftest-artifacts/selftest-report/selftest-report.json` for mismatched artifacts and reproduce dependency drift
+  issues locally or to validate lockfile drift fixes with `pytest tests/test_lockfile_consistency.py -k "up_to_date" -q`.
 ## 7.5 Universal Logs Summary (Issue #1351)
 Source: `logs_summary` job inside `reusable-ci-python.yml` enumerates all jobs via the Actions API and writes a Markdown table to the run summary. Columns include Job, Status (emoji), Duration, and Log link.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -222,6 +222,10 @@ Retention Guidance: Use 7–14 days. Shorter (<7 days) risks losing comparison c
   `tests/test_lockfile_consistency.py` to fail during the reusable matrix runs. Refresh `requirements.lock` with
   `uv pip compile --upgrade pyproject.toml -o requirements.lock` before re-running the workflow. The matrix now completes when
   invoked manually or on schedule.
+- **Diagnostics:** Each run uploads a `selftest-report` artifact summarising scenario coverage and any unexpected or missing
+  artifacts. Use it alongside the job logs to validate new reusable features before promoting changes.
+- **Local reproduction:** To validate the lockfile drift fix locally, execute `pytest tests/test_lockfile_consistency.py -k
+  "up_to_date" -q`. This mirrors the failure that blocked the latest nightly run.
 
 ## 7.5 Universal Logs Summary (Issue #1351)
 Source: `logs_summary` job inside `reusable-ci-python.yml` enumerates all jobs via the Actions API and writes a Markdown table to the run summary. Columns include Job, Status (emoji), Duration, and Log link.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -217,7 +217,8 @@ Retention Guidance: Use 7–14 days. Shorter (<7 days) risks losing comparison c
 - **Trigger scope:** Manual dispatch plus a nightly cron (`02:30 UTC`). This keeps reusable pipeline coverage fresh without
   consuming PR minutes. Dispatch from the Actions tab under **Self-Test Reusable CI** when validating changes to
   `.github/workflows/reusable-ci-python.yml` or its helper scripts. The legacy PR-comment notifier was removed because the
-  workflow no longer runs on pull_request events.
+  workflow no longer runs on pull_request events. After shipping a change, monitor the next two nightly runs and confirm
+  their success in the self-test health issue before considering the work complete.
 - **Latest remediation:** The October 2025 failure stemmed from `typing-inspection` drifting from `0.4.1` to `0.4.2`, causing
   `tests/test_lockfile_consistency.py` to fail during the reusable matrix runs. Refresh `requirements.lock` with
   `uv pip compile --upgrade pyproject.toml -o requirements.lock` before re-running the workflow. The matrix now completes when

--- a/.github/workflows/reusable-99-selftest.yml
+++ b/.github/workflows/reusable-99-selftest.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:
   schedule:
     # Nightly verification run at 02:30 UTC to keep the reusable workflow healthy without
-    # overlapping with the main CI rush hour.
+    # overlapping with the main CI rush hour. No other triggers (e.g. pull_request) should run
+    # this workflow – Issue #1660 scopes it strictly to manual/nightly execution.
     - cron: '30 2 * * *'
 
 jobs:
@@ -171,44 +172,3 @@ jobs:
           echo "Artifact expectation mismatches detected." >&2
           exit 1
 
-  pr_comment:
-    name: PR Comment (Self-Test Summary)
-    if: ${{ github.event_name == 'pull_request' && always() }}
-    needs: [aggregate]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download self-test report
-        uses: actions/download-artifact@v4
-        with:
-          name: selftest-report
-          path: .
-        continue-on-error: true
-      - name: Post / update PR comment
-        uses: actions/github-script@v7
-        env:
-          TABLE: ${{ needs.aggregate.outputs.verification_table }}
-          FAILURES: ${{ needs.aggregate.outputs.failures }}
-        with:
-          script: |
-            const marker = '<!-- selftest-reusable-ci -->';
-            const failures = process.env.FAILURES || '0';
-            let summaryJson = '';
-            try { summaryJson = require('fs').readFileSync('selftest-report.json','utf8'); } catch(e) {}
-            let parsed;
-            try { parsed = JSON.parse(summaryJson); } catch(e) { parsed = null; }
-            const table = process.env.TABLE || '*No table available*';
-            const statusLine = failures === '0' ? '✅ **Self-test passed** (all scenarios matched expected artifacts).'
-              : `❌ **Self-test found ${failures} scenario mismatch(es)**.`;
-            const body = `${marker}\n${statusLine}\n\n${table}\n\n<details><summary>Raw JSON report</summary>\n\n\n\n${parsed ? '```json\n'+JSON.stringify(parsed,null,2)+'\n```' : '_Report not available_'}\n\n</details>`;
-            const {owner, repo} = context.repo;
-            const issue_number = context.payload.pull_request.number;
-            // list existing comments and find marker
-            const comments = await github.rest.issues.listComments({owner, repo, issue_number, per_page:100});
-            const existing = comments.data.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({owner, repo, comment_id: existing.id, body});
-              core.info(`Updated PR comment #${existing.id}`);
-            } else {
-              const created = await github.rest.issues.createComment({owner, repo, issue_number, body});
-              core.info(`Created PR comment #${created.data.id}`);
-            }

--- a/.github/workflows/reusable-99-selftest.yml
+++ b/.github/workflows/reusable-99-selftest.yml
@@ -85,6 +85,9 @@ jobs:
             echo "## Self-Test Reusable CI Summary"
             echo "Scenarios executed: minimal, metrics_only, metrics_history, classification_only, coverage_delta, full_soft_gate"
             echo "Each scenario's internal ci_feature_assert.py step already enforced expectations."
+            echo "Download the \`selftest-report\` artifact for a JSON summary of expected vs. actual uploads."
+            echo "Reproduce the October 2025 lockfile failure locally with:"
+            echo "\`pytest tests/test_lockfile_consistency.py -k \"up_to_date\" -q\`"
             echo "This aggregate job can be extended to download & re-assert artifacts if needed."
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Verify artifact inventory

--- a/.github/workflows/reusable-99-selftest.yml
+++ b/.github/workflows/reusable-99-selftest.yml
@@ -1,16 +1,11 @@
 name: Self-Test Reusable CI
 
 on:
-  workflow_dispatch: {}
-  pull_request:
-    paths:
-      - '.github/workflows/reusable-ci-python.yml'
-      - '.github/workflows/selftest-reusable-ci.yml'
-      - 'scripts/ci_feature_assert.py'
-      - 'scripts/ci_metrics.py'
-      - 'scripts/ci_history.py'
-      - 'scripts/ci_coverage_delta.py'
-      - 'scripts/coverage_history_append.py'
+  workflow_dispatch:
+  schedule:
+    # Nightly verification run at 02:30 UTC to keep the reusable workflow healthy without
+    # overlapping with the main CI rush hour.
+    - cron: '30 2 * * *'
 
 jobs:
   # Matrix of feature scenarios exercising the reusable workflow with different flag combinations.

--- a/.github/workflows/reusable-99-selftest.yml
+++ b/.github/workflows/reusable-99-selftest.yml
@@ -144,7 +144,9 @@ jobs:
               report.push({scenario: s.name, expected: exp, missing, unexpected, ok});
             }
             // Detect stray artifacts from scenarios not defined (defensive)
-            const stray = [...names].filter(n=>n.startsWith('sf-') && !expectedAll.has(n.split(/sf-[^-]+-/).length>1 ? n : n));
+            // Defensive catch-all: if a reusable scenario starts emitting new artifact names that
+            // are not declared in the matrix above, flag them so the self-test can evolve in lockstep.
+            const stray = [...names].filter(n => n.startsWith('sf-') && !expectedAll.has(n));
             if(stray.length){
               rows.push(`| (stray) | (n/a) | (n/a) | ${stray.join('<br>')} | ❌ |`);
               report.push({scenario:'_stray_', expected:[], missing:[], unexpected:stray, ok:false});

--- a/agents/codex-1660.md
+++ b/agents/codex-1660.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1660 -->

--- a/requirements.lock
+++ b/requirements.lock
@@ -120,7 +120,7 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspect==0.9.0
     # via pandera
-typing-inspection==0.4.1
+typing-inspection==0.4.2
     # via pydantic
 tzdata==2025.2
     # via pandas


### PR DESCRIPTION
### Source Issue #1660: Scope the reusable‑CI selftest to manual + nightly and fix current failure

Source: https://github.com/stranske/Trend_Model_Project/issues/1660

> Topic GUID: c93c903a-dc23-536b-8879-45bd657d1623
> 
> ## Why
> Depends on: Issue 0
> Summary
> selftest-reusable-ci.yml should a) prove the reusables work, b) stay out of the way. Limit triggers to workflow_dispatch and a nightly cron; confirm the failing run is addressed. The Actions page shows a failure on this workflow today. 
> GitHub
> 
> ## Tasks
> _Not provided._
> 
> ## Acceptance criteria
> on: contains only workflow_dispatch and a nightly schedule.
> 
> Last two nightly runs succeed.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18086613665).

—
(After opening the PR, comment with `@codex start`.)