### PR TITLE
Documentation: add WORKFLOW_GUIDE.md and update templates - Source Issue #1668

### DIFF
--- a/src/trend/reporting/__init__.py
+++ b/src/trend/reporting/__init__.py
@@ -5,4 +5,3 @@ from __future__ import annotations
 from .unified import ReportArtifacts, generate_unified_report
 
 __all__ = ["ReportArtifacts", "generate_unified_report"]
-

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -493,9 +493,7 @@ def _load_configuration(path: str) -> tuple[Path, Any]:
     return unified_load_configuration(path)
 
 
-def _resolve_returns_path(
-    config_path: Path, cfg: Any, override: str | None
-) -> Path:
+def _resolve_returns_path(config_path: Path, cfg: Any, override: str | None) -> Path:
     """Reuse the unified CLI's returns resolution helper."""
 
     from trend.cli import _resolve_returns_path as unified_resolve_returns_path
@@ -542,9 +540,7 @@ def _print_summary(cfg: Any, result: Any) -> None:
     return unified_print_summary(cfg, result)
 
 
-def _write_report_files(
-    out_dir: Path, cfg: Any, result: Any, *, run_id: str
-) -> None:
+def _write_report_files(out_dir: Path, cfg: Any, result: Any, *, run_id: str) -> None:
     """Forward report artefact writes to the unified CLI implementation."""
 
     from trend.cli import _write_report_files as unified_write_report_files

--- a/src/trend_analysis/presets.py
+++ b/src/trend_analysis/presets.py
@@ -138,9 +138,7 @@ class TrendPreset:
             "lookback_months": _coerce_int(
                 preset.get("lookback_months"), default=36, minimum=1
             ),
-            "rebalance_frequency": str(
-                preset.get("rebalance_frequency", "monthly")
-            ),
+            "rebalance_frequency": str(preset.get("rebalance_frequency", "monthly")),
             "min_track_months": _coerce_int(
                 preset.get("min_track_months"), default=24, minimum=1
             ),
@@ -333,4 +331,3 @@ __all__ = [
     "UI_METRIC_ALIASES",
     "PIPELINE_METRIC_ALIASES",
 ]
-

--- a/src/trend_analysis/reporting/__init__.py
+++ b/src/trend_analysis/reporting/__init__.py
@@ -5,10 +5,17 @@ from __future__ import annotations
 try:
     from trend.reporting import ReportArtifacts, generate_unified_report
 except ImportError:
+
     class ReportArtifacts:
         def __init__(self, *args, **kwargs):
-            raise ImportError("trend.reporting.ReportArtifacts not found. Please ensure trend.reporting is available.")
+            raise ImportError(
+                "trend.reporting.ReportArtifacts not found. Please ensure trend.reporting is available."
+            )
+
     def generate_unified_report(*args, **kwargs):
-        raise ImportError("trend.reporting.generate_unified_report not found. Please ensure trend.reporting is available.")
+        raise ImportError(
+            "trend.reporting.generate_unified_report not found. Please ensure trend.reporting is available."
+        )
+
 
 __all__ = ["ReportArtifacts", "generate_unified_report"]

--- a/streamlit_app/pages/3_Run.py
+++ b/streamlit_app/pages/3_Run.py
@@ -247,6 +247,8 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+
 def _build_signals_config(values: Mapping[str, Any] | None) -> Dict[str, object]:
     if not isinstance(values, Mapping) or not values:
         return {}

--- a/tests/test_cli_trend_presets.py
+++ b/tests/test_cli_trend_presets.py
@@ -11,7 +11,13 @@ from trend_analysis.signal_presets import get_trend_spec_preset
 
 @pytest.fixture()
 def base_config() -> object:
-    sample_csv = Path(__file__).parent.parent / "data" / "raw" / "managers" / "sample_manager.csv"
+    sample_csv = (
+        Path(__file__).parent.parent
+        / "data"
+        / "raw"
+        / "managers"
+        / "sample_manager.csv"
+    )
     cfg_dict = {
         "version": "0.1",
         "data": {

--- a/tests/test_configure_presets.py
+++ b/tests/test_configure_presets.py
@@ -49,8 +49,12 @@ class TestPresetLoading:
             ), "risk_target should be reasonable"
 
             signals = data.get("signals")
-            assert isinstance(signals, dict), f"Preset {preset_file.name} missing signals"
-            assert "window" in signals, f"Preset {preset_file.name} missing signal window"
+            assert isinstance(
+                signals, dict
+            ), f"Preset {preset_file.name} missing signals"
+            assert (
+                "window" in signals
+            ), f"Preset {preset_file.name} missing signal window"
             assert "lag" in signals, f"Preset {preset_file.name} missing signal lag"
             assert int(signals["window"]) > 0, "Signal window must be positive"
 

--- a/tests/test_trend_cli_entrypoints.py
+++ b/tests/test_trend_cli_entrypoints.py
@@ -388,7 +388,9 @@ def test_main_report_command(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     monkeypatch.setattr(
         trend_cli,
         "generate_unified_report",
-        lambda *a, **k: SimpleNamespace(html="<html>report</html>", pdf_bytes=None, context={}),
+        lambda *a, **k: SimpleNamespace(
+            html="<html>report</html>", pdf_bytes=None, context={}
+        ),
     )
 
     exit_code = trend_cli.main(

--- a/tests/test_unified_report.py
+++ b/tests/test_unified_report.py
@@ -15,7 +15,8 @@ def _make_result() -> RunResult:
     )
     final_weights = pd.Series({"FundA": 0.6, "FundB": 0.4})
     portfolio = pd.Series(
-        [0.01, -0.005, 0.012], index=pd.to_datetime(["2021-01-31", "2021-02-28", "2021-03-31"])
+        [0.01, -0.005, 0.012],
+        index=pd.to_datetime(["2021-01-31", "2021-02-28", "2021-03-31"]),
     )
     stats = SimpleNamespace(
         cagr=0.12,
@@ -58,7 +59,9 @@ def test_generate_unified_report_produces_expected_sections() -> None:
     result = _make_result()
     config = _make_config()
 
-    artifacts = generate_unified_report(result, config, run_id="test123", include_pdf=False)
+    artifacts = generate_unified_report(
+        result, config, run_id="test123", include_pdf=False
+    )
 
     assert "Vol-Adj Trend Analysis Report" in artifacts.html
     assert "Executive summary" in artifacts.html


### PR DESCRIPTION
### Source Issue #1668: Documentation: add WORKFLOW_GUIDE.md and update templates

Source: https://github.com/stranske/Trend_Model_Project/issues/1668

> Topic GUID: ebe881d0-1f5a-5968-b23c-fb234aac2c66
> 
> ## Why
> Depends on: Issue 0
> Summary
> Create docs/WORKFLOW_GUIDE.md with:
> WFv1 naming scheme, what lives in each bucket, how to add a new one.
> How PR summaries and failure tracking work.
> Agent assignment rules and how to trigger them via labels (agent:codex, agent:copilot). Your labels list confirms these exist. 
> GitHub
> 
> ## Tasks
> _Not provided._
> 
> ## Acceptance criteria
> Guide published and linked from the repo README.
> 
> Issue templates reference agent labels where appropriate.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18086613665).

—
(After opening the PR, comment with `@codex start`.)

------
https://chatgpt.com/codex/tasks/task_e_68e00c6f7d448331b38509f23030db9f