### PR TITLE
Refine Streamlit upload error handling for Issue #1684

### DIFF
--- a/app/streamlit/state.py
+++ b/app/streamlit/state.py
@@ -52,16 +52,24 @@ def store_validated_data(df: pd.DataFrame, meta: dict):
     clear_analysis_results()
 
 
-def record_upload_error(message: str, issues: Sequence[str] | None = None) -> None:
+def record_upload_error(
+    message: str,
+    issues: Sequence[str] | None = None,
+    *,
+    detail: str | None = None,
+) -> None:
     """Persist an upload failure and clear any stale data."""
 
     st.session_state["returns_df"] = None
     st.session_state["schema_meta"] = None
     st.session_state["benchmark_candidates"] = []
-    st.session_state["validation_report"] = {
+    report = {
         "message": message,
         "issues": list(issues or []),
     }
+    if detail:
+        report["detail"] = detail
+    st.session_state["validation_report"] = report
     st.session_state["upload_status"] = "error"
     clear_analysis_results()
 

--- a/streamlit_app/pages/1_Data.py
+++ b/streamlit_app/pages/1_Data.py
@@ -64,13 +64,24 @@ def _store_dataset(df: pd.DataFrame, meta: SchemaMeta | dict[str, Any], key: str
 
 
 def _handle_failure(error: Exception) -> None:
-    message = str(error)
     issues: list[str] | None = None
+    detail: str | None = None
+    message = (
+        "We couldn't process the file. Please confirm the format and try again."
+    )
     if isinstance(error, MarketDataValidationError):
         message = error.user_message
         issues = list(error.issues)
-    app_state.record_upload_error(message, issues)
+    else:
+        detail = str(error).strip() or None
+
+    app_state.record_upload_error(message, issues, detail=detail)
     st.error(message)
+    if issues:
+        for issue in issues:
+            st.write(f"• {issue}")
+    if detail and not issues:
+        st.caption(detail)
 
 
 def _load_sample_dataset(label: str, path: Path) -> None:

--- a/tests/app/test_streamlit_state.py
+++ b/tests/app/test_streamlit_state.py
@@ -144,6 +144,16 @@ def test_record_upload_error_sets_error_state(session_state: dict) -> None:
         assert key not in session_state
 
 
+def test_record_upload_error_records_detail(session_state: dict) -> None:
+    state.record_upload_error("problem", ["issue"], detail="raw message")
+
+    assert session_state["validation_report"] == {
+        "message": "problem",
+        "issues": ["issue"],
+        "detail": "raw message",
+    }
+
+
 def test_clear_analysis_results_removes_cached_outputs(session_state: dict) -> None:
     session_state.update(
         {


### PR DESCRIPTION
## Summary
- add optional detail storage to upload error state and reuse plain-language messaging on the data and legacy upload pages
- surface validation issue bullets and human-readable captions when dataset validation fails
- extend data page and session-state unit tests to cover the new error reporting behaviour

## Testing
- pytest tests/app/test_data_page.py tests/app/test_model_page_helpers.py tests/app/test_results_page.py tests/app/test_streamlit_state.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e16533a9e483319a59faccc6e23925