### PR TITLE
Add legacy compatibility shims for unified report

### DIFF
--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -46,9 +46,9 @@ try:  # ``trend_analysis.cli`` is heavy but provides useful helpers
 except Exception:  # pragma: no cover - defensive fallback
     _legacy_cli_module = None
 else:
-    maybe_log = getattr(_legacy_cli_module, "maybe_log_step", None)
-    if callable(maybe_log):
-        _legacy_maybe_log_step = maybe_log  # type: ignore[assignment]
+    maybe_log_step_fn = getattr(_legacy_cli_module, "maybe_log_step", None)
+    if callable(maybe_log_step_fn):
+        _legacy_maybe_log_step = maybe_log_step_fn  # type: ignore[assignment]
     _legacy_extract_cache_stats = getattr(
         _legacy_cli_module, "_extract_cache_stats", None
     )

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import uuid
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Callable, Iterable, Protocol
 
 import pandas as pd
@@ -36,21 +37,21 @@ def _noop_maybe_log_step(
     return None
 
 
-_legacy_extract_cache_stats: LegacyExtractCacheStats | None
-_legacy_maybe_log_step: LegacyMaybeLogStep
+_legacy_cli_module: ModuleType | None = None
+_legacy_extract_cache_stats: LegacyExtractCacheStats | None = None
+_legacy_maybe_log_step: LegacyMaybeLogStep = _noop_maybe_log_step
 
 try:  # ``trend_analysis.cli`` is heavy but provides useful helpers
-    from trend_analysis.cli import _extract_cache_stats as _legacy_extract_cache_stats
-    from trend_analysis.cli import maybe_log_step as _legacy_maybe_log_step
+    import trend_analysis.cli as _legacy_cli_module
 except Exception:  # pragma: no cover - defensive fallback
-    _legacy_extract_cache_stats = None
-
-    def _legacy_maybe_log_step(
-        enabled: bool, run_id: str, event: str, message: str, **fields: Any
-    ) -> None:  # noqa: D401 - simple noop
-        """Fallback when legacy helpers unavailable (signature matches
-        maybe_log_step)."""
-        return None
+    _legacy_cli_module = None
+else:
+    maybe_log = getattr(_legacy_cli_module, "maybe_log_step", None)
+    if callable(maybe_log):
+        _legacy_maybe_log_step = maybe_log  # type: ignore[assignment]
+    _legacy_extract_cache_stats = getattr(
+        _legacy_cli_module, "_extract_cache_stats", None
+    )
 
 
 APP_PATH = Path(__file__).resolve().parents[2] / "streamlit_app" / "app.py"
@@ -61,6 +62,14 @@ SCENARIO_WINDOWS: dict[str, tuple[tuple[str, str], tuple[str, str]]] = {
     "2008": (("2006-01", "2007-12"), ("2008-01", "2009-12")),
     "2020": (("2018-01", "2019-12"), ("2020-01", "2021-12")),
 }
+
+
+def _legacy_callable(name: str, fallback: Callable[..., Any]) -> Callable[..., Any]:
+    if _legacy_cli_module is not None:
+        attr = getattr(_legacy_cli_module, name, None)
+        if callable(attr):
+            return attr
+    return fallback
 
 
 class TrendCLIError(RuntimeError):
@@ -431,15 +440,21 @@ def main(argv: list[str] | None = None) -> int:
                 f"The --config option is required for the '{command}' command"
             )
 
