### PR TITLE
Add shared trend preset registry and wire to UI/CLI

### DIFF
--- a/README_APP.md
+++ b/README_APP.md
@@ -40,6 +40,23 @@ reports downloaded from the UI are byte-identical to those produced via
 - If available, the code calls `trend_analysis.pipeline.single_period_run(...)` to compute the score frame.
 - If import fails, it falls back to a local metrics implementation so the app still runs.
 
+## Trend presets in the UI and CLI
+
+The Configure page surfaces curated signal presets so users can quickly load
+the "Conservative" or "Aggressive" trend settings without tuning every slider.
+Selecting a preset updates the trend signal lookback, minimum periods, lag, and
+volatility scaling controls alongside the existing portfolio inputs.
+
+The same registry powers the CLI. Run the analysis with a preset by supplying
+`--preset`:
+
+```bash
+trend-model run --preset conservative -c my_config.yml -i returns.csv
+```
+
+Both surfaces share the underlying `TrendSpec` parameters, keeping the Streamlit
+app and CLI in sync.
+
 ## Monte Carlo
 Skeletons for multi-path generation and feature sweeps live under `src/trend_portfolio_app/monte_carlo/`.
 

--- a/config/presets/aggressive.yml
+++ b/config/presets/aggressive.yml
@@ -20,6 +20,15 @@ metrics:
   max_drawdown: 0.15  # Lower concern for drawdowns
   volatility: 0.15
 
+# Trend signal configuration
+signals:
+  window: 42           # ≈2 months of trading days
+  min_periods: 30      # Require at least ~1.5 months of history
+  lag: 1
+  vol_adjust: true
+  vol_target: 0.15
+  zscore: true
+
 # Aggressive portfolio construction
 portfolio:
   max_weight: 0.10  # Lower max weight for diversification

--- a/config/presets/balanced.yml
+++ b/config/presets/balanced.yml
@@ -16,9 +16,18 @@ risk_target: 0.10  # Standard target volatility (10%)
 # Balanced metrics weighting
 metrics:
   sharpe_ratio: 0.3
-  return_ann: 0.3  
+  return_ann: 0.3
   max_drawdown: 0.25
   volatility: 0.15
+
+# Trend signal configuration
+signals:
+  window: 84           # ≈4 months of trading days
+  min_periods: 63
+  lag: 1
+  vol_adjust: true
+  vol_target: 0.10
+  zscore: false
 
 # Balanced portfolio construction
 portfolio:

--- a/config/presets/cash_constrained.yml
+++ b/config/presets/cash_constrained.yml
@@ -24,3 +24,12 @@ rebalance_frequency: monthly
 min_track_months: 24
 selection_count: 8
 risk_target: 0.10
+
+# Trend signal configuration
+signals:
+  window: 63
+  min_periods: 42
+  lag: 1
+  vol_adjust: true
+  vol_target: 0.10
+  zscore: false

--- a/config/presets/conservative.yml
+++ b/config/presets/conservative.yml
@@ -20,6 +20,15 @@ metrics:
   volatility: 0.2
   return_ann: 0.1
 
+# Trend signal configuration
+signals:
+  window: 126          # ≈6 months of trading days
+  min_periods: 84      # Require at least 4 months of history
+  lag: 1               # One-period execution delay
+  vol_adjust: true
+  vol_target: 0.08
+  zscore: false
+
 # Conservative portfolio construction
 portfolio:
   max_weight: 0.25  # Higher concentration allowed for conservative picks

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -21,6 +21,7 @@ from .constants import DEFAULT_OUTPUT_DIRECTORY, DEFAULT_OUTPUT_FORMATS
 from .data import load_csv
 from .io.market_data import MarketDataValidationError
 from .perf.rolling_cache import set_cache_enabled
+from .presets import apply_trend_preset, get_trend_preset, list_preset_slugs
 
 APP_PATH = Path(__file__).resolve().parents[2] / "streamlit_app" / "app.py"
 LOCK_PATH = Path(__file__).resolve().parents[2] / "requirements.lock"
@@ -183,6 +184,10 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Disable persistent caching for rolling computations",
     )
+    run_p.add_argument(
+        "--preset",
+        help="Apply a named trend preset to signal generation",
+    )
 
     # Handle --check flag before parsing subcommands
     # This allows --check to work without requiring a subcommand
@@ -209,6 +214,17 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "run":
         cfg = load_config(args.config)
         set_cache_enabled(not args.no_cache)
+        if getattr(args, "preset", None):
+            try:
+                preset = get_trend_preset(args.preset)
+            except KeyError:
+                available = ", ".join(list_preset_slugs())
+                print(
+                    f"Unknown preset '{args.preset}'. Available: {available}",
+                    file=sys.stderr,
+                )
+                return 2
+            apply_trend_preset(cfg, preset)
         cli_seed = args.seed
         env_seed = os.getenv("TREND_SEED")
         # Precedence: CLI flag > TREND_SEED > config.seed > default 42

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -199,7 +199,7 @@ if _HAS_PYDANTIC:
         """Typed access to the YAML configuration (Pydantic mode)."""
 
         # Field lists generated dynamically from model fields to prevent maintenance burden
