### PR TITLE
docs: document unified report workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ trend run --config config/demo.yml
 trend report --config config/demo.yml --out perf
 
 # Produce a unified HTML report (and optional PDF) alongside artefacts
-trend report --config config/demo.yml --out perf --output reports --pdf
+trend report --config config/demo.yml --output reports --pdf
 
 # Execute a canned stress scenario focused on the 2008 crisis window
 trend stress --config config/demo.yml --scenario 2008

--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ trend run --config config/demo.yml
 # Generate a structured report bundle in ./perf
 trend report --config config/demo.yml --out perf
 
+# Produce a unified HTML report (and optional PDF) alongside artefacts
+trend report --config config/demo.yml --out perf --output reports --pdf
+
 # Execute a canned stress scenario focused on the 2008 crisis window
 trend stress --config config/demo.yml --scenario 2008
 
@@ -175,7 +178,12 @@ trend app
 
 Provide ``--returns`` to override ``data.csv_path`` from the configuration when
 running in ad-hoc mode.  The ``TREND_SEED`` environment variable and ``--seed``
-flag follow the same precedence as the legacy CLI.
+flag follow the same precedence as the legacy CLI.  The ``trend report``
+command accepts ``--output`` to write the unified HTML report to a specific
+file or directory and ``--pdf`` to request a matching PDF copy (requires the
+``fpdf2`` dependency).  These downloads match the Streamlit "Download report"
+buttons byte-for-byte so analysts receive identical content regardless of the
+interface they use.
 
 The historical ``trend-model`` command remains available for backward
 compatibility and forwards to the new implementation.

--- a/README_APP.md
+++ b/README_APP.md
@@ -31,7 +31,7 @@ scripts/run_streamlit.sh
 ### Unified report downloads
 
 The Results page now exposes "Download report" buttons for HTML and, when the
-optional ``fpdf2`` dependency is installed, PDF output.  Both use the same
+optional ``fpdf2`` dependency is installed, PDF output. Both use the same
 `trend.reporting.generate_unified_report` helper that powers the CLI, ensuring
 reports downloaded from the UI are byte-identical to those produced via
 ``trend report --output``.

--- a/README_APP.md
+++ b/README_APP.md
@@ -28,6 +28,14 @@ Or use the repo launcher which ensures the venv and extras are present:
 scripts/run_streamlit.sh
 ```
 
+### Unified report downloads
+
+The Results page now exposes "Download report" buttons for HTML and, when the
+optional ``fpdf2`` dependency is installed, PDF output.  Both use the same
+`trend.reporting.generate_unified_report` helper that powers the CLI, ensuring
+reports downloaded from the UI are byte-identical to those produced via
+``trend report --output``.
+
 ## Integration with your pipeline
 - If available, the code calls `trend_analysis.pipeline.single_period_run(...)` to compute the score frame.
 - If import fails, it falls back to a local metrics implementation so the app still runs.


### PR DESCRIPTION
## Summary
- document the new `trend report --output/--pdf` flow in the main README and note parity with the Streamlit downloads
- describe the Streamlit "Download report" buttons and their shared generator in `README_APP.md`

## Testing
- pytest tests/test_trend_cli.py::test_cli_report_matches_shared_generator -q
- pytest tests/test_unified_report.py tests/test_trend_cli.py::test_main_report_supports_output_file_only tests/test_trend_cli.py::test_main_report_uses_requested_directory tests/test_trend_cli.py::test_main_report_writes_pdf_when_requested tests/test_trend_cli.py::test_main_report_pdf_dependency_error tests/test_trend_cli_entrypoints.py::test_main_report_command -q


------
https://chatgpt.com/codex/tasks/task_e_68dfd1859de88331a12b61fd2db421aa