### PR TITLE
One signal engine to rule them all - Source Issue #1679

### DIFF
--- a/src/trend_analysis/signals.py
+++ b/src/trend_analysis/signals.py
@@ -136,7 +136,9 @@ def generate_signals(
         Configuration object describing the requested signal transformations.
     rebalance_dates:
         Optional sequence of timestamps indicating when the strategy rebalances.
-        Execution lag is applied on these dates.
+        Execution lag is applied on these dates. If none of the provided
+        timestamps align with ``prices.index`` a :class:`ValueError` is raised to
+        avoid returning an unlagged signal.
     """
 
     if not isinstance(prices, pd.DataFrame):
@@ -232,7 +234,10 @@ def _apply_execution_lag(
     shifted = frame.shift(periods)
     rebal_index = frame.index.intersection(pd.DatetimeIndex(list(rebalance_dates)))
     if not len(rebal_index):
-        return frame
+        raise ValueError(
+            "None of the provided rebalance_dates overlap with the price index; "
+            "execution lag cannot be applied."
+        )
 
     result = frame.copy()
     result.loc[rebal_index] = shifted.loc[rebal_index]

--- a/tests/test_signals_engine.py
+++ b/tests/test_signals_engine.py
@@ -109,6 +109,16 @@ def test_execution_lag_without_rebalance_dates_shifts_all_periods(
     pd.testing.assert_frame_equal(frame.final, expected)
 
 
+def test_execution_lag_errors_when_rebalance_dates_missing_from_index(
+    sample_prices: pd.DataFrame,
+) -> None:
+    spec = TrendSpec(lookback=1, execution_lag=1)
+    missing_dates = pd.date_range("2019-12-01", periods=3, freq="D")
+
+    with pytest.raises(ValueError, match="execution lag cannot be applied"):
+        generate_signals(sample_prices, spec, rebalance_dates=missing_dates)
+
+
 def test_trend_spec_toggles_modify_signal(sample_prices: pd.DataFrame) -> None:
     base_spec = TrendSpec(lookback=1, execution_lag=0)
     vol_spec = TrendSpec(lookback=1, vol_lookback=2, use_vol_adjust=True, execution_lag=0)


### PR DESCRIPTION
**Summary**
* Implemented a unified signal engine with `TrendSpec`, `SignalFrame`, and `generate_signals` to deliver baseline momentum, optional volatility adjustment, cross-sectional z-scores, and execution lag handling while maintaining a consistent schema.
* Exposed the new signal module through the `trend_analysis` package exports for downstream consumers.
* Added targeted unit tests covering momentum, volatility adjustment, normalization, lag alignment, and configuration toggles for the new engine.
* Ensure the signal engine shifts executed signals by the configured lag whenever no rebalance schedule is provided, preventing inadvertent look-ahead usage.
* Added a regression test that validates lagged execution in the absence of explicit rebalance dates to keep all signal variants look-ahead safe.
* Raise an explicit error when supplied rebalance dates do not overlap with the price index so unlagged signals are never returned inadvertently, and documented the behavior.
* Added a unit test that asserts the new error path when rebalance dates are misaligned.

**Testing**
* ✅ `pytest tests/test_signals_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68df1aaa9af48331bdcff339bac57f3a