### PR TITLE
Unify agent assignment and watchdog workflows

### DIFF
--- a/.github/workflows/agents-41-assign-and-watch.yml
+++ b/.github/workflows/agents-41-assign-and-watch.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: "assign | clear | watch | sweep | auto"
+        description: "assign | clear | watch | sweep"
         required: false
         default: ""
       issue:

--- a/.github/workflows/agents-41-assign-and-watch.yml
+++ b/.github/workflows/agents-41-assign-and-watch.yml
@@ -45,7 +45,7 @@ permissions:
   actions: write
 
 concurrency:
-  group: agents-assign-and-watch-${{ github.event.inputs.issue || github.event.inputs.event_payload || github.run_id }}
+  group: agents-assign-and-watch-${{ github.event.inputs.issue || github.run_id }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/agents-41-assign-and-watch.yml
+++ b/.github/workflows/agents-41-assign-and-watch.yml
@@ -1,0 +1,670 @@
+name: Agents Assign + Watch
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "assign | clear | watch | sweep | auto"
+        required: false
+        default: ""
+      issue:
+        description: "Issue number"
+        required: false
+        default: ""
+      agent:
+        description: "Agent key (codex | copilot)"
+        required: false
+        default: ""
+      timeout_minutes:
+        description: "Timeout window for watchdog checks"
+        required: false
+        default: ""
+      started_at:
+        description: "Override watchdog start timestamp (ISO)"
+        required: false
+        default: ""
+      expected_pr:
+        description: "Expected PR number when invoking watchdog manually"
+        required: false
+        default: ""
+      event_name:
+        description: "Original event name forwarded by wrapper workflows"
+        required: false
+        default: ""
+      event_payload:
+        description: "JSON payload forwarded by wrapper workflows"
+        required: false
+        default: ""
+  schedule:
+    - cron: "*/30 * * * *"
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: agents-assign-and-watch-${{ github.event.inputs.issue || github.event.inputs.event_payload || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve agent operation
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.ctx.outputs.should_run }}
+      operation: ${{ steps.ctx.outputs.operation }}
+      agent: ${{ steps.ctx.outputs.agent }}
+      issue: ${{ steps.ctx.outputs.issue }}
+      assignees: ${{ steps.ctx.outputs.assignees }}
+      command: ${{ steps.ctx.outputs.command }}
+      timeout: ${{ steps.ctx.outputs.timeout }}
+      started_at: ${{ steps.ctx.outputs.started_at }}
+      expected_pr: ${{ steps.ctx.outputs.expected_pr }}
+      watchdog_enabled: ${{ steps.ctx.outputs.watchdog_enabled }}
+      readiness_agents: ${{ steps.ctx.outputs.readiness_agents }}
+      default_branch: ${{ steps.ctx.outputs.default_branch }}
+      stale_minutes: ${{ steps.ctx.outputs.stale_minutes }}
+    steps:
+      - name: Determine action
+        id: ctx
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const CONFIG = {
+              codex: {
+                labels: ['agent:codex', 'agents:codex'],
+                assignees: ['chatgpt-codex-connector'],
+                command: '@codex start',
+                watchdog_timeout: 7,
+                stale_minutes: 240,
+                mention: '@codex',
+                watchdog_enabled: true
+              },
+              copilot: {
+                labels: ['agent:copilot', 'agents:copilot'],
+                assignees: ['copilot'],
+                command: '@copilot start',
+                watchdog_timeout: 7,
+                stale_minutes: 360,
+                mention: '@copilot',
+                watchdog_enabled: false
+              }
+            };
+
+            const labelToAgent = {};
+            for (const [agentKey, cfg] of Object.entries(CONFIG)) {
+              for (const label of cfg.labels) {
+                labelToAgent[label.toLowerCase()] = agentKey;
+              }
+            }
+
+            const { owner, repo } = context.repo;
+            const { data: repoInfo } = await github.rest.repos.get({ owner, repo });
+            const defaultBranch = repoInfo.default_branch || 'main';
+
+            const dispatchInputs = context.payload?.inputs || {};
+            const manualMode = (dispatchInputs.mode || '').trim().toLowerCase();
+            const manualIssue = (dispatchInputs.issue || '').trim();
+            const manualAgent = (dispatchInputs.agent || '').trim().toLowerCase();
+            const manualTimeout = (dispatchInputs.timeout_minutes || '').trim();
+            const manualStartedAt = (dispatchInputs.started_at || '').trim();
+            const manualExpectedPr = (dispatchInputs.expected_pr || '').trim();
+            const forwardedEventName = (dispatchInputs.event_name || '').trim().toLowerCase();
+            const payloadRaw = dispatchInputs.event_payload || '';
+
+            let forwardedPayload = null;
+            if (payloadRaw) {
+              try {
+                forwardedPayload = JSON.parse(payloadRaw);
+              } catch (error) {
+                core.warning(`Failed to parse forwarded payload: ${error.message}`);
+              }
+            }
+
+            const eventName = context.eventName === 'workflow_dispatch' && forwardedEventName
+              ? forwardedEventName
+              : context.eventName;
+
+            const nowIso = new Date().toISOString();
+
+            let operation = 'none';
+            let agentKey = '';
+            let issueNumber = 0;
+            let timeoutMinutes = '';
+            let startedAt = '';
+            let expectedPr = manualExpectedPr;
+            let readinessAgents = '';
+            let watchdogEnabled = 'false';
+            let staleMinutes = '';
+
+            const resolveFromIssuePayload = (payload, actionOverride = '') => {
+              if (!payload) { return; }
+              const action = (actionOverride || payload.action || '').toLowerCase();
+              const issue = payload.issue || {};
+              const number = Number(issue.number || 0);
+              const labelName = (payload.label?.name || '').toLowerCase();
+              const labels = (issue.labels || []).map(l => (l.name || '').toLowerCase());
+
+              if (!number) {
+                return;
+              }
+
+              if (action === 'labeled') {
+                const directAgent = labelToAgent[labelName];
+                if (directAgent) {
+                  issueNumber = number;
+                  agentKey = directAgent;
+                  operation = 'assign';
+                }
+              } else if (action === 'unlabeled') {
+                const removedAgent = labelToAgent[labelName];
+                if (removedAgent) {
+                  issueNumber = number;
+                  agentKey = removedAgent;
+                  operation = 'clear';
+                }
+              } else if (!action && labels.length) {
+                for (const lbl of labels) {
+                  if (labelToAgent[lbl]) {
+                    issueNumber = number;
+                    agentKey = labelToAgent[lbl];
+                    operation = 'assign';
+                    break;
+                  }
+                }
+              }
+            };
+
+            if (context.eventName === 'schedule') {
+              operation = 'sweep';
+              readinessAgents = Object.keys(CONFIG).join(',');
+            } else if (manualMode) {
+              if (manualMode === 'assign') {
+                const cfg = CONFIG[manualAgent] || null;
+                if (cfg && manualIssue) {
+                  operation = 'assign';
+                  agentKey = manualAgent;
+                  issueNumber = Number(manualIssue);
+                }
+              } else if (manualMode === 'clear') {
+                const cfg = CONFIG[manualAgent] || null;
+                if (cfg && manualIssue) {
+                  operation = 'clear';
+                  agentKey = manualAgent;
+                  issueNumber = Number(manualIssue);
+                }
+              } else if (manualMode === 'watch') {
+                const cfg = CONFIG[manualAgent] || null;
+                if (cfg && manualIssue) {
+                  operation = 'watch';
+                  agentKey = manualAgent;
+                  issueNumber = Number(manualIssue);
+                }
+              } else if (manualMode === 'sweep') {
+                operation = 'sweep';
+                readinessAgents = manualAgent ? manualAgent : Object.keys(CONFIG).join(',');
+              }
+            } else if (eventName === 'issues') {
+              resolveFromIssuePayload(forwardedPayload || context.payload);
+            }
+
+            if (operation === 'assign' || operation === 'watch') {
+              const cfg = CONFIG[agentKey] || {};
+              timeoutMinutes = manualTimeout || String(cfg.watchdog_timeout || 7);
+              startedAt = manualStartedAt || nowIso;
+              readinessAgents = agentKey;
+              staleMinutes = String(cfg.stale_minutes || 240);
+              if (operation === 'assign' && cfg) {
+                watchdogEnabled = cfg.watchdog_enabled ? 'true' : 'false';
+              } else if (operation === 'watch') {
+                watchdogEnabled = 'true';
+              }
+            } else if (operation === 'clear') {
+              const cfg = CONFIG[agentKey] || {};
+              staleMinutes = String(cfg.stale_minutes || 240);
+            } else if (operation === 'sweep') {
+              startedAt = nowIso;
+            }
+
+            const cfg = CONFIG[agentKey] || {};
+            const assignees = JSON.stringify(cfg.assignees || []);
+            const command = cfg.command || '';
+
+            const shouldRun = Boolean(
+              (operation === 'assign' && issueNumber && agentKey) ||
+              (operation === 'clear' && issueNumber && agentKey) ||
+              (operation === 'watch' && issueNumber && agentKey) ||
+              operation === 'sweep'
+            );
+
+            core.setOutput('should_run', shouldRun ? 'true' : 'false');
+            core.setOutput('operation', operation);
+            core.setOutput('agent', agentKey);
+            core.setOutput('issue', issueNumber ? String(issueNumber) : '');
+            core.setOutput('assignees', assignees);
+            core.setOutput('command', command);
+            core.setOutput('timeout', timeoutMinutes || '');
+            core.setOutput('started_at', startedAt || '');
+            core.setOutput('expected_pr', expectedPr || '');
+            core.setOutput('watchdog_enabled', watchdogEnabled);
+            core.setOutput('readiness_agents', readinessAgents || '');
+            core.setOutput('default_branch', defaultBranch);
+            core.setOutput('stale_minutes', staleMinutes || '');
+
+            if (!shouldRun) {
+              core.info('No actionable agent event detected.');
+            } else {
+              core.info(`Operation=${operation} agent=${agentKey} issue=${issueNumber}`);
+            }
+
+  readiness_probe:
+    if: needs.resolve.outputs.should_run == 'true' && (needs.resolve.outputs.operation == 'assign' || needs.resolve.outputs.operation == 'sweep')
+    name: Agent availability check
+    uses: ./.github/workflows/reusable-90-agents.yml
+    with:
+      enable_readiness: 'true'
+      readiness_agents: ${{ needs.resolve.outputs.readiness_agents }}
+      require_all: ${{ needs.resolve.outputs.operation == 'assign' && 'true' || 'false' }}
+      enable_preflight: 'false'
+      enable_diagnostic: 'false'
+      enable_verify_issue: 'false'
+      enable_watchdog: 'false'
+    secrets:
+      service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+
+  assign_issue:
+    needs:
+      - resolve
+      - readiness_probe
+    if: needs.resolve.outputs.should_run == 'true' && needs.resolve.outputs.operation == 'assign' && needs.readiness_probe.result == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      expected_pr: ${{ steps.bootstrap.outputs.pr || needs.resolve.outputs.expected_pr }}
+    steps:
+      - name: Assign agent actor
+        uses: actions/github-script@v7
+        env:
+          ISSUE: ${{ needs.resolve.outputs.issue }}
+          ASSIGNEES: ${{ needs.resolve.outputs.assignees }}
+        with:
+          script: |
+            const issue = Number(process.env.ISSUE || '0');
+            const assignees = JSON.parse(process.env.ASSIGNEES || '[]').filter(Boolean);
+            if (!issue || !assignees.length) {
+              core.info('No assignment performed (missing issue or assignees).');
+              return;
+            }
+            const { owner, repo } = context.repo;
+            await github.rest.issues.addAssignees({ owner, repo, issue_number: issue, assignees });
+            core.info(`Assigned ${assignees.join(', ')} to #${issue}.`);
+
+      - name: Bootstrap Codex issue branch
+        id: bootstrap
+        if: needs.resolve.outputs.agent == 'codex'
+        continue-on-error: true
+        uses: ./.github/actions/codex-bootstrap-lite
+        with:
+          issue: ${{ needs.resolve.outputs.issue }}
+          service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+          allow_fallback: 'true'
+          codex_command: '@codex start'
+          draft: 'false'
+          auto_ready: 'true'
+          post_codex_comment: 'true'
+          pr_mode: 'create'
+
+      - name: Surface bootstrap failure
+        if: needs.resolve.outputs.agent == 'codex' && steps.bootstrap.outcome == 'failure'
+        run: |
+          echo "::warning::Codex bootstrap step failed (non-fatal while fallback evaluated)."
+
+      - name: Fallback dispatch Codex Issue Bridge
+        id: fallback_dispatch
+        if: needs.resolve.outputs.agent == 'codex' && steps.bootstrap.outcome == 'failure'
+        uses: actions/github-script@v7
+        env:
+          ISSUE: ${{ needs.resolve.outputs.issue }}
+          REF: ${{ needs.resolve.outputs.default_branch }}
+        with:
+          script: |
+            const issue = Number(process.env.ISSUE || '0');
+            const ref = (process.env.REF || '').trim() || 'main';
+            if (!issue) {
+              core.setFailed('Fallback dispatch aborted: missing issue number.');
+              return;
+            }
+            const { owner, repo } = context.repo;
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: 'codex-issue-bridge.yml',
+              ref,
+              inputs: {
+                test_issue: String(issue),
+                pr_mode: 'create',
+                post_codex_comment: 'true',
+                codex_pr_draft: 'false'
+              }
+            });
+            core.info(`Fallback codex-issue-bridge dispatched for issue #${issue}.`);
+
+      - name: Fail if both primary and fallback bootstrap failed
+        if: needs.resolve.outputs.agent == 'codex' && steps.bootstrap.outcome == 'failure' && steps.fallback_dispatch.outcome == 'failure'
+        run: |
+          echo "::error::Both primary bootstrap and fallback dispatch failed."
+          exit 1
+
+  clear_assignment:
+    needs: resolve
+    if: needs.resolve.outputs.should_run == 'true' && needs.resolve.outputs.operation == 'clear'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove agent assignment after label removal
+        uses: actions/github-script@v7
+        env:
+          ISSUE: ${{ needs.resolve.outputs.issue }}
+          ASSIGNEES: ${{ needs.resolve.outputs.assignees }}
+          AGENT: ${{ needs.resolve.outputs.agent }}
+        with:
+          script: |
+            const issue = Number(process.env.ISSUE || '0');
+            const assignees = JSON.parse(process.env.ASSIGNEES || '[]').filter(Boolean);
+            if (!issue || !assignees.length) {
+              core.info('Nothing to clear.');
+              return;
+            }
+            const { owner, repo } = context.repo;
+            try {
+              await github.rest.issues.removeAssignees({ owner, repo, issue_number: issue, assignees });
+              core.info(`Removed ${assignees.join(', ')} from #${issue}.`);
+            } catch (error) {
+              core.warning(`Failed to remove assignees: ${error.message}`);
+            }
+            const note = `Agent label removed; cleared ${process.env.AGENT || 'agent'} assignment.`;
+            await github.rest.issues.createComment({ owner, repo, issue_number: issue, body: note });
+
+  watch_pr:
+    needs:
+      - resolve
+      - assign_issue
+    if: always() && needs.resolve.outputs.should_run == 'true' && (needs.resolve.outputs.operation == 'watch' || (needs.resolve.outputs.operation == 'assign' && needs.resolve.outputs.watchdog_enabled == 'true' && needs.assign_issue.result == 'success'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Monitor for cross-referenced PR
+        uses: actions/github-script@v7
+        env:
+          ISSUE: ${{ needs.resolve.outputs.issue }}
+          AGENT: ${{ needs.resolve.outputs.agent }}
+          TIMEOUT: ${{ needs.resolve.outputs.timeout }}
+          STARTED_AT: ${{ needs.resolve.outputs.started_at }}
+          EXPECTED_PR_RESOLVE: ${{ needs.resolve.outputs.expected_pr }}
+          EXPECTED_PR_ASSIGN: ${{ needs.assign_issue.outputs.expected_pr }}
+        with:
+          script: |
+            const issueNumber = Number(process.env.ISSUE || '0');
+            if (!issueNumber) {
+              core.setFailed('Missing issue number input.');
+              return;
+            }
+            const agent = process.env.AGENT || '';
+            const expectedAssign = process.env.EXPECTED_PR_ASSIGN || '';
+            const expectedResolve = process.env.EXPECTED_PR_RESOLVE || '';
+            const expectedPr = expectedAssign || expectedResolve;
+            const timeoutInput = process.env.TIMEOUT || '7';
+            const timeoutMinutes = Number(timeoutInput) > 0 ? Number(timeoutInput) : 7;
+            const startInput = process.env.STARTED_AT || '';
+            let startTime = startInput ? new Date(startInput) : new Date();
+            if (Number.isNaN(startTime.getTime())) {
+              startTime = new Date();
+            }
+            const startMs = startTime.getTime();
+            const pollMs = 30000;
+            const deadline = startMs + timeoutMinutes * 60000;
+            const threshold = startMs - 5000;
+            const { owner, repo } = context.repo;
+
+            const findCrossReference = async () => {
+              const events = await github.paginate(
+                github.request,
+                {
+                  method: 'GET',
+                  url: '/repos/{owner}/{repo}/issues/{issue_number}/timeline',
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  per_page: 100,
+                  headers: { 'accept': 'application/vnd.github.mockingbird-preview+json' }
+                }
+              );
+              for (const event of events) {
+                if ((event.event || '') !== 'cross-referenced') {
+                  continue;
+                }
+                const sourceIssue = event.source?.issue;
+                if (!sourceIssue || !sourceIssue.pull_request) {
+                  continue;
+                }
+                const prNumber = Number(sourceIssue.number || 0);
+                if (!prNumber) {
+                  continue;
+                }
+                if (expectedPr && prNumber !== Number(expectedPr)) {
+                  continue;
+                }
+                const createdAt = new Date(event.created_at || '').getTime();
+                if (Number.isNaN(createdAt) || createdAt < threshold) {
+                  continue;
+                }
+                return {
+                  number: prNumber,
+                  url: sourceIssue.html_url || `https://github.com/${owner}/${repo}/pull/${prNumber}`,
+                  title: sourceIssue.title || '',
+                  createdAt
+                };
+              }
+              return null;
+            };
+
+            let found = null;
+            while (Date.now() < deadline) {
+              found = await findCrossReference();
+              if (found) {
+                break;
+              }
+              await new Promise(resolve => setTimeout(resolve, pollMs));
+            }
+
+            const elapsedMs = found ? Math.max(0, found.createdAt - startMs) : Math.max(0, Date.now() - startMs);
+            const elapsedMinutes = elapsedMs / 60000;
+            const friendlyElapsed = elapsedMinutes.toFixed(2);
+            const agentLabel = agent ? agent : 'agent';
+
+            core.setOutput('found', found ? 'true' : 'false');
+            core.setOutput('pr', found ? String(found.number) : '');
+            core.setOutput('elapsed_minutes', friendlyElapsed);
+
+            const summary = core.summary.addHeading('Agent Watchdog Result');
+            if (found) {
+              summary.addTable([
+                [{ data: 'Status', header: true }, { data: 'Details', header: true }],
+                ['✅ PR detected', `#${found.number} (${found.url}) in ${friendlyElapsed} minutes`]
+              ]);
+            } else {
+              summary.addTable([
+                [{ data: 'Status', header: true }, { data: 'Details', header: true }],
+                ['⚠️ Timeout', `No PR detected within ${timeoutMinutes} minute window`]
+              ]);
+            }
+            await summary.write();
+
+            const commentPrefix = found ? '✅ Agent Watchdog' : '⚠️ Agent Watchdog';
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: issueNumber, per_page: 100, page: 1 });
+            const alreadyCommented = (comments || []).some(c => (c.body || '').startsWith(commentPrefix));
+
+            if (found) {
+              const body = `${commentPrefix}: Detected PR #${found.number} referencing this issue after ${friendlyElapsed} minute${elapsedMinutes === 1 ? '' : 's'}.\n\nLink: ${found.url}`;
+              if (!alreadyCommented) {
+                await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
+              }
+            } else {
+              const mention = agentLabel && agentLabel !== 'agent' ? `${agentLabel} ` : '';
+              const body = `${commentPrefix}: ${mention}no pull request cross-reference detected within ${timeoutMinutes} minute${timeoutMinutes === 1 ? '' : 's'}.`;
+              if (!alreadyCommented) {
+                await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
+              }
+            }
+
+  watchdog_sweep:
+    needs:
+      - resolve
+      - readiness_probe
+    if: needs.resolve.outputs.operation == 'sweep' && needs.readiness_probe.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sweep stale agent issues
+        uses: actions/github-script@v7
+        env:
+          READINESS_REPORT: ${{ needs.readiness_probe.outputs.readiness_report }}
+          STALE_MINUTES: ${{ needs.resolve.outputs.stale_minutes }}
+        with:
+          script: |
+            const readiness = (() => {
+              const raw = process.env.READINESS_REPORT || '{}';
+              try { return JSON.parse(raw); } catch (error) { core.warning('Failed to parse readiness report JSON.'); return {}; }
+            })();
+            const CONFIG = {
+              codex: {
+                labels: ['agent:codex', 'agents:codex'],
+                assignees: ['chatgpt-codex-connector'],
+                stale_minutes: 240,
+                ping_prefix: '🤖 Watchdog ping (codex)',
+                escalate_prefix: '🚨 Watchdog escalation (codex)',
+                mention: '@codex'
+              },
+              copilot: {
+                labels: ['agent:copilot', 'agents:copilot'],
+                assignees: ['copilot'],
+                stale_minutes: 360,
+                ping_prefix: '🤖 Watchdog ping (copilot)',
+                escalate_prefix: '🚨 Watchdog escalation (copilot)',
+                mention: '@copilot'
+              }
+            };
+
+            const labelToAgent = {};
+            for (const [agent, cfg] of Object.entries(CONFIG)) {
+              for (const label of cfg.labels) {
+                labelToAgent[label.toLowerCase()] = agent;
+              }
+            }
+
+            const { owner, repo } = context.repo;
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+              labels: undefined
+            });
+
+            const staleActions = [];
+            const nowMs = Date.now();
+
+            for (const issue of issues) {
+              if (!issue || issue.pull_request) {
+                continue;
+              }
+              const labels = (issue.labels || []).map(l => (typeof l === 'string' ? l : l.name || '').toLowerCase());
+              let agent = '';
+              for (const lbl of labels) {
+                if (labelToAgent[lbl]) {
+                  agent = labelToAgent[lbl];
+                  break;
+                }
+              }
+              if (!agent) {
+                continue;
+              }
+
+              const cfg = CONFIG[agent];
+              const staleMinutes = cfg?.stale_minutes || 240;
+              const updatedAt = new Date(issue.updated_at || issue.created_at || '').getTime();
+              if (!updatedAt) {
+                continue;
+              }
+              const ageMs = nowMs - updatedAt;
+              if (ageMs < staleMinutes * 60000) {
+                continue;
+              }
+
+              staleActions.push({ issue, agent, cfg, ageMinutes: Math.round(ageMs / 60000) });
+            }
+
+            if (!staleActions.length) {
+              core.info('No stale agent issues detected.');
+              await core.summary.addHeading('Agent Watchdog Sweep').addRaw('✅ No stale issues detected.').write();
+              return;
+            }
+
+            const readinessOk = (agent) => {
+              const key = agent.toLowerCase();
+              const report = readiness[key];
+              return report ? Boolean(report.ok) : false;
+            };
+
+            for (const entry of staleActions) {
+              const issueNumber = entry.issue.number;
+              const agent = entry.agent;
+              const cfg = entry.cfg;
+              const pingPrefix = cfg.ping_prefix;
+              const escalatePrefix = cfg.escalate_prefix;
+              const mention = cfg.mention || '';
+              const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: issueNumber, per_page: 100, page: 1 });
+              const hasPing = (comments || []).some(c => (c.body || '').startsWith(pingPrefix));
+              const hasEscalation = (comments || []).some(c => (c.body || '').startsWith(escalatePrefix));
+
+              if (readinessOk(agent)) {
+                if (hasPing) {
+                  core.info(`#${issueNumber} already pinged.`);
+                  continue;
+                }
+                const body = `${pingPrefix}: ${mention} issue has been inactive for ${entry.ageMinutes} minutes.`;
+                await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
+                core.info(`Pinged ${mention || agent} on issue #${issueNumber}.`);
+              } else {
+                if (hasEscalation) {
+                  core.info(`#${issueNumber} already escalated.`);
+                  continue;
+                }
+                const body = `${escalatePrefix}: ${mention || agent} is currently unavailable. Removing assignment so maintainers can re-triage.`;
+                await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
+                const assignees = (cfg.assignees || []).filter(Boolean);
+                if (assignees.length) {
+                  await github.rest.issues.removeAssignees({ owner, repo, issue_number: issueNumber, assignees });
+                }
+                for (const label of cfg.labels) {
+                  const present = (entry.issue.labels || []).some(l => (typeof l === 'string' ? l : l.name || '').toLowerCase() === label.toLowerCase());
+                  if (present) {
+                    try {
+                      await github.rest.issues.removeLabel({ owner, repo, issue_number: issueNumber, name: label });
+                    } catch (error) {
+                      core.warning(`Unable to remove label ${label} from #${issueNumber}: ${error.message}`);
+                    }
+                  }
+                }
+                core.info(`Escalated issue #${issueNumber} due to unavailable agent ${agent}.`);
+              }
+            }
+
+            const summary = core.summary.addHeading('Agent Watchdog Sweep');
+            summary.addTable([
+              [{ data: 'Issue', header: true }, { data: 'Agent', header: true }, { data: 'Action', header: true }],
+              ...staleActions.map(entry => {
+                const ready = readinessOk(entry.agent);
+                return [`#${entry.issue.number}`, entry.agent, ready ? 'Pinged owner' : 'Escalated'];
+              })
+            ]);
+            await summary.write();
+

