### PR TITLE
Docker: keep as a fast smoke with lint and deterministic caching - Source Issue #1663

### DIFF
--- a/.github/workflows/pr-12-docker-smoke.yml
+++ b/.github/workflows/pr-12-docker-smoke.yml
@@ -51,6 +51,9 @@ jobs:
       IMAGE_NAME: ${{ vars.IMAGE_NAME || format('{0}/{1}', github.repository_owner, 'trend-model') }}
       HEALTH_PORT: ${{ vars.HEALTH_PORT || '8000' }}
       HEALTH_PATH: ${{ vars.HEALTH_PATH || '/health' }}
+      BUILD_CACHE_PATH: /tmp/.buildx-cache
+      BUILD_CACHE_TEMP: /tmp/.buildx-cache-new
+      BUILD_CACHE_KEY: docker-smoke-buildx-${{ hashFiles('requirements.lock') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -67,20 +70,22 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Ensure buildx cache directory exists
-        run: mkdir -p /tmp/.buildx-cache
+        run: |
+          mkdir -p "${BUILD_CACHE_PATH}"
+          rm -rf "${BUILD_CACHE_TEMP}"
 
       - name: Restore buildx cache
         # Deterministic cache keyed solely by the lock file to keep smoke builds reproducible.
         id: restore-buildx-cache
         uses: actions/cache/restore@v4
         with:
-          path: /tmp/.buildx-cache
-          key: docker-smoke-buildx-${{ hashFiles('requirements.lock') }}
+          path: ${{ env.BUILD_CACHE_PATH }}
+          key: ${{ env.BUILD_CACHE_KEY }}
 
       - name: Summarize buildx cache
         env:
           CACHE_HIT: ${{ steps.restore-buildx-cache.outputs.cache-hit }}
-          CACHE_KEY: docker-smoke-buildx-${{ hashFiles('requirements.lock') }}
+          CACHE_KEY: ${{ env.BUILD_CACHE_KEY }}
         run: |
           if [ "$CACHE_HIT" = "true" ]; then
             echo "::notice title=BuildxCache::Cache hit for ${CACHE_KEY}"
@@ -99,21 +104,21 @@ jobs:
       - name: Build image (cached)
         run: |
           docker buildx build --pull --load \
-            --cache-from type=local,src=/tmp/.buildx-cache \
-            --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --cache-from type=local,src=${{ env.BUILD_CACHE_PATH }} \
+            --cache-to type=local,dest=${{ env.BUILD_CACHE_TEMP }},mode=max \
             -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest .
 
       - name: Finalize cache
         run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          rm -rf "${BUILD_CACHE_PATH}"
+          mv "${BUILD_CACHE_TEMP}" "${BUILD_CACHE_PATH}"
 
       - name: Save buildx cache
         if: github.event_name != 'pull_request' && steps.restore-buildx-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: /tmp/.buildx-cache
-          key: docker-smoke-buildx-${{ hashFiles('requirements.lock') }}
+          path: ${{ env.BUILD_CACHE_PATH }}
+          key: ${{ env.BUILD_CACHE_KEY }}
       - name: Run test suite (reuses cached image)
         env:
           WF_CALL_DEBUG: ${{ inputs.debug_build && 'true' || '' }}

--- a/.github/workflows/pr-12-docker-smoke.yml
+++ b/.github/workflows/pr-12-docker-smoke.yml
@@ -1,3 +1,4 @@
+# Docker smoke workflow (Issue #1663) – keep lint + smoke lean while using deterministic caching
 name: Docker
 
 on:
@@ -64,19 +65,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Ensure buildx cache directory exists
+        run: mkdir -p /tmp/.buildx-cache
+
       - name: Restore buildx cache
-        id: buildx-cache
-        uses: actions/cache@v4
+        # Deterministic cache keyed solely by the lock file to keep smoke builds reproducible.
+        id: restore-buildx-cache
+        uses: actions/cache/restore@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ format('buildx-{0}-{1}', runner.os, hashFiles('Dockerfile', 'requirements.lock')) }}
-          restore-keys: |
-            ${{ format('buildx-{0}-', runner.os) }}
+          key: docker-smoke-buildx-${{ hashFiles('requirements.lock') }}
 
       - name: Summarize buildx cache
         env:
-          CACHE_HIT: ${{ steps.buildx-cache.outputs.cache-hit }}
-          CACHE_KEY: ${{ format('buildx-{0}-{1}', runner.os, hashFiles('Dockerfile', 'requirements.lock')) }}
+          CACHE_HIT: ${{ steps.restore-buildx-cache.outputs.cache-hit }}
+          CACHE_KEY: docker-smoke-buildx-${{ hashFiles('requirements.lock') }}
         run: |
           if [ "$CACHE_HIT" = "true" ]; then
             echo "::notice title=BuildxCache::Cache hit for ${CACHE_KEY}"
