### PR TITLE
Fix Docker workflow checkout ref for push events

### DIFF
--- a/.github/workflows/pr-12-docker-smoke.yml
+++ b/.github/workflows/pr-12-docker-smoke.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - name: Log in to container registry
         if: github.event_name == 'push' && github.ref == 'refs/heads/phase-2-dev'
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary
- guard checkout ref expression by event type so push/workflow_dispatch use github.sha
- keeps pull request builds pinned to head SHA to preserve existing behaviour

## Testing
- manual: verified workflow syntax change locally (no automation yet)