--- a/.github/workflows/agents-41-assign.yml
+++ b/.github/workflows/agents-41-assign.yml
@@ -1,278 +1,79 @@
-name: Assign to agents
+name: Assign to agents (wrapper)
 
 on:
   issues:
-    types: [labeled]
+    types: [labeled, unlabeled]
   pull_request_target:
     types: [labeled]
   workflow_dispatch:
     inputs:
-      target_type:
-        description: "issue | pr"
+      mode:
+        description: "assign | clear | watch | sweep"
         required: false
-        default: "issue"
-      number:
-        description: "Issue or PR number"
+        default: ""
+      issue:
+        description: "Issue number"
         required: false
         default: ""
       agent:
-        description: "codex | copilot"
+        description: "Agent key"
         required: false
         default: ""
       timeout_minutes:
-        description: "Override watchdog timeout"
+        description: "Timeout override for watchdog"
         required: false
         default: ""
       started_at:
-        description: "Override watchdog start timestamp (ISO)"
+        description: "Override watchdog start timestamp"
+        required: false
+        default: ""
+      expected_pr:
+        description: "Expected PR number for watchdog"
         required: false
         default: ""
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  actions: write
+  contents: read
+  issues: read
+  pull-requests: read
 
 jobs:
-  assign:
+  forward:
     runs-on: ubuntu-latest
     steps:
