### PR TITLE
Add guardrails for reusable agents workflow contract

### DIFF
--- a/tests/test_workflow_agents_consolidation.py
+++ b/tests/test_workflow_agents_consolidation.py
@@ -46,3 +46,14 @@ def test_agents_consumer_and_reusable_present():
     reusable = WORKFLOWS_DIR / "reusable-90-agents.yml"
     assert consumer.exists(), "agents-40-consumer.yml must exist"
     assert reusable.exists(), "reusable-90-agents.yml must exist"
+    consumer_text = _load_yaml_text(consumer)
+    reusable_text = _load_yaml_text(reusable)
+    assert (
+        "uses: ./.github/workflows/reusable-90-agents.yml" in consumer_text
+    ), "agents-40-consumer.yml must call reusable-90-agents.yml"
+    assert (
+        "workflow_call:" in reusable_text
+    ), "reusable-90-agents.yml must expose a workflow_call trigger"
+    assert (
+        "fromJSON(format('[{0}]', steps.ready.outputs.issue_numbers))[0]" in reusable_text
+    ), "Bootstrap expression must parse issue numbers via format()"


### PR DESCRIPTION
## Summary
- add regression checks that agents-40-consumer.yml invokes the renamed reusable workflow
- ensure reusable-90-agents.yml continues to expose workflow_call and the format()-based bootstrap expression

## Testing
- pytest tests/test_workflow_agents_consolidation.py

------
https://chatgpt.com/codex/tasks/task_e_68def535108883318669b355dc7b1104