### PR TITLE
Implement TrendSpec preset registry and wire presets through CLI and UI

### DIFF
--- a/docs/PresetStrategies.md
+++ b/docs/PresetStrategies.md
@@ -8,6 +8,11 @@ The project ships with three configuration presets that provide sensible default
 | **Balanced** | Moderate risk | 36‑month lookback, monthly rebalancing, target volatility 10%, even mix of return and risk metrics |
 | **Aggressive** | High risk tolerance | 24‑month lookback, monthly rebalancing, target volatility 15%, emphasises return and agility |
 
+The trend-signal presets follow the same spectrum. Conservative applies a 126-period
+window with heavier smoothing (min 90 periods, z-scored, 8% volatility target),
+Balanced uses an 84-period window with moderate smoothing and a 10% target, while
+Aggressive drops to 42 periods with minimal smoothing and a 15% volatility cap.
+
 ## When to use each preset
 
 ### Conservative

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -54,6 +54,20 @@ python -m trend_analysis.run_analysis -c config/presets/balanced.yml
 Replace `balanced` with `conservative` or `aggressive` as needed. See
 [PresetStrategies.md](PresetStrategies.md) for a summary of each option.
 
+The CLI also supports merging signal presets into any configuration without
+swapping YAML files. Supply `--preset` to `trend-model run` and the TrendSpec
+parameters (window, lag, volatility scaling, and z-score toggle) are injected
+before the analysis starts:
+
+```bash
+trend-model run -c config/demo.yml -i data/returns.csv --preset Aggressive
+```
+
+On the Streamlit side the **Trend Signal Settings** card mirrors the registry.
+Selecting “Conservative” or “Aggressive” updates the window, minimum period,
+volatility scaling and target sliders immediately so the form and CLI stay in
+sync.
+
 ### 4.1 Handling missing data
 
 Two configuration knobs control how sparse series are treated during ingest:

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -17,6 +17,11 @@ from . import logging as run_logging
 from . import pipeline
 from .api import run_simulation
 from .config import load_config
+from .signal_presets import (
+    TrendSpecPreset,
+    get_trend_spec_preset,
+    list_trend_spec_presets,
+)
 from .constants import DEFAULT_OUTPUT_DIRECTORY, DEFAULT_OUTPUT_FORMATS
 from .data import load_csv
 from .io.market_data import MarketDataValidationError
@@ -42,6 +47,35 @@ def load_market_data_csv(
         include_date_column if include_date_column is not None else True,
     )
     return load_csv(path, **effective_kwargs)
+
+
+def _apply_trend_spec_preset(cfg: Any, preset: TrendSpecPreset) -> None:
+    """Merge TrendSpec preset parameters into ``cfg`` in-place."""
+
+    payload = preset.as_signal_config()
+    if isinstance(cfg, dict):
+        existing = cfg.get("signals")
+        merged = dict(existing) if isinstance(existing, Mapping) else {}
+        merged.update(payload)
+        cfg["signals"] = merged
+        cfg["trend_spec_preset"] = preset.name
+        return
+
+    existing = getattr(cfg, "signals", None)
+    if isinstance(existing, Mapping):
+        merged = dict(existing)
+        merged.update(payload)
+    else:
+        merged = dict(payload)
+
+    try:
+        setattr(cfg, "signals", merged)
+    except ValueError:
+        object.__setattr__(cfg, "signals", merged)
+    try:
+        setattr(cfg, "trend_spec_preset", preset.name)
+    except ValueError:
+        object.__setattr__(cfg, "trend_spec_preset", preset.name)
 
 
 def _log_step(
@@ -183,6 +217,10 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Disable persistent caching for rolling computations",
     )
+    run_p.add_argument(
+        "--preset",
+        help="TrendSpec preset to apply (e.g. Conservative, Aggressive)",
+    )
 
     # Handle --check flag before parsing subcommands
     # This allows --check to work without requiring a subcommand
@@ -208,6 +246,17 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "run":
         cfg = load_config(args.config)
+        if args.preset:
+            try:
+                preset = get_trend_spec_preset(args.preset)
+            except KeyError:
+                available = ", ".join(list_trend_spec_presets())
+                print(
+                    f"Unknown preset '{args.preset}'. Available presets: {available}",
+                    file=sys.stderr,
+                )
+                return 2
+            _apply_trend_spec_preset(cfg, preset)
         set_cache_enabled(not args.no_cache)
         cli_seed = args.seed
         env_seed = os.getenv("TREND_SEED")