@@ -105,11 +108,11 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Save buildx cache
-        if: steps.buildx-cache.outputs.cache-hit != 'true'
+        if: steps.restore-buildx-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ format('buildx-{0}-{1}', runner.os, hashFiles('Dockerfile', 'requirements.lock')) }}
+          key: docker-smoke-buildx-${{ hashFiles('requirements.lock') }}
       - name: Run test suite
         env:
           WF_CALL_DEBUG: ${{ inputs.debug_build && 'true' || '' }}
@@ -152,5 +155,6 @@ jobs:
             exit 1
           fi
       - name: Push image
+        # Only publish from the protected main development branch per Issue #1663.
         if: github.event_name == 'push' && github.ref == 'refs/heads/phase-2-dev'
         run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/pr-12-docker-smoke.yml
+++ b/.github/workflows/pr-12-docker-smoke.yml
@@ -109,7 +109,7 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Save buildx cache
-        if: steps.restore-buildx-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && steps.restore-buildx-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: /tmp/.buildx-cache
@@ -119,6 +119,7 @@ jobs:
           WF_CALL_DEBUG: ${{ inputs.debug_build && 'true' || '' }}
           DISPATCH_DEBUG: ${{ github.event.inputs.debug_build || '' }}
         run: |
+          # Pytest executes inside the freshly built container to mirror production smoke coverage.
           debug_flag="${WF_CALL_DEBUG:-${DISPATCH_DEBUG:-false}}"
           if [ "$debug_flag" = "true" ]; then
             echo "Running tests with verbose output for debugging..."
@@ -129,6 +130,7 @@ jobs:
           fi
       - name: Smoke test health endpoint
         run: |
+          # Launch the image and poll its health endpoint to validate runtime readiness.
           echo " Testing health endpoint with retry logic..."
           CONTAINER_ID=$(docker run -d -p ${{ env.HEALTH_PORT }}:${{ env.HEALTH_PORT }} ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest)
           echo "Started container: $CONTAINER_ID"

--- a/.github/workflows/pr-12-docker-smoke.yml
+++ b/.github/workflows/pr-12-docker-smoke.yml
@@ -57,6 +57,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Log in to container registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/phase-2-dev'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -86,7 +87,7 @@ jobs:
             SUMMARY=" Cache hit for \`${CACHE_KEY}\`"
           else
             echo "::notice title=BuildxCache::Cache miss for ${CACHE_KEY}"
-            SUMMARY=" Cache miss  priming \`${CACHE_KEY}\`"
+            SUMMARY=" Cache miss priming \`${CACHE_KEY}\`"
           fi
 
           {
@@ -113,7 +114,7 @@ jobs:
         with:
           path: /tmp/.buildx-cache
           key: docker-smoke-buildx-${{ hashFiles('requirements.lock') }}
-      - name: Run test suite
+      - name: Run test suite (reuses cached image)
         env:
           WF_CALL_DEBUG: ${{ inputs.debug_build && 'true' || '' }}
           DISPATCH_DEBUG: ${{ github.event.inputs.debug_build || '' }}

--- a/agents/codex-1663.md
+++ b/agents/codex-1663.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1663 -->

--- a/agents/codex-1663.md
+++ b/agents/codex-1663.md
@@ -1,1 +1,14 @@
-<!-- bootstrap for codex on issue #1663 -->
+# Issue 1663 – Docker smoke workflow upkeep
+
+## Verification checklist
+
+- [x] Workflow still identified as **Docker** and keeps existing triggers for push, pull_request, workflow_call, and dispatch events.
+- [x] Lint job runs `hadolint` only, ensuring the Dockerfile check remains lean.
+- [x] Buildx cache restored and saved with the deterministic `requirements.lock` hash key, with cache paths centralised under `/tmp/.buildx-cache`.
+- [x] Docker image built once via Buildx and reused for pytest and health validation runs.
+- [x] Smoke tests execute `pytest -q` (or verbose mode when debugging) inside the freshly built container image.
+- [x] Health endpoint probed after tests to guarantee the container starts cleanly.
+- [x] Registry login and image push steps gated so they only execute on `phase-2-dev` pushes, skipping PRs and other refs.
+- [x] Step names, cache keys, and inline comments reflect repository conventions to keep maintenance straightforward.
+
+These checks confirm the workflow satisfies the acceptance criteria while remaining aligned with repository expectations for deterministic caching and smoke coverage.


### PR DESCRIPTION
### Source Issue #1663: Docker: keep as a fast smoke with lint and deterministic caching

Source: https://github.com/stranske/Trend_Model_Project/issues/1663

> Topic GUID: 7fb3cd13-a138-58b2-b195-f71c22310334
> 
> ## Why
> Depends on: Issue 0
> Summary
> Keep pr-12-docker-smoke.yml lean: hadolint, buildx with a lock‑file keyed cache, run pytest -q, hit the health endpoint, push only on the protected branch. This already exists; just keep it aligned with naming and artifact conventions. 
> GitHub
> 
> ## Tasks
> _Not provided._
> 
> ## Acceptance criteria
> Workflow name remains “Docker.”
> 
> Lint, build, smoke test steps pass on PRs; push gated to the main dev branch.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18086613665).

—
(After opening the PR, comment with `@codex start`.)