-      - name: Resolve assignment context
-        id: ctx
+      - name: Forward event to unified workflow
         uses: actions/github-script@v7
         with:
           script: |
-            const CONFIG = {
-              codex: {
-                labels: ['agent:codex', 'agents:codex'],
-                assignees: ['chatgpt-codex-connector'],
-                command: '@codex start',
-                watchdog_timeout: 7
-              },
-              copilot: {
-                labels: ['agent:copilot', 'agents:copilot'],
-                assignees: ['copilot'],
-                command: '@copilot start',
-                watchdog_timeout: 7
-              }
+            const { owner, repo } = context.repo;
+            const { data: repoInfo } = await github.rest.repos.get({ owner, repo });
+            const ref = repoInfo.default_branch || 'main';
+            const payload = JSON.stringify(context.payload || {});
+            const dispatchInputs = context.payload?.inputs || {};
+            const manualInputs = {
+              mode: (dispatchInputs.mode || '').toString(),
+              issue: (dispatchInputs.issue || '').toString(),
+              agent: (dispatchInputs.agent || '').toString(),
+              timeout_minutes: (dispatchInputs.timeout_minutes || '').toString(),
+              started_at: (dispatchInputs.started_at || '').toString(),
+              expected_pr: (dispatchInputs.expected_pr || '').toString()
             };
-
-            const labelToAgent = {};
-            for (const [key, cfg] of Object.entries(CONFIG)) {
-              for (const label of cfg.labels) {
-                labelToAgent[label.toLowerCase()] = key;
+            if (context.eventName !== 'workflow_dispatch') {
+              for (const key of Object.keys(manualInputs)) {
+                manualInputs[key] = '';
               }
             }
-
-            const { owner, repo } = context.repo;
-            const { data: repoInfo } = await github.rest.repos.get({ owner, repo });
-            const defaultBranch = repoInfo.default_branch || 'main';
-
-            const eventName = context.eventName;
-            const action = context.payload.action || '';
-            const inputs = context.payload.inputs || {};
-
-            let targetType = '';
-            let number = 0;
-            let agentKey = '';
-            let timeoutOverride = '';
-            let startedAt = '';
-
-            const normalize = (value) => (value || '').toString().trim().toLowerCase();
-            const normalizeLabel = (value) => normalize(value);
-
-            if (eventName === 'issues') {
-              targetType = 'issue';
-              number = context.payload.issue?.number || 0;
-              const eventLabel = normalizeLabel(context.payload.label?.name);
-              if (labelToAgent[eventLabel]) {
-                agentKey = labelToAgent[eventLabel];
-              }
-              if (!agentKey) {
-                const labels = (context.payload.issue?.labels || []).map(l => normalizeLabel(l.name));
-                for (const lbl of labels) {
-                  if (labelToAgent[lbl]) { agentKey = labelToAgent[lbl]; break; }
-                }
-              }
-            } else if (eventName === 'pull_request_target') {
-              targetType = 'pr';
-              number = context.payload.pull_request?.number || 0;
-              const eventLabel = normalizeLabel(context.payload.label?.name);
-              if (labelToAgent[eventLabel]) {
-                agentKey = labelToAgent[eventLabel];
-              }
-              if (!agentKey) {
-                const labels = (context.payload.pull_request?.labels || []).map(l => normalizeLabel(l.name));
-                for (const lbl of labels) {
-                  if (labelToAgent[lbl]) { agentKey = labelToAgent[lbl]; break; }
-                }
-              }
-            } else if (eventName === 'workflow_dispatch') {
-              targetType = normalize(inputs.target_type) === 'pr' ? 'pr' : 'issue';
-              number = Number(inputs.number || 0);
-              const agentInput = normalize(inputs.agent);
-              if (agentInput && CONFIG[agentInput]) {
-                agentKey = agentInput;
-              }
-              timeoutOverride = normalize(inputs.timeout_minutes);
-              startedAt = (inputs.started_at || '').trim();
-            }
-
-            const shouldRun = Boolean(number && agentKey);
-            const config = CONFIG[agentKey] || { assignees: [], command: '', watchdog_timeout: 7 };
-
-            core.setOutput('should_run', shouldRun ? 'true' : 'false');
-            core.setOutput('agent', agentKey);
-            core.setOutput('number', number ? String(number) : '');
-            core.setOutput('target_type', targetType || '');
-            core.setOutput('assignees', JSON.stringify(config.assignees || []));
-            core.setOutput('command', config.command || '');
-            core.setOutput('watchdog_timeout', timeoutOverride || String(config.watchdog_timeout || 7));
-            core.setOutput('default_branch', defaultBranch);
-            core.setOutput('started_at', startedAt || new Date().toISOString());
-
-            if (!shouldRun) {
-              core.info('No agent assignment detected for this event.');
-            } else {
-              core.info(`Preparing ${agentKey} assignment for ${targetType} #${number}.`);
-            }
-
-      - name: Abort when no agent label present
-        if: steps.ctx.outputs.should_run != 'true'
-        run: |
-          echo "No agent label detected. Nothing to do."
-
-      - name: Assign agent actor
-        if: steps.ctx.outputs.should_run == 'true'
-        uses: actions/github-script@v7
-        env:
-          NUMBER: ${{ steps.ctx.outputs.number }}
-          ASSIGNEES: ${{ steps.ctx.outputs.assignees }}
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const number = Number(process.env.NUMBER || '0');
-            const assignees = JSON.parse(process.env.ASSIGNEES || '[]').filter(Boolean);
-            if (!number || !assignees.length) {
-              core.info('No assignees resolved for this event.');
-              return;
-            }
-            try {
-              await github.rest.issues.addAssignees({ owner, repo, issue_number: number, assignees });
-              core.info(`Assigned ${assignees.join(', ')} to #${number}.`);
-            } catch (error) {
-              core.warning(`Failed to assign ${assignees.join(', ')} to #${number}: ${error.message}`);
-            }
-
-      - name: Post trigger command on PR
-        if: steps.ctx.outputs.should_run == 'true' && steps.ctx.outputs.target_type == 'pr' && steps.ctx.outputs.command != ''
-        uses: actions/github-script@v7
-        env:
-          NUMBER: ${{ steps.ctx.outputs.number }}
-          COMMAND: ${{ steps.ctx.outputs.command }}
-          AGENT: ${{ steps.ctx.outputs.agent }}
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const number = Number(process.env.NUMBER || '0');
-            const command = (process.env.COMMAND || '').trim();
-            if (!number || !command) {
-              core.info('No command to post.');
-              return;
-            }
-            const lower = command.toLowerCase();
-            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: number, per_page: 50, page: 1 });
-            const already = (comments || []).some(c => (c.body || '').toLowerCase().includes(lower));
-            if (already) {
-              core.info('Trigger command already present on PR.');
-              return;
-            }
-            const agent = process.env.AGENT || 'agent';
-            const body = `${command}\n\nAutomation engaged for **${agent}** by agents-41-assign workflow.`;
-            await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
-            core.info('Posted trigger command.');
-
-      - name: Bootstrap Codex issue branch
-        id: bootstrap
-        if: steps.ctx.outputs.should_run == 'true' && steps.ctx.outputs.target_type == 'issue' && steps.ctx.outputs.agent == 'codex'
-        continue-on-error: true
-        uses: ./.github/actions/codex-bootstrap-lite
-        with:
-          issue: ${{ steps.ctx.outputs.number }}
-          service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
-          allow_fallback: 'true'
-          codex_command: '@codex start'
-          draft: 'false'
-          auto_ready: 'true'
-          post_codex_comment: 'true'
-          pr_mode: 'create'
-
-      - name: Dispatch agent watchdog
-        if: steps.ctx.outputs.should_run == 'true' && steps.ctx.outputs.target_type == 'issue' && steps.ctx.outputs.agent == 'codex'
-        uses: actions/github-script@v7
-        env:
-          ISSUE: ${{ steps.ctx.outputs.number }}
-          AGENT: ${{ steps.ctx.outputs.agent }}
-          REF: ${{ steps.ctx.outputs.default_branch }}
-          TIMEOUT: ${{ steps.ctx.outputs.watchdog_timeout }}
-          STARTED_AT: ${{ steps.ctx.outputs.started_at }}
-          EXPECTED_PR: ${{ steps.bootstrap.outputs.pr }}
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const issue = Number(process.env.ISSUE || '0');
-            if (!issue) {
-              core.info('No issue provided for watchdog dispatch.');
-              return;
-            }
-            const ref = (process.env.REF || '').trim() || (context.ref || 'main');
             const inputs = {
-              issue: String(issue),
-              agent: process.env.AGENT || '',
-              expected_pr: (process.env.EXPECTED_PR || '').trim(),
-              timeout_minutes: (process.env.TIMEOUT || '').trim() || '7',
-              started_at: (process.env.STARTED_AT || '').trim() || new Date().toISOString()
+              ...manualInputs,
+              event_name: context.eventName,
+              event_payload: payload
             };
-            await github.rest.actions.createWorkflowDispatch({ owner, repo, workflow_id: 'agents-42-watchdog.yml', ref, inputs });
-            core.info(`Watchdog dispatched for issue #${issue}.`);
-
-      - name: Surface bootstrap failure
-        if: steps.ctx.outputs.should_run == 'true' && steps.ctx.outputs.target_type == 'issue' && steps.ctx.outputs.agent == 'codex' && steps.bootstrap.outcome == 'failure'
-        run: |
-          echo "::warning::Codex bootstrap step failed (non-fatal while fallback evaluated)."
-
-      - name: Fallback dispatch Codex Issue Bridge
-        id: fallback_dispatch
-        if: steps.ctx.outputs.should_run == 'true' && steps.ctx.outputs.target_type == 'issue' && steps.ctx.outputs.agent == 'codex' && steps.bootstrap.outcome == 'failure'
-        uses: actions/github-script@v7
-        env:
-          ISSUE: ${{ steps.ctx.outputs.number }}
-          REF: ${{ steps.ctx.outputs.default_branch }}
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const issue = Number(process.env.ISSUE || '0');
-            const ref = (process.env.REF || '').trim() || (context.ref || 'main');
-            if (!issue) {
-              core.setFailed('Fallback dispatch aborted: missing issue number.');
-            } else {
-              await github.rest.actions.createWorkflowDispatch({
-                owner,
-                repo,
-                workflow_id: 'codex-issue-bridge.yml',
-                ref,
-                inputs: {
-                  test_issue: String(issue),
-                  pr_mode: 'create',
-                  post_codex_comment: 'true',
-                  codex_pr_draft: 'false'
-                }
-              });
-              core.info(`Dispatched codex-issue-bridge.yml (create mode) for issue #${issue} as fallback.`);
-            }
-
-      - name: Fail if both primary and fallback bootstrap failed
-        if: steps.ctx.outputs.should_run == 'true' && steps.ctx.outputs.target_type == 'issue' && steps.ctx.outputs.agent == 'codex' && steps.bootstrap.outcome == 'failure' && steps.fallback_dispatch.outcome == 'failure'
-        run: |
-          echo "::error::Both primary bootstrap and fallback dispatch failed."
-          exit 1
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: 'agents-41-assign-and-watch.yml',
+              ref,
+              inputs
+            });
+            core.info('Forwarded event to agents-41-assign-and-watch.yml.');

