### PR TITLE
Follow-up: prioritize pending jobs in automated status summary

### DIFF
--- a/tools/post_ci_summary.py
+++ b/tools/post_ci_summary.py
@@ -62,11 +62,11 @@ def _priority(state: str | None) -> int:
     normalized = (state or "").lower()
     if normalized in {"failure", "cancelled", "timed_out", "action_required"}:
         return 0
-    if normalized == "success":
-        return 1
-    if normalized == "skipped":
-        return 2
     if normalized in {"in_progress", "queued", "waiting", "requested"}:
+        return 1
+    if normalized == "success":
+        return 2
+    if normalized == "skipped":
         return 3
     return 4
 


### PR DESCRIPTION
## Summary
- ensure the job-table sorter ranks in-progress workflow jobs ahead of skipped entries so pending work stays visible

## Testing
- pytest tests/test_post_ci_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68df805f595083319888288ae81f83e8