-        OPTIONAL_DICT_FIELDS: ClassVar[set[str]] = {"performance"}
+        OPTIONAL_DICT_FIELDS: ClassVar[set[str]] = {"performance", "signals"}
 
         @classmethod
         def _dict_field_names(cls) -> List[str]:
@@ -279,6 +279,7 @@ if _HAS_PYDANTIC:
         portfolio: dict[str, Any] = Field(default_factory=dict)
         benchmarks: dict[str, str] = Field(default_factory=dict)
         metrics: dict[str, Any] = Field(default_factory=dict)
+        signals: dict[str, Any] = Field(default_factory=dict)
         export: dict[str, Any] = Field(default_factory=dict)
         performance: dict[str, Any] = Field(default_factory=dict)
         output: dict[str, Any] | None = None
@@ -394,6 +395,7 @@ else:  # Fallback mode for tests without pydantic
             "portfolio",
             "benchmarks",
             "metrics",
+            "signals",
             "export",
             "performance",
             "output",
@@ -404,7 +406,7 @@ else:  # Fallback mode for tests without pydantic
             "seed",
         ]
 
-        OPTIONAL_DICT_FIELDS: ClassVar[set[str]] = {"performance"}
+        OPTIONAL_DICT_FIELDS: ClassVar[set[str]] = {"performance", "signals"}
 
         # Attribute declarations for linters/type-checkers
         version: str
@@ -415,6 +417,7 @@ else:  # Fallback mode for tests without pydantic
         portfolio: Dict[str, Any]
         benchmarks: Dict[str, str]
         metrics: Dict[str, Any]
+        signals: Dict[str, Any]
         export: Dict[str, Any]
         performance: Dict[str, Any]
         output: Dict[str, Any] | None
@@ -433,6 +436,7 @@ else:  # Fallback mode for tests without pydantic
                 "portfolio": {},
                 "benchmarks": {},
                 "metrics": {},
+                "signals": {},
                 "export": {},
                 "performance": {},
                 "output": None,
@@ -520,6 +524,7 @@ class PresetConfig(SimpleBaseModel):
         "sample_split",
         "portfolio",
         "metrics",
+        "signals",
         "export",
         "run",
     ]

