### PR TITLE
Post-CI summarizer: robust coverage artifact detection

### DIFF
--- a/.github/workflows/maint-30-post-ci-summary.yml
+++ b/.github/workflows/maint-30-post-ci-summary.yml
@@ -222,17 +222,39 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p summary_artifacts
-          summary_file="artifacts/coverage-summary/coverage-summary.md"
-          if [ -f "$summary_file" ]; then
-            cp "$summary_file" summary_artifacts/coverage-summary.md
-            {
-              echo 'body<<EOF'
-              cat "$summary_file"
-              echo 'EOF'
-            } >> "$GITHUB_OUTPUT"
-          else
-            echo "No coverage summary markdown found; continuing without it."
-          fi
+          python <<'PY'
+          import os
+          from pathlib import Path
+
+          output_path = os.environ.get('GITHUB_OUTPUT')
+          root = Path('summary_artifacts')
+          search_roots = [root, Path('artifacts')]
+
+          summary_path: Path | None = None
+          for base in search_roots:
+              if not base.exists():
+                  continue
+              for candidate in base.rglob('coverage-summary.md'):
+                  summary_path = candidate
+                  break
+              if summary_path:
+                  break
+
+          if summary_path is None:
+              print('No coverage summary markdown found; continuing without it.')
+          else:
+              text = summary_path.read_text(encoding='utf-8')
+              dest = root / 'coverage-summary.md'
+              dest.write_text(text, encoding='utf-8')
+              if output_path:
+                  with Path(output_path).open('a', encoding='utf-8') as handle:
+                      handle.write('body<<EOF\n')
+                      handle.write(text)
+                      if not text.endswith('\n'):
+                          handle.write('\n')
+                      handle.write('EOF\n')
+              print(f'Embedded coverage summary from {summary_path}')
+          PY
 
       - name: Compute coverage stats
         id: coverage_stats

--- a/.github/workflows/maint-30-post-ci-summary.yml
+++ b/.github/workflows/maint-30-post-ci-summary.yml
@@ -231,14 +231,14 @@ jobs:
           search_roots = [root, Path('artifacts')]
 
           summary_path: Path | None = None
+          candidates = []
           for base in search_roots:
               if not base.exists():
                   continue
-              for candidate in base.rglob('coverage-summary.md'):
-                  summary_path = candidate
-                  break
-              if summary_path:
-                  break
+              candidates.extend(base.rglob('coverage-summary.md'))
+          if candidates:
+              # Prefer files in earlier search_roots; if multiple, pick the first found
+              summary_path = candidates[0]
 
           if summary_path is None:
               print('No coverage summary markdown found; continuing without it.')


### PR DESCRIPTION
## Summary
- load the coverage-summary markdown directly from downloaded artifacts so the unified comment always embeds the snippet when present
- preserve the stored preview and comment output when the artifact lacks a trailing newline

## Testing
- pytest tests/test_post_ci_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68df813a38dc83319b210fc1c7037ca0