### PR TITLE
docs: add nightly verification reminder for self-test

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -217,7 +217,8 @@ Retention Guidance: Use 7–14 days. Shorter (<7 days) risks losing comparison c
 - **Trigger scope:** Manual dispatch plus a nightly cron (`02:30 UTC`). This keeps reusable pipeline coverage fresh without
   consuming PR minutes. Dispatch from the Actions tab under **Self-Test Reusable CI** when validating changes to
   `.github/workflows/reusable-ci-python.yml` or its helper scripts. The legacy PR-comment notifier was removed because the
-  workflow no longer runs on pull_request events.
+  workflow no longer runs on pull_request events. After shipping a change, monitor the next two nightly runs and confirm
+  their success in the self-test health issue before considering the work complete.
 - **Latest remediation:** The October 2025 failure stemmed from `typing-inspection` drifting from `0.4.1` to `0.4.2`, causing
   `tests/test_lockfile_consistency.py` to fail during the reusable matrix runs. Refresh `requirements.lock` with
   `uv pip compile --upgrade pyproject.toml -o requirements.lock` before re-running the workflow. The matrix now completes when


### PR DESCRIPTION
## Summary
- remind maintainers in the workflow README to watch the next two nightly runs after self-test changes

## Testing
- pytest tests/test_lockfile_consistency.py -k "up_to_date" -q

------
https://chatgpt.com/codex/tasks/task_e_68dec282e4c88331a7203922208abd08