--- a/src/trend_analysis/presets.py
+++ b/src/trend_analysis/presets.py
@@ -1,0 +1,336 @@
+"""Registry of named TrendSpec presets shared across CLI and Streamlit UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping, MutableMapping
+
+import yaml
+
+from .signals import TrendSpec
+
+PRESETS_DIR = Path(__file__).resolve().parents[2] / "config" / "presets"
+
+# Metric aliases exposed for UI components and pipeline wiring.
+UI_METRIC_ALIASES: Mapping[str, str] = MappingProxyType(
+    {
+        "sharpe_ratio": "sharpe",
+        "sharpe": "sharpe",
+        "return_ann": "return_ann",
+        "annual_return": "return_ann",
+        "max_drawdown": "drawdown",
+        "drawdown": "drawdown",
+        "volatility": "vol",
+        "vol": "vol",
+    }
+)
+
+PIPELINE_METRIC_ALIASES: Mapping[str, str] = MappingProxyType(
+    {
+        "sharpe": "Sharpe",
+        "return_ann": "AnnualReturn",
+        "drawdown": "MaxDrawdown",
+        "max_drawdown": "MaxDrawdown",
+        "vol": "Volatility",
+        "volatility": "Volatility",
+    }
+)
+
+
+def _freeze_mapping(data: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return an immutable view over ``data`` suitable for storage on presets."""
+
+    return MappingProxyType({k: data[k] for k in data})
+
+
+def _normalise_metric_weights(raw: Mapping[str, Any]) -> dict[str, float]:
+    weights: dict[str, float] = {}
+    for key, value in raw.items():
+        alias = normalise_metric_key(str(key))
+        if alias is None:
+            continue
+        try:
+            weight = float(value)
+        except (TypeError, ValueError):
+            continue
+        weights[alias] = weight
+    return weights
+
+
+def _coerce_int(value: Any, default: int, minimum: int = 1) -> int:
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(coerced, minimum)
+
+
+def _coerce_optional_int(value: Any | None, minimum: int = 1) -> int | None:
+    if value is None:
+        return None
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return None
+    if coerced < minimum:
+        return None
+    return coerced
+
+
+def _coerce_optional_float(value: Any | None, minimum: float = 0.0) -> float | None:
+    if value is None:
+        return None
+    try:
+        coerced = float(value)
+    except (TypeError, ValueError):
+        return None
+    if coerced < minimum:
+        return None
+    return coerced
+
+
+def _build_trend_spec(config: Mapping[str, Any]) -> TrendSpec:
+    signals = config.get("signals")
+    if not isinstance(signals, Mapping):
+        signals = {}
+
+    window = _coerce_int(signals.get("window"), default=63, minimum=1)
+    min_periods = _coerce_optional_int(signals.get("min_periods"))
+    if min_periods is not None and min_periods > window:
+        min_periods = window
+    lag = _coerce_int(signals.get("lag"), default=1, minimum=1)
+    vol_adjust = bool(signals.get("vol_adjust", False))
+    vol_target = _coerce_optional_float(signals.get("vol_target"))
+    zscore = bool(signals.get("zscore", False))
+
+    return TrendSpec(
+        window=window,
+        min_periods=min_periods,
+        lag=lag,
+        vol_adjust=vol_adjust,
+        vol_target=vol_target,
+        zscore=zscore,
+    )
+
+
+@dataclass(frozen=True)
+class TrendPreset:
+    """Container holding preset metadata and normalised configuration."""
+
+    slug: str
+    label: str
+    description: str
+    trend_spec: TrendSpec
+    _config: Mapping[str, Any]
+
+    def form_defaults(self) -> dict[str, Any]:
+        """Return UI-ready defaults derived from the preset."""
+
+        preset = self._config
+        portfolio = preset.get("portfolio")
+        if not isinstance(portfolio, Mapping):
+            portfolio = {}
+
+        defaults = {
+            "lookback_months": _coerce_int(
+                preset.get("lookback_months"), default=36, minimum=1
+            ),
+            "rebalance_frequency": str(
+                preset.get("rebalance_frequency", "monthly")
+            ),
+            "min_track_months": _coerce_int(
+                preset.get("min_track_months"), default=24, minimum=1
+            ),
+            "selection_count": _coerce_int(
+                preset.get("selection_count"), default=10, minimum=1
+            ),
+            "risk_target": _coerce_optional_float(
+                preset.get("risk_target"), minimum=0.0
+            )
+            or 0.1,
+            "weighting_scheme": str(portfolio.get("weighting_scheme", "equal")),
+            "cooldown_months": _coerce_int(
+                portfolio.get("cooldown_months"), default=3, minimum=0
+            ),
+            "metrics": _normalise_metric_weights(
+                preset.get("metrics", {})
+                if isinstance(preset.get("metrics"), Mapping)
+                else {}
+            ),
+        }
+        return defaults
+
+    def signals_mapping(self) -> dict[str, Any]:
+        """Return a mapping suitable for embedding into configuration."""
+
+        spec = self.trend_spec
+        mapping: dict[str, Any] = {
+            "kind": spec.kind,
+            "window": spec.window,
+            "lag": spec.lag,
+            "vol_adjust": spec.vol_adjust,
+            "zscore": spec.zscore,
+        }
+        if spec.min_periods is not None:
+            mapping["min_periods"] = spec.min_periods
+        if spec.vol_target is not None:
+            mapping["vol_target"] = spec.vol_target
+        return mapping
+
+    def vol_adjust_defaults(self) -> dict[str, Any]:
+        """Return a shallow copy of vol adjustment overrides."""
+
+        preset = self._config.get("vol_adjust")
+        base: dict[str, Any] = {}
+        if isinstance(preset, Mapping):
+            base.update(preset)
+        if "enabled" not in base:
+            base["enabled"] = self.trend_spec.vol_adjust
+        base.setdefault("target_vol", self.trend_spec.vol_target)
+        window = base.get("window")
+        if isinstance(window, MutableMapping):
+            window = dict(window)
+        elif isinstance(window, Mapping):
+            window = dict(window.items())
+        else:
+            window = {}
+        window.setdefault("length", self.trend_spec.window)
+        base["window"] = window
+        return base
+
+    def metrics_pipeline(self) -> dict[str, float]:
+        """Return metrics mapped to pipeline registry names."""
+
+        weights = self.form_defaults()["metrics"]
+        return {
+            pipeline_metric_key(metric) or metric: float(weight)
+            for metric, weight in weights.items()
+        }
+
+
+def _load_yaml(path: Path) -> Mapping[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, Mapping):
+        return {}
+    return data
+
+
+@lru_cache(maxsize=None)
+def _preset_registry() -> Mapping[str, TrendPreset]:
+    registry: dict[str, TrendPreset] = {}
+    if not PRESETS_DIR.exists():
+        return MappingProxyType(registry)
+    for path in sorted(PRESETS_DIR.glob("*.yml")):
+        slug = path.stem.lower()
+        raw = _load_yaml(path)
+        if not raw:
+            continue
+        label = str(raw.get("name") or slug.title())
+        description = str(raw.get("description") or "")
+        spec = _build_trend_spec(raw)
+        preset = TrendPreset(
+            slug=slug,
+            label=label,
+            description=description,
+            trend_spec=spec,
+            _config=_freeze_mapping(dict(raw)),
+        )
+        registry[slug] = preset
+    return MappingProxyType(registry)
+
+
+def list_trend_presets() -> tuple[TrendPreset, ...]:
+    """Return all presets sorted by display label."""
+
+    registry = _preset_registry().values()
+    return tuple(sorted(registry, key=lambda preset: preset.label.lower()))
+
+
+def list_preset_slugs() -> tuple[str, ...]:
+    """Return available preset slugs (lowercase identifiers)."""
+
+    return tuple(sorted(_preset_registry().keys()))
+
+
+def get_trend_preset(name: str) -> TrendPreset:
+    """Look up a preset by slug or display label."""
+
+    if not name:
+        raise KeyError("Preset name must be provided")
+    lowered = name.lower()
+    registry = _preset_registry()
+    if lowered in registry:
+        return registry[lowered]
+    for preset in registry.values():
+        if preset.label.lower() == lowered:
+            return preset
+    raise KeyError(f"Unknown trend preset: {name}")
+
+
+def normalise_metric_key(name: str) -> str | None:
+    """Return the UI metric key corresponding to ``name`` or ``None``."""
+
+    if not name:
+        return None
+    key = UI_METRIC_ALIASES.get(name.lower())
+    return key if key is not None else None
+
+
+def pipeline_metric_key(name: str) -> str | None:
+    """Return the pipeline metric registry name for ``name`` when available."""
+
+    if not name:
+        return None
+    key = PIPELINE_METRIC_ALIASES.get(name.lower())
+    return key if key is not None else None
+
+
+def apply_trend_preset(config: Any, preset: TrendPreset) -> None:
+    """Mutate ``config`` so future pipeline runs use ``preset`` parameters."""
+
+    signals_mapping = preset.signals_mapping()
+    current_signals = getattr(config, "signals", None)
+    if isinstance(current_signals, Mapping):
+        merged = {**current_signals, **signals_mapping}
+    else:
+        merged = dict(signals_mapping)
+    setattr(config, "signals", merged)
+
+    vol_adjust_cfg = getattr(config, "vol_adjust", {})
+    if isinstance(vol_adjust_cfg, MutableMapping):
+        vol_adjust = vol_adjust_cfg
+    elif isinstance(vol_adjust_cfg, Mapping):
+        vol_adjust = dict(vol_adjust_cfg)
+    else:
+        vol_adjust = {}
+
+    defaults = preset.vol_adjust_defaults()
+    vol_adjust.update({k: v for k, v in defaults.items() if v is not None})
+    setattr(config, "vol_adjust", vol_adjust)
+
+    run_section = getattr(config, "run", {})
+    if isinstance(run_section, MutableMapping):
+        run_cfg = run_section
+    elif isinstance(run_section, Mapping):
+        run_cfg = dict(run_section)
+    else:
+        run_cfg = {}
+    run_cfg["trend_preset"] = preset.slug
+    setattr(config, "run", run_cfg)
+
+
+__all__ = [
+    "TrendPreset",
+    "apply_trend_preset",
+    "get_trend_preset",
+    "list_trend_presets",
+    "list_preset_slugs",
+    "normalise_metric_key",
+    "pipeline_metric_key",
+    "UI_METRIC_ALIASES",
+    "PIPELINE_METRIC_ALIASES",
+]
+

