### PR TITLE
Docker: keep as a fast smoke with lint and deterministic caching - Source Issue #1663

### DIFF
--- a/.github/workflows/pr-12-docker-smoke.yml
+++ b/.github/workflows/pr-12-docker-smoke.yml
@@ -51,6 +51,9 @@ jobs:
       IMAGE_NAME: ${{ vars.IMAGE_NAME || format('{0}/{1}', github.repository_owner, 'trend-model') }}
       HEALTH_PORT: ${{ vars.HEALTH_PORT || '8000' }}
       HEALTH_PATH: ${{ vars.HEALTH_PATH || '/health' }}
+      BUILD_CACHE_PATH: /tmp/.buildx-cache
+      BUILD_CACHE_TEMP: /tmp/.buildx-cache-new
+      BUILD_CACHE_KEY: docker-smoke-buildx-${{ hashFiles('requirements.lock') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -67,20 +70,22 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Ensure buildx cache directory exists
-        run: mkdir -p /tmp/.buildx-cache
+        run: |
+          mkdir -p "${BUILD_CACHE_PATH}"
+          rm -rf "${BUILD_CACHE_TEMP}"
 
       - name: Restore buildx cache
         # Deterministic cache keyed solely by the lock file to keep smoke builds reproducible.
         id: restore-buildx-cache
         uses: actions/cache/restore@v4
         with:
-          path: /tmp/.buildx-cache
-          key: docker-smoke-buildx-${{ hashFiles('requirements.lock') }}
+          path: ${{ env.BUILD_CACHE_PATH }}
+          key: ${{ env.BUILD_CACHE_KEY }}
 
       - name: Summarize buildx cache
         env:
           CACHE_HIT: ${{ steps.restore-buildx-cache.outputs.cache-hit }}
-          CACHE_KEY: docker-smoke-buildx-${{ hashFiles('requirements.lock') }}
+          CACHE_KEY: ${{ env.BUILD_CACHE_KEY }}
         run: |
           if [ "$CACHE_HIT" = "true" ]; then
             echo "::notice title=BuildxCache::Cache hit for ${CACHE_KEY}"
@@ -99,21 +104,21 @@ jobs:
       - name: Build image (cached)
         run: |
           docker buildx build --pull --load \
-            --cache-from type=local,src=/tmp/.buildx-cache \
-            --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --cache-from type=local,src=${{ env.BUILD_CACHE_PATH }} \
+            --cache-to type=local,dest=${{ env.BUILD_CACHE_TEMP }},mode=max \
             -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest .
 
       - name: Finalize cache
         run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          rm -rf "${BUILD_CACHE_PATH}"
+          mv "${BUILD_CACHE_TEMP}" "${BUILD_CACHE_PATH}"
 
       - name: Save buildx cache
         if: github.event_name != 'pull_request' && steps.restore-buildx-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: /tmp/.buildx-cache
-          key: docker-smoke-buildx-${{ hashFiles('requirements.lock') }}
+          path: ${{ env.BUILD_CACHE_PATH }}
+          key: ${{ env.BUILD_CACHE_KEY }}
       - name: Run test suite (reuses cached image)
         env:
           WF_CALL_DEBUG: ${{ inputs.debug_build && 'true' || '' }}

--- a/agents/codex-1663.md
+++ b/agents/codex-1663.md
@@ -1,1 +1,14 @@
-<!-- bootstrap for codex on issue #1663 -->
+# Issue 1663 – Docker smoke workflow upkeep
+
+## Verification checklist
+
+- [x] Workflow still identified as **Docker** and keeps existing triggers for push, pull_request, workflow_call, and dispatch events.
+- [x] Lint job runs `hadolint` only, ensuring the Dockerfile check remains lean.
+- [x] Buildx cache restored and saved with the deterministic `requirements.lock` hash key, with cache paths centralised under `/tmp/.buildx-cache`.
+- [x] Docker image built once via Buildx and reused for pytest and health validation runs.
+- [x] Smoke tests execute `pytest -q` (or verbose mode when debugging) inside the freshly built container image.
+- [x] Health endpoint probed after tests to guarantee the container starts cleanly.
+- [x] Registry login and image push steps gated so they only execute on `phase-2-dev` pushes, skipping PRs and other refs.
+- [x] Step names, cache keys, and inline comments reflect repository conventions to keep maintenance straightforward.
+
+These checks confirm the workflow satisfies the acceptance criteria while remaining aligned with repository expectations for deterministic caching and smoke coverage.


### PR DESCRIPTION
### Source Issue #1663: Docker: keep as a fast smoke with lint and deterministic caching

Source: https://github.com/stranske/Trend_Model_Project/issues/1663

> Topic GUID: 7fb3cd13-a138-58b2-b195-f71c22310334
> 
> ## Why
> Depends on: Issue 0
> Summary
> Keep pr-12-docker-smoke.yml lean: hadolint, buildx with a lock-file keyed cache, run pytest -q, hit the health endpoint, push only on the protected branch. This already exists; just keep it aligned with naming and artifact conventions. 
> GitHub
> 
> ## Tasks
> _Not provided._
> 
> ## Acceptance criteria
> Workflow name remains “Docker.”
> 
> Lint, build, smoke test steps pass on PRs; push gated to the main dev branch.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18086613665).

—
(After opening the PR, comment with `@codex start`.)

------
https://chatgpt.com/codex/tasks/task_e_68df5f1822b483318a5a8117438b6cd8