### PR TITLE
Honest backtesting harness: walk-forward, costs, and calendar - Source Issue #1681

### DIFF
--- a/docs/backtesting_harness.md
+++ b/docs/backtesting_harness.md
@@ -19,8 +19,9 @@ walk-forward portfolio evaluation with:
 Downstream integrations can serialise the result via
 `BacktestResult.to_json()`, which emits a JSON payload containing the summary
 metrics, rolling Sharpe series, drawdown path, rebalance calendar, turnover,
-transaction-cost ledger, and sparse weight history so that UI layers can present
-the walk-forward evaluation without bespoke post-processing.
+transaction-cost ledger, sparse weight history, and the full set of training
+window boundaries so that UI layers can present the walk-forward evaluation
+without bespoke post-processing or duplicated window bookkeeping.
 
 See `tests/backtesting/test_harness.py` for end-to-end usage examples covering
 window switching and transaction-cost verification.

--- a/src/trend_analysis/backtesting/harness.py
+++ b/src/trend_analysis/backtesting/harness.py
@@ -44,6 +44,13 @@ class BacktestResult:
             "turnover": _series_to_dict(self.turnover),
             "transaction_costs": _series_to_dict(self.transaction_costs),
             "weights": _weights_to_dict(self.weights),
+            "training_windows": {
+                ts.isoformat(): {
+                    "start": window[0].isoformat(),
+                    "end": window[1].isoformat(),
+                }
+                for ts, window in self.training_windows.items()
+            },
         }
 
     def to_json(self, **dumps_kwargs: object) -> str:

--- a/tests/backtesting/test_harness.py
+++ b/tests/backtesting/test_harness.py
@@ -94,6 +94,12 @@ def test_rolling_and_expanding_windows_diverge() -> None:
     assert isinstance(first_calendar_entry, str)
     assert "metrics" in summary
     assert expected_metrics.issubset(summary["metrics"].keys())
+    training_windows = summary["training_windows"]
+    assert training_windows
+    assert first_calendar_entry in training_windows
+    first_window = training_windows[first_calendar_entry]
+    assert first_window["end"] == first_calendar_entry
+    assert first_window["start"] <= first_calendar_entry
     assert "rolling_sharpe" in summary
     assert "turnover" in summary
     assert "transaction_costs" in summary


### PR DESCRIPTION
## Summary
- Implemented a reusable `run_backtest` harness that enforces calendar-based rebalances, supports rolling/expanding estimation windows, applies basis-point transaction costs, and returns rich performance analytics plus JSON summaries.
- Exposed the new backtesting package at the top level and documented how consumers can integrate the harness outputs.
- Added unit tests that contrast rolling versus expanding windows and verify transaction-cost deductions within the rebalance schedule.
- Extended the JSON summary to include training window boundaries so downstream consumers can align rebalance dates with the historical slices that informed each decision.

## Testing
- ✅ `pytest tests/backtesting/test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68df6361caf08331aa92b82a3dd5f515