--- a/streamlit_app/pages/2_Configure.py
+++ b/streamlit_app/pages/2_Configure.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional
 import pandas as pd
 import streamlit as st
 
-import yaml
 
 
 def _ensure_src_path() -> None:
@@ -24,35 +23,9 @@ from streamlit_app.components.guardrails import (  # noqa: E402
     estimate_resource_usage,
     validate_startup_payload,
 )
+from trend_analysis.presets import TrendPreset, list_trend_presets  # noqa: E402
 from trend_portfolio_app.metrics_extra import AVAILABLE_METRICS  # noqa: E402
 from trend_portfolio_app.policy_engine import MetricSpec, PolicyConfig  # noqa: E402
-
-
-def _resolve_presets_dir() -> Path:
-    """Return the absolute path to the presets directory."""
-
-    return Path(__file__).parent.parent.parent / "config" / "presets"
-
-
-def load_preset_direct(preset_name: str) -> dict:
-    """Load a preset configuration from file."""
-
-    preset_path = _resolve_presets_dir() / f"{preset_name.lower()}.yml"
-    if not preset_path.exists():
-        return {}
-
-    with preset_path.open("r", encoding="utf-8") as preset_file:
-        data = yaml.safe_load(preset_file)
-    return data if isinstance(data, dict) else {}
-
-
-def list_available_presets_direct() -> List[str]:
-    """List all available preset names."""
-
-    presets_dir = _resolve_presets_dir()
-    if not presets_dir.exists():
-        return []
-    return sorted(preset.stem.title() for preset in presets_dir.glob("*.yml"))
 
 
 def _map_payload_errors(payload_errors: Iterable[str]) -> Dict[str, List[str]]:
