### PR TITLE
docs: align workflow docs with WFv1 workflow slugs

### DIFF
--- a/agents/codex-1205.md
+++ b/agents/codex-1205.md
@@ -39,7 +39,7 @@ Establish automated lifecycle management for inactive pull requests so queues st
 - Confirm the canonical label names for "stale" and "keep open" to match repository conventions.
 - Determine whether draft PRs should be exempt by default or receive a separate TTL clock.
 - Decide on localization/templating strategy for reminder + closure comments (single template vs. separate markdown partials).
-- Align with existing cleanup workflows (e.g., `cleanup-codex-bootstrap.yml`) to avoid overlapping responsibilities.
+- Align with existing cleanup workflows (e.g., `maint-38-cleanup-codex-bootstrap.yml`) to avoid overlapping responsibilities.
 
 ## Definition of done
 - Scheduled workflow merged on `phase-2-dev`, documented in `docs/ops/codex-bootstrap-facts.md` (automation inventory) and `docs/agent-automation.md` if necessary.

--- a/agents/codex-1667.md
+++ b/agents/codex-1667.md
@@ -16,7 +16,7 @@ This document outlines the acceptance criteria and implementation details for au
 - Quiet period elapsed and no active CI/Autofix workflow executions
 
 ## Task List
-- [x] Audit automerge and supporting workflows to confirm they enforce the label and status rules from Issue #1667 (`.github/workflows/merge-manager.yml`).
+- [x] Audit automerge and supporting workflows to confirm they enforce the label and status rules from Issue #1667 (`.github/workflows/maint-45-merge-manager.yml`).
 - [x] Update automerge workflow logic so it requires successful CI and Docker runs for the PR head commit (see "Check required workflows" gate).
 - [x] Require the `automerge` label before auto-merge can be enabled (reason logged as "missing automerge label").
 - [x] Block auto-merge when any label containing `breaking` is applied (reason logged as "breaking label present").
@@ -28,7 +28,7 @@ This document outlines the acceptance criteria and implementation details for au
 - **Relevant workflow files:**
   - `.github/workflows/pr-10-ci-python.yml` (primary CI jobs)
   - `.github/workflows/pr-12-docker-smoke.yml` (Docker build/test checks)
-  - `.github/workflows/merge-manager.yml` (automerge orchestration)
+  - `.github/workflows/maint-45-merge-manager.yml` (automerge orchestration)
 - **Labels involved:**
   - `automerge` (required for merge automation)
   - Any label containing `breaking` (must be absent)

--- a/docs/ci-failure-tracker.md
+++ b/docs/ci-failure-tracker.md
@@ -81,7 +81,7 @@ Workflow: `maint-40-ci-signature-guard.yml` runs on pushes / PRs and validates t
 ## Manual Self-Test
 You can manually validate behaviour:
 1. Dispatch `CI Selftest` (will create a failing issue).
-2. Rerun it but edit the `ci-selftest.yml` to succeed (or manually re-run jobs) to test auto-heal logic after adjusting `INACTIVITY_HOURS`.
+2. Rerun it but edit the `maint-37-ci-selftest.yml` workflow to succeed (or manually re-run jobs) to test auto-heal logic after adjusting `INACTIVITY_HOURS`.
 
 ## Local Simulation Harness
 For a fast feedback loop without touching GitHub, run `node tools/simulate_failure_tracker.js`. The harness lifts the tracker script straight out of the workflow file and replays three sequential failures against an in-memory stub of the GitHub API. It asserts that:

--- a/docs/ci_reuse.md
+++ b/docs/ci_reuse.md
@@ -119,7 +119,7 @@ Issue #1662 consolidated the assigner/watchdog pair into a single orchestrator. 
 - [ ] Identify old CI workflows to retire.
 - [ ] Introduce new consumer pointing at `reusable-ci-python.yml`.
 - [ ] Validate coverage gate matches previous policy.
-- [ ] Enable the autofix follower (`autofix.yml`) if policy allows automated commits.
+- [ ] Enable the autofix follower (`maint-32-autofix.yml`) if policy allows automated commits.
 - [ ] Add agents consumer (if using Codex automation).
 - [ ] Remove redundant workflows.
 

--- a/docs/ci_reuse_consolidation_plan.md
+++ b/docs/ci_reuse_consolidation_plan.md
@@ -6,7 +6,7 @@ The `.github/workflows` directory contains both new reusable workflows and sever
 ### Redundant / Superseded (Removed in Cleanup PR for #1259)
 | Legacy (now removed) | Reusable Replacement | Removal Rationale |
 | -------------------- | -------------------- | ----------------- |
-| `maint-32-autofix.yml` | `reusable-autofix.yml` | Eliminated duplication; stabilization period complete post PR #1257. |
+| `autofix.yml` | `maint-32-autofix.yml` + `reusable-autofix.yml` | Eliminated duplication; stabilization period complete post PR #1257. |
 | `agent-readiness.yml` | _(archived)_ | No direct replacement; run ad-hoc GitHub Script checks when needed. |
 | `agents-42-watchdog.yml` | `agents-41-assign-and-watch.yml` | Manual watchdog wrapper retained; core logic migrated to unified workflow. |
 | `codex-preflight.yml` | _(archived)_ | Manual diagnostics or future targeted scripts as needed. |
