### PR TITLE
Documentation: add WORKFLOW_GUIDE.md and update templates - Source Issue #1668

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_codex.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_codex.yml
@@ -5,12 +5,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        **Agent routing:** This form defaults to the `agent:codex` label. Switch the label to `agent:copilot` in the sidebar if Copilot should own the request instead.
+        **Agent routing:** This form defaults to the `agent:codex` label. Switch the label to `agent:copilot` in the sidebar if Copilot should own the request instead, and remove the previous agent label so only one remains before submitting.
   - type: checkboxes
     id: agent_label
     attributes:
       label: Agent label confirmation
-      description: Confirm the sidebar shows the right agent label so automation can assign the issue immediately.
+      description: Confirm the sidebar shows the right agent label so automation can assign the issue immediately and that the other agent label has been cleared.
       options:
         - label: I verified the issue uses either `agent:codex` or `agent:copilot`, whichever matches the help I need.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request_codex.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_codex.yml
@@ -5,12 +5,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        **Agent routing:** This request queues Codex by default. Change the label to `agent:copilot` before submitting if you need the Copilot team instead.
+        **Agent routing:** This request queues Codex by default. Change the label to `agent:copilot` before submitting if you need the Copilot team instead, and clear the other agent label so only one agent is selected.
   - type: checkboxes
     id: agent_label
     attributes:
       label: Agent label confirmation
-      description: Confirm the issue shows the correct agent label so assignment automation runs without delay.
+      description: Confirm the issue shows the correct agent label so assignment automation runs without delay and that no second agent label remains.
       options:
         - label: I confirmed the labels sidebar shows the appropriate agent (`agent:codex` or `agent:copilot`).
           required: true

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -64,6 +64,19 @@ files move or new ones are introduced:
 5. **Stage via branch + PR.** Push the branch and open a PR. The CI suite and
    post-CI summary will validate the workflow wiring before merge.
 
+### Quick staging checklist
+
+- [ ] New or renamed workflow listed in `.github/workflows/README.md` and this
+      guide.
+- [ ] Downstream `workflow_run` consumers updated (`maint-30`, `maint-33`,
+      `merge-manager.yml`, and any custom followers).
+- [ ] Tests that lock workflow names (for example, `tests/test_workflow_*.py`)
+      updated when introducing or retiring slugs.
+- [ ] Failure-tracker label taxonomy confirmed or refreshed if new failure
+      signatures are expected.
+- [ ] Manual workflow dispatches (if applicable) verified in a fork before
+      requesting review.
+
 ## Post-CI status summaries & failure tracking
 
 Two maintenance workflows keep pull requests informed about CI health:


### PR DESCRIPTION
## Summary
- Creates a comprehensive workflow guide covering WFv1 naming scheme, PR processes, and agent assignment
- Updates issue templates to reference appropriate agent labels
- Adds bootstrap file for agent coordination
- Expands the workflow guide with a staging checklist and clarifies issue templates so only one agent label is applied before submission

## Testing
- Not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e00a9b4d348331a8637512f52bb3db