### PR TITLE
Improve job status rendering in post-CI summary

### DIFF
--- a/tests/test_post_ci_summary.py
+++ b/tests/test_post_ci_summary.py
@@ -164,7 +164,7 @@ def test_job_table_prioritises_failing_and_pending_jobs(sample_runs):
     assert optional_index is not None, "'main / optional' job not found in table_lines"
     assert "❌ failure" in table_lines[docker_index]
     assert "❌ failure" in table_lines[flaky_index]
-    assert "⏳ in_progress" in table_lines[docs_index]
+    assert "⏳ in progress" in table_lines[docs_index]
     assert "⏭️ skipped" in table_lines[optional_index]
 
     assert max(flaky_index, docker_index) < optional_index


### PR DESCRIPTION
## Summary
- continue the unified automated status summary work by ensuring job state text is human-friendly while retaining badge prioritisation
- keep the required-check rollup and Docker line in sync with the new state labels so the summary reads naturally
- maintain regression coverage by updating the post-ci summary tests for the revised status strings

## Testing
- `pytest tests/test_post_ci_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_68df82cb80608331b1cff706a528f6b8