@@ -103,49 +76,45 @@ def display_inline_errors(field: str) -> None:
         st.markdown(f":red[⚠️ {message}]")
 
 
-def render_preset_selection():
+def render_preset_selection() -> TrendPreset | None:
     """Render preset selection UI."""
+
     st.subheader("📋 Configuration Preset")
 
-    available_presets = list_available_presets_direct()
-    if not available_presets:
+    presets = list_trend_presets()
+    if not presets:
         st.warning("No presets found in config/presets/")
         return None
 
-    preset_options = ["Custom"] + available_presets
-
-    # Get current selection
-    current_preset = st.session_state.config_state.get("preset_name") or "Custom"
+    preset_options = ["Custom"] + [preset.label for preset in presets]
+    current_label = st.session_state.config_state.get("preset_name") or "Custom"
     try:
-        current_index = preset_options.index(current_preset)
+        current_index = preset_options.index(current_label)
     except ValueError:
         current_index = 0
 
-    selected_preset = st.selectbox(
+    selected_label = st.selectbox(
         "Choose a configuration preset:",
         options=preset_options,
         index=current_index,
         help="Presets provide sensible defaults for different risk profiles",
     )
 
-    if selected_preset != "Custom":
-        try:
-            preset_config = load_preset_direct(selected_preset)
-            st.session_state.config_state["preset_name"] = selected_preset
-            st.session_state.config_state["preset_config"] = preset_config
-
-            # Display preset info
-            if preset_config.get("description"):
-                st.info(f"**{selected_preset}**: {preset_config['description']}")
-
-            return preset_config
-        except Exception as e:
-            st.error(f"Failed to load preset '{selected_preset}': {e}")
-            return None
-    else:
+    if selected_label == "Custom":
         st.session_state.config_state["preset_name"] = None
         st.session_state.config_state["preset_config"] = None
         return None
+
+    selected = next((p for p in presets if p.label == selected_label), None)
+    if selected is None:
+        st.error(f"Unknown preset '{selected_label}'")
+        return None
+
+    st.session_state.config_state["preset_name"] = selected.label
+    st.session_state.config_state["preset_config"] = selected
+    if selected.description:
+        st.info(f"**{selected.label}**: {selected.description}")
+    return selected
 
 
 def render_column_mapping(df: pd.DataFrame):
@@ -244,23 +213,32 @@ def render_column_mapping(df: pd.DataFrame):
     return mapping
 
 
-def render_parameter_forms(preset_config: Optional[Dict[str, Any]]):
+def render_parameter_forms(preset: TrendPreset | None):
     """Render parameter configuration forms."""
     st.subheader("⚙️ Analysis Parameters")
 
-    # Get default values from preset or use fallback defaults
-    if preset_config:
-        default_lookback = preset_config.get("lookback_months", 36)
-        default_rebalance = preset_config.get("rebalance_frequency", "monthly")
-        default_min_track = preset_config.get("min_track_months", 24)
-        default_selection = preset_config.get("selection_count", 10)
-        default_risk_target = preset_config.get("risk_target", 0.10)
-    else:
-        default_lookback = 36
-        default_rebalance = "monthly"
-        default_min_track = 24
-        default_selection = 10
-        default_risk_target = 0.10
+    defaults = preset.form_defaults() if preset else {}
+    default_lookback = int(defaults.get("lookback_months", 36))
+    default_rebalance = str(defaults.get("rebalance_frequency", "monthly"))
+    default_min_track = int(defaults.get("min_track_months", 24))
+    default_selection = int(defaults.get("selection_count", 10))
+    default_risk_target = float(defaults.get("risk_target", 0.10))
+
+    signal_spec = preset.trend_spec if preset else None
+    default_signal_window = int(signal_spec.window if signal_spec else 63)
+    default_signal_min = (
+        int(signal_spec.min_periods)
+        if signal_spec and signal_spec.min_periods is not None
+        else default_signal_window
+    )
+    default_signal_lag = int(signal_spec.lag if signal_spec else 1)
+    default_signal_vol_adjust = bool(signal_spec.vol_adjust if signal_spec else False)
+    default_signal_vol_target = (
+        float(signal_spec.vol_target)
+        if signal_spec and signal_spec.vol_target is not None
+        else 0.10
+    )
+    default_signal_zscore = bool(signal_spec.zscore if signal_spec else False)
 
     df = st.session_state.get("returns_df")
     total_months = 0
@@ -357,14 +335,76 @@ def render_parameter_forms(preset_config: Optional[Dict[str, Any]]):
             help="How to allocate weights across selected funds",
         )
 
