### PR TITLE
Scope reusable self-test workflow to manual/nightly triggers

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -216,7 +216,8 @@ Retention Guidance: Use 7–14 days. Shorter (<7 days) risks losing comparison c
 
 - **Trigger scope:** Manual dispatch plus a nightly cron (`02:30 UTC`). This keeps reusable pipeline coverage fresh without
   consuming PR minutes. Dispatch from the Actions tab under **Self-Test Reusable CI** when validating changes to
-  `.github/workflows/reusable-ci-python.yml` or its helper scripts.
+  `.github/workflows/reusable-ci-python.yml` or its helper scripts. The legacy PR-comment notifier was removed because the
+  workflow no longer runs on pull_request events.
 - **Latest remediation:** The October 2025 failure stemmed from `typing-inspection` drifting from `0.4.1` to `0.4.2`, causing
   `tests/test_lockfile_consistency.py` to fail during the reusable matrix runs. Refresh `requirements.lock` with
   `uv pip compile --upgrade pyproject.toml -o requirements.lock` before re-running the workflow. The matrix now completes when

--- a/.github/workflows/reusable-99-selftest.yml
+++ b/.github/workflows/reusable-99-selftest.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:
   schedule:
     # Nightly verification run at 02:30 UTC to keep the reusable workflow healthy without
-    # overlapping with the main CI rush hour.
+    # overlapping with the main CI rush hour. No other triggers (e.g. pull_request) should run
+    # this workflow – Issue #1660 scopes it strictly to manual/nightly execution.
     - cron: '30 2 * * *'
 
 jobs:
@@ -171,44 +172,3 @@ jobs:
           echo "Artifact expectation mismatches detected." >&2
           exit 1
 
-  pr_comment:
-    name: PR Comment (Self-Test Summary)
-    if: ${{ github.event_name == 'pull_request' && always() }}
-    needs: [aggregate]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download self-test report
-        uses: actions/download-artifact@v4
-        with:
-          name: selftest-report
-          path: .
-        continue-on-error: true
-      - name: Post / update PR comment
-        uses: actions/github-script@v7
-        env:
-          TABLE: ${{ needs.aggregate.outputs.verification_table }}
-          FAILURES: ${{ needs.aggregate.outputs.failures }}
-        with:
-          script: |
-            const marker = '<!-- selftest-reusable-ci -->';
-            const failures = process.env.FAILURES || '0';
-            let summaryJson = '';
-            try { summaryJson = require('fs').readFileSync('selftest-report.json','utf8'); } catch(e) {}
-            let parsed;
-            try { parsed = JSON.parse(summaryJson); } catch(e) { parsed = null; }
-            const table = process.env.TABLE || '*No table available*';
-            const statusLine = failures === '0' ? '✅ **Self-test passed** (all scenarios matched expected artifacts).'
-              : `❌ **Self-test found ${failures} scenario mismatch(es)**.`;
-            const body = `${marker}\n${statusLine}\n\n${table}\n\n<details><summary>Raw JSON report</summary>\n\n\n\n${parsed ? '```json\n'+JSON.stringify(parsed,null,2)+'\n```' : '_Report not available_'}\n\n</details>`;
-            const {owner, repo} = context.repo;
-            const issue_number = context.payload.pull_request.number;
-            // list existing comments and find marker
-            const comments = await github.rest.issues.listComments({owner, repo, issue_number, per_page:100});
-            const existing = comments.data.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({owner, repo, comment_id: existing.id, body});
-              core.info(`Updated PR comment #${existing.id}`);
-            } else {
-              const created = await github.rest.issues.createComment({owner, repo, issue_number, body});
-              core.info(`Created PR comment #${created.data.id}`);
-            }


### PR DESCRIPTION
## Summary
- ensure the Self-Test Reusable CI workflow is only triggered manually or by the nightly schedule and drop the unused PR comment job
- document the trigger scope change and legacy notifier removal in the workflow README to guide maintainers

## Testing
- pytest tests/test_lockfile_consistency.py -k "up_to_date" -q

------
https://chatgpt.com/codex/tasks/task_e_68debb438f148331b8554b165988ac57