### PR TITLE
Ensure signal frame indices remain aligned

### DIFF
--- a/tests/test_signals_engine.py
+++ b/tests/test_signals_engine.py
@@ -76,6 +76,7 @@ def test_signal_frame_columns_are_consistent(sample_prices: pd.DataFrame) -> Non
 
     for frame in frames:
         assert isinstance(frame, pd.DataFrame)
+        assert frame.index.equals(sample_prices.index)
         assert frame.columns.names == ["stage", "asset"]
         assert tuple(frame.columns.get_level_values(0).unique()) == SignalFrame._STAGES
 


### PR DESCRIPTION
## Summary
- add coverage to the signal engine tests to confirm every generated SignalFrame retains the source price index across configuration toggles

## Testing
- pytest tests/test_signals_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68df1f8339088331ad8ff51130df8708