### PR TITLE
Fix execution lag for signal engine without rebalance dates

### DIFF
--- a/src/trend_analysis/signals.py
+++ b/src/trend_analysis/signals.py
@@ -165,12 +165,15 @@ def generate_signals(
         normalized = vol_adjusted
 
     executed = normalized
-    if rebalance_dates is not None and spec.execution_lag > 0:
-        executed = _apply_execution_lag(
-            normalized,
-            rebalance_dates=rebalance_dates,
-            periods=spec.execution_lag,
-        )
+    if spec.execution_lag > 0:
+        if rebalance_dates is None:
+            executed = normalized.shift(spec.execution_lag)
+        else:
+            executed = _apply_execution_lag(
+                normalized,
+                rebalance_dates=rebalance_dates,
+                periods=spec.execution_lag,
+            )
 
     frame = _assemble_frame(
         index=prices.index,

--- a/tests/test_signals_engine.py
+++ b/tests/test_signals_engine.py
@@ -97,6 +97,18 @@ def test_execution_lag_applied_only_on_rebalance_dates(sample_prices: pd.DataFra
     pd.testing.assert_frame_equal(frame.final, expected)
 
 
+def test_execution_lag_without_rebalance_dates_shifts_all_periods(
+    sample_prices: pd.DataFrame,
+) -> None:
+    spec = TrendSpec(lookback=1, execution_lag=1)
+    frame = generate_signals(sample_prices, spec, rebalance_dates=None)
+
+    normalized = frame.stage("normalized")
+    expected = normalized.shift(1)
+
+    pd.testing.assert_frame_equal(frame.final, expected)
+
+
 def test_trend_spec_toggles_modify_signal(sample_prices: pd.DataFrame) -> None:
     base_spec = TrendSpec(lookback=1, execution_lag=0)
     vol_spec = TrendSpec(lookback=1, vol_lookback=2, use_vol_adjust=True, execution_lag=0)


### PR DESCRIPTION
## Summary
- shift the unified signal output by the configured execution lag when no rebalance dates are supplied
- extend signal engine tests to cover the no-rebalance lag scenario and guarantee look-ahead protection

## Testing
- pytest tests/test_signals_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68df1855511c833192ce625bb209e2e1