### PR TITLE
Clarify self-test self-test diagnostics

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -222,6 +222,10 @@ Retention Guidance: Use 7–14 days. Shorter (<7 days) risks losing comparison c
   `tests/test_lockfile_consistency.py` to fail during the reusable matrix runs. Refresh `requirements.lock` with
   `uv pip compile --upgrade pyproject.toml -o requirements.lock` before re-running the workflow. The matrix now completes when
   invoked manually or on schedule.
+- **Diagnostics:** Each run uploads a `selftest-report` artifact summarising scenario coverage and any unexpected or missing
+  artifacts. Use it alongside the job logs to validate new reusable features before promoting changes.
+- **Local reproduction:** To validate the lockfile drift fix locally, execute `pytest tests/test_lockfile_consistency.py -k
+  "up_to_date" -q`. This mirrors the failure that blocked the latest nightly run.
 
 ## 7.5 Universal Logs Summary (Issue #1351)
 Source: `logs_summary` job inside `reusable-ci-python.yml` enumerates all jobs via the Actions API and writes a Markdown table to the run summary. Columns include Job, Status (emoji), Duration, and Log link.

--- a/.github/workflows/reusable-99-selftest.yml
+++ b/.github/workflows/reusable-99-selftest.yml
@@ -144,7 +144,9 @@ jobs:
               report.push({scenario: s.name, expected: exp, missing, unexpected, ok});
             }
             // Detect stray artifacts from scenarios not defined (defensive)
-            const stray = [...names].filter(n=>n.startsWith('sf-') && !expectedAll.has(n.split(/sf-[^-]+-/).length>1 ? n : n));
+            // Defensive catch-all: if a reusable scenario starts emitting new artifact names that
+            // are not declared in the matrix above, flag them so the self-test can evolve in lockstep.
+            const stray = [...names].filter(n => n.startsWith('sf-') && !expectedAll.has(n));
             if(stray.length){
               rows.push(`| (stray) | (n/a) | (n/a) | ${stray.join('<br>')} | ❌ |`);
               report.push({scenario:'_stray_', expected:[], missing:[], unexpected:stray, ok:false});


### PR DESCRIPTION
## Summary
- clarify the self-test aggregate verification step by simplifying stray artifact detection and documenting the intent
- document the selftest-report artifact and local lockfile reproduction command so maintainers can validate fixes quickly

## Testing
- pytest tests/test_lockfile_consistency.py -k "up_to_date" -q

------
https://chatgpt.com/codex/tasks/task_e_68debf3f02f88331bffa979bb6a29fec