+    # Trend signal configuration
+    st.markdown("**Trend Signal Parameters**")
+    sig_col1, sig_col2 = st.columns(2)
+    with sig_col1:
+        signal_window = st.number_input(
+            "Signal lookback (trading days)",
+            min_value=10,
+            max_value=504,
+            value=default_signal_window,
+            step=5,
+            help="Rolling window length used to compute the trend signal.",
+        )
+        display_inline_errors("signal_window")
+
+        signal_min_periods = st.number_input(
+            "Minimum periods for signal",
+            min_value=0,
+            max_value=int(signal_window),
+            value=default_signal_min,
+            step=1,
+            help="Required history before the trend signal becomes active.",
+        )
+        display_inline_errors("signal_min_periods")
+
+        signal_lag = st.number_input(
+            "Signal lag (periods)",
+            min_value=1,
+            max_value=12,
+            value=default_signal_lag,
+            step=1,
+            help="Execution delay applied to the computed signal.",
+        )
+
+    with sig_col2:
+        signal_vol_adjust = st.checkbox(
+            "Volatility adjust signals",
+            value=default_signal_vol_adjust,
+            help="Scale signals by recent volatility to stabilise exposures.",
+        )
+        signal_vol_target = None
+        if signal_vol_adjust:
+            signal_vol_target = st.number_input(
+                "Signal volatility target",
+                min_value=0.0,
+                max_value=1.0,
+                value=default_signal_vol_target,
+                step=0.01,
+                format="%.2f",
+                help="Target volatility used when rescaling the signal.",
+            )
+        display_inline_errors("signal_vol_target")
+
+        signal_zscore = st.checkbox(
+            "Apply row-wise z-score normalisation",
+            value=default_signal_zscore,
+            help="Normalise signals across assets for each period.",
+        )
+
     # Metrics selection
     st.markdown("**Selection Metrics**")
     metric_names = list(AVAILABLE_METRICS.keys())
 
-    if preset_config and preset_config.get("metrics"):
-        # Use preset metrics if available
-        default_metrics = list(preset_config["metrics"].keys())
-        preset_weights = preset_config["metrics"]
+    preset_metrics = defaults.get("metrics") if defaults else {}
+    if isinstance(preset_metrics, Mapping) and preset_metrics:
+        default_metrics = [m for m in preset_metrics if m in metric_names]
+        preset_weights = {
+            metric: float(weight)
+            for metric, weight in preset_metrics.items()
+            if metric in metric_names
+        }
     else:
         default_metrics = ["sharpe", "return_ann", "drawdown"]
         preset_weights = {}
@@ -397,6 +437,23 @@ def render_parameter_forms(preset_config: Optional[Dict[str, Any]]):
         display_inline_errors("metric_weights")
 
     # Store custom overrides
+    signals_override = {
+        "window": int(signal_window),
+        "lag": int(signal_lag),
+        "vol_adjust": bool(signal_vol_adjust),
+        "zscore": bool(signal_zscore),
+    }
+    min_periods_val = int(signal_min_periods)
+    if min_periods_val > 0:
+        signals_override["min_periods"] = min_periods_val
+    vol_target_val = (
+        float(signal_vol_target)
+        if signal_vol_target is not None and signal_vol_adjust
+        else None
+    )
+    if vol_target_val is not None:
+        signals_override["vol_target"] = vol_target_val
+
     overrides = {
         "lookback_months": lookback_months,
         "rebalance_frequency": rebalance_freq,
@@ -407,6 +464,7 @@ def render_parameter_forms(preset_config: Optional[Dict[str, Any]]):
         "selected_metrics": selected_metrics,
         "metric_weights": weights,
         "weighting_scheme": weighting_scheme,
+        "signals": signals_override,
     }
 
     st.session_state.config_state["custom_overrides"] = overrides
@@ -490,6 +548,54 @@ def validate_configuration() -> List[str]:
                 "Enter a risk target between 0.01 and 0.50."
             )
 
+        signals = overrides.get("signals", {}) or {}
+        if signals:
+            window_val = signals.get("window", 0)
+            try:
+                window_int = int(window_val)
+            except (TypeError, ValueError):
+                window_int = 0
+            if window_int <= 0:
+                errors.append("Signal window must be a positive integer.")
+                field_errors.setdefault("signal_window", []).append(
+                    "Set a positive number of periods for the signal window."
+                )
+
+            min_periods_raw = signals.get("min_periods")
+            if min_periods_raw is not None:
+                try:
+                    min_periods_int = int(min_periods_raw)
+                except (TypeError, ValueError):
+                    min_periods_int = None
+                if min_periods_int is None or min_periods_int <= 0:
+                    errors.append(
+                        "Minimum periods must be a positive integer when provided."
+                    )
+                    field_errors.setdefault("signal_min_periods", []).append(
+                        "Enter a positive number of periods or leave blank."
+                    )
+                elif window_int and min_periods_int > window_int:
+                    errors.append(
+                        "Signal minimum periods cannot exceed the signal window."
+                    )
+                    field_errors.setdefault("signal_min_periods", []).append(
+                        "Reduce minimum periods so it is not greater than the signal window."
+                    )
+
+            if bool(signals.get("vol_adjust")):
+                vol_target_raw = signals.get("vol_target")
+                try:
+                    vol_target_val = float(vol_target_raw) if vol_target_raw is not None else None
+                except (TypeError, ValueError):
+                    vol_target_val = None
+                if vol_target_val is None or vol_target_val <= 0:
+                    errors.append(
+                        "Provide a positive signal volatility target when volatility adjustment is enabled."
+                    )
+                    field_errors.setdefault("signal_vol_target", []).append(
+                        "Set a positive target or disable volatility adjustment."
+                    )
+
         if df is not None and not df.empty and mapping and mapping.get("date_column"):
             unique_months = df.index.to_period("M").unique()
             lookback = int(overrides.get("lookback_months", 0) or 0)