--- a/src/trend_analysis/signal_presets.py
+++ b/src/trend_analysis/signal_presets.py
@@ -1,0 +1,142 @@
+"""Named TrendSpec presets shared between CLI and UI layers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+from .signals import TrendSpec
+
+
+@dataclass(frozen=True, slots=True)
+class TrendSpecPreset:
+    """Container describing a preset TrendSpec configuration."""
+
+    name: str
+    description: str
+    spec: TrendSpec
+
+    def as_signal_config(self) -> Dict[str, object]:
+        """Return a mapping suitable for config ``signals`` sections."""
+
+        payload: Dict[str, object] = {
+            "kind": self.spec.kind,
+            "window": self.spec.window,
+            "lag": self.spec.lag,
+            "vol_adjust": self.spec.vol_adjust,
+            "zscore": self.spec.zscore,
+        }
+        if self.spec.min_periods is not None:
+            payload["min_periods"] = self.spec.min_periods
+        if self.spec.vol_target is not None:
+            payload["vol_target"] = self.spec.vol_target
+        return payload
+
+    def form_defaults(self) -> Dict[str, object]:
+        """Return defaults for interactive forms (min periods/vol target optional)."""
+
+        defaults: Dict[str, object] = {
+            "window": self.spec.window,
+            "min_periods": self.spec.min_periods or 0,
+            "lag": self.spec.lag,
+            "vol_adjust": self.spec.vol_adjust,
+            "vol_target": self.spec.vol_target or 0.0,
+            "zscore": self.spec.zscore,
+        }
+        return defaults
+
+
+_DEFAULT_PRESET_NAME = "Balanced"
+
+_PRESETS: Dict[str, TrendSpecPreset] = {
+    "conservative": TrendSpecPreset(
+        name="Conservative",
+        description="Longer window with heavier smoothing and lower volatility target.",
+        spec=TrendSpec(
+            window=126,
+            min_periods=90,
+            lag=1,
+            vol_adjust=True,
+            vol_target=0.08,
+            zscore=True,
+        ),
+    ),
+    "balanced": TrendSpecPreset(
+        name="Balanced",
+        description="Default configuration offering a balance between responsiveness and stability.",
+        spec=TrendSpec(
+            window=84,
+            min_periods=63,
+            lag=1,
+            vol_adjust=True,
+            vol_target=0.10,
+            zscore=True,
+        ),
+    ),
+    "aggressive": TrendSpecPreset(
+        name="Aggressive",
+        description="Shorter window prioritising responsiveness with higher volatility allowance.",
+        spec=TrendSpec(
+            window=42,
+            min_periods=30,
+            lag=1,
+            vol_adjust=True,
+            vol_target=0.15,
+            zscore=False,
+        ),
+    ),
+}
+
+
+def default_preset_name() -> str:
+    """Return the default preset name used by the application."""
+
+    return _DEFAULT_PRESET_NAME
+
+
+def list_trend_spec_presets() -> List[str]:
+    """Return the available TrendSpec preset names (title case)."""
+
+    return [preset.name for preset in _ordered_presets()]
+
+
+def list_trend_spec_keys() -> List[str]:
+    """Return canonical keys for TrendSpec presets (lower case)."""
+
+    return [key for key, _ in _ordered_presets_items()]
+
+
+def get_trend_spec_preset(name: str) -> TrendSpecPreset:
+    """Look up a preset by name (case-insensitive)."""
+
+    key = name.strip().lower()
+    if key not in _PRESETS:
+        raise KeyError(f"Unknown TrendSpec preset: {name}")
+    return _PRESETS[key]
+
+
+def resolve_trend_spec(name: str | None) -> TrendSpecPreset:
+    """Return preset by name falling back to the default when ``name`` is falsy."""
+
+    if not name:
+        return _PRESETS[_DEFAULT_PRESET_NAME.lower()]
+    return get_trend_spec_preset(name)
+
+
+def _ordered_presets() -> Iterable[TrendSpecPreset]:
+    for _, preset in _ordered_presets_items():
+        yield preset
+
+
+def _ordered_presets_items() -> List[tuple[str, TrendSpecPreset]]:
+    return sorted(_PRESETS.items(), key=lambda item: item[0])
+
+
+__all__ = [
+    "TrendSpecPreset",
+    "default_preset_name",
+    "get_trend_spec_preset",
+    "list_trend_spec_presets",
+    "list_trend_spec_keys",
+    "resolve_trend_spec",
+]

--- a/tests/app/test_trend_spec_state.py
+++ b/tests/app/test_trend_spec_state.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+from typing import Any, Dict
+
+import pytest
+
+
+@pytest.fixture()
+def configure_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    stub = ModuleType("streamlit")
+    stub.session_state = {}
+    noop = lambda *args, **kwargs: None
+    for attr in [
+        "subheader",
+        "warning",
+        "selectbox",
+        "number_input",
+        "checkbox",
+        "divider",
+        "info",
+        "error",
+        "success",
+        "button",
+        "markdown",
+        "columns",
+        "expander",
+    ]:
+        setattr(stub, attr, noop)
+    monkeypatch.setitem(sys.modules, "streamlit", stub)
+    module = importlib.reload(importlib.import_module("streamlit_app.pages.2_Configure"))
+    return module
+
+
+def test_apply_trend_spec_preset_to_state_sets_defaults(
+    configure_module: ModuleType,
+) -> None:
+    state: Dict[str, Any] = {
+        "trend_spec_values": {},
+        "trend_spec_defaults": {},
+        "trend_spec_preset": None,
+        "trend_spec_config": {},
+    }
+    result = configure_module._apply_trend_spec_preset_to_state(state, "Conservative")
+    assert result["window"] == 126
+    assert state["trend_spec_values"]["window"] == 126
+    assert state["trend_spec_preset"] == "Conservative"
+    assert state["trend_spec_config"]["lag"] == 1
+
+
+def test_apply_trend_spec_preset_none_falls_back_to_defaults(
+    configure_module: ModuleType,
+) -> None:
+    state: Dict[str, Any] = {
+        "trend_spec_values": {},
+        "trend_spec_defaults": {},
+        "trend_spec_preset": None,
+        "trend_spec_config": {},
+    }
+    result = configure_module._apply_trend_spec_preset_to_state(state, None)
+    assert result["window"] == configure_module.TrendSpec().window
+    assert state["trend_spec_preset"] is None

--- a/tests/test_cli_trend_presets.py
+++ b/tests/test_cli_trend_presets.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from trend_analysis.cli import _apply_trend_spec_preset
+from trend_analysis.config import load_config
+from trend_analysis.signal_presets import get_trend_spec_preset
+
+
+@pytest.fixture()
+def base_config() -> object:
+    sample_csv = Path(__file__).parent.parent / "data" / "raw" / "managers" / "sample_manager.csv"
+    cfg_dict = {
+        "version": "0.1",
+        "data": {
+            "date_column": "Date",
+            "frequency": "M",
+            "csv_path": str(sample_csv),
+        },
+        "preprocessing": {},
+        "vol_adjust": {"target_vol": 0.1},
+        "sample_split": {},
+        "portfolio": {
+            "rebalance_calendar": "NYSE",
+            "max_turnover": 1.0,
+            "transaction_cost_bps": 0,
+        },
+        "metrics": {},
+        "export": {},
+        "run": {},
+    }
+    return load_config(cfg_dict)
+
+
+def test_apply_trend_spec_preset_sets_signals(base_config: object) -> None:
+    preset = get_trend_spec_preset("Aggressive")
+    _apply_trend_spec_preset(base_config, preset)
+    signals = getattr(base_config, "signals")
+    assert signals["window"] == preset.spec.window
+    assert signals["lag"] == preset.spec.lag
+    assert signals["vol_adjust"] is preset.spec.vol_adjust
+    assert pytest.approx(signals.get("vol_target", 0.0), rel=1e-6) == pytest.approx(
+        preset.spec.vol_target or 0.0
+    )
+    assert getattr(base_config, "trend_spec_preset") == "Aggressive"
+
+
+def test_apply_trend_spec_preset_on_mapping() -> None:
+    preset = get_trend_spec_preset("Balanced")
+    cfg: dict[str, object] = {}
+    _apply_trend_spec_preset(cfg, preset)
+    assert cfg["trend_spec_preset"] == "Balanced"
+    assert cfg["signals"]["window"] == preset.spec.window

--- a/tests/test_signal_presets.py
+++ b/tests/test_signal_presets.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from trend_analysis.signal_presets import (
+    TrendSpecPreset,
+    get_trend_spec_preset,
+    list_trend_spec_presets,
+    resolve_trend_spec,
+)
+
+
+def test_list_trend_spec_presets_contains_expected_names() -> None:
+    names = list_trend_spec_presets()
+    assert {"Conservative", "Balanced", "Aggressive"}.issubset(set(names))
+
+
+def test_get_trend_spec_preset_case_insensitive() -> None:
+    preset = get_trend_spec_preset("conservative")
+    assert isinstance(preset, TrendSpecPreset)
+    assert preset.spec.window == 126
+    assert preset.spec.vol_adjust is True
+    assert pytest.approx(preset.spec.vol_target or 0.0, rel=1e-6) == 0.08
+
+
+def test_resolve_trend_spec_falls_back_to_default() -> None:
+    fallback = resolve_trend_spec(None)
+    assert fallback.name == "Balanced"
+    config = fallback.as_signal_config()
+    assert config["window"] == fallback.spec.window
+    assert config["vol_adjust"] is True
+    assert config["lag"] == 1
+
+
+def test_unknown_preset_raises_key_error() -> None:
+    with pytest.raises(KeyError):
+        get_trend_spec_preset("missing")


### PR DESCRIPTION
## Summary
- add a shared TrendSpec preset registry with conservative/balanced/aggressive defaults
- extend the Streamlit Configure page with Trend Signal settings backed by the preset registry
- allow `trend-model run` to accept a `--preset` flag that merges the preset into the loaded config and document the workflow
- cover the new preset flows with targeted CLI/UI tests and unit tests for the registry

## Testing
- PYTHONPATH=src pytest tests/test_signal_presets.py tests/test_cli_trend_presets.py tests/app/test_trend_spec_state.py

------
https://chatgpt.com/codex/tasks/task_e_68dfd8d4898883318c6d28c612423b38