### PR TITLE
Address review comments for trend signal engine

### DIFF
--- a/src/trend_analysis/signals.py
+++ b/src/trend_analysis/signals.py
@@ -12,7 +12,7 @@ signals reach the caller.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, Sequence
+from typing import Any, Iterable, Iterator, Sequence
 
 import numpy as np
 import pandas as pd
@@ -88,13 +88,13 @@ class SignalFrame:
         )
         self._frame = frame.reindex(columns=target_columns)
 
-    def __getattr__(self, item: str) -> object:  # pragma: no cover - thin delegation
+    def __getattr__(self, item: str) -> Any:  # pragma: no cover - thin delegation
         return getattr(self._frame, item)
 
-    def __getitem__(self, key) -> object:  # pragma: no cover - thin delegation
+    def __getitem__(self, key) -> Any:  # pragma: no cover - thin delegation
         return self._frame.__getitem__(key)
 
-    def __iter__(self) -> Iterable:  # pragma: no cover - thin delegation
+    def __iter__(self) -> Iterator[str]:  # pragma: no cover - thin delegation
         return iter(self._frame)
 
     def __repr__(self) -> str:  # pragma: no cover - formatting helper

--- a/tests/test_signals_engine.py
+++ b/tests/test_signals_engine.py
@@ -69,9 +69,10 @@ def test_signal_frame_columns_are_consistent(sample_prices: pd.DataFrame) -> Non
     vol_spec = TrendSpec(lookback=1, vol_lookback=2, use_vol_adjust=True, execution_lag=0)
     zscore_spec = TrendSpec(lookback=1, use_zscore=True, execution_lag=0)
 
-    frames = [
-        generate_signals(sample_prices, spec).frame for spec in (base_spec, vol_spec, zscore_spec)
-    ]
+    base_frame = generate_signals(sample_prices, base_spec).frame
+    vol_frame = generate_signals(sample_prices, vol_spec).frame
+    zscore_frame = generate_signals(sample_prices, zscore_spec).frame
+    frames = [base_frame, vol_frame, zscore_frame]
 
     for frame in frames:
         assert isinstance(frame, pd.DataFrame)


### PR DESCRIPTION
## Summary
- add a dedicated `trend_analysis.signals` module that builds time-series momentum signals with optional volatility adjustment, z-score normalisation, and execution lag control through `TrendSpec`
- expose the new signal engine via the `trend_analysis` package export surface
- cover the signal variants with targeted unit tests that verify column alignment, lag discipline, and parameter toggles
- address review feedback by tightening delegation type hints in `SignalFrame` and simplifying the column consistency test setup

## Testing
- pytest tests/test_signals_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68def9ca5e0c8331a5394412eff444e2