### PR TITLE
Expand honest backtesting JSON summary outputs

### DIFF
--- a/docs/backtesting_harness.md
+++ b/docs/backtesting_harness.md
@@ -18,8 +18,9 @@ walk-forward portfolio evaluation with:
 
 Downstream integrations can serialise the result via
 `BacktestResult.to_json()`, which emits a JSON payload containing the summary
-metrics, rolling Sharpe series, drawdown path, and rebalance calendar so that UI
-layers can present the walk-forward evaluation without bespoke post-processing.
+metrics, rolling Sharpe series, drawdown path, rebalance calendar, turnover,
+transaction-cost ledger, and sparse weight history so that UI layers can present
+the walk-forward evaluation without bespoke post-processing.
 
 See `tests/backtesting/test_harness.py` for end-to-end usage examples covering
 window switching and transaction-cost verification.

--- a/src/trend_analysis/backtesting/harness.py
+++ b/src/trend_analysis/backtesting/harness.py
@@ -41,6 +41,9 @@ class BacktestResult:
             "rolling_sharpe": _series_to_dict(self.rolling_sharpe),
             "drawdown": _series_to_dict(self.drawdown),
             "equity_curve": _series_to_dict(self.equity_curve),
+            "turnover": _series_to_dict(self.turnover),
+            "transaction_costs": _series_to_dict(self.transaction_costs),
+            "weights": _weights_to_dict(self.weights),
         }
 
     def to_json(self, **dumps_kwargs: object) -> str:
@@ -323,6 +326,21 @@ def _series_to_dict(series: pd.Series) -> Dict[str, float]:
         return {}
     cleaned = series.dropna()
     return {idx.isoformat(): _to_float(val) for idx, val in cleaned.items()}
+
+
+def _weights_to_dict(weights: pd.DataFrame) -> Dict[str, Dict[str, float]]:
+    if weights.empty:
+        return {}
+    result: Dict[str, Dict[str, float]] = {}
+    for timestamp, row in weights.dropna(how="all").iterrows():
+        cleaned_row = {
+            col: _to_float(val)
+            for col, val in row.items()
+            if not np.isclose(val, 0.0)
+        }
+        if cleaned_row:
+            result[timestamp.isoformat()] = cleaned_row
+    return result
 
 
 def _json_default(obj: object) -> object:

--- a/tests/backtesting/test_harness.py
+++ b/tests/backtesting/test_harness.py
@@ -79,6 +79,15 @@ def test_rolling_and_expanding_windows_diverge() -> None:
     assert summary["window_mode"] == "expanding"
     assert "metrics" in summary and "cagr" in summary["metrics"]
     assert "rolling_sharpe" in summary
+    assert "turnover" in summary
+    assert "transaction_costs" in summary
+    assert "weights" in summary
+    if summary["weights"]:
+        first_weight_entry = next(iter(summary["weights"].values()))
+        assert isinstance(first_weight_entry, dict)
+        if first_weight_entry:
+            first_weight_value = next(iter(first_weight_entry.values()))
+            assert isinstance(first_weight_value, float)
     assert json.loads(expanding.to_json())["window_mode"] == "expanding"
 
 


### PR DESCRIPTION
## Summary
- extend `BacktestResult.summary()` to expose turnover, transaction-costs, and sparse weight history in the JSON payload
- add helper to convert weight history to JSON-friendly dictionaries and document the richer output surface
- tighten unit tests to ensure the expanded summary contract is covered

## Testing
- pytest tests/backtesting/test_harness.py

------
https://chatgpt.com/codex/tasks/task_e_68df5bbd29b0833183bcbc4acb73fd75