### PR TITLE
Fix reuse-agents.yml expression bug and rename to reusable-90-agents.yml - Source Issue #1661

### DIFF
--- a/tests/test_workflow_agents_consolidation.py
+++ b/tests/test_workflow_agents_consolidation.py
@@ -57,3 +57,6 @@ def test_agents_consumer_and_reusable_present():
     assert (
         "fromJSON(format('[{0}]', steps.ready.outputs.issue_numbers))[0]" in reusable_text
     ), "Bootstrap expression must parse issue numbers via format()"
+    assert (
+        "'[' + steps.ready.outputs.issue_numbers + ']'" not in reusable_text
+    ), "Legacy string concatenation pattern must not remain in reusable-90-agents.yml"


### PR DESCRIPTION
## Summary
- Fixed invalid GitHub expression syntax by replacing string concatenation with the `format()` function.
- Renamed workflow file from `reuse-agents.yml` to `reusable-90-agents.yml` to reflect its reusable status.
- Added bootstrap file for tracking the issue resolution.
- Extended the workflow consolidation test to guard against reintroducing the legacy concatenation expression.

## Testing
- pytest tests/test_workflow_agents_consolidation.py

------
https://chatgpt.com/codex/tasks/task_e_68defb2155d483318f839ab88c6cbcf2