### PR TITLE
Add workflow naming compliance audit and guards

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -31,6 +31,11 @@ Temporary state: `pr-10-ci-python.yml` (formerly `ci.yml`) exists solely to pres
 
 > ℹ️ **Gate wrapper retired (Issue #1657).** The invalid standalone `gate.yml` workflow was deleted; the `gate / all-required-green` job within `pr-10-ci-python.yml` is now the sole aggregation point. Do not recreate the wrapper—tests assert the file remains absent.
 
+### 1.2 Naming policy & archive status (Issue #1669)
+- Active workflows **must** use one of the WFv1 prefixes: `pr-*`, `maint-*`, `agents-*`, or `reusable-*`. Guard tests (`tests/test_workflow_naming.py`) enforce this policy.
+- Historical directories `Old/.github/workflows/` and `.github/workflows/archive/` were removed. Reference [ARCHIVE_WORKFLOWS.md](../../ARCHIVE_WORKFLOWS.md) when you need the legacy slugs.
+- New workflows should document their purpose in this README and in [WORKFLOW_AUDIT_TEMP.md](../../WORKFLOW_AUDIT_TEMP.md) so future audits inherit a complete inventory.
+
 Flow:
 1. PR opened → labelers apply path + agent labels.
 2. Labels / branch rules trigger CI, autofix, readiness.

--- a/ARCHIVE_WORKFLOWS.md
+++ b/ARCHIVE_WORKFLOWS.md
@@ -1,17 +1,17 @@
-# Archived GitHub Workflows (updated 2026-10-05)
+# Archived GitHub Workflows (updated 2026-10-07)
 
-This document records the archival and eventual deletion of legacy agent-related workflows now replaced by consolidated reusable pipelines. The most recent sweep (Issue #1419) retired the reusable agent matrix in favour of the focused assigner/watchdog pair.
+This document records the archival and eventual deletion of legacy agent-related workflows now replaced by consolidated reusable pipelines. The most recent sweep (Issue #1419) retired the reusable agent matrix in favour of the focused assigner/watchdog pair. The follow-up sweep for Issue #1669 removed the on-disk archive directory so the history now lives exclusively in git along with this ledger.
 
 ## Removed Legacy Files (Cleanup PR for Issue #1259)
-All deprecated agent automation workflows were deleted from `.github/workflows/` on 2025-09-21 once the stabilization window for the reusable equivalents closed. Historical copies remain under `.github/workflows/archive/` for reference.
+All deprecated agent automation workflows were deleted from `.github/workflows/` on 2025-09-21 once the stabilization window for the reusable equivalents closed. Historical copies formerly lived under `.github/workflows/archive/` but that directory was removed on 2026-10-07 as part of the Issue #1669 cleanup. Retrieve any prior YAML from git history when needed.
 
-| Legacy Workflow | Archived Copy | Replacement Path | Replacement Mode |
-|-----------------|---------------|------------------|------------------|
-| `agent-readiness.yml` | `archive/agent-readiness.yml` | `reuse-agents.yml` → `agents-41-assign-and-watch.yml` | `enable_readiness=true` |
-| `agent-watchdog.yml` | `archive/agent-watchdog.yml` | `reuse-agents.yml` → `agents-41-assign-and-watch.yml` | `enable_watchdog=true` |
-| `codex-preflight.yml` | `archive/codex-preflight.yml` | `reuse-agents.yml` (legacy) | `enable_preflight=true` |
-| `codex-bootstrap-diagnostic.yml` | `archive/codex-bootstrap-diagnostic.yml` | `reuse-agents.yml` (legacy) | `enable_diagnostic=true` |
-| `verify-agent-task.yml` | `archive/verify-agent-task.yml` | `reuse-agents.yml` (legacy) | `enable_verify_issue=true` |
+| Legacy Workflow | Historical Archive Path | Replacement Path | Replacement Mode |
+|-----------------|-------------------------|------------------|------------------|
+| `agent-readiness.yml` | `archive/agent-readiness.yml` (deleted 2026-10-07) | `reuse-agents.yml` → `agents-41-assign-and-watch.yml` | `enable_readiness=true` |
+| `agent-watchdog.yml` | `archive/agent-watchdog.yml` (deleted 2026-10-07) | `reuse-agents.yml` → `agents-41-assign-and-watch.yml` | `enable_watchdog=true` |
+| `codex-preflight.yml` | `archive/codex-preflight.yml` (deleted 2026-10-07) | `reuse-agents.yml` (legacy) | `enable_preflight=true` |
+| `codex-bootstrap-diagnostic.yml` | `archive/codex-bootstrap-diagnostic.yml` (deleted 2026-10-07) | `reuse-agents.yml` (legacy) | `enable_diagnostic=true` |
+| `verify-agent-task.yml` | `archive/verify-agent-task.yml` (deleted 2026-10-07) | `reuse-agents.yml` (legacy) | `enable_verify_issue=true` |
 
 ## Additional Archived Workflows
 - (2026-02-07) `codex-issue-bridge.yml`, `reuse-agents.yml`, and `agents-consumer.yml` moved to the archive before the assigner/watchdog consolidation. The WFv1 renumbering landed in 2026-09 (`agents-40-consumer.yml`, `agents-41-assign-and-watch.yml`, wrappers, plus `reusable-90-agents.yml`).
@@ -19,6 +19,7 @@ All deprecated agent automation workflows were deleted from `.github/workflows/`
 - (2026-10-05) `autoapprove.yml` and `enable-automerge.yml` permanently retired once `maint-45-merge-manager.yml` proved stable (guard test asserts documentation coverage).
 - (2026-10-05) `guard-no-reuse-pr-branches.yml` and `lint-verification.yml` removed after governance documentation and branch protection policies caught up with the consolidated CI stack.
 - (2026-10-05) Remaining stub archives under `Old/.github/workflows/` were deleted; historical copies are available via git history and the references below.
+- (2026-10-07) `.github/workflows/archive/` removed entirely; Issue #1669 ledger (this file) is now the canonical index for prior workflow names.
 
 ## Retired Autofix Wrapper
 - Legacy `autofix.yml` (pre-2025) was deleted during the earlier cleanup. As of 2026-02-15 a new consolidated `maint-32-autofix.yml` now drives both small fixes and trivial failure remediation; the former consumer wrappers have been removed.

--- a/WORKFLOW_AUDIT_TEMP.md
+++ b/WORKFLOW_AUDIT_TEMP.md
@@ -16,6 +16,66 @@ Additional categories retained so every workflow has a single primary home.
 
 ## Inventory by Category
 
+### Naming Compliance Snapshot (Issue #1669)
+- ✅ **All active workflows comply with the WFv1 families** (`pr-*`, `maint-*`, `agents-*`, `reusable-*`). No stragglers remain under legacy slugs.
+- 📁 Historical directories `Old/.github/workflows/` and `.github/workflows/archive/` were deleted; disposition now lives solely in [ARCHIVE_WORKFLOWS.md](ARCHIVE_WORKFLOWS.md).
+- 🧾 The tables below enumerate every workflow with its triggers and the primary consumer so future audits start from an authoritative inventory.
+
+#### Agents family
+| Workflow | Triggers | Primary consumers / notes |
+|----------|----------|----------------------------|
+| `agents-40-consumer.yml` | schedule, workflow_dispatch | Hourly/adhoc entry point that calls `reusable-90-agents.yml` for readiness, diagnostics, or verification drills. |
+| `agents-41-assign-and-watch.yml` | workflow_dispatch, schedule | Unified assigner/watchdog orchestrator invoked by wrappers; handles bootstrap, stale sweeps, and diagnostics. |
+| `agents-41-assign.yml` | issues, pull_request_target, workflow_dispatch | Label-driven wrapper that forwards issue/PR events to the assign-and-watch orchestrator. |
+| `agents-42-watchdog.yml` | workflow_dispatch | Manual watchdog wrapper that redispatches requests through the assign-and-watch workflow. |
+| `agents-43-codex-issue-bridge.yml` | issues, workflow_dispatch | Compatibility shim translating historical Codex bootstrap commands into the unified orchestrator. |
+| `agents-44-copilot-readiness.yml` | workflow_dispatch | Manual readiness probe for Copilot assignments, implemented as a thin wrapper around the reusable agents stack. |
+| `agents-45-verify-codex-bootstrap-matrix.yml` | workflow_dispatch, schedule, push | Scenario matrix validating Codex bootstrap paths on dispatch, nightly schedule, and repository pushes. |
+
+#### Maintenance family
+| Workflow | Triggers | Primary consumers / notes |
+|----------|----------|----------------------------|
+| `maint-30-post-ci-summary.yml` | workflow_run | Posts the consolidated CI/Docker status comment after pipeline completion. |
+| `maint-31-autofix-residual-cleanup.yml` | schedule, workflow_dispatch | Removes stale autofix branches/patch artifacts on schedule or manual dispatch. |
+| `maint-32-autofix.yml` | workflow_run | Consolidated autofix follower that applies hygiene fixes and retries trivial CI failures via `reusable-autofix.yml`. |
+| `maint-33-check-failure-tracker.yml` | workflow_run | Opens/closes CI failure issues once the gate runner finishes. |
+| `maint-34-quarantine-ttl.yml` | schedule, workflow_dispatch, pull_request, push | Governs quarantine TTL enforcement and provides manual diagnostics. |
+| `maint-35-repo-health-self-check.yml` | schedule, workflow_dispatch, pull_request, push | Nightly/weekly ops health probe with manual override support. |
+| `maint-36-actionlint.yml` | pull_request, push, schedule, workflow_dispatch | Actionlint guard for workflow edits, phase-2-dev pushes, and the weekly sweep. |
+| `maint-37-ci-selftest.yml` | workflow_dispatch | Intentional success/failure pair to keep Merge Manager guardrails exercised. |
+| `maint-38-cleanup-codex-bootstrap.yml` | schedule, workflow_dispatch | Prunes stale Codex bootstrap branches and temporary artifacts. |
+| `maint-40-ci-signature-guard.yml` | push, pull_request | Signature verification for CI job manifests; fails if fixtures drift. |
+| `maint-41-chatgpt-issue-sync.yml` | workflow_dispatch | Synchronises ChatGPT topic lists into GitHub issues on demand. |
+| `maint-43-verify-service-bot-pat.yml` | workflow_dispatch | Scheduled/manual check ensuring the automation PAT remains valid. |
+| `maint-44-verify-ci-stack.yml` | workflow_dispatch | Manual diagnostics harness to validate CI/Docker/autofix interplay. |
+| `maint-45-merge-manager.yml` | pull_request, workflow_run | Unified auto-approval + auto-merge gate checking CI, Docker, allowlists, and quiet-period constraints. |
+| `maint-48-selftest-reusable-ci.yml` | workflow_dispatch, schedule, workflow_call | Nightly and ad-hoc self-test of the reusable CI workflow matrix. |
+| `maint-49-stale-prs.yml` | schedule, workflow_dispatch | Stale PR triage/closure. |
+| `maint-52-perf-benchmark.yml` | push, schedule, workflow_dispatch | Performance regression benchmarking with optional manual kicks. |
+| `maint-60-release.yml` | push, workflow_dispatch | Release promotion flow for tagged/main pushes and manual dispatches. |
+
+#### PR family
+| Workflow | Triggers | Primary consumers / notes |
+|----------|----------|----------------------------|
+| `pr-01-gate-orchestrator.yml` | pull_request, workflow_dispatch | Aggregates CI/Docker/actionlint/quarantine status into a single gate job. |
+| `pr-02-label-agent-prs.yml` | pull_request_target | Hardened PR labeler that applies agent origin and risk labels. |
+| `pr-10-ci-python.yml` | workflow_call, pull_request, push | Legacy required-check wrapper invoking `reusable-ci-python.yml` while branch protection migrates. |
+| `pr-12-docker-smoke.yml` | workflow_call, push, pull_request, workflow_dispatch | Docker build + smoke test wrapper over reusable Docker matrix. |
+| `pr-18-workflow-lint.yml` | pull_request, push | Actionlint validation for workflow edits. |
+| `pr-20-selftest-pr-comment.yml` | pull_request | Self-test harness for PR summary bot comment paths. |
+| `pr-30-codeql.yml` | push, pull_request, schedule, workflow_dispatch | CodeQL scanning with manual rerun support. |
+| `pr-31-dependency-review.yml` | pull_request | Dependency diff vulnerability check. |
+| `pr-path-labeler.yml` | pull_request | Path-based labeling for taxonomy/enforcement. |
+
+#### Reusable family
+| Workflow | Triggers | Primary consumers / notes |
+|----------|----------|----------------------------|
+| `reusable-90-agents.yml` | workflow_call | Reusable agent orchestration stack called by the `agents-4x-*` wrappers. |
+| `reusable-99-selftest.yml` | workflow_dispatch, schedule | Nightly/adhoc smoke-test matrix for reusable CI features. |
+| `reusable-autofix.yml` | workflow_call | Reusable autofix logic consumed by `maint-32-autofix.yml`. |
+| `reusable-ci-python.yml` | workflow_call | WFv1 reusable CI executor referenced by PR and maintenance workflows. |
+| `reusable-legacy-ci-python.yml` | workflow_call | Legacy reusable CI contract retained for downstream consumers migrating to WFv1. |
+
 ### 1. Pre-PR / Standard Checks
 - `pr-01-gate-orchestrator.yml` – Aggregates CI, Docker, actionlint, and quarantine TTL for PR events.
 - `pr-10-ci-python.yml` – Core test & coverage gate (consumes `reusable-ci-python.yml`).

--- a/agents/codex-1669.md
+++ b/agents/codex-1669.md
@@ -1,1 +1,14 @@
 <!-- bootstrap for codex on issue #1669 -->
+
+## Issue #1669 – Workflow hygiene follow-up
+
+### Focus areas
+- Finish renaming or retiring any workflows that still used legacy slugs (`ci.yml`, `gate.yml`, `cleanup-codex-bootstrap.yml`, etc.).
+- Remove the archived copies under `Old/.github/workflows/` and `.github/workflows/archive/`; log the disposition in `ARCHIVE_WORKFLOWS.md`.
+- Produce an authoritative inventory of the remaining workflows with triggers + consumers so future audits have a fast starting point.
+
+### Acceptance criteria
+1. Actions tab lists only `pr-*`, `maint-*`, `agents-*`, and `reusable-*` workflows.
+2. Historical archive directories are gone; `ARCHIVE_WORKFLOWS.md` documents where to find replacements in git history.
+3. `WORKFLOW_AUDIT_TEMP.md`, `.github/workflows/README.md`, and `docs/WORKFLOW_GUIDE.md` reflect the cleaned inventory and reference the new guard test coverage.
+4. Guard tests under `tests/test_workflow_*.py` enforce the naming rules and pass locally (`pytest tests/test_workflow_*.py`).

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -35,6 +35,11 @@ possible; introduce a new bucket only when a new lifecycle warrants it.
 4. Update the workflow inventory documentation (this guide and
    `.github/workflows/README.md`) when adding, renaming, or retiring workflows.
 
+### Compliance guardrails (Issue #1669)
+- Tests under `tests/test_workflow_*.py` (notably `test_workflow_naming.py`) fail if a workflow filename falls outside the `pr-*`, `maint-*`, `agents-*`, or `reusable-*` families.
+- Historical archives were removed; lean on [ARCHIVE_WORKFLOWS.md](../ARCHIVE_WORKFLOWS.md) for disposition history and on [WORKFLOW_AUDIT_TEMP.md](../WORKFLOW_AUDIT_TEMP.md) for the authoritative inventory snapshot.
+- When retiring a workflow, ensure the corresponding table entries in those docs reflect the removal to keep audits fast for the next cleanup.
+
 ## Staging new or renamed workflows
 
 Maintaining trigger fidelity requires a bit of bookkeeping whenever workflow

--- a/tests/test_workflow_naming.py
+++ b/tests/test_workflow_naming.py
@@ -1,0 +1,27 @@
+import pathlib
+
+ALLOWED_PREFIXES = ("pr-", "maint-", "agents-", "reusable-")
+WORKFLOW_DIR = pathlib.Path(".github/workflows")
+
+
+def _workflow_paths():
+    return sorted(WORKFLOW_DIR.glob("*.yml"))
+
+
+def test_workflow_slugs_follow_wfv1_prefixes():
+    non_compliant = [path.name for path in _workflow_paths() if not path.name.startswith(ALLOWED_PREFIXES)]
+    assert (
+        not non_compliant
+    ), f"Non-compliant workflow slug(s) detected outside {ALLOWED_PREFIXES}: {non_compliant}"
+
+
+def test_archive_directories_removed():
+    assert not (WORKFLOW_DIR / "archive").exists(), ".github/workflows/archive/ should be removed (tracked in ARCHIVE_WORKFLOWS.md)"
+    legacy_dir = pathlib.Path("Old/.github/workflows")
+    assert not legacy_dir.exists(), "Old/.github/workflows/ should remain deleted"
+
+
+def test_inventory_doc_lists_all_workflows():
+    audit_doc = pathlib.Path("WORKFLOW_AUDIT_TEMP.md").read_text(encoding="utf-8")
+    missing = [path.name for path in _workflow_paths() if f"`{path.name}`" not in audit_doc]
+    assert not missing, f"Workflow inventory missing entries for: {missing}"


### PR DESCRIPTION
## Summary
- add a naming-compliance snapshot with triggers and consumers to WORKFLOW_AUDIT_TEMP and refresh the agent bootstrap brief for issue 1669
- document the removal of the legacy workflow archive in ARCHIVE_WORKFLOWS.md, the workflow README, and the WFv1 guide
- add a workflow-naming guard test to enforce the pr-/maint-/agents-/reusable- prefixes

## Testing
- pytest tests/test_workflow_*.py
- gh workflow list | head *(fails: GitHub CLI not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e11f7dd58483318b72d60d1103fc9c