### PR TITLE
Ensure bootstrap equity bands respect capital scale

### DIFF
--- a/docs/backtesting_harness.md
+++ b/docs/backtesting_harness.md
@@ -43,6 +43,8 @@ Key parameters:
   deterministic bands.
 
 Any leading `NaN` values in the original return series are reinserted so charts
-and exports align with the point where the strategy becomes live.  See
+and exports align with the point where the strategy becomes live.  The helper
+also honours the realised equity scale (e.g. starting capital of 100) so the
+resulting quantiles overlay correctly on absolute-dollar curves.  See
 `tests/backtesting/test_bootstrap.py` for worked examples and edge-case
 coverage.

--- a/src/trend_analysis/backtesting/bootstrap.py
+++ b/src/trend_analysis/backtesting/bootstrap.py
@@ -87,6 +87,26 @@ def bootstrap_equity(
     sampled = _bootstrap_paths(realised, n_paths=n, block=block, rng=rng)
     equity_paths = np.cumprod(1.0 + sampled, axis=1)
 
+    first_active = realised.index[0]
+    first_return = float(realised.iloc[0])
+    try:
+        equity_after_first = float(result.equity_curve.loc[first_active])
+    except KeyError:  # pragma: no cover - defensive alignment fallback
+        eq_non_na = result.equity_curve.dropna()
+        equity_after_first = float(eq_non_na.iloc[0]) if not eq_non_na.empty else 1.0
+    if not np.isfinite(equity_after_first):
+        equity_after_first = 1.0
+
+    denom = 1.0 + first_return
+    if not np.isfinite(denom) or abs(denom) < 1e-12:
+        base_value = 1.0
+    else:
+        base_value = equity_after_first / denom
+        if not np.isfinite(base_value):
+            base_value = 1.0
+
+    equity_paths *= base_value
+
     quantiles = np.percentile(equity_paths, [5, 50, 95], axis=0)
     index = realised.index
     data = pd.DataFrame(


### PR DESCRIPTION
## Summary
* Added a reusable block-bootstrap helper for `BacktestResult`, exported it through the backtesting namespace, and documented its usage.
* Extended `SimResult` with cached bootstrap bands and replaced the Streamlit equity chart with a matplotlib view that optionally overlays the 5–95% band.
* Layered bootstrap quantiles into the export bundle (PNG shading plus `equity_bootstrap.csv`), refreshed README/CHANGELOG notes, and added regression tests for the new artifacts.
* Ensured bootstrap quantiles honour the realised equity scale so overlays match capital-sized curves, with regression coverage and updated docs.

## Testing
* `pytest tests/backtesting/test_bootstrap.py`
* `pytest tests/app/test_sim_runner_extra.py tests/test_export_bundle.py`


------
https://chatgpt.com/codex/tasks/task_e_68df752a81208331971da17f8a12f1a0