-        cfg_path, cfg = _load_configuration(args.config)
-        returns_path = _resolve_returns_path(
+        load_config_fn = _legacy_callable("_load_configuration", _load_configuration)
+        cfg_path, cfg = load_config_fn(args.config)
+        resolve_returns = _legacy_callable(
+            "_resolve_returns_path", _resolve_returns_path
+        )
+        returns_path = resolve_returns(
             cfg_path, cfg, getattr(args, "returns", None)
         )
-        returns_df = _ensure_dataframe(returns_path)
+        ensure_df = _legacy_callable("_ensure_dataframe", _ensure_dataframe)
+        returns_df = ensure_df(returns_path)
         seed = _determine_seed(cfg, getattr(args, "seed", None))
 
         if command == "run":
-            result, run_id, log_path = _run_pipeline(
+            run_pipeline = _legacy_callable("_run_pipeline", _run_pipeline)
+            result, run_id, log_path = run_pipeline(
                 cfg,
                 returns_df,
                 source_path=returns_path,
@@ -447,7 +462,8 @@ def main(argv: list[str] | None = None) -> int:
                 structured_log=not args.no_structured_log,
                 bundle=Path(args.bundle) if args.bundle else None,
             )
-            _print_summary(cfg, result)
+            print_summary = _legacy_callable("_print_summary", _print_summary)
+            print_summary(cfg, result)
             if log_path:
                 print(f"Structured log: {log_path}")
             return 0
@@ -460,7 +476,8 @@ def main(argv: list[str] | None = None) -> int:
                 )
             formats = args.formats or DEFAULT_REPORT_FORMATS
             _prepare_export_config(cfg, export_dir, formats if export_dir is not None else None)
-            result, run_id, _ = _run_pipeline(
+            run_pipeline = _legacy_callable("_run_pipeline", _run_pipeline)
+            result, run_id, _ = run_pipeline(
                 cfg,
                 returns_df,
                 source_path=returns_path,
@@ -468,9 +485,13 @@ def main(argv: list[str] | None = None) -> int:
                 structured_log=False,
                 bundle=None,
             )
-            _print_summary(cfg, result)
+            print_summary = _legacy_callable("_print_summary", _print_summary)
+            print_summary(cfg, result)
             if export_dir is not None:
-                _write_report_files(export_dir, cfg, result, run_id=run_id)
+                write_report = _legacy_callable(
+                    "_write_report_files", _write_report_files
+                )
+                write_report(export_dir, cfg, result, run_id=run_id)
             report_path = _resolve_report_output_path(args.output, export_dir, run_id)
             report_path.parent.mkdir(parents=True, exist_ok=True)
             try:
@@ -499,7 +520,8 @@ def main(argv: list[str] | None = None) -> int:
             _adjust_for_scenario(cfg, args.scenario)
             export_dir = Path(args.out) if args.out else None
             _prepare_export_config(cfg, export_dir, None)
-            result, run_id, _ = _run_pipeline(
+            run_pipeline = _legacy_callable("_run_pipeline", _run_pipeline)
+            result, run_id, _ = run_pipeline(
                 cfg,
                 returns_df,
                 source_path=returns_path,
@@ -508,9 +530,13 @@ def main(argv: list[str] | None = None) -> int:
                 bundle=None,
             )
             print(f"Stress scenario '{args.scenario}' completed (seed={seed}).")
-            _print_summary(cfg, result)
+            print_summary = _legacy_callable("_print_summary", _print_summary)
+            print_summary(cfg, result)
             if export_dir:
-                _write_report_files(export_dir, cfg, result, run_id=run_id)
+                write_report = _legacy_callable(
+                    "_write_report_files", _write_report_files
+                )
+                write_report(export_dir, cfg, result, run_id=run_id)
             return 0
 
         raise TrendCLIError(f"Unknown command: {command}")

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -417,3 +417,75 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation
     raise SystemExit(main())
+
+
+# ---------------------------------------------------------------------------
+# Unified CLI compatibility layer
+# ---------------------------------------------------------------------------
+
+
+def _load_configuration(path: str) -> tuple[Path, Any]:
+    """Delegate to the unified CLI loader for backwards-compatibility."""
+
+    from trend.cli import _load_configuration as unified_load_configuration
+
+    return unified_load_configuration(path)
+
+
+def _resolve_returns_path(
+    config_path: Path, cfg: Any, override: str | None
+) -> Path:
+    """Reuse the unified CLI's returns resolution helper."""
+
+    from trend.cli import _resolve_returns_path as unified_resolve_returns_path
+
+    return unified_resolve_returns_path(config_path, cfg, override)
+
+
+def _ensure_dataframe(path: Path) -> pd.DataFrame:
+    """Proxy to the unified CLI dataframe loader."""
+
+    from trend.cli import _ensure_dataframe as unified_ensure_dataframe
+
+    return unified_ensure_dataframe(path)
+
+
+def _run_pipeline(
+    cfg: Any,
+    returns_df: pd.DataFrame,
+    *,
+    source_path: Path | None,
+    log_file: Path | None,
+    structured_log: bool,
+    bundle: Path | None,
+) -> tuple[Any, str, Path | None]:
+    """Call the unified CLI pipeline execution helper."""
+
+    from trend.cli import _run_pipeline as unified_run_pipeline
+
+    return unified_run_pipeline(
+        cfg,
+        returns_df,
+        source_path=source_path,
+        log_file=log_file,
+        structured_log=structured_log,
+        bundle=bundle,
+    )
+
+
+def _print_summary(cfg: Any, result: Any) -> None:
+    """Defer to the shared summary printer used by ``trend.cli``."""
+
+    from trend.cli import _print_summary as unified_print_summary
+
+    return unified_print_summary(cfg, result)
+
+
+def _write_report_files(
+    out_dir: Path, cfg: Any, result: Any, *, run_id: str
+) -> None:
+    """Forward report artefact writes to the unified CLI implementation."""
+
+    from trend.cli import _write_report_files as unified_write_report_files
+
+    return unified_write_report_files(out_dir, cfg, result, run_id=run_id)

--- a/src/trend_analysis/reporting/__init__.py
+++ b/src/trend_analysis/reporting/__init__.py
@@ -1,0 +1,7 @@
+"""Backwards-compatible reporting access for legacy imports."""
+
+from __future__ import annotations
+
+from trend.reporting import ReportArtifacts, generate_unified_report
+
+__all__ = ["ReportArtifacts", "generate_unified_report"]

--- a/src/trend_analysis/reporting/__init__.py
+++ b/src/trend_analysis/reporting/__init__.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
-from trend.reporting import ReportArtifacts, generate_unified_report
+try:
+    from trend.reporting import ReportArtifacts, generate_unified_report
+except ImportError:
+    class ReportArtifacts:
+        def __init__(self, *args, **kwargs):
+            raise ImportError("trend.reporting.ReportArtifacts not found. Please ensure trend.reporting is available.")
+    def generate_unified_report(*args, **kwargs):
+        raise ImportError("trend.reporting.generate_unified_report not found. Please ensure trend.reporting is available.")
 
 __all__ = ["ReportArtifacts", "generate_unified_report"]


### PR DESCRIPTION
## Summary
- proxy the unified CLI through legacy helpers so monkeypatched `trend_analysis.cli` functions continue to work
- add thin compatibility wrappers inside `trend_analysis.cli` that delegate to the new shared CLI implementation
- expose the unified report generator from `trend_analysis.reporting` for older import paths

## Testing
- `pytest tests/test_trend_cli.py::test_cli_report_matches_shared_generator -q`
- `pytest tests/test_unified_report.py tests/test_trend_cli.py::test_main_report_supports_output_file_only tests/test_trend_cli.py::test_main_report_uses_requested_directory tests/test_trend_cli.py::test_main_report_writes_pdf_when_requested tests/test_trend_cli.py::test_main_report_pdf_dependency_error tests/test_trend_cli_entrypoints.py::test_main_report_command -q`


------
https://chatgpt.com/codex/tasks/task_e_68dfc66967e883319189fc3872372b6d