### PR TITLE
test: cover backtesting metrics in summary

### DIFF
--- a/tests/backtesting/test_harness.py
+++ b/tests/backtesting/test_harness.py
@@ -76,11 +76,24 @@ def test_rolling_and_expanding_windows_diverge() -> None:
         assert window_end == date
 
     summary = expanding.summary()
+    expected_metrics = {
+        "cagr",
+        "volatility",
+        "sortino",
+        "calmar",
+        "max_drawdown",
+        "final_value",
+        "sharpe",
+    }
+
+    assert expanding.metrics.keys() >= expected_metrics
+
     assert summary["window_mode"] == "expanding"
     assert summary["calendar"]
     first_calendar_entry = summary["calendar"][0]
     assert isinstance(first_calendar_entry, str)
-    assert "metrics" in summary and "cagr" in summary["metrics"]
+    assert "metrics" in summary
+    assert summary["metrics"].keys() >= expected_metrics
     assert "rolling_sharpe" in summary
     assert "turnover" in summary
     assert "transaction_costs" in summary

--- a/tests/backtesting/test_harness.py
+++ b/tests/backtesting/test_harness.py
@@ -93,7 +93,7 @@ def test_rolling_and_expanding_windows_diverge() -> None:
     first_calendar_entry = summary["calendar"][0]
     assert isinstance(first_calendar_entry, str)
     assert "metrics" in summary
-    assert summary["metrics"].keys() >= expected_metrics
+    assert expected_metrics.issubset(summary["metrics"].keys())
     assert "rolling_sharpe" in summary
     assert "turnover" in summary
     assert "transaction_costs" in summary


### PR DESCRIPTION
## Summary
- assert that `BacktestResult.metrics` exposes the full analytics set promised by the honest backtesting harness
- verify the JSON summary includes the same metric keys, ensuring downstream consumers keep their contract

## Testing
- pytest tests/backtesting/test_harness.py

------
https://chatgpt.com/codex/tasks/task_e_68df604cc7c883318d79d0c3c64e3f65