### PR TITLE
Implement unified trend signal engine

### DIFF
--- a/src/trend_analysis/__init__.py
+++ b/src/trend_analysis/__init__.py
@@ -16,6 +16,7 @@ _EAGER_SUBMODULES = [
     "data",
     "pipeline",
     "export",
+    "signals",
 ]
 
 # Modules that may drag optional / heavy deps; imported on first attribute access.
@@ -96,6 +97,7 @@ __all__ = [
     "pipeline",
     "api",
     "export",
+    "signals",
     "selector",
     "weighting",
     "load_csv",

--- a/src/trend_analysis/signals.py
+++ b/src/trend_analysis/signals.py
@@ -74,7 +74,7 @@ class SignalFrame:
     _STAGES = ("raw_momentum", "vol_adjusted", "normalized", "signal")
 
     def __init__(self, frame: pd.DataFrame):
-        if not isinstance(frame, pd.DataFrame):  # pragma: no cover - guard rail
+        if not isinstance(frame, pd.DataFrame):  # pragma: no cover - guardrail
             raise TypeError("frame must be a pandas DataFrame")
         if frame.columns.nlevels != 2:
             raise ValueError("SignalFrame requires a two-level column index")

--- a/src/trend_analysis/signals.py
+++ b/src/trend_analysis/signals.py
@@ -1,0 +1,236 @@
+"""Unified signal engine for trend strategies.
+
+The module exposes a :func:`generate_signals` entry-point that produces a
+:class:`SignalFrame` representing the intermediate transformation stages of the
+trend signal pipeline.  The function supports a baseline time-series momentum
+signal with optional volatility adjustment and cross-sectional z-score
+normalisation.  The resulting frame enforces a consistent schema regardless of
+which features are enabled and ensures execution lag is applied before the
+signals reach the caller.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import numpy as np
+import pandas as pd
+
+__all__ = ["TrendSpec", "SignalFrame", "generate_signals"]
+
+
+@dataclass(frozen=True)
+class TrendSpec:
+    """Specification describing how trend signals should be constructed.
+
+    Parameters
+    ----------
+    lookback:
+        Number of periods used to compute the time-series momentum signal.
+    vol_lookback:
+        Optional rolling window for realised volatility.  When ``None`` the
+        lookback used for momentum is re-used.
+    use_vol_adjust:
+        Divide the momentum signal by realised volatility when set to ``True``.
+    use_zscore:
+        Apply cross-sectional z-score normalisation when ``True``.
+    execution_lag:
+        Number of periods to shift the final signal forward to avoid
+        look-ahead.  A value of ``0`` disables the lag.
+    """
+
+    lookback: int = 1
+    vol_lookback: int | None = None
+    use_vol_adjust: bool = False
+    use_zscore: bool = False
+    execution_lag: int = 1
+
+    def __post_init__(self) -> None:
+        if self.lookback < 1:
+            raise ValueError("lookback must be at least 1")
+        if self.vol_lookback is not None and self.vol_lookback < 1:
+            raise ValueError("vol_lookback must be at least 1 when provided")
+        if self.execution_lag < 0:
+            raise ValueError("execution_lag cannot be negative")
+
+    @property
+    def effective_vol_window(self) -> int:
+        """Return the window length used for volatility adjustment."""
+
+        return self.vol_lookback or self.lookback
+
+
+class SignalFrame:
+    """Container representing the stages of the signal pipeline.
+
+    The frame stores data in a :class:`pandas.DataFrame` with a two-level column
+    index.  The first level identifies the transformation stage while the second
+    level enumerates the asset symbols.  This structure guarantees callers can
+    rely on a consistent schema independent of the configuration used to
+    generate the signal.
+    """
+
+    _STAGES = ("raw_momentum", "vol_adjusted", "normalized", "signal")
+
+    def __init__(self, frame: pd.DataFrame):
+        if not isinstance(frame, pd.DataFrame):  # pragma: no cover - guard rail
+            raise TypeError("frame must be a pandas DataFrame")
+        if frame.columns.nlevels != 2:
+            raise ValueError("SignalFrame requires a two-level column index")
+        stages = frame.columns.get_level_values(0)
+        missing = [stage for stage in self._STAGES if stage not in stages]
+        if missing:
+            raise ValueError(f"SignalFrame missing columns for stages: {missing}")
+        assets = frame.columns.get_level_values(1).unique()
+        target_columns = pd.MultiIndex.from_product(
+            (self._STAGES, assets), names=frame.columns.names
+        )
+        self._frame = frame.reindex(columns=target_columns)
+
+    def __getattr__(self, item: str):  # pragma: no cover - thin delegation
+        return getattr(self._frame, item)
+
+    def __getitem__(self, key):  # pragma: no cover - thin delegation
+        return self._frame.__getitem__(key)
+
+    def __iter__(self):  # pragma: no cover - thin delegation
+        return iter(self._frame)
+
+    def __repr__(self) -> str:  # pragma: no cover - formatting helper
+        return f"SignalFrame({repr(self._frame)})"
+
+    @property
+    def frame(self) -> pd.DataFrame:
+        """Return a defensive copy of the underlying DataFrame."""
+
+        return self._frame.copy()
+
+    def stage(self, name: str) -> pd.DataFrame:
+        """Return the DataFrame slice associated with a particular stage."""
+
+        if name not in self._STAGES:
+            raise KeyError(f"Unknown stage '{name}'")
+        return self._frame.xs(name, axis=1, level=0)
+
+    @property
+    def final(self) -> pd.DataFrame:
+        """Convenience accessor for the executed signal layer."""
+
+        return self.stage("signal")
+
+
+def generate_signals(
+    prices: pd.DataFrame,
+    spec: TrendSpec,
+    *,
+    rebalance_dates: Sequence[pd.Timestamp] | Iterable[pd.Timestamp] | None = None,
+) -> SignalFrame:
+    """Return trend signals derived from ``prices`` according to ``spec``.
+
+    Parameters
+    ----------
+    prices:
+        Historical asset prices with a monotonically increasing ``DatetimeIndex``.
+    spec:
+        Configuration object describing the requested signal transformations.
+    rebalance_dates:
+        Optional sequence of timestamps indicating when the strategy rebalances.
+        Execution lag is applied on these dates.
+    """
+
+    if not isinstance(prices, pd.DataFrame):
+        raise TypeError("prices must be a pandas DataFrame")
+    if not isinstance(prices.index, pd.DatetimeIndex):
+        raise TypeError("prices must have a DatetimeIndex")
+    if not prices.index.is_monotonic_increasing:
+        prices = prices.sort_index()
+
+    prices = prices.astype(float)
+    assets = list(prices.columns)
+    returns = prices.pct_change()
+    raw_momentum = prices.pct_change(spec.lookback)
+
+    if spec.use_vol_adjust:
+        window = spec.effective_vol_window
+        realised_vol = returns.rolling(window).std()
+        realised_vol = realised_vol.replace(0.0, np.nan)
+        vol_adjusted = raw_momentum.divide(realised_vol)
+    else:
+        vol_adjusted = raw_momentum
+
+    if spec.use_zscore:
+        normalized = _zscore_normalise(vol_adjusted)
+    else:
+        normalized = vol_adjusted
+
+    executed = normalized
+    if rebalance_dates is not None and spec.execution_lag > 0:
+        executed = _apply_execution_lag(
+            normalized,
+            rebalance_dates=rebalance_dates,
+            periods=spec.execution_lag,
+        )
+
+    frame = _assemble_frame(
+        index=prices.index,
+        assets=assets,
+        stages={
+            "raw_momentum": raw_momentum,
+            "vol_adjusted": vol_adjusted,
+            "normalized": normalized,
+            "signal": executed,
+        },
+    )
+    return SignalFrame(frame)
+
+
+def _assemble_frame(
+    *,
+    index: pd.Index,
+    assets: Sequence[str],
+    stages: dict[str, pd.DataFrame],
+) -> pd.DataFrame:
+    columns = pd.MultiIndex.from_product(
+        (SignalFrame._STAGES, assets), names=("stage", "asset")
+    )
+    combined = pd.DataFrame(index=index, columns=columns, dtype=float)
+    idx = pd.IndexSlice
+    for stage in SignalFrame._STAGES:
+        data = stages[stage].reindex(index=index, columns=assets)
+        combined.loc[:, idx[stage, :]] = data.to_numpy()
+    return combined
+
+
+def _zscore_normalise(frame: pd.DataFrame) -> pd.DataFrame:
+    demeaned = frame.sub(frame.mean(axis=1, skipna=True), axis=0)
+    std = frame.std(axis=1, skipna=True, ddof=0)
+    std = std.replace(0.0, np.nan)
+    normalized = demeaned.divide(std, axis=0)
+    normalized = normalized.where(np.isfinite(normalized))
+    # Where all entries were NaN we retain NaNs.  Where std was zero, fallback to
+    # zeros (no cross-sectional differentiation) while preserving original NaNs.
+    zero_std_rows = std.isna() & frame.notna().any(axis=1)
+    if zero_std_rows.any():
+        normalized.loc[zero_std_rows] = 0.0
+        normalized = normalized.where(frame.notna())
+    return normalized
+
+
+def _apply_execution_lag(
+    frame: pd.DataFrame,
+    *,
+    rebalance_dates: Sequence[pd.Timestamp] | Iterable[pd.Timestamp],
+    periods: int,
+) -> pd.DataFrame:
+    if periods <= 0:
+        return frame
+
+    shifted = frame.shift(periods)
+    rebal_index = frame.index.intersection(pd.DatetimeIndex(list(rebalance_dates)))
+    if not len(rebal_index):
+        return frame
+
+    result = frame.copy()
+    result.loc[rebal_index] = shifted.loc[rebal_index]
+    return result

--- a/src/trend_analysis/signals.py
+++ b/src/trend_analysis/signals.py
@@ -88,13 +88,13 @@ class SignalFrame:
         )
         self._frame = frame.reindex(columns=target_columns)
 
-    def __getattr__(self, item: str):  # pragma: no cover - thin delegation
+    def __getattr__(self, item: str) -> object:  # pragma: no cover - thin delegation
         return getattr(self._frame, item)
 
-    def __getitem__(self, key):  # pragma: no cover - thin delegation
+    def __getitem__(self, key) -> object:  # pragma: no cover - thin delegation
         return self._frame.__getitem__(key)
 
-    def __iter__(self):  # pragma: no cover - thin delegation
+    def __iter__(self) -> Iterable:  # pragma: no cover - thin delegation
         return iter(self._frame)
 
     def __repr__(self) -> str:  # pragma: no cover - formatting helper

--- a/src/trend_analysis/signals.py
+++ b/src/trend_analysis/signals.py
@@ -12,7 +12,7 @@ signals reach the caller.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, Sequence
+from typing import Any, Iterable, Iterator, Sequence
 
 import numpy as np
 import pandas as pd
@@ -88,13 +88,13 @@ class SignalFrame:
         )
         self._frame = frame.reindex(columns=target_columns)
 
-    def __getattr__(self, item: str) -> object:  # pragma: no cover - thin delegation
+    def __getattr__(self, item: str) -> Any:  # pragma: no cover - thin delegation
         return getattr(self._frame, item)
 
-    def __getitem__(self, key) -> object:  # pragma: no cover - thin delegation
+    def __getitem__(self, key) -> Any:  # pragma: no cover - thin delegation
         return self._frame.__getitem__(key)
 
-    def __iter__(self) -> Iterable:  # pragma: no cover - thin delegation
+    def __iter__(self) -> Iterator[str]:  # pragma: no cover - thin delegation
         return iter(self._frame)
 
     def __repr__(self) -> str:  # pragma: no cover - formatting helper

--- a/tests/test_signals_engine.py
+++ b/tests/test_signals_engine.py
@@ -69,9 +69,10 @@ def test_signal_frame_columns_are_consistent(sample_prices: pd.DataFrame) -> Non
     vol_spec = TrendSpec(lookback=1, vol_lookback=2, use_vol_adjust=True, execution_lag=0)
     zscore_spec = TrendSpec(lookback=1, use_zscore=True, execution_lag=0)
 
-    frames = [
-        generate_signals(sample_prices, spec).frame for spec in (base_spec, vol_spec, zscore_spec)
-    ]
+    base_frame = generate_signals(sample_prices, base_spec).frame
+    vol_frame = generate_signals(sample_prices, vol_spec).frame
+    zscore_frame = generate_signals(sample_prices, zscore_spec).frame
+    frames = [base_frame, vol_frame, zscore_frame]
 
     for frame in frames:
         assert isinstance(frame, pd.DataFrame)

--- a/tests/test_signals_engine.py
+++ b/tests/test_signals_engine.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from trend_analysis.signals import SignalFrame, TrendSpec, generate_signals
+
+
+@pytest.fixture
+def sample_prices() -> pd.DataFrame:
+    index = pd.date_range("2020-01-01", periods=6, freq="D")
+    data = {
+        "AssetA": [100, 102, 104, 108, 110, 115],
+        "AssetB": [50, 49, 51, 50, 52, 55],
+    }
+    return pd.DataFrame(data, index=index)
+
+
+def test_generate_signals_basic_momentum(sample_prices: pd.DataFrame) -> None:
+    spec = TrendSpec(lookback=1, execution_lag=0)
+    signal = generate_signals(sample_prices, spec)
+
+    expected = sample_prices.pct_change(1)
+    expected.columns.name = "asset"
+    pd.testing.assert_frame_equal(signal.stage("raw_momentum"), expected)
+    pd.testing.assert_frame_equal(signal.stage("vol_adjusted"), expected)
+    pd.testing.assert_frame_equal(signal.stage("normalized"), expected)
+    pd.testing.assert_frame_equal(signal.final, expected)
+
+
+def test_generate_signals_vol_adjust_and_zscore(sample_prices: pd.DataFrame) -> None:
+    spec = TrendSpec(
+        lookback=1,
+        vol_lookback=2,
+        use_vol_adjust=True,
+        use_zscore=True,
+        execution_lag=1,
+    )
+    frame = generate_signals(sample_prices, spec, rebalance_dates=sample_prices.index)
+
+    momentum = sample_prices.pct_change(1)
+    realised_vol = sample_prices.pct_change().rolling(2).std().replace(0.0, np.nan)
+    expected_vol_adjusted = momentum.divide(realised_vol)
+    expected_vol_adjusted.columns.name = "asset"
+
+    demeaned = expected_vol_adjusted.sub(
+        expected_vol_adjusted.mean(axis=1, skipna=True), axis=0
+    )
+    std = expected_vol_adjusted.std(axis=1, skipna=True, ddof=0).replace(0.0, np.nan)
+    expected_normalized = demeaned.divide(std, axis=0)
+    expected_normalized = expected_normalized.where(np.isfinite(expected_normalized))
+    zero_std_rows = std.isna() & expected_vol_adjusted.notna().any(axis=1)
+    if zero_std_rows.any():
+        expected_normalized.loc[zero_std_rows] = 0.0
+        expected_normalized = expected_normalized.where(expected_vol_adjusted.notna())
+    expected_normalized.columns.name = "asset"
+
+    expected_signal = expected_normalized.shift(1)
+    expected_signal.columns.name = "asset"
+
+    pd.testing.assert_frame_equal(frame.stage("vol_adjusted"), expected_vol_adjusted)
+    pd.testing.assert_frame_equal(frame.stage("normalized"), expected_normalized)
+    pd.testing.assert_frame_equal(frame.final, expected_signal)
+
+
+def test_signal_frame_columns_are_consistent(sample_prices: pd.DataFrame) -> None:
+    base_spec = TrendSpec(lookback=1, execution_lag=0)
+    vol_spec = TrendSpec(lookback=1, vol_lookback=2, use_vol_adjust=True, execution_lag=0)
+    zscore_spec = TrendSpec(lookback=1, use_zscore=True, execution_lag=0)
+
+    frames = [
+        generate_signals(sample_prices, spec).frame for spec in (base_spec, vol_spec, zscore_spec)
+    ]
+
+    for frame in frames:
+        assert isinstance(frame, pd.DataFrame)
+        assert frame.columns.names == ["stage", "asset"]
+        assert tuple(frame.columns.get_level_values(0).unique()) == SignalFrame._STAGES
+
+    first_columns = frames[0].columns.tolist()
+    for frame in frames[1:]:
+        assert frame.columns.tolist() == first_columns
+
+
+def test_execution_lag_applied_only_on_rebalance_dates(sample_prices: pd.DataFrame) -> None:
+    spec = TrendSpec(lookback=1, execution_lag=1)
+    rebalance_dates = sample_prices.index[2:]
+    frame = generate_signals(sample_prices, spec, rebalance_dates=rebalance_dates)
+
+    normalized = frame.stage("normalized")
+    expected = normalized.copy()
+    shifted = normalized.shift(1)
+    expected.loc[rebalance_dates] = shifted.loc[rebalance_dates]
+
+    pd.testing.assert_frame_equal(frame.final, expected)
+
+
+def test_trend_spec_toggles_modify_signal(sample_prices: pd.DataFrame) -> None:
+    base_spec = TrendSpec(lookback=1, execution_lag=0)
+    vol_spec = TrendSpec(lookback=1, vol_lookback=2, use_vol_adjust=True, execution_lag=0)
+    zscore_spec = TrendSpec(lookback=1, use_zscore=True, execution_lag=0)
+
+    base_frame = generate_signals(sample_prices, base_spec)
+    vol_frame = generate_signals(sample_prices, vol_spec)
+    zscore_frame = generate_signals(sample_prices, zscore_spec)
+
+    assert not base_frame.final.equals(vol_frame.final)
+    assert not vol_frame.final.equals(zscore_frame.final)


### PR DESCRIPTION
## Summary
- add a dedicated `trend_analysis.signals` module that builds time-series momentum signals with optional volatility adjustment, z-score normalisation, and execution lag control through `TrendSpec`
- expose the new signal engine via the `trend_analysis` package export surface
- cover the signal variants with targeted unit tests that verify column alignment, lag discipline, and parameter toggles

## Testing
- pytest tests/test_signals_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68deee4e92c48331b38a2e516f552549