--- a/.github/workflows/agents-42-watchdog.yml
+++ b/.github/workflows/agents-42-watchdog.yml
@@ -1,4 +1,4 @@
-name: Agent watchdog
+name: Agent watchdog (wrapper)
 
 on:
   workflow_dispatch:
@@ -24,127 +24,37 @@ on:
         default: ""
 
 permissions:
+  actions: write
   contents: read
-  issues: write
+  issues: read
   pull-requests: read
 
 jobs:
-  monitor:
+  forward:
     runs-on: ubuntu-latest
     steps:
-      - name: Watch for cross-referenced PR
-        id: monitor
+      - name: Dispatch unified watchdog
         uses: actions/github-script@v7
         with:
           script: |
-            const issueNumber = Number(core.getInput('issue'));
-            if (!issueNumber) {
-              core.setFailed('Missing issue number input.');
-              return;
-            }
-            const agent = core.getInput('agent') || '';
-            const expectedPrRaw = core.getInput('expected_pr') || '';
-            const expectedPr = expectedPrRaw ? Number(expectedPrRaw) : 0;
-            const timeoutInput = core.getInput('timeout_minutes') || '7';
-            const timeoutMinutes = Number(timeoutInput) > 0 ? Number(timeoutInput) : 7;
-            const startInput = core.getInput('started_at') || '';
-            let startTime = startInput ? new Date(startInput) : new Date();
-            if (Number.isNaN(startTime.getTime())) {
-              startTime = new Date();
-            }
-            const startMs = startTime.getTime();
-            const pollMs = 30000;
-            const deadline = startMs + timeoutMinutes * 60000;
-            const threshold = startMs - 5000;
             const { owner, repo } = context.repo;
