### PR TITLE
One report builder (HTML/PDF) shared by CLI and app - Source Issue #1683

### DIFF
--- a/tests/test_trend_cli.py
+++ b/tests/test_trend_cli.py
@@ -217,6 +217,81 @@ def test_main_report_supports_output_file_only(monkeypatch, tmp_path: Path) -> N
     assert target.read_text(encoding="utf-8") == "<html>report</html>"
 
 
+def test_main_report_writes_pdf_when_requested(monkeypatch, tmp_path: Path) -> None:
+    dummy_result = RunResult(pd.DataFrame(), {}, 42, {})
+
+    def fake_run_pipeline(*args, **kwargs):  # type: ignore[override]
+        return dummy_result, "pdf001", None
+
+    pdf_bytes = b"%PDF-1.4\n..."
+    recorded: dict[str, object] = {}
+
+    monkeypatch.setattr("trend.cli._ensure_dataframe", lambda _p: pd.DataFrame())
+    monkeypatch.setattr("trend.cli._run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr("trend.cli._print_summary", lambda *args, **kwargs: None)
+    monkeypatch.setattr("trend.cli._write_report_files", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "trend.cli._resolve_returns_path",
+        lambda *args, **kwargs: tmp_path / "returns.csv",
+    )
+    monkeypatch.setattr(
+        "trend.cli.generate_unified_report",
+        lambda *a, **k: recorded.update(k) or SimpleNamespace(
+            html="<html>with-pdf</html>", pdf_bytes=pdf_bytes, context={}
+        ),
+    )
+
+    target = tmp_path / "report-output.html"
+    exit_code = main([
+        "report",
+        "--config",
+        "config/demo.yml",
+        "--output",
+        str(target),
+        "--pdf",
+    ])
+
+    assert exit_code == 0
+    assert target.read_text(encoding="utf-8") == "<html>with-pdf</html>"
+    pdf_path = target.with_suffix(".pdf")
+    assert pdf_path.read_bytes() == pdf_bytes
+    assert recorded["include_pdf"] is True
+
+
+def test_main_report_pdf_dependency_error(monkeypatch, tmp_path: Path, capsys) -> None:
+    dummy_result = RunResult(pd.DataFrame(), {}, 42, {})
+
+    def fake_run_pipeline(*args, **kwargs):  # type: ignore[override]
+        return dummy_result, "pdf001", None
+
+    monkeypatch.setattr("trend.cli._ensure_dataframe", lambda _p: pd.DataFrame())
+    monkeypatch.setattr("trend.cli._run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr("trend.cli._print_summary", lambda *args, **kwargs: None)
+    monkeypatch.setattr("trend.cli._write_report_files", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "trend.cli._resolve_returns_path",
+        lambda *args, **kwargs: tmp_path / "returns.csv",
+    )
+    monkeypatch.setattr(
+        "trend.cli.generate_unified_report",
+        lambda *a, **k: SimpleNamespace(html="<html>ok</html>", pdf_bytes=None, context={}),
+    )
+
+    target = tmp_path / "report-output.html"
+    exit_code = main([
+        "report",
+        "--config",
+        "config/demo.yml",
+        "--output",
+        str(target),
+        "--pdf",
+    ])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "PDF generation failed" in captured.err
+
+
 def test_main_report_requires_output_directory() -> None:
     exit_code = main(["report", "--config", "config/demo.yml"])
     assert exit_code == 2


### PR DESCRIPTION
**Summary**
* Introduced a `trend.reporting` module that produces deterministic HTML reports and optional PDF exports for both the CLI and Streamlit workflows.
* Enhanced the `trend report` command with `--output`/`--pdf` options, unified report generation, and shared path resolution while preserving existing artefacts.
* Added Streamlit download buttons wired to the shared generator, broadened unit coverage for report/CLI flows, and declared the `fpdf2` dependency.
* Extended CLI report command tests to cover PDF success output and dependency-failure handling.

**Testing**
* ✅ `pytest tests/test_unified_report.py tests/test_trend_cli.py::test_main_report_supports_output_file_only tests/test_trend_cli.py::test_main_report_uses_requested_directory tests/test_trend_cli.py::test_main_report_writes_pdf_when_requested tests/test_trend_cli.py::test_main_report_pdf_dependency_error tests/test_trend_cli_entrypoints.py::test_main_report_command -q`


------
https://chatgpt.com/codex/tasks/task_e_68df830644108331ba8170ce041ce3db