### PR TITLE
Post‑CI PR comment: unify and enrich - Source Issue #1665

### DIFF
--- a/.github/workflows/maint-30-post-ci-summary.yml
+++ b/.github/workflows/maint-30-post-ci-summary.yml
@@ -374,7 +374,8 @@ jobs:
               return;
             }
 
-            const marker = 'Automated Status Summary';
+            const marker = '<!-- post-ci-summary:do-not-edit -->';
+            const heading = 'Automated Status Summary';
             const { data: comments } = await github.rest.issues.listComments({
               owner,
               repo,
@@ -382,7 +383,13 @@ jobs:
               per_page: 100,
             });
 
-            const existing = comments.find(comment => comment.body && comment.body.includes(marker));
+            const hasMarker = comment =>
+              Boolean(comment && comment.body && comment.body.includes(marker));
+            const hasHeading = comment =>
+              Boolean(comment && comment.body && comment.body.includes(heading));
+
+            const existing =
+              comments.find(hasMarker) || comments.find(hasHeading);
 
             if (existing) {
               if ((existing.body || '').trim() === body.trim()) {

--- a/docs/ops/ci-status-summary.md
+++ b/docs/ops/ci-status-summary.md
@@ -46,8 +46,9 @@ The workflow collects status data from three places:
 
 * The workflow uses a concurrency group keyed by the head SHA to cancel stale
   runs.
-* Comment discovery matches the `### Automated Status Summary` heading, so
-  reruns patch the original comment instead of posting duplicates.
+* Comment discovery prefers the hidden `<!-- post-ci-summary:do-not-edit -->`
+  marker (with the heading as a fallback), so reruns patch the original comment
+  instead of posting duplicates.
 * If neither CI nor Docker has produced artifacts yet, the helper still posts a
   pending table so reviewers can see progress.
 


### PR DESCRIPTION
### Source Issue #1665: Post‑CI PR comment: unify and enrich

Source: https://github.com/stranske/Trend_Model_Project/issues/1665

> Topic GUID: 1edc5a6c-70d2-5d52-b465-53b9e3521874
> 
> ## Why
> Depends on: Issue 3
> Summary
> Ensure the merged summarizer includes:
> Job table with badge emojis and links to logs.
> Coverage section from the coverage-summary artifact when present.
> Clear “required” job list derived from actual jobs. Current “PR Status Summary” already does this; keep the behavior in the unified summary. 
> GitHub
> 
> ## Tasks
> _Not provided._
> 
> ## Acceptance criteria
> One “Automated Status Summary” comment per PR, updated after CI and Docker.
> 
> No duplicate comments.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18086613665).

---

### Follow-up update
- Prefer the hidden summary marker when selecting an existing comment so reruns always patch the same entry, with the heading search as a fallback.
- Document the marker-first lookup in the CI status summary guide.


------
https://chatgpt.com/codex/tasks/task_e_68df7b7f94e883319453a0a9b82503d8