-
-            const findCrossReference = async () => {
-              const events = await github.paginate(
-                github.request,
-                {
-                  method: 'GET',
-                  url: '/repos/{owner}/{repo}/issues/{issue_number}/timeline',
-                  owner,
-                  repo,
-                  issue_number: issueNumber,
-                  per_page: 100,
-                  headers: { 'accept': 'application/vnd.github.mockingbird-preview+json' }
-                }
-              );
-              for (const event of events) {
-                if ((event.event || '') !== 'cross-referenced') {
-                  continue;
-                }
-                const sourceIssue = event.source?.issue;
-                if (!sourceIssue || !sourceIssue.pull_request) {
-                  continue;
-                }
-                const prNumber = Number(sourceIssue.number || 0);
-                if (!prNumber) {
-                  continue;
-                }
-                if (expectedPr && prNumber !== expectedPr) {
-                  continue;
-                }
-                const createdAt = new Date(event.created_at || '').getTime();
-                if (Number.isNaN(createdAt) || createdAt < threshold) {
-                  continue;
-                }
-                return {
-                  number: prNumber,
-                  url: sourceIssue.html_url || `https://github.com/${owner}/${repo}/pull/${prNumber}`,
-                  title: sourceIssue.title || '',
-                  createdAt
-                };
+            const { data: repoInfo } = await github.rest.repos.get({ owner, repo });
+            const ref = repoInfo.default_branch || 'main';
+            const inputs = context.payload?.inputs || {};
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: 'agents-41-assign-and-watch.yml',
+              ref,
+              inputs: {
+                mode: 'watch',
+                issue: (inputs.issue || '').toString(),
+                agent: (inputs.agent || '').toString(),
+                expected_pr: (inputs.expected_pr || '').toString(),
+                timeout_minutes: (inputs.timeout_minutes || '').toString(),
+                started_at: (inputs.started_at || '').toString(),
+                event_name: 'workflow_dispatch',
+                event_payload: JSON.stringify({ inputs })
               }
-              return null;
-            };
-
-            let found = null;
-            while (Date.now() < deadline) {
-              found = await findCrossReference();
-              if (found) {
-                break;
-              }
-              await new Promise(resolve => setTimeout(resolve, pollMs));
-            }
-
-            const elapsedMs = found ? Math.max(0, found.createdAt - startMs) : Math.max(0, Date.now() - startMs);
-            const elapsedMinutes = elapsedMs / 60000;
-            const friendlyElapsed = elapsedMinutes.toFixed(2);
-            const agentLabel = agent ? agent : 'agent';
-
-            core.setOutput('found', found ? 'true' : 'false');
-            core.setOutput('pr', found ? String(found.number) : '');
-            core.setOutput('elapsed_minutes', friendlyElapsed);
-
-            const summary = core.summary.addHeading('Agent Watchdog Result');
-            if (found) {
-              summary.addTable([
-                [{ data: 'Status', header: true }, { data: 'Details', header: true }],
-                ['✅ PR detected', `#${found.number} (${found.url}) in ${friendlyElapsed} minutes`]
-              ]);
-            } else {
-              summary.addTable([
-                [{ data: 'Status', header: true }, { data: 'Details', header: true }],
-                ['⚠️ Timeout', `No PR detected within ${timeoutMinutes} minute window`]
-              ]);
-            }
-            await summary.write();
-
-            const commentPrefix = found ? '✅ Agent Watchdog' : '⚠️ Agent Watchdog';
-            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: issueNumber, per_page: 100, page: 1 });
-            const alreadyCommented = (comments || []).some(c => (c.body || '').startsWith(commentPrefix));
-
-            if (found) {
-              const body = `${commentPrefix}: Detected PR #${found.number} referencing this issue after ${friendlyElapsed} minute${elapsedMinutes === 1 ? '' : 's'}.\n\nLink: ${found.url}`;
-              if (!alreadyCommented) {
-                await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
-              }
-            } else {
-              const body = `${commentPrefix}: No pull request cross-reference detected for **${agentLabel}** within `
-                + `${timeoutMinutes} minute${timeoutMinutes === 1 ? '' : 's'}.`;
-              if (!alreadyCommented) {
-                await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
-              }
-            }
+            });
+            core.info('Dispatched watch operation to agents-41-assign-and-watch.yml.');