@@ -17,13 +17,13 @@ The `.github/workflows` directory contains both new reusable workflows and sever
 | Workflow | Notes |
 | -------- | ----- |
 | `verify-codex-bootstrap-matrix.yml` | Specialized matrix verification; keep separate (long-running, matrix heavy). |
-| `perf-benchmark.yml` | Performance regression; intentionally standalone (different triggers, resource profile). |
+| `maint-52-perf-benchmark.yml` | Performance regression; intentionally standalone (different triggers, resource profile). |
 
 ### Keep As-Is
 Release, docker, auto-merge enablement, PR status summary, quarantine TTL, failure trackers remain orthogonal to the three reusable workflows.
 
 ## Consolidation Actions Executed
-All previously flagged legacy workflows were deleted in alignment with Issue #1259. Consumers now invoke the reusable equivalents (`reuse-autofix.yml`) alongside the unified agent orchestrator (`agents-41-assign-and-watch.yml`, surfaced through the thin wrappers). This concludes the stabilization window referenced in PR #1257.
+All previously flagged legacy workflows were deleted in alignment with Issue #1259. Consumers now invoke the reusable equivalents (`reusable-autofix.yml`) alongside the unified agent orchestrator (`agents-41-assign-and-watch.yml`, surfaced through the thin wrappers). This concludes the stabilization window referenced in PR #1257.
 
 ## Deletion Timetable (Superseded)
 Original timetable replaced by immediate removal once validation completed. Retained here for historical context only.

--- a/docs/ops/template-setup.md
+++ b/docs/ops/template-setup.md
@@ -78,7 +78,7 @@ Security posture: The `pull_request_target` workflows in this template do not ch
 ## 9. Troubleshooting
 
 - Merge manager fails with branch context error:
-  - Ensure `.github/workflows/merge-manager.yml` passes `pull-request-number` when enabling auto-merge.
+  - Ensure `.github/workflows/maint-45-merge-manager.yml` passes `pull-request-number` when enabling auto-merge.
 - Labels not applied on fork PRs:
   - Ensure `pr-02-label-agent-prs.yml` exists and `pull_request_target` triggers are enabled.
 - Autofix doesn’t push on forks:

--- a/docs/performance_benchmark.md
+++ b/docs/performance_benchmark.md
@@ -1,6 +1,6 @@
 # Performance Benchmark CI
 
-This workflow (perf-benchmark.yml) enforces a regression budget for key
+This workflow (maint-52-perf-benchmark.yml) enforces a regression budget for key
 vectorised performance hotspots.
 
 ## Monitored Metrics

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -13,7 +13,7 @@ The repository includes an automated CI/CD pipeline that:
 
 ## Workflow Triggers
 
-The release workflow (`.github/workflows/release.yml`) can be triggered in two ways:
+The release workflow (`.github/workflows/maint-60-release.yml`) can be triggered in two ways:
 
 ### 1. Automatic Release on Version Tags
 
@@ -85,12 +85,12 @@ For enhanced security, configure PyPI trusted publishing:
 
 1. Create publisher on PyPI:
    - Repository: `stranske/Trend_Model_Project`
-   - Workflow: `release.yml`
+   - Workflow: `maint-60-release.yml`
    - Environment: `pypi`
 
 2. Create publisher on TestPyPI (for testing):
    - Repository: `stranske/Trend_Model_Project` 
-   - Workflow: `release.yml`
+   - Workflow: `maint-60-release.yml`
    - Environment: `test-pypi`
 
 ## Changelog Generation
@@ -120,7 +120,7 @@ Test the release process without affecting production:
 ```bash
 # Trigger via GitHub UI with dry_run=true
 # Or manually via GitHub CLI:
-gh workflow run release.yml -f tag=v0.1.0-test -f dry_run=true
+gh workflow run maint-60-release.yml -f tag=v0.1.0-test -f dry_run=true
 ```
 
 ### Local Testing

--- a/docs/workflow-chatgpt-issue-sync.md
+++ b/docs/workflow-chatgpt-issue-sync.md
@@ -2,7 +2,7 @@
 
 _Last updated: 2025-09-20_
 
-This document explains how to use and operate the `chatgpt-issue-sync.yml` GitHub Actions workflow that ingests ChatGPT topic lists and synchronizes them to GitHub Issues with strong normalization, diagnostics, and fallback behavior.
+This document explains how to use and operate the `maint-41-chatgpt-issue-sync.yml` GitHub Actions workflow that ingests ChatGPT topic lists and synchronizes them to GitHub Issues with strong normalization, diagnostics, and fallback behavior.
 
 ## Purpose
 Convert a (potentially long) enumerated list of topic ideas generated in ChatGPT into individual, consistently labeled GitHub issues. The workflow hardens ingestion against UI truncation, collapsed newlines, odd whitespace characters, and partial formatting. It also supports sourcing the content directly from a tracked repository file (preferred) or a remote URL as fallbacks.


### PR DESCRIPTION
## Summary
- update Codex bootstrap task briefs and workflow operations docs to reference the new `maint-*` and `agents-*` filenames instead of legacy slugs
- refresh the release and performance workflow guides plus the consolidation ledger so all workflow examples, tables, and CLI snippets match the WFv1 naming convention
- adjust the workflow migration checklist to point at the consolidated autofix follower and reusable stack

## Testing
- pytest tests/test_workflow_*.py

------
https://chatgpt.com/codex/tasks/task_e_68e12851c13c833182923e1ad38a101c