### PR TITLE
test: assert calendar emitted in backtest summary

### DIFF
--- a/tests/backtesting/test_harness.py
+++ b/tests/backtesting/test_harness.py
@@ -77,6 +77,9 @@ def test_rolling_and_expanding_windows_diverge() -> None:
 
     summary = expanding.summary()
     assert summary["window_mode"] == "expanding"
+    assert summary["calendar"]
+    first_calendar_entry = summary["calendar"][0]
+    assert isinstance(first_calendar_entry, str)
     assert "metrics" in summary and "cagr" in summary["metrics"]
     assert "rolling_sharpe" in summary
     assert "turnover" in summary


### PR DESCRIPTION
## Summary
- extend the backtesting harness regression test to assert the JSON summary exposes the rebalance calendar entries

## Testing
- pytest tests/backtesting/test_harness.py

------
https://chatgpt.com/codex/tasks/task_e_68df5e1c41f48331983818b6f9d668a3