@@ -565,6 +671,9 @@ def save_configuration():
     config_state["validated_min_config"] = validated_payload
 
     # Save to session state in expected format
+    preset_config = config_state.get("preset_config")
+    preset_slug = preset_config.slug if isinstance(preset_config, TrendPreset) else None
+
     st.session_state["sim_config"] = {
         "start": pd.Timestamp(df.index.min()),
         "end": pd.Timestamp(df.index.max()),
@@ -581,6 +690,8 @@ def save_configuration():
         "risk_target": overrides.get("risk_target", 0.10),
         "column_mapping": config_state.get("column_mapping"),
         "preset_name": config_state.get("preset_name"),
+        "trend_preset": preset_slug,
+        "signals": overrides.get("signals", {}),
         "portfolio": {
             "weighting_scheme": overrides.get("weighting_scheme", "equal"),
         },

--- a/streamlit_app/pages/2_Configure.py
+++ b/streamlit_app/pages/2_Configure.py
@@ -399,12 +399,9 @@ def render_parameter_forms(preset: TrendPreset | None):
 
     preset_metrics = defaults.get("metrics") if defaults else {}
     if isinstance(preset_metrics, Mapping) and preset_metrics:
-        default_metrics = [m for m in preset_metrics if m in metric_names]
-        preset_weights = {
-            metric: float(weight)
-            for metric, weight in preset_metrics.items()
-            if metric in metric_names
-        }
+        filtered_preset_metrics = {metric: weight for metric, weight in preset_metrics.items() if metric in metric_names}
+        default_metrics = list(filtered_preset_metrics.keys())
+        preset_weights = {metric: float(weight) for metric, weight in filtered_preset_metrics.items()}
     else:
         default_metrics = ["sharpe", "return_ann", "drawdown"]
         preset_weights = {}

--- a/streamlit_app/pages/3_Run.py
+++ b/streamlit_app/pages/3_Run.py
@@ -148,6 +148,7 @@ def main():
         "data": {},
         "preprocessing": {},
         "vol_adjust": {"target_vol": cfg_get(cfg, "risk_target", 1.0)},
+        "signals": cfg_get(cfg, "signals", {}),
         "sample_split": {
             "in_start": (start - pd.DateOffset(months=lookback)).strftime("%Y-%m"),
             "in_end": (start - pd.DateOffset(months=1)).strftime("%Y-%m"),
@@ -158,7 +159,7 @@ def main():
         "metrics": {},
         "export": {},
         "benchmarks": {},
-        "run": {},
+        "run": {"trend_preset": cfg_get(cfg, "trend_preset")},
     }
 
     run_sim = _resolve_run_simulation()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,7 +103,7 @@ def test_cli_run_with_preset_applies_signals(tmp_path, monkeypatch):
     monkeypatch.setattr(
         cli,
         "load_market_data_csv",
-        lambda path: SimpleNamespace(frame=frame.copy()),
+        lambda path: SimpleNamespace(frame=frame),
     )
     monkeypatch.setattr(cli, "run_simulation", fake_run_simulation)
     monkeypatch.setattr(cli.export, "format_summary_text", lambda *a, **k: "")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pandas as pd
+import pytest
 
 import yaml
 from trend_analysis import cli
@@ -64,6 +65,68 @@ def _write_cfg(path: Path, version: str, *, csv_path: Path) -> None:
     }
 
     path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+
