### PR TITLE
Expose realised returns in backtest JSON summary

### DIFF
--- a/docs/backtesting_harness.md
+++ b/docs/backtesting_harness.md
@@ -18,10 +18,11 @@ walk-forward portfolio evaluation with:
 
 Downstream integrations can serialise the result via
 `BacktestResult.to_json()`, which emits a JSON payload containing the summary
-metrics, rolling Sharpe series, drawdown path, rebalance calendar, turnover,
-transaction-cost ledger, sparse weight history, and the full set of training
-window boundaries so that UI layers can present the walk-forward evaluation
-without bespoke post-processing or duplicated window bookkeeping.
+metrics, realised return path, rolling Sharpe series, drawdown profile,
+rebalance calendar, turnover, transaction-cost ledger, sparse weight history,
+and the full set of training window boundaries so that UI layers can present
+the walk-forward evaluation without bespoke post-processing or duplicated
+window bookkeeping.
 
 See `tests/backtesting/test_harness.py` for end-to-end usage examples covering
 window switching and transaction-cost verification.

--- a/src/trend_analysis/backtesting/harness.py
+++ b/src/trend_analysis/backtesting/harness.py
@@ -38,6 +38,7 @@ class BacktestResult:
             "window_size": self.window_size,
             "calendar": [ts.isoformat() for ts in self.calendar],
             "metrics": {k: _to_float(v) for k, v in self.metrics.items()},
+            "returns": _series_to_dict(self.returns),
             "rolling_sharpe": _series_to_dict(self.rolling_sharpe),
             "drawdown": _series_to_dict(self.drawdown),
             "equity_curve": _series_to_dict(self.equity_curve),

--- a/tests/backtesting/test_harness.py
+++ b/tests/backtesting/test_harness.py
@@ -103,6 +103,12 @@ def test_rolling_and_expanding_windows_diverge() -> None:
     assert "rolling_sharpe" in summary
     assert "turnover" in summary
     assert "transaction_costs" in summary
+    assert "returns" in summary
+    returns_summary = summary["returns"]
+    assert isinstance(returns_summary, dict)
+    if returns_summary:
+        first_return_value = next(iter(returns_summary.values()))
+        assert isinstance(first_return_value, float)
     assert "weights" in summary
     if summary["weights"]:
         first_weight_entry = next(iter(summary["weights"].values()))


### PR DESCRIPTION
## Summary
- add the realised returns path to `BacktestResult.summary()` so JSON consumers receive the series alongside the other analytics
- document the expanded payload contents in `docs/backtesting_harness.md`
- extend the regression test to assert the returns mapping is present in the JSON contract

## Testing
- pytest tests/backtesting/test_harness.py

------
https://chatgpt.com/codex/tasks/task_e_68df651a7b908331a646893884319cb3