### PR TITLE
Validate rebalance alignment before applying signal lag

### DIFF
--- a/tests/test_signals_engine.py
+++ b/tests/test_signals_engine.py
@@ -119,6 +119,18 @@ def test_execution_lag_errors_when_rebalance_dates_missing_from_index(
         generate_signals(sample_prices, spec, rebalance_dates=missing_dates)
 
 
+def test_execution_lag_errors_when_rebalance_dates_partially_missing(
+    sample_prices: pd.DataFrame,
+) -> None:
+    spec = TrendSpec(lookback=1, execution_lag=1)
+    partial_dates = sample_prices.index[:3].union(
+        pd.DatetimeIndex([pd.Timestamp("2020-02-01")])
+    )
+
+    with pytest.raises(ValueError, match="Rebalance dates missing from price index"):
+        generate_signals(sample_prices, spec, rebalance_dates=partial_dates)
+
+
 def test_trend_spec_toggles_modify_signal(sample_prices: pd.DataFrame) -> None:
     base_spec = TrendSpec(lookback=1, execution_lag=0)
     vol_spec = TrendSpec(lookback=1, vol_lookback=2, use_vol_adjust=True, execution_lag=0)


### PR DESCRIPTION
## Summary
- implement a unified trend signal engine with configurable momentum, volatility adjustment, z-score normalisation, and execution lag handling
- expose the signal engine through the trend_analysis package exports
- add comprehensive unit tests covering all signal paths and lag enforcement, including new guards that fail fast when any rebalance date is absent from the price index

## Testing
- pytest tests/test_signals_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68df1ccce4e48331b25f5b19e5d4a1a7