--- a/.github/workflows/reusable-90-agents.yml
+++ b/.github/workflows/reusable-90-agents.yml
@@ -81,6 +81,13 @@ on:
     secrets:
       service_bot_pat:
         required: false
+    outputs:
+      readiness_report:
+        description: 'JSON report emitted by the readiness probe when enabled'
+        value: ${{ jobs.readiness.outputs.report_json }}
+      readiness_table:
+        description: 'Markdown table emitted by the readiness probe when enabled'
+        value: ${{ jobs.readiness.outputs.table_md }}
 
 permissions:
   contents: write
@@ -92,6 +99,9 @@ jobs:
     if: inputs.enable_readiness == 'true'
     name: Agent Readiness Probe
     runs-on: ubuntu-latest
+    outputs:
+      report_json: ${{ steps.try.outputs.report || '{}' }}
+      table_md: ${{ steps.try.outputs.table || '' }}
     permissions:
       contents: read
       issues: write

--- a/ARCHIVE_WORKFLOWS.md
+++ b/ARCHIVE_WORKFLOWS.md
@@ -7,22 +7,22 @@ All deprecated agent automation workflows were deleted from `.github/workflows/`
 
 | Legacy Workflow | Archived Copy | Replacement Path | Replacement Mode |
 |-----------------|---------------|------------------|------------------|
-| `agent-readiness.yml` | `archive/agent-readiness.yml` | `reuse-agents.yml` → `agents-41-assign.yml` | `enable_readiness=true` |
-| `agent-watchdog.yml` | `archive/agent-watchdog.yml` | `reuse-agents.yml` → `agents-42-watchdog.yml` | `enable_watchdog=true` |
+| `agent-readiness.yml` | `archive/agent-readiness.yml` | `reuse-agents.yml` → `agents-41-assign-and-watch.yml` | `enable_readiness=true` |
+| `agent-watchdog.yml` | `archive/agent-watchdog.yml` | `reuse-agents.yml` → `agents-41-assign-and-watch.yml` | `enable_watchdog=true` |
 | `codex-preflight.yml` | `archive/codex-preflight.yml` | `reuse-agents.yml` (legacy) | `enable_preflight=true` |
 | `codex-bootstrap-diagnostic.yml` | `archive/codex-bootstrap-diagnostic.yml` | `reuse-agents.yml` (legacy) | `enable_diagnostic=true` |
 | `verify-agent-task.yml` | `archive/verify-agent-task.yml` | `reuse-agents.yml` (legacy) | `enable_verify_issue=true` |
 
 ## Additional Archived Workflows
 - `guard-no-reuse-pr-branches.yml` – Archived in place (no functional replacement required; governance policy only). Removal candidate after 2025-10-20.
