### PR TITLE
Document reusable self-test diagnostics workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -225,6 +225,16 @@ Retention Guidance: Use 7–14 days. Shorter (<7 days) risks losing comparison c
   invoked manually or on schedule.
 - **Diagnostics:** Each run uploads a `selftest-report` artifact summarising scenario coverage and any unexpected or missing
   artifacts. Use it alongside the job logs to validate new reusable features before promoting changes.
+- **Failure triage workflow:** When a nightly run fails, open the run in the Actions tab and download diagnostics with the
+  GitHub CLI:
+
+  ```bash
+  gh run download <run-id> --dir selftest-artifacts
+  gh run view <run-id> --log
+  ```
+
+  Inspect `selftest-artifacts/selftest-report/selftest-report.json` for mismatched artifacts and reproduce dependency drift
+  issues locally with `pytest tests/test_lockfile_consistency.py -k "up_to_date" -q`.
 - **Local reproduction:** To validate the lockfile drift fix locally, execute `pytest tests/test_lockfile_consistency.py -k
   "up_to_date" -q`. This mirrors the failure that blocked the latest nightly run.
 

--- a/.github/workflows/reusable-99-selftest.yml
+++ b/.github/workflows/reusable-99-selftest.yml
@@ -85,6 +85,9 @@ jobs:
             echo "## Self-Test Reusable CI Summary"
             echo "Scenarios executed: minimal, metrics_only, metrics_history, classification_only, coverage_delta, full_soft_gate"
             echo "Each scenario's internal ci_feature_assert.py step already enforced expectations."
+            echo "Download the \`selftest-report\` artifact for a JSON summary of expected vs. actual uploads."
+            echo "Reproduce the October 2025 lockfile failure locally with:"
+            echo "\`pytest tests/test_lockfile_consistency.py -k \"up_to_date\" -q\`"
             echo "This aggregate job can be extended to download & re-assert artifacts if needed."
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Verify artifact inventory


### PR DESCRIPTION
## Summary
* Add nightly failure triage instructions to the Self-Test Reusable CI workflow run summary so maintainers can grab diagnostics and rerun the lockfile check locally.
* Document the GitHub CLI commands and artifact inspection path in `.github/workflows/README.md` to complete the reusable self-test remediation runbook.

## Testing
* `pytest tests/test_lockfile_consistency.py -k "up_to_date" -q`


------
https://chatgpt.com/codex/tasks/task_e_68ded48458a8833192a212b1165444db