+def test_cli_run_with_preset_applies_signals(tmp_path, monkeypatch):
+    cfg = tmp_path / "cfg.yml"
+    csv = tmp_path / "data.csv"
+    csv.write_text("Date,A\n2020-01-31,0.0\n")
+    _write_cfg(cfg, "1", csv_path=csv)
+
+    captured: dict[str, object] = {}
+
+    def fake_run_simulation(cfg_obj, df):
+        captured["signals"] = getattr(cfg_obj, "signals", {})
+        captured["vol_adjust"] = getattr(cfg_obj, "vol_adjust", {})
+        captured["run"] = getattr(cfg_obj, "run", {})
+        return RunResult(pd.DataFrame(), {"out_sample_stats": {}}, 42, {})
+
+    original_load_config = cli.load_config
+
+    def fake_load_config(path):
+        cfg_obj = original_load_config(path)
+        setattr(
+            cfg_obj,
+            "sample_split",
+            {
+                "in_start": "2020-01",
+                "in_end": "2020-02",
+                "out_start": "2020-03",
+                "out_end": "2020-04",
+            },
+        )
+        return cfg_obj
+
+    monkeypatch.setattr(cli, "load_config", fake_load_config)
+
+    frame = pd.DataFrame({"Date": pd.to_datetime(["2020-01-31"]), "A": [0.0]})
+    monkeypatch.setattr(
+        cli,
+        "load_market_data_csv",
+        lambda path: SimpleNamespace(frame=frame.copy()),
+    )
+    monkeypatch.setattr(cli, "run_simulation", fake_run_simulation)
+    monkeypatch.setattr(cli.export, "format_summary_text", lambda *a, **k: "")
+    monkeypatch.setattr(cli.export, "export_to_excel", lambda *a, **k: None)
+    monkeypatch.setattr(cli.export, "export_data", lambda *a, **k: None)
+    monkeypatch.setattr(cli.run_logging, "init_run_logger", lambda *a, **k: None)
+
+    rc = cli.main(["run", "-c", str(cfg), "-i", str(csv), "--preset", "conservative"])
+
+    assert rc == 0
+    signals = captured["signals"]
+    assert isinstance(signals, dict)
+    assert signals["window"] == 126
+    assert signals["vol_adjust"] is True
+    assert pytest.approx(signals["vol_target"], rel=1e-6) == 0.08
+
+    vol_adjust = captured["vol_adjust"]
+    assert isinstance(vol_adjust, dict)
+    assert vol_adjust["window"]["length"] == 126
+
+    run_section = captured["run"]
+    assert isinstance(run_section, dict)
+    assert run_section.get("trend_preset") == "conservative"
 
 
 def test_cli_version_custom(tmp_path, monkeypatch):

--- a/tests/test_configure_presets.py
+++ b/tests/test_configure_presets.py
@@ -48,6 +48,12 @@ class TestPresetLoading:
                 0.01 <= data["risk_target"] <= 0.50
             ), "risk_target should be reasonable"
 
+            signals = data.get("signals")
+            assert isinstance(signals, dict), f"Preset {preset_file.name} missing signals"
+            assert "window" in signals, f"Preset {preset_file.name} missing signal window"
+            assert "lag" in signals, f"Preset {preset_file.name} missing signal lag"
+            assert int(signals["window"]) > 0, "Signal window must be positive"
+
     def test_preset_content_differences(self):
         """Test that presets have meaningfully different configurations."""
         presets_dir = Path(__file__).parent.parent / "config" / "presets"

--- a/tests/test_trend_presets.py
+++ b/tests/test_trend_presets.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+
+import pytest
+
+from trend_analysis.presets import (
+    apply_trend_preset,
+    get_trend_preset,
+    list_preset_slugs,
+)
+
+
+def test_preset_registry_includes_expected_slugs():
+    slugs = list_preset_slugs()
+    assert "conservative" in slugs
+    assert "aggressive" in slugs
+
+
+@pytest.mark.parametrize("name", ["conservative", "Conservative"])
+def test_get_trend_preset_resolves_case_insensitive(name):
+    preset = get_trend_preset(name)
+    assert preset.slug == "conservative"
+    assert preset.trend_spec.window == 126
+    assert pytest.approx(preset.trend_spec.vol_target or 0.0, rel=1e-6) == 0.08
+
+
+def test_apply_trend_preset_updates_config():
+    preset = get_trend_preset("aggressive")
+    cfg = SimpleNamespace(vol_adjust={}, run={}, signals={})
+
+    apply_trend_preset(cfg, preset)
+
+    assert cfg.signals["window"] == preset.trend_spec.window
+    assert cfg.signals["vol_adjust"] is True
+    assert pytest.approx(cfg.signals["vol_target"], rel=1e-6) == 0.15
+    assert cfg.vol_adjust["window"]["length"] == preset.trend_spec.window
+    assert cfg.run["trend_preset"] == "aggressive"


### PR DESCRIPTION
## Summary
- add a shared preset registry that exposes TrendSpec definitions from the preset YAML files
- hook the Streamlit configure flow and CLI into the registry so presets synchronise signal settings
- document the new `--preset` flag and extend automated coverage around presets

## Testing
- pytest tests/test_trend_presets.py tests/test_cli.py::test_cli_run_with_preset_applies_signals

------
https://chatgpt.com/codex/tasks/task_e_68dfdc79f34c833185e87116dc509473