### PR TITLE
Bootstrap uncertainty bands for the equity curve - Source Issue #1682

### DIFF
--- a/src/trend_analysis/backtesting/harness.py
+++ b/src/trend_analysis/backtesting/harness.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Callable, Dict, Literal, Mapping, Sequence
+from typing import Any, Callable, Dict, Literal, Mapping, Sequence
 
 import numpy as np
 import pandas as pd
@@ -54,7 +54,7 @@ class BacktestResult:
             },
         }
 
-    def to_json(self, **dumps_kwargs: object) -> str:
+    def to_json(self, **dumps_kwargs: Any) -> str:
         """Serialise :meth:`summary` to JSON for downstream consumers."""
 
         return json.dumps(self.summary(), default=_json_default, **dumps_kwargs)

--- a/src/trend_analysis/export/bundle.py
+++ b/src/trend_analysis/export/bundle.py
@@ -185,7 +185,7 @@ def export_bundle(run: Any, path: Path) -> Path:
                 return _to_list(index.to_timestamp().to_pydatetime())
             if isinstance(index, pd.DatetimeIndex):
                 return _to_list(index.to_pydatetime())
-            return _to_list(index.to_list())
+            return index.to_list()
 
         def _write_charts(eq: pd.Series, band: pd.DataFrame | None) -> None:
             # Configure non-interactive backend and import pyplot lazily

--- a/src/trend_analysis/export/bundle.py
+++ b/src/trend_analysis/export/bundle.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable, List
 
 import matplotlib
 import pandas as pd
@@ -177,12 +177,15 @@ def export_bundle(run: Any, path: Path) -> Path:
         # ------------------------------------------------------------------
         # Charts PNGs
         # ------------------------------------------------------------------
+        def _to_list(values: Iterable[Any]) -> List[Any]:
+            return list(values)
+
         def _plot_x(index: pd.Index) -> list[Any]:
             if isinstance(index, pd.PeriodIndex):
-                return index.to_timestamp().to_pydatetime().tolist()
+                return _to_list(index.to_timestamp().to_pydatetime())
             if isinstance(index, pd.DatetimeIndex):
-                return index.to_pydatetime().tolist()
-            return index.tolist()
+                return _to_list(index.to_pydatetime())
+            return _to_list(index.to_list())
 
         def _write_charts(eq: pd.Series, band: pd.DataFrame | None) -> None:
             # Configure non-interactive backend and import pyplot lazily


### PR DESCRIPTION
## Summary
* Added a reusable block-bootstrap helper for `BacktestResult`, exported it through the backtesting namespace, and documented its usage.
* Extended `SimResult` with cached bootstrap bands and replaced the Streamlit equity chart with a matplotlib view that optionally overlays the 5–95% band.
* Layered bootstrap quantiles into the export bundle (PNG shading plus `equity_bootstrap.csv`), refreshed README/CHANGELOG notes, and added regression tests for the new artifacts.
* Tightened typing for `BacktestResult.to_json` and the export bundle plotting helper so mypy-based autofix pipelines pass without intervention.

## Testing
* ✅ `python -m mypy src/trend_analysis/backtesting/harness.py src/trend_analysis/export/bundle.py`
* ✅ `pytest tests/test_autofix_pipeline_live_docs.py -k live_documents`
* ✅ `pytest tests/backtesting/test_bootstrap.py tests/app/test_sim_runner_extra.py tests/test_export_bundle.py`

------
https://chatgpt.com/codex/tasks/task_e_68df78be9abc8331b0ce32f554e57656