### PR TITLE
Add honest backtesting harness with calendar, window modes, and costs

### DIFF
--- a/docs/backtesting_harness.md
+++ b/docs/backtesting_harness.md
@@ -1,0 +1,25 @@
+# Honest Backtesting Harness
+
+The honest backtesting harness introduced for Issue #1681 adds a reusable
+`run_backtest` function under `trend_analysis.backtesting`.  The helper couples
+walk-forward portfolio evaluation with:
+
+* **Fixed rebalance calendars** – pass any pandas frequency string (e.g. `"M"`
+  or `"W"`) and the harness will only adjust weights on the corresponding
+  calendar boundaries.
+* **Rolling *and* expanding windows** – switch between the two behaviours with
+  the `window_mode` flag without changing your strategy code.
+* **Basis-point transaction costs** – supply `transaction_cost_bps` to apply
+  fees on the absolute change in target weights at each rebalance.
+* **Rich performance analytics** – the returned `BacktestResult` exposes the
+  equity curve, turnover, transaction-cost ledger, rolling Sharpe ratios, and
+  drawdown time series alongside summary statistics (CAGR, volatility, Sortino,
+  Calmar, max drawdown, Sharpe).
+
+Downstream integrations can serialise the result via
+`BacktestResult.to_json()`, which emits a JSON payload containing the summary
+metrics, rolling Sharpe series, drawdown path, and rebalance calendar so that UI
+layers can present the walk-forward evaluation without bespoke post-processing.
+
+See `tests/backtesting/test_harness.py` for end-to-end usage examples covering
+window switching and transaction-cost verification.

--- a/src/trend_analysis/__init__.py
+++ b/src/trend_analysis/__init__.py
@@ -17,6 +17,7 @@ _EAGER_SUBMODULES = [
     "pipeline",
     "export",
     "signals",
+    "backtesting",
 ]
 
 # Modules that may drag optional / heavy deps; imported on first attribute access.