-- (2026-02-07) `codex-issue-bridge.yml`, `reuse-agents.yml`, and `agents-consumer.yml` moved to `Old/.github/workflows/` after assigner/watchdog consolidation. In 2026-09 the agent utilities were renumbered under WFv1: `agents-40-consumer.yml`, `agents-41-assign.yml`, `agents-42-watchdog.yml`, and `reusable-90-agents.yml` now live in `.github/workflows/`.
+- (2026-02-07) `codex-issue-bridge.yml`, `reuse-agents.yml`, and `agents-consumer.yml` moved to `Old/.github/workflows/` after assigner/watchdog consolidation. In 2026-09 the agent utilities were renumbered under WFv1: `agents-40-consumer.yml`, `agents-41-assign-and-watch.yml` (plus wrappers), and `reusable-90-agents.yml` now live in `.github/workflows/`.
 - (2026-09-30) Standalone `gate.yml` wrapper deleted (Issue #1657). Aggregation now lives exclusively in the `gate / all-required-green` job inside `pr-10-ci-python.yml`; no archived copy retained because the YAML was invalid.
 
 ## Retired Autofix Wrapper
 - Legacy `autofix.yml` (pre-2025) was deleted during the earlier cleanup. As of 2026-02-15 a new consolidated `autofix.yml` now drives both small fixes and trivial failure remediation; the former consumer wrappers have been removed.
 
 ## Rationale
-The 2025 cleanup centralized agent probe, diagnostic, and verification logic into `reuse-agents.yml`. In 2026 this was further simplified: `agents-41-assign.yml` handles label-driven assignment + Codex bootstrap while `agents-42-watchdog.yml` supplies the diagnostic signal, reducing optional flags and clarifying ownership.
+The 2025 cleanup centralized agent probe, diagnostic, and verification logic into `reuse-agents.yml`. In 2026 this was further simplified: `agents-41-assign-and-watch.yml` now owns assignment, bootstrap, watchdog, and stale sweep duties with thin wrappers preserved for backwards compatibility.
 
 ## Rollback Procedure
 If a regression is traced to consolidation:
@@ -39,7 +39,7 @@ If a regression is traced to consolidation:
 ## Verification Checklist
 - [x] Archive directory created: `.github/workflows/archive/`
 - [x] Stub headers inserted in original workflows marking ARCHIVED status
-- [x] Replacements confirmed operational (`agents-41-assign.yml` + `agents-42-watchdog.yml` present)
+- [x] Replacements confirmed operational (`agents-41-assign-and-watch.yml` present, wrappers maintained)
 
 ---
 Generated as part of workflow hygiene initiative.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains experiments and utilities for analyzing volatility-adju
 
 For a beginner-friendly overview, see [docs/UserGuide.md](docs/UserGuide.md).
 
-📦 **Reusable CI & Automation**: Standardise tests, autofix, and agent automation across repositories using the new reusable workflows documented in [docs/ci_reuse.md](docs/ci_reuse.md). Consumers call `reuse-ci-python.yml`, `reuse-autofix.yml`, plus the agent pair (`agents-41-assign.yml`, `agents-42-watchdog.yml`) via thin `uses:` wrappers.
+📦 **Reusable CI & Automation**: Standardise tests, autofix, and agent automation across repositories using the new reusable workflows documented in [docs/ci_reuse.md](docs/ci_reuse.md). Consumers call `reuse-ci-python.yml`, `reuse-autofix.yml`, and the unified agent orchestrator `agents-41-assign-and-watch.yml` (invoked via the lightweight wrappers `agents-41-assign.yml` / `agents-42-watchdog.yml`).
 
 🔁 **Layered Test Workflow (Phases 1–3)**: The staged metrics → history/classification → coverage delta reusable workflow implemented in this repository is documented in [docs/ci-workflow.md](docs/ci-workflow.md). All advanced phases are disabled by default for back‑compat.
 

--- a/WORKFLOW_AUDIT_TEMP.md
+++ b/WORKFLOW_AUDIT_TEMP.md
@@ -25,8 +25,9 @@ Additional categories added (5–8) to accommodate all workflows cleanly.
 - `maint-34-quarantine-ttl.yml` – Ensures test quarantine entries not expired.
 
 ### 2. Agent Initiation & Support
-- `agents-41-assign.yml` – Label-driven assignment, Codex bootstrap branch/PR creation, trigger comment.
-- `agents-42-watchdog.yml` – Short-horizon diagnostic that confirms a Codex PR cross-reference (or posts a timeout report).
+- `agents-41-assign-and-watch.yml` – Unified label-driven assignment, Codex bootstrap integration, cross-reference watchdog, and scheduled stale sweep.
+- `agents-41-assign.yml` – Thin wrapper that forwards issue label/unlabel events into the unified workflow.
+- `agents-42-watchdog.yml` – Wrapper that preserves the manual watchdog interface while delegating to the unified workflow.
 - `verify-codex-bootstrap-matrix.yml` – Scenario matrix harness for Codex bootstrap flows (validation / simulation). Potentially classed as debugging but retains agent-specific scope.
 - Legacy orchestrators (`codex-issue-bridge.yml`, `reuse-agents.yml`, plus older probes) now live under `Old/.github/workflows/` for reference after consolidation in Issue #1419.
 
@@ -65,13 +66,13 @@ Update: `cleanup-codex-bootstrap.yml` confirmed – prunes stale `agents/codex-i
 ## Deprecated / Superseded (Post-Removal Status)
 | Workflow | Replacement | Status | Notes |
 |----------|-------------|--------|-------|
-| agent-readiness.yml | reuse-agents.yml (enable_readiness) | REMOVED (2025-09-21) | Archived copy retained under `.github/workflows/archive/`; modern flow handled by `agents-41-assign.yml`. |
-| agent-watchdog.yml | reuse-agents.yml (enable_watchdog) | REMOVED (2025-09-21) | Watchdog functionality first moved into `reuse-agents.yml`, now superseded by `agents-42-watchdog.yml`. |
+| agent-readiness.yml | reuse-agents.yml (enable_readiness) | REMOVED (2025-09-21) | Archived copy retained under `.github/workflows/archive/`; modern flow handled by `agents-41-assign-and-watch.yml`. |
+| agent-watchdog.yml | reuse-agents.yml (enable_watchdog) | REMOVED (2025-09-21) | Watchdog functionality first moved into `reuse-agents.yml`, now superseded by `agents-41-assign-and-watch.yml` (manual access via wrapper). |
 | codex-preflight.yml | reuse-agents.yml (enable_preflight) | REMOVED (2025-09-21) | Archived copy retained for reference; preflight folded into assigner if reintroduced. |
 | codex-bootstrap-diagnostic.yml | reuse-agents.yml (enable_diagnostic) | REMOVED (2025-09-21) | Archived copy retained for reference; diagnostics covered by assigner/watchdog pair. |
 | verify-agent-task.yml | reuse-agents.yml (enable_verify_issue) | REMOVED (2025-09-21) | Archived copy retained for reference; latest verification runs via watchdog comment. |
-| codex-issue-bridge.yml | agents-41-assign.yml | ARCHIVED (2026-02-07) | Moved to `Old/.github/workflows/` after Issue #1419 consolidation. |
-| reuse-agents.yml | agents-41-assign.yml + agents-42-watchdog.yml | ARCHIVED (2026-02-07) | Archived in `Old/.github/workflows/`; parameter matrix deprecated. |
+| codex-issue-bridge.yml | agents-41-assign-and-watch.yml | ARCHIVED (2026-02-07) | Moved to `Old/.github/workflows/` after Issue #1419 consolidation. |
+| reuse-agents.yml | agents-41-assign-and-watch.yml | ARCHIVED (2026-02-07) | Archived in `Old/.github/workflows/`; parameter matrix deprecated. |
 | guard-no-reuse-pr-branches.yml | Policy (no automation) | ARCHIVED | In-place archived with no-op job. |
 | autofix-consumer.yml | `autofix.yml` | REMOVED (2026-02-15) | Small-fix lane now runs inside consolidated follower workflow. |
 | autofix-on-failure.yml | `autofix.yml` | REMOVED (2026-02-15) | Failure remediation merged into consolidated follower workflow. |
@@ -83,7 +84,7 @@ Update: `cleanup-codex-bootstrap.yml` confirmed – prunes stale `agents/codex-i
 - `verify-ci-stack.yml` does not run tests; observational. Keep distinct (diagnostic harness) but could merge into a generalized "ops diagnostics" workflow.
 
 ### Agent Workflows
-- Legacy probes previously converged on `reuse-agents.yml`; latest consolidation replaces that matrix with the focused pair `agents-41-assign.yml` + `agents-42-watchdog.yml`.
+- Legacy probes previously converged on `reuse-agents.yml`; latest consolidation routes all assignment, watchdog, and stale-sweep logic through `agents-41-assign-and-watch.yml` with wrappers maintained for compatibility.
 - Archived `codex-issue-bridge.yml` and `reuse-agents.yml` remain in `Old/.github/workflows/` for reference but should not receive new consumers.
 
 ### Autofix
@@ -97,7 +98,7 @@ Update: `cleanup-codex-bootstrap.yml` confirmed – prunes stale `agents/codex-i
 1. (DONE) Archive deprecated agent workflows (6 listed) with historical copies retained under `.github/workflows/archive/`.
 2. (DONE) Remove `autofix.yml` now that the stabilization window following PR #1257 has closed.
 3. Evaluate merging `verify-ci-stack.yml` and adding a diagnostics job into `pr-10-ci-python.yml` guarded by a manual `workflow_dispatch` input (optional enhancement).
-4. Long-term: monitor `agents-41-assign.yml` / `agents-42-watchdog.yml` telemetry; expand with optional readiness probes only if required (no plan to resurrect `reuse-agents.yml`).
+4. Long-term: monitor `agents-41-assign-and-watch.yml` telemetry; expand with optional readiness probes only if required (no plan to resurrect `reuse-agents.yml`).
 5. Refactor `autofix-on-failure.yml` to call `reuse-autofix.yml` for single source of truth (pass through head ref context). Not urgent.
 
 ## Archival Impact Analysis

--- a/WORKFLOW_GUIDE.md
+++ b/WORKFLOW_GUIDE.md
@@ -11,7 +11,7 @@ GitHub’s UI and in git diffs.
 |--------|-------|------------------|----------|
 | `pr-1x-*` | Pull request checks and fast feedback | `pull_request`, `push` to default branches | `pr-10-ci-python.yml`, `pr-12-docker-smoke.yml` |
 | `maint-3x-*` | Repository maintenance, hygiene, and reporting | `schedule`, `workflow_run`, governance automations | `maint-30-post-ci-summary.yml`, `maint-33-check-failure-tracker.yml`, `maint-35-repo-health-self-check.yml`, `maint-40-ci-signature-guard.yml` |
-| `agents-4x-*` | Issue and agent orchestration workflows | `issues`, `pull_request_target`, manual diagnostics | `agents-40-consumer.yml`, `agents-41-assign.yml`, `agents-42-watchdog.yml` |
+| `agents-4x-*` | Issue and agent orchestration workflows | `issues`, `pull_request_target`, manual diagnostics | `agents-40-consumer.yml`, `agents-41-assign-and-watch.yml` (+ wrappers `agents-41-assign.yml` / `agents-42-watchdog.yml`) |
 | `reusable-9x-*` | Reusable building blocks invoked via `workflow_call` | `workflow_call`, `workflow_dispatch` | `reusable-90-agents.yml`, `reusable-ci-python.yml`, `reusable-99-selftest.yml` |
 
 > **Numbering tips**

--- a/docs/agent_codex_troubleshooting.md
+++ b/docs/agent_codex_troubleshooting.md
@@ -121,7 +121,7 @@ Failures after preflight indicate persistent issues (permissions, logic) rather 
 
 ## Future Hardening Ideas
 
-- Use `agents-41-assign.yml` (manual `workflow_dispatch`) to replay bootstrap or run a targeted GitHub Script to assert branch + marker invariants.
+- Use `agents-41-assign-and-watch.yml` (manual `workflow_dispatch`, or trigger via the `agents-41-assign.yml` wrapper) to replay bootstrap or run a targeted GitHub Script to assert branch + marker invariants.
 - Emit a machine-readable JSON summary comment (reaction toggles rerun).
 - Add metrics export (counts of reused vs new bootstraps) to an org dashboard.
 

--- a/docs/ci_reuse_consolidation_plan.md
+++ b/docs/ci_reuse_consolidation_plan.md
@@ -8,7 +8,7 @@ The `.github/workflows` directory contains both new reusable workflows and sever
 | -------------------- | -------------------- | ----------------- |
 | `autofix.yml` | `reuse-autofix.yml` + `autofix-consumer.yml` | Eliminated duplication; stabilization period complete post PR #1257. |
 | `agent-readiness.yml` | _(archived)_ | No direct replacement; run ad-hoc GitHub Script checks when needed. |
-| `agents-42-watchdog.yml` | `agents-42-watchdog.yml` | Standalone watchdog workflow introduced with Issue #1419. |
+| `agents-42-watchdog.yml` | `agents-41-assign-and-watch.yml` | Manual watchdog wrapper retained; core logic migrated to unified workflow. |
 | `codex-preflight.yml` | _(archived)_ | Manual diagnostics or future targeted scripts as needed. |
 | `codex-bootstrap-diagnostic.yml` | _(archived)_ | Superseded by agents-41 assign + agents-42 watchdog pairing. |
 | `verify-agent-task.yml` | _(archived)_ | Use issue audit scripts or custom GitHub Script snippets.
@@ -23,7 +23,7 @@ The `.github/workflows` directory contains both new reusable workflows and sever
 Release, docker, auto-merge enablement, PR status summary, quarantine TTL, failure trackers remain orthogonal to the three reusable workflows.
 
 ## Consolidation Actions Executed
-All previously flagged legacy workflows were deleted in alignment with Issue #1259. Consumers now invoke the reusable equivalents (`reuse-autofix.yml`) alongside the new agent pair (`agents-41-assign.yml`, `agents-42-watchdog.yml`). This concludes the stabilization window referenced in PR #1257.
+All previously flagged legacy workflows were deleted in alignment with Issue #1259. Consumers now invoke the reusable equivalents (`reuse-autofix.yml`) alongside the unified agent orchestrator (`agents-41-assign-and-watch.yml`, surfaced through the thin wrappers). This concludes the stabilization window referenced in PR #1257.
 
 ## Deletion Timetable (Superseded)
 Original timetable replaced by immediate removal once validation completed. Retained here for historical context only.

--- a/docs/ops/codex-bootstrap-facts.md
+++ b/docs/ops/codex-bootstrap-facts.md
@@ -95,7 +95,7 @@ This catalog explains what each active workflow does, how it’s triggered, the 
   - Links to: Unified orchestrator (above)
 
 <a id="wf-label-agent-prs"></a>
-3) [`label-agent-prs.yml`](../../.github/workflows/label-agent-prs.yml) — Apply agent labels to PRs (keeps downstream automation deterministic)
+4) [`label-agent-prs.yml`](../../.github/workflows/label-agent-prs.yml) — Apply agent labels to PRs (keeps downstream automation deterministic)
    - Triggers: `pull_request_target: [opened, synchronize, reopened]`
    - Jobs: `label`
      - Computes desired labels based on actor/head-ref; adds `from:codex|copilot`, `agent:codex|copilot`, `automerge`, `risk:low`


### PR DESCRIPTION
## Summary
- add `agents-41-assign-and-watch.yml` to orchestrate label-triggered assignments, manual watchdog checks, and the scheduled stale sweep while reusing readiness probes
- convert `agents-41-assign.yml` and `agents-42-watchdog.yml` into thin dispatch wrappers and expose readiness outputs from `reusable-90-agents.yml`
- update automation docs and tests to describe the unified workflow and wrappers

## Testing
- pytest tests/test_workflow_agents_consolidation.py

------
https://chatgpt.com/codex/tasks/task_e_68df1d17b3c08331ad3e6b609c7fa802