### PR TITLE
Documentation: add WORKFLOW_GUIDE.md and update templates - Source Issue #1668

### DIFF
--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -133,6 +133,18 @@ need:
 Only one agent label should be present on an issue at a time. Remove any stale
 label before switching to the other agent to prevent conflicting assignments.
 
+### Quick reference: agent request checklist
+
+When filing an issue that requires Codex or Copilot support:
+
+- [ ] Pick the issue template that matches your request (bug vs. feature).
+- [ ] Ensure the sidebar shows exactly one agent label
+      (`agent:codex` **or** `agent:copilot`).
+- [ ] Remove the other agent label if it was auto-applied from a previous
+      request so assignment does not stall.
+- [ ] Submit the form only after the confirmation checkbox passes—automation
+      will fail fast when both agent labels are present.
+
 ## Cross-references & additional resources
 
 - `.github/workflows/README.md` – Architectural overview and onboarding


### PR DESCRIPTION
## Summary
- publish docs/WORKFLOW_GUIDE.md detailing WFv1 workflow buckets, staging checklists, post-CI status reporting, and agent routing
- link the new guide from README.md and .github/workflows/README.md, plus update Codex issue templates with agent label guidance
- add an agent label quick-reference checklist so requesters confirm the correct `agent:*` label before submitting

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e011cba1cc833190c3fb6b9a065474