@@ -95,6 +96,7 @@ __all__ = [
     "config",
     "data",
     "pipeline",
+    "backtesting",
     "api",
     "export",
     "signals",

--- a/src/trend_analysis/backtesting/__init__.py
+++ b/src/trend_analysis/backtesting/__init__.py
@@ -1,0 +1,5 @@
+"""Backtesting utilities for walk-forward portfolio evaluation."""
+
+from .harness import BacktestResult, run_backtest
+
+__all__ = ["BacktestResult", "run_backtest"]

--- a/src/trend_analysis/backtesting/harness.py
+++ b/src/trend_analysis/backtesting/harness.py
@@ -1,0 +1,340 @@
+"""Backtesting harness with walk-forward support and transaction costs."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Callable, Dict, Literal, Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+from pandas.tseries.frequencies import to_offset
+
+WindowMode = Literal["rolling", "expanding"]
+
+
+@dataclass
+class BacktestResult:
+    """Container for backtest artefacts and computed performance statistics."""
+
+    returns: pd.Series
+    equity_curve: pd.Series
+    weights: pd.DataFrame
+    turnover: pd.Series
+    transaction_costs: pd.Series
+    rolling_sharpe: pd.Series
+    drawdown: pd.Series
+    metrics: Dict[str, float]
+    calendar: pd.DatetimeIndex
+    window_mode: WindowMode
+    window_size: int
+    training_windows: Mapping[pd.Timestamp, tuple[pd.Timestamp, pd.Timestamp]]
+
+    def summary(self) -> Dict[str, object]:
+        """Return a JSON-serialisable summary of the backtest metrics."""
+
+        return {
+            "window_mode": self.window_mode,
+            "window_size": self.window_size,
+            "calendar": [ts.isoformat() for ts in self.calendar],
+            "metrics": {k: _to_float(v) for k, v in self.metrics.items()},
+            "rolling_sharpe": _series_to_dict(self.rolling_sharpe),
+            "drawdown": _series_to_dict(self.drawdown),
+            "equity_curve": _series_to_dict(self.equity_curve),
+        }
+
+    def to_json(self, **dumps_kwargs: object) -> str:
+        """Serialise :meth:`summary` to JSON for downstream consumers."""
+
+        return json.dumps(self.summary(), default=_json_default, **dumps_kwargs)
+
+
+def run_backtest(
+    returns: pd.DataFrame,
+    strategy: Callable[[pd.DataFrame], pd.Series | Mapping[str, float]],
+    *,
+    rebalance_freq: str,
+    window_size: int,
+    window_mode: WindowMode = "rolling",
+    transaction_cost_bps: float = 0.0,
+    rolling_sharpe_window: int | None = None,
+    initial_weights: Mapping[str, float] | None = None,
+) -> BacktestResult:
+    """Run a walk-forward backtest with a fixed rebalance calendar."""
+
+    if window_size <= 0:
+        raise ValueError("window_size must be a positive integer")
+    if window_mode not in {"rolling", "expanding"}:
+        raise ValueError("window_mode must be 'rolling' or 'expanding'")
+    if transaction_cost_bps < 0:
+        raise ValueError("transaction_cost_bps must be non-negative")
+
+    data = _prepare_returns(returns)
+    if data.empty:
+        raise ValueError("returns must contain at least one row")
+
+    calendar = _rebalance_calendar(data.index, rebalance_freq)
+    if not len(calendar):
+        raise ValueError("rebalance calendar produced no dates – check frequency")
+
+    periods_per_year = _infer_periods_per_year(data.index)
+    roll_window = rolling_sharpe_window or min(window_size, max(1, periods_per_year // 3))
+
+    asset_columns = list(data.columns)
+    portfolio_returns = pd.Series(index=data.index, dtype=float)
+    weights_history: Dict[pd.Timestamp, pd.Series] = {}
+    turnover = pd.Series(dtype=float)
+    tx_costs = pd.Series(dtype=float)
+    training_windows: Dict[pd.Timestamp, tuple[pd.Timestamp, pd.Timestamp]] = {}
+
+    prev_weights = _initial_weights(asset_columns, initial_weights)
+    data_values = data.values
+
+    eligible_dates = [
+        date
+        for date in calendar
+        if len(data.loc[:date]) >= window_size
+    ]
+    if not eligible_dates:
+        raise ValueError("window_size too large – no eligible rebalance dates")
+
+    for i, date in enumerate(eligible_dates):
+        history = data.loc[:date]
+        if window_mode == "rolling":
+            train_window = history.tail(window_size)
+        else:
+            train_window = history
+        training_windows[date] = (train_window.index[0], train_window.index[-1])
+
+        raw_weights = strategy(train_window)
+        new_weights = _normalise_weights(raw_weights, asset_columns)
+
+        delta = (new_weights - prev_weights).abs().sum()
+        cost = (transaction_cost_bps / 10000.0) * delta
+
+        weights_history[date] = new_weights
+        turnover.loc[date] = float(delta)
+        tx_costs.loc[date] = float(cost)
+
+        prev_weights = new_weights
+
+        start_idx = data.index.get_loc(date)
+        if isinstance(start_idx, slice):
+            start_idx = start_idx.stop - 1
+        next_date = eligible_dates[i + 1] if i + 1 < len(eligible_dates) else None
+        if next_date is not None:
+            end_idx = data.index.get_loc(next_date)
+            if isinstance(end_idx, slice):
+                end_idx = end_idx.start
+            stop = end_idx + 1
+        else:
+            stop = len(data.index)
+
+        apply_slice = slice(start_idx + 1, stop)
+        if apply_slice.start >= len(data.index) or apply_slice.start >= apply_slice.stop:
+            continue
+
+        pending_cost = float(cost)
+        for idx in range(apply_slice.start, apply_slice.stop):
+            ret = float(np.dot(data_values[idx], prev_weights.values))
+            if pending_cost:
+                ret -= pending_cost
+                pending_cost = 0.0
+            portfolio_returns.iloc[idx] = ret
+
+    active_mask = portfolio_returns.notna()
+    filled_returns = portfolio_returns.fillna(0.0)
+    equity_curve = (1.0 + filled_returns).cumprod()
+    drawdown = _compute_drawdown(equity_curve)
+    rolling_input = portfolio_returns.where(active_mask)
+    rolling_sharpe = _rolling_sharpe(rolling_input, periods_per_year, roll_window)
+
+    metrics = _compute_metrics(
+        filled_returns,
+        equity_curve,
+        drawdown,
+        periods_per_year,
+        active_mask,
+    )
+
+    weights_df = (
+        pd.DataFrame(weights_history).T.reindex(columns=asset_columns).fillna(0.0)
+        if weights_history
+        else pd.DataFrame(columns=asset_columns, dtype=float)
+    )
+
+    return BacktestResult(
+        returns=portfolio_returns,
+        equity_curve=equity_curve,
+        weights=weights_df,
+        turnover=turnover.sort_index(),
+        transaction_costs=tx_costs.sort_index(),
+        rolling_sharpe=rolling_sharpe,
+        drawdown=drawdown,
+        metrics=metrics,
+        calendar=pd.DatetimeIndex(eligible_dates),
+        window_mode=window_mode,
+        window_size=window_size,
+        training_windows=training_windows,
+    )
+
+
+def _prepare_returns(df: pd.DataFrame) -> pd.DataFrame:
+    if "Date" in df.columns:
+        df = df.set_index("Date")
+    if not isinstance(df.index, pd.DatetimeIndex):
+        raise ValueError("returns index must be a DatetimeIndex or include a 'Date' column")
+    df = df.sort_index()
+    numeric_df = df.select_dtypes(include=["number"]).astype(float)
+    if numeric_df.empty:
+        raise ValueError("returns must contain numeric columns")
+    return numeric_df
+
+
+def _rebalance_calendar(index: pd.DatetimeIndex, freq: str) -> pd.DatetimeIndex:
+    offset = to_offset(_normalise_frequency(freq))
+    resampled = index.to_series().resample(offset).last().dropna()
+    calendar = pd.DatetimeIndex(resampled, name="rebalance_date")
+    return calendar.intersection(index)
+
+
+def _normalise_frequency(freq: str) -> str:
+    freq_clean = freq.strip()
+    freq_upper = freq_clean.upper()
+    replacements = {"M": "ME", "Q": "QE", "A": "YE", "Y": "YE"}
+    for suffix, replacement in replacements.items():
+        if freq_upper.endswith(replacement):
+            return freq_clean
+        if freq_upper.endswith(suffix):
+            prefix = freq_upper[: -len(suffix)]
+            if prefix and not prefix.isdigit():
+                continue
+            return prefix + replacement
+    return freq_clean
+
+
+def _infer_periods_per_year(index: pd.DatetimeIndex) -> int:
+    if len(index) < 2:
+        return 1
+    diffs = np.diff(index.values.astype("datetime64[ns]").astype(np.int64))
+    if len(diffs) == 0:
+        return 1
+    median_ns = np.median(diffs)
+    if median_ns <= 0:
+        return 1
+    median_days = median_ns / (24 * 60 * 60 * 1e9)
+    approx = int(round(365 / median_days)) if median_days else 1
+    if approx >= 300:
+        return 252
+    if 45 <= approx <= 60:
+        return 52
+    if 10 <= approx <= 14:
+        return 12
+    if 3 <= approx <= 5:
+        return 4
+    return max(1, approx)
+
+
+def _initial_weights(columns: Sequence[str], initial: Mapping[str, float] | None) -> pd.Series:
+    base = pd.Series(0.0, index=columns, dtype=float)
+    if initial is None:
+        return base
+    init = pd.Series(initial, dtype=float)
+    return base.add(init, fill_value=0.0)
+
+
+def _normalise_weights(
+    weights: pd.Series | Mapping[str, float],
+    columns: Sequence[str],
+) -> pd.Series:
+    if isinstance(weights, pd.Series):
+        series = weights.astype(float)
+    else:
+        series = pd.Series(dict(weights), dtype=float)
+    series = series.reindex(columns, fill_value=0.0)
+    return series
+
+
+def _compute_drawdown(equity_curve: pd.Series) -> pd.Series:
+    running_max = equity_curve.cummax()
+    drawdown = equity_curve / running_max - 1.0
+    return drawdown
+
+
+def _rolling_sharpe(returns: pd.Series, periods_per_year: int, window: int) -> pd.Series:
+    if window <= 1:
+        window = 2
+    rolling_mean = returns.rolling(window=window).mean()
+    rolling_std = returns.rolling(window=window).std(ddof=0)
+    sharpe = rolling_mean / rolling_std
+    sharpe *= np.sqrt(periods_per_year)
+    return sharpe.replace([np.inf, -np.inf], np.nan)
+
+
+def _compute_metrics(
+    returns: pd.Series,
+    equity_curve: pd.Series,
+    drawdown: pd.Series,
+    periods_per_year: int,
+    active_mask: pd.Series,
+) -> Dict[str, float]:
+    active_returns = returns.where(active_mask).dropna()
+    if active_returns.empty:
+        active_returns = returns.iloc[0:0]
+
+    total_periods = len(active_returns)
+    cumulative_return = float(equity_curve.iloc[-1]) if len(equity_curve) else 1.0
+    years = total_periods / periods_per_year if periods_per_year else 0.0
+
+    if years > 0 and cumulative_return > 0:
+        cagr = cumulative_return ** (1.0 / years) - 1.0
+    else:
+        cagr = float("nan")
+
+    vol = active_returns.std(ddof=0) * np.sqrt(periods_per_year)
+    downside = active_returns[active_returns < 0]
+    downside_std = downside.std(ddof=0) * np.sqrt(periods_per_year)
+    sharpe = (
+        active_returns.mean() / active_returns.std(ddof=0) * np.sqrt(periods_per_year)
+        if active_returns.std(ddof=0)
+        else float("nan")
+    )
+    sortino = (
+        active_returns.mean() / downside_std
+        if downside_std
+        else float("nan")
+    )
+    max_drawdown = float(drawdown.min()) if len(drawdown) else float("nan")
+    calmar = cagr / abs(max_drawdown) if max_drawdown and not np.isnan(cagr) else float("nan")
+
+    return {
+        "cagr": _to_float(cagr),
+        "volatility": _to_float(vol),
+        "sortino": _to_float(sortino),
+        "calmar": _to_float(calmar),
+        "max_drawdown": _to_float(max_drawdown),
+        "final_value": _to_float(cumulative_return),
+        "sharpe": _to_float(sharpe),
+    }
+
+
+def _series_to_dict(series: pd.Series) -> Dict[str, float]:
+    if series.empty:
+        return {}
+    cleaned = series.dropna()
+    return {idx.isoformat(): _to_float(val) for idx, val in cleaned.items()}
+
+
+def _json_default(obj: object) -> object:
+    if isinstance(obj, (pd.Timestamp, pd.Timedelta)):
+        return obj.isoformat()
+    if isinstance(obj, (np.floating, np.integer)):
+        return float(obj)
+    raise TypeError(f"Object of type {type(obj)!r} is not JSON serialisable")
+
+
+def _to_float(value: float | np.floating | np.integer) -> float:
+    return float(value) if value is not None and not pd.isna(value) else float("nan")
+
+
+__all__ = ["BacktestResult", "run_backtest"]

--- a/tests/backtesting/test_harness.py
+++ b/tests/backtesting/test_harness.py
@@ -1,0 +1,109 @@
+"""Tests for the backtesting harness."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pandas as pd
+
+from trend_analysis.backtesting import run_backtest
+
+
+class MeanWinnerStrategy:
+    """Allocate all weight to the asset with the highest trailing mean return."""
+
+    def __call__(self, window: pd.DataFrame) -> pd.Series:
+        means = window.mean()
+        winner = means.idxmax()
+        weights = pd.Series(0.0, index=window.columns)
+        weights[winner] = 1.0
+        return weights
+
+
+class AlternatingStrategy:
+    """Alternate between two assets to force turnover for testing costs."""
+
+    def __init__(self) -> None:
+        self.toggle = False
+
+    def __call__(self, window: pd.DataFrame) -> pd.Series:
+        weights = pd.Series(0.0, index=window.columns)
+        if self.toggle:
+            weights.iloc[1] = 1.0
+        else:
+            weights.iloc[0] = 1.0
+        self.toggle = not self.toggle
+        return weights
+
+
+def _synthetic_returns(start: str, periods: int, freq: str = "B") -> pd.DataFrame:
+    index = pd.date_range(start=start, periods=periods, freq=freq)
+    half = periods // 2
+    a_returns = np.concatenate([
+        np.full(half, 0.001),
+        np.full(periods - half, 0.01),
+    ])
+    b_returns = np.concatenate([
+        np.full(half, 0.015),
+        np.full(periods - half, -0.004),
+    ])
+    return pd.DataFrame({"A": a_returns, "B": b_returns}, index=index)
+
+
+def test_rolling_and_expanding_windows_diverge() -> None:
+    returns = _synthetic_returns("2020-01-01", 260)
+    strategy = MeanWinnerStrategy()
+
+    expanding = run_backtest(
+        returns,
+        strategy,
+        rebalance_freq="M",
+        window_size=60,
+        window_mode="expanding",
+    )
+    rolling = run_backtest(
+        returns,
+        strategy,
+        rebalance_freq="M",
+        window_size=60,
+        window_mode="rolling",
+    )
+
+    assert expanding.equity_curve.iloc[-1] != rolling.equity_curve.iloc[-1]
+
+    for date, (_, window_end) in expanding.training_windows.items():
+        assert window_end == date
+
+    summary = expanding.summary()
+    assert summary["window_mode"] == "expanding"
+    assert "metrics" in summary and "cagr" in summary["metrics"]
+    assert "rolling_sharpe" in summary
+    assert json.loads(expanding.to_json())["window_mode"] == "expanding"
+
+
+def test_transaction_costs_applied_to_turnover() -> None:
+    index = pd.date_range("2021-01-01", periods=40, freq="B")
+    returns = pd.DataFrame({"A": 0.01, "B": -0.005}, index=index)
+    strategy = AlternatingStrategy()
+
+    result = run_backtest(
+        returns,
+        strategy,
+        rebalance_freq="W",
+        window_size=5,
+        transaction_cost_bps=50,
+    )
+
+    assert not result.transaction_costs.empty
+    first_cost = result.transaction_costs.iloc[0]
+    second_cost = result.transaction_costs.iloc[1]
+    assert np.isclose(first_cost, 0.005)
+    assert np.isclose(second_cost, 0.01)
+
+    active_returns = result.returns.dropna()
+    assert np.isclose(active_returns.iloc[0], 0.01 - 0.005)
+    assert np.isclose(active_returns.iloc[1], 0.01)
+
+    assert result.turnover.iloc[0] == 1.0
+    assert result.turnover.iloc[1] == 2.0


### PR DESCRIPTION
## Summary
- add a `trend_analysis.backtesting` module that runs walk-forward backtests with calendar rebalances, window selection, and transaction cost deductions while returning rich performance metrics and JSON summaries
- expose the backtesting package at the top level and document how to consume the harness output
- cover rolling versus expanding windows and transaction cost handling with focused unit tests

## Testing
- pytest tests/backtesting/test_harness.py


------
https://chatgpt.com/codex/tasks/task_e_68df57bc806c8331842cc0caa8c8c2f2