### PR TITLE
Add regime tagging pipeline and reporting integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This repository contains experiments and utilities for analyzing volatility-adju
 
 For a beginner-friendly overview, see [docs/UserGuide.md](docs/UserGuide.md).
 
+Latest addition: the pipeline now tags market regimes (Risk-On / Risk-Off) via
+a configurable rolling return filter and adds a "Performance by Regime" table to
+the CLI, exports, and unified HTML/PDF report. Tweak lookback, smoothing, and
+thresholds under the new `regime` section in `config/defaults.yml` to align the
+analysis with your preferred market proxy.
+
 📦 **Reusable CI & Automation**: Standardise tests, autofix, and agent automation across repositories using the new reusable workflows documented in [docs/ci_reuse.md](docs/ci_reuse.md). Consumers call `reusable-ci-python.yml`, `reusable-autofix.yml`, and the unified agent orchestrator `agents-41-assign-and-watch.yml` (invoked via the lightweight wrappers `agents-41-assign.yml` / `agents-42-watchdog.yml`).
 
 🧭 **Workflow topology & agent routing**: Learn how workflow buckets, naming, post-CI summaries, and agent labels fit together in [docs/WORKFLOW_GUIDE.md](docs/WORKFLOW_GUIDE.md).

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -118,7 +118,23 @@ benchmarks:
   tsx: TSX
 
 # ----------------------------------------------------------------------
-# 6. PERFORMANCE METRICS
+# 6. REGIME ANALYSIS
+# ----------------------------------------------------------------------
+regime:
+  enabled: true
+  proxy: "SPX"
+  method: "rolling_return"
+  lookback: 126
+  smoothing: 3
+  threshold: 0.0
+  neutral_band: 0.001
+  min_observations: 4
+  risk_on_label: "Risk-On"
+  risk_off_label: "Risk-Off"
+  cache: true
+
+# ----------------------------------------------------------------------
+# 7. PERFORMANCE METRICS
 # ----------------------------------------------------------------------
 metrics:
   rf_rate_annual:     0.02            # flat rf or link to series
@@ -146,7 +162,7 @@ metrics:
     n_iter: 2000
     ci_level: 0.95
 # ----------------------------------------------------------------------
-# 7. EXPORT OPTIONS
+# 8. EXPORT OPTIONS
 # ----------------------------------------------------------------------
 export:
   directory: "results/"
@@ -161,7 +177,7 @@ export:
   include_vol_adj: true
   include_figures: false # Phase-2
 # ----------------------------------------------------------------------
-# 8. LOGGING & EXECUTION
+# 9. LOGGING & EXECUTION
 # ----------------------------------------------------------------------
 performance:
   enable_cache: true

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -259,11 +259,47 @@ print(error_summary(log_path))
 
 Disable logging only if you have strict I/O limits or are micro‑benchmarking; overhead is negligible (dozens of lines per run).
 
-## 14. Further help
+## 14. Regime tagging and reporting
+
+The default configuration now ships with a `regime` block that tags each
+out-of-sample period as **Risk-On** or **Risk-Off** using the rolling return of
+the `SPX` proxy. The engine compounds six months of index returns, optionally
+smooths the signal, and compares the result with the configured threshold.
+Positive or neutral readings map to Risk-On while negative readings map to
+Risk-Off. All controls can be tuned without touching the code:
+
+```yaml
+regime:
+  enabled: true          # disable to skip regime analysis entirely
+  proxy: "SPX"           # column in the returns frame or uploaded index file
+  method: "rolling_return"
+  lookback: 126          # number of observations to compound
+  smoothing: 3           # optional moving average over the rolling return
+  threshold: 0.0         # shift the cut-over between regimes
+  neutral_band: 0.001    # treat small deviations as neutral noise
+  min_observations: 4    # minimum rows required to compute metrics
+```
+
+When `regime.enabled` is true the CLI summary, Excel workbook, JSON/CSV/TXT
+exports, and the unified HTML/PDF report include a **Performance by Regime**
+table. It lists CAGR, Sharpe, max drawdown, hit rate, and the observation count
+for the user-weight portfolio (and equal-weight baseline when available) across
+Risk-On, Risk-Off and aggregate windows. Any regime with fewer than
+`min_observations` samples is shown as `N/A` and annotated with a descriptive
+footnote. The unified report also appends a sentence to the executive summary
+and narrative highlighting the relative performance between regimes.
+
+The `regime_notes` entry in the result dictionary carries the collected
+footnotes; they are exported as a one-column table for easy auditing alongside
+the numeric breakdown. Supplying your own proxy is as simple as adding the
+column to the input data or pointing `regime.proxy` at a custom series in the
+indices bundle.
+
+## 15. Further help
 
 See `README.md` for a short overview of the repository structure and the example notebooks for end‑to‑end demonstrations.
 
-## 15. Turnover and Transaction Cost Controls
+## 16. Turnover and Transaction Cost Controls
 
 Two optional portfolio execution controls make simulation results closer to
 realistic implementation:
@@ -289,7 +325,7 @@ to each result dictionary. These appear in a separate execution metrics export
 (`execution_metrics` sheet / file) so the legacy Phase‑1 summary schema remains
 unchanged.
 
-## 16. Portfolio Constraint Set (advanced)
+## 17. Portfolio Constraint Set (advanced)
 
 The engine can project preliminary weights onto a feasible region defined by a constraint set:
 

--- a/src/trend/reporting/unified.py
+++ b/src/trend/reporting/unified.py
@@ -324,6 +324,9 @@ def _build_exec_summary(result: Any, backtest: BacktestResult | None) -> list[st
                 sharpe=_format_ratio(metrics.get("sharpe_ratio")),
             )
         )
+    regime_summary = details.get("regime_summary")
+    if isinstance(regime_summary, str) and regime_summary.strip():
+        bullets.append(regime_summary.strip())
     return bullets
 
 
@@ -475,12 +478,56 @@ def _metrics_table_html(metrics: pd.DataFrame) -> tuple[str, list[str]]:
     return html_table, text_rows
 
 
-def _narrative(backtest: BacktestResult | None) -> str:
+def _format_regime_table(table: pd.DataFrame) -> tuple[str, list[str]]:
+    if table is None or table.empty:
+        return "<p>Regime analysis unavailable.</p>", []
+
+    display = table.copy().astype(object)
+    idx_names = ["CAGR", "Max Drawdown", "Hit Rate", "Sharpe", "Observations"]
+    for metric in display.index:
+        if metric not in idx_names:
+            continue
+        series = display.loc[metric]
+        if metric in {"CAGR", "Max Drawdown", "Hit Rate"}:
+            display.loc[metric] = series.map(
+                lambda val: "—" if pd.isna(val) else f"{float(val):.1%}"
+            )
+        elif metric == "Sharpe":
+            display.loc[metric] = series.map(
+                lambda val: "—" if pd.isna(val) else f"{float(val):.2f}"
+            )
+        elif metric == "Observations":
+            display.loc[metric] = series.map(
+                lambda val: "—" if pd.isna(val) else f"{int(round(float(val)))}"
+            )
+
+    if isinstance(display.columns, pd.MultiIndex):
+        column_labels = [" / ".join(map(str, col)).strip() for col in display.columns]
+    else:
+        column_labels = [str(col) for col in display.columns]
+
+    html_table = display.to_html(classes=["report-table"], border=0, escape=False)
+    text_rows: list[str] = []
+    header = ["Metric"] + column_labels
+    text_rows.append(" | ".join(header))
+    text_rows.append("-" * len(text_rows[0]))
+    for metric, row in display.iterrows():
+        values = [str(metric)] + [str(row[col]) for col in display.columns]
+        text_rows.append(" | ".join(values))
+    return html_table, text_rows
+
+
+def _narrative(
+    backtest: BacktestResult | None, regime_summary: str | None = None
+) -> str:
     if backtest is None or backtest.returns.empty:
-        return (
+        base = (
             "Backtest metrics were unavailable; please review the configuration and ensure "
             "that portfolio returns were produced."
         )
+        if regime_summary:
+            return f"{base} {regime_summary}".strip()
+        return base
     metrics = backtest.metrics
     start = backtest.returns.index[0]
     end = backtest.returns.index[-1]
@@ -506,7 +553,7 @@ def _narrative(backtest: BacktestResult | None) -> str:
     else:
         alloc_sentence = ""
     turnover = metrics.get("turnover_mean", 0.0)
-    return (
+    narrative = (
         f"From {start_text} through {end_text}, the portfolio compounded to "
         f"{_format_percent(metrics.get('total_return'))} overall "
         f"({_format_percent(metrics.get('annual_return'))} annualised). Volatility averaged "
@@ -515,6 +562,9 @@ def _narrative(backtest: BacktestResult | None) -> str:
         f"{_format_percent(metrics.get('max_drawdown'))}, and mean turnover per rebalance was "
         f"{_format_percent(turnover)}.{alloc_sentence}"
     )
+    if regime_summary:
+        narrative = f"{narrative} {regime_summary}".strip()
+    return narrative
 
 
 def _render_html(context: Mapping[str, Any]) -> str:
@@ -525,6 +575,16 @@ def _render_html(context: Mapping[str, Any]) -> str:
     )
     narrative = html.escape(context["narrative"])
     metrics_html = context["metrics_html"]
+    regime_table_html = context["regime_html"]
+    regime_summary_text = context.get("regime_summary") or ""
+    regime_summary_html = (
+        f"    <p>{html.escape(regime_summary_text)}</p>\n" if regime_summary_text else ""
+    )
+    regime_notes = context.get("regime_notes", [])
+    regime_notes_html = ""
+    if regime_notes:
+        items = "\n".join(f"      <li>{html.escape(note)}</li>" for note in regime_notes)
+        regime_notes_html = f"    <ul>\n{items}\n    </ul>\n"
     params_rows = "\n".join(
         f"      <tr><th>{html.escape(k)}</th><td>{html.escape(v)}</td></tr>"
         for k, v in context["parameters"]
@@ -575,6 +635,12 @@ def _render_html(context: Mapping[str, Any]) -> str:
         '  <section id="metrics">\n'
         "    <h2>Metrics</h2>\n"
         f"    {metrics_html}\n"
+        "  </section>\n"
+        '  <section id="regimes">\n'
+        "    <h2>Performance by Regime</h2>\n"
+        f"{regime_summary_html}"
+        f"    {regime_table_html}\n"
+        f"{regime_notes_html}"
         "  </section>\n"
         '  <section id="charts" class="two-column">\n'
         "    <div><h2>Turnover</h2>\n"
@@ -696,6 +762,26 @@ def _render_pdf(context: Mapping[str, Any]) -> bytes:
     pdf.ln(2)
 
     pdf.set_font("Helvetica", "B", 13)
+    pdf.cell(0, 8, "Performance by Regime", ln=True)
+    pdf.set_font("Helvetica", "", 10)
+    regime_summary = context.get("regime_summary")
+    if regime_summary:
+        pdf.multi_cell(
+            usable_width,
+            5,
+            _pdf_safe(_wrap_pdf_text(str(regime_summary), width=84)),
+        )
+    for row in context.get("regime_text", []):
+        pdf.multi_cell(usable_width, 5, _pdf_safe(_wrap_pdf_text(row, width=84)))
+    regime_notes = context.get("regime_notes", [])
+    for note in regime_notes:
+        wrapped_note = _wrap_pdf_text(
+            note, initial_indent="- ", subsequent_indent="  ", width=84
+        )
+        pdf.multi_cell(usable_width, 5, _pdf_safe(wrapped_note))
+    pdf.ln(2)
+
+    pdf.set_font("Helvetica", "B", 13)
     pdf.cell(0, 8, "Parameter summary", ln=True)
     pdf.set_font("Helvetica", "", 10)
     for key, value in context["parameters"]:
@@ -770,7 +856,17 @@ def generate_unified_report(
     metrics_html, metrics_text = _metrics_table_html(metrics_df)
     params = _build_param_summary(config)
     caveats = _build_caveats(result, backtest)
-    narrative = _narrative(backtest)
+    details_mapping = (
+        getattr(result, "details", {})
+        if isinstance(getattr(result, "details", None), Mapping)
+        else {}
+    )
+    raw_regime_table = details_mapping.get("performance_by_regime")
+    regime_table = raw_regime_table if isinstance(raw_regime_table, pd.DataFrame) else pd.DataFrame()
+    regime_html, regime_text = _format_regime_table(regime_table)
+    regime_notes = list(details_mapping.get("regime_notes", []))
+    regime_summary = details_mapping.get("regime_summary")
+    narrative = _narrative(backtest, regime_summary if isinstance(regime_summary, str) else None)
     turnover_chart = _turnover_chart(backtest)
     exposure_chart = _exposure_chart(backtest)
     footer = "Past performance does not guarantee future results."
@@ -781,6 +877,10 @@ def generate_unified_report(
         "narrative": narrative,
         "metrics_html": metrics_html,
         "metrics_text": metrics_text,
+        "regime_html": regime_html,
+        "regime_text": regime_text,
+        "regime_notes": regime_notes,
+        "regime_summary": regime_summary,
         "parameters": params,
         "caveats": caveats
         or [

--- a/src/trend_analysis/api.py
+++ b/src/trend_analysis/api.py
@@ -95,6 +95,8 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
             risk_free=0.0,
         )
 
+    regime_cfg = getattr(config, "regime", {}) or {}
+
     preprocessing_section = getattr(config, "preprocessing", {}) or {}
     missing_section = (
         preprocessing_section.get("missing_data")
@@ -134,6 +136,7 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
         risk_window=config.vol_adjust.get("window"),
         previous_weights=config.portfolio.get("previous_weights"),
         max_turnover=config.portfolio.get("max_turnover"),
+        regime_cfg=regime_cfg,
     )
     if res is None:
         logger.warning("run_simulation produced no result")

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -60,6 +60,7 @@ class ConfigProtocol(Protocol):
     portfolio: dict[str, Any]
     benchmarks: dict[str, str]
     metrics: dict[str, Any]
+    regime: dict[str, Any]
     export: dict[str, Any]
     output: dict[str, Any] | None
     run: dict[str, Any]
@@ -199,7 +200,7 @@ if _HAS_PYDANTIC:
         """Typed access to the YAML configuration (Pydantic mode)."""
 
         # Field lists generated dynamically from model fields to prevent maintenance burden
-        OPTIONAL_DICT_FIELDS: ClassVar[set[str]] = {"performance", "signals"}
+        OPTIONAL_DICT_FIELDS: ClassVar[set[str]] = {"performance", "signals", "regime"}
 
         @classmethod
         def _dict_field_names(cls) -> List[str]:
@@ -279,6 +280,7 @@ if _HAS_PYDANTIC:
         portfolio: dict[str, Any] = Field(default_factory=dict)
         benchmarks: dict[str, str] = Field(default_factory=dict)
         metrics: dict[str, Any] = Field(default_factory=dict)
+        regime: dict[str, Any] = Field(default_factory=dict)
         signals: dict[str, Any] = Field(default_factory=dict)
         export: dict[str, Any] = Field(default_factory=dict)
         performance: dict[str, Any] = Field(default_factory=dict)
@@ -301,6 +303,7 @@ if _HAS_PYDANTIC:
             "sample_split",
             "portfolio",
             "metrics",
+            "regime",
             "export",
             "run",
             mode="before",
@@ -395,6 +398,7 @@ else:  # Fallback mode for tests without pydantic
             "portfolio",
             "benchmarks",
             "metrics",
+            "regime",
             "signals",
             "export",
             "performance",
@@ -406,7 +410,7 @@ else:  # Fallback mode for tests without pydantic
             "seed",
         ]
 
-        OPTIONAL_DICT_FIELDS: ClassVar[set[str]] = {"performance", "signals"}
+        OPTIONAL_DICT_FIELDS: ClassVar[set[str]] = {"performance", "signals", "regime"}
 
         # Attribute declarations for linters/type-checkers
         version: str
@@ -417,6 +421,7 @@ else:  # Fallback mode for tests without pydantic
         portfolio: Dict[str, Any]
         benchmarks: Dict[str, str]
         metrics: Dict[str, Any]
+        regime: Dict[str, Any]
         signals: Dict[str, Any]
         export: Dict[str, Any]
         performance: Dict[str, Any]
@@ -436,6 +441,7 @@ else:  # Fallback mode for tests without pydantic
                 "portfolio": {},
                 "benchmarks": {},
                 "metrics": {},
+                "regime": {},
                 "signals": {},
                 "export": {},
                 "performance": {},
@@ -464,6 +470,7 @@ else:  # Fallback mode for tests without pydantic
                 "sample_split",
                 "portfolio",
                 "metrics",
+                "regime",
                 "export",
                 "performance",
                 "run",

--- a/src/trend_analysis/pipeline.py
+++ b/src/trend_analysis/pipeline.py
@@ -31,6 +31,7 @@ from .risk import (
     realised_volatility,
 )
 from .perf.rolling_cache import compute_dataset_hash, get_cache
+from .regimes import build_regime_payload
 from .signals import TrendSpec, compute_trend_signals
 from .timefreq import MONTHLY_DATE_FREQ
 from .util.frequency import FrequencySummary, detect_frequency
@@ -539,6 +540,7 @@ def _run_analysis(
     previous_weights: Mapping[str, float] | None = None,
     max_turnover: float | None = None,
     signal_spec: TrendSpec | None = None,
+    regime_cfg: Mapping[str, Any] | None = None,
 ) -> dict[str, object] | None:
     if df is None:
         return None
@@ -1029,6 +1031,20 @@ def _run_analysis(
             pass
         benchmark_ir[label] = ir_dict
 
+    regime_returns_map: dict[str, pd.Series] = {
+        "User": out_user.astype(float, copy=False),
+        "Equal-Weight": out_ew.astype(float, copy=False),
+    }
+    regime_payload = build_regime_payload(
+        data=df,
+        out_index=out_df.index,
+        returns_map=regime_returns_map,
+        risk_free=rf_out,
+        config=regime_cfg,
+        freq_code=freq_summary.target,
+        periods_per_year=periods_per_year,
+    )
+
     return {
         "selected_funds": fund_cols,
         "in_sample_scaled": in_scaled,
@@ -1053,6 +1069,14 @@ def _run_analysis(
         "risk_diagnostics": risk_payload,
         "signal_frame": signal_frame,
         "signal_spec": effective_signal_spec,
+        "performance_by_regime": regime_payload.get("table", pd.DataFrame()),
+        "regime_labels": regime_payload.get("labels", pd.Series(dtype="string")),
+        "regime_labels_out": regime_payload.get(
+            "out_labels", pd.Series(dtype="string")
+        ),
+        "regime_notes": regime_payload.get("notes", []),
+        "regime_settings": regime_payload.get("settings", {}),
+        "regime_summary": regime_payload.get("summary"),
     }
 
 
@@ -1085,6 +1109,7 @@ def run_analysis(
     previous_weights: Mapping[str, float] | None = None,
     max_turnover: float | None = None,
     signal_spec: TrendSpec | None = None,
+    regime_cfg: Mapping[str, Any] | None = None,
 ) -> dict[str, object] | None:
     """Backward-compatible wrapper around ``_run_analysis``."""
     return _run_analysis(
@@ -1115,6 +1140,7 @@ def run_analysis(
         previous_weights=previous_weights,
         max_turnover=max_turnover,
         signal_spec=signal_spec,
+        regime_cfg=regime_cfg,
     )
 
 

--- a/src/trend_analysis/regimes.py
+++ b/src/trend_analysis/regimes.py
@@ -1,0 +1,407 @@
+"""Market regime classification and performance aggregation helpers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping
+
+import numpy as np
+import pandas as pd
+
+from .metrics import annual_return, max_drawdown, sharpe_ratio
+from .perf.rolling_cache import compute_dataset_hash, get_cache
+
+
+@dataclass(frozen=True)
+class RegimeSettings:
+    """Normalised configuration controlling regime detection."""
+
+    enabled: bool = False
+    proxy: str | None = None
+    method: str = "rolling_return"
+    lookback: int = 126
+    smoothing: int = 3
+    threshold: float = 0.0
+    neutral_band: float = 0.001
+    min_obs: int = 6
+    risk_on_label: str = "Risk-On"
+    risk_off_label: str = "Risk-Off"
+    default_label: str = "Risk-On"
+    cache: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _coerce_positive_int(value: Any, default: int, *, minimum: int = 1) -> int:
+    try:
+        num = int(value)
+    except (TypeError, ValueError):
+        return max(default, minimum)
+    if num < minimum:
+        return minimum
+    return num
+
+
+def _coerce_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def normalise_settings(cfg: Mapping[str, Any] | None) -> RegimeSettings:
+    """Return :class:`RegimeSettings` populated from a mapping."""
+
+    if cfg is None:
+        return RegimeSettings()
+
+    enabled = bool(cfg.get("enabled", False))
+    proxy = cfg.get("proxy")
+    if proxy is not None:
+        proxy = str(proxy).strip() or None
+
+    method = str(cfg.get("method", "rolling_return") or "rolling_return").lower()
+    if method not in {"rolling_return", "return", "rolling"}:
+        method = "rolling_return"
+
+    lookback = _coerce_positive_int(cfg.get("lookback"), 126)
+    smoothing = _coerce_positive_int(cfg.get("smoothing"), 3)
+    threshold = _coerce_float(cfg.get("threshold"), 0.0)
+    neutral_band = abs(_coerce_float(cfg.get("neutral_band"), 0.001))
+    min_obs = _coerce_positive_int(cfg.get("min_observations"), 6, minimum=1)
+    cache = bool(cfg.get("cache", True))
+
+    risk_on_label = str(cfg.get("risk_on_label", "Risk-On") or "Risk-On").strip()
+    risk_off_label = str(cfg.get("risk_off_label", "Risk-Off") or "Risk-Off").strip()
+    default_label = (
+        str(cfg.get("default_label", risk_on_label) or risk_on_label).strip()
+    )
+    if not risk_on_label:
+        risk_on_label = "Risk-On"
+    if not risk_off_label:
+        risk_off_label = "Risk-Off"
+    if not default_label:
+        default_label = risk_on_label
+
+    return RegimeSettings(
+        enabled=enabled,
+        proxy=proxy,
+        method=method,
+        lookback=lookback,
+        smoothing=smoothing,
+        threshold=threshold,
+        neutral_band=neutral_band,
+        min_obs=min_obs,
+        risk_on_label=risk_on_label,
+        risk_off_label=risk_off_label,
+        default_label=default_label,
+        cache=cache,
+    )
+
+
+def _rolling_return_signal(series: pd.Series, *, window: int, smoothing: int) -> pd.Series:
+    """Return rolling compounded returns smoothed by ``smoothing`` window."""
+
+    if window <= 0:
+        raise ValueError("window must be positive")
+    compounded = (1.0 + series).rolling(window).apply(np.prod, raw=True) - 1.0
+    if smoothing > 1:
+        compounded = compounded.rolling(smoothing).mean()
+    return compounded
+
+
+def _compute_regime_series(
+    proxy: pd.Series,
+    settings: RegimeSettings,
+    *,
+    freq: str,
+) -> pd.Series:
+    """Classify ``proxy`` observations into regimes using ``settings``."""
+
+    if proxy.empty:
+        return pd.Series(dtype="string")
+
+    clean = proxy.astype(float).dropna()
+    if clean.empty:
+        return pd.Series(dtype="string")
+
+    window = max(int(settings.lookback), 1)
+    smoothing = max(int(settings.smoothing), 1)
+
+    signal = _rolling_return_signal(clean, window=window, smoothing=smoothing)
+    signal = signal - settings.threshold
+
+    labels = pd.Series(settings.default_label, index=clean.index, dtype="string")
+    upper = settings.neutral_band
+    lower = -settings.neutral_band
+    if upper <= 0:
+        labels.loc[signal >= 0] = settings.risk_on_label
+        labels.loc[signal < 0] = settings.risk_off_label
+    else:
+        labels.loc[signal >= upper] = settings.risk_on_label
+        labels.loc[signal <= lower] = settings.risk_off_label
+    labels = labels.ffill().bfill()
+
+    if len(labels) < window:
+        # Not enough history to form a stable view
+        return labels
+
+    if not settings.cache:
+        return labels
+
+    dataset_hash = compute_dataset_hash([clean])
+    cache = get_cache()
+    method_tag = (
+        f"regime_{settings.method}_thr{settings.threshold:.6f}_"
+        f"smooth{smoothing}_band{settings.neutral_band:.6f}"
+    )
+
+    def _compute() -> pd.Series:
+        return labels
+
+    return cache.get_or_compute(dataset_hash, window, freq, method_tag, _compute)
+
+
+def compute_regimes(
+    proxy: pd.Series,
+    settings: RegimeSettings,
+    *,
+    freq: str,
+) -> pd.Series:
+    """Return per-period regime labels for ``proxy`` respecting ``settings``."""
+
+    if not settings.enabled:
+        return pd.Series(dtype="string")
+    return _compute_regime_series(proxy, settings, freq=freq)
+
+
+def _format_hit_rate(series: pd.Series) -> float:
+    if series.empty:
+        return float("nan")
+    total = series.count()
+    if total == 0:
+        return float("nan")
+    return float((series > 0).sum() / total)
+
+
+def aggregate_performance_by_regime(
+    returns_map: Mapping[str, pd.Series],
+    risk_free: pd.Series | float,
+    regimes: pd.Series,
+    settings: RegimeSettings,
+    *,
+    periods_per_year: float,
+) -> tuple[pd.DataFrame, list[str]]:
+    """Aggregate performance metrics conditioned on ``regimes``."""
+
+    if not settings.enabled or not returns_map:
+        return pd.DataFrame(), []
+
+    if regimes.empty:
+        return pd.DataFrame(), ["Regime labels were unavailable for the analysis window."]
+
+    # Ensure string dtype for comparisons and align to returns index
+    regimes = regimes.astype("string")
+
+    portfolios = {str(name): series.astype(float) for name, series in returns_map.items()}
+    all_index = pd.Index([])
+    for series in portfolios.values():
+        all_index = all_index.union(series.index)
+
+    regimes = regimes.reindex(all_index).ffill().bfill()
+
+    columns = []
+    for portfolio in portfolios:
+        for regime in (settings.risk_on_label, settings.risk_off_label, "All"):
+            columns.append((portfolio, regime))
+
+    idx = ["CAGR", "Sharpe", "Max Drawdown", "Hit Rate", "Observations"]
+    table = pd.DataFrame(
+        np.nan,
+        index=idx,
+        columns=pd.MultiIndex.from_tuples(columns, names=["portfolio", "regime"]),
+        dtype=float,
+    )
+
+    notes: list[str] = []
+
+    for portfolio, series in portfolios.items():
+        aligned = series.reindex(all_index).astype(float)
+        rf_aligned: pd.Series | float
+        if isinstance(risk_free, pd.Series):
+            rf_aligned = risk_free.reindex(all_index).astype(float)
+        else:
+            rf_aligned = float(risk_free)
+
+        for regime in (settings.risk_on_label, settings.risk_off_label):
+            mask = regimes == regime
+            subset = aligned[mask]
+            if isinstance(rf_aligned, pd.Series):
+                rf_subset = rf_aligned[mask]
+            else:
+                rf_subset = rf_aligned
+            obs = int(subset.count())
+            table.loc["Observations", (portfolio, regime)] = float(obs)
+            if obs < settings.min_obs:
+                notes.append(
+                    f"{regime} regime has fewer than {settings.min_obs} observations; "
+                    "metrics shown as N/A."
+                )
+                continue
+            table.loc["CAGR", (portfolio, regime)] = float(
+                annual_return(subset.dropna(), periods_per_year=int(periods_per_year))
+            )
+            table.loc["Sharpe", (portfolio, regime)] = float(
+                sharpe_ratio(subset.dropna(), rf_subset, periods_per_year=int(periods_per_year))
+            )
+            table.loc["Max Drawdown", (portfolio, regime)] = float(
+                max_drawdown(subset.dropna())
+            )
+            table.loc["Hit Rate", (portfolio, regime)] = _format_hit_rate(subset.dropna())
+
+        # All periods aggregate
+        subset_all = aligned.dropna()
+        if isinstance(rf_aligned, pd.Series):
+            rf_all = rf_aligned.reindex(subset_all.index).dropna()
+        else:
+            rf_all = rf_aligned
+        obs_all = int(subset_all.count())
+        table.loc["Observations", (portfolio, "All")] = float(obs_all)
+        if obs_all >= settings.min_obs:
+            table.loc["CAGR", (portfolio, "All")] = float(
+                annual_return(subset_all, periods_per_year=int(periods_per_year))
+            )
+            table.loc["Sharpe", (portfolio, "All")] = float(
+                sharpe_ratio(subset_all, rf_all, periods_per_year=int(periods_per_year))
+            )
+            table.loc["Max Drawdown", (portfolio, "All")] = float(
+                max_drawdown(subset_all)
+            )
+            table.loc["Hit Rate", (portfolio, "All")] = _format_hit_rate(subset_all)
+
+    if notes:
+        # Deduplicate while preserving order
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for note in notes:
+            if note not in seen:
+                deduped.append(note)
+                seen.add(note)
+        notes = deduped
+
+    return table, notes
+
+
+def build_regime_payload(
+    *,
+    data: pd.DataFrame,
+    out_index: pd.Index,
+    returns_map: Mapping[str, pd.Series],
+    risk_free: pd.Series | float,
+    config: Mapping[str, Any] | None,
+    freq_code: str,
+    periods_per_year: float,
+) -> dict[str, Any]:
+    """Compute regime labels and aggregates for the provided inputs."""
+
+    settings = normalise_settings(config)
+    payload: dict[str, Any] = {
+        "settings": settings.to_dict(),
+        "labels": pd.Series(dtype="string"),
+        "out_labels": pd.Series(dtype="string"),
+        "table": pd.DataFrame(),
+        "notes": [],
+        "summary": None,
+    }
+
+    if not settings.enabled:
+        payload["notes"] = ["Regime analysis disabled in configuration."]
+        return payload
+
+    if not settings.proxy:
+        payload["notes"] = ["Regime proxy column not specified; skipping regime analysis."]
+        return payload
+
+    if settings.proxy not in data.columns:
+        payload["notes"] = [
+            f"Proxy column '{settings.proxy}' not found in input data; regime analysis skipped.",
+        ]
+        return payload
+
+    proxy_series = data.set_index("Date")[settings.proxy].astype(float)
+    regimes = compute_regimes(proxy_series, settings, freq=freq_code)
+    if regimes.empty:
+        payload["notes"] = [
+            "Market proxy series did not produce regime labels for the requested window.",
+        ]
+        return payload
+
+    payload["labels"] = regimes
+
+    out_labels = regimes.reindex(out_index).ffill().bfill()
+    if out_labels.isna().any():
+        out_labels = out_labels.fillna(settings.default_label)
+        payload.setdefault("notes", []).append(
+            "Regime labels contained gaps; forward/backward fill applied for reporting."
+        )
+    payload["out_labels"] = out_labels
+
+    table, notes = aggregate_performance_by_regime(
+        returns_map,
+        risk_free,
+        out_labels,
+        settings,
+        periods_per_year=periods_per_year,
+    )
+    payload["table"] = table
+
+    missing = out_index.difference(out_labels.index)
+    if len(missing) > 0:
+        payload.setdefault("notes", []).append(
+            "Proxy series missing for portions of the out-of-sample window; regime labels "
+            "may be incomplete."
+        )
+
+    payload.setdefault("notes", []).extend(notes)
+
+    if not table.empty:
+        # Build a compact summary sentence using the first portfolio columns
+        user_cols = [col for col in table.columns if col[1] != "All"]
+        if user_cols:
+            first = user_cols[0]
+            regime = first[1]
+            risk_on = table.get((first[0], settings.risk_on_label))
+            risk_off = table.get((first[0], settings.risk_off_label))
+            if isinstance(risk_on, pd.Series) and isinstance(risk_off, pd.Series):
+                ro = risk_on.get("CAGR")
+                rf = risk_off.get("CAGR")
+                if pd.notna(ro) and pd.notna(rf):
+                    payload["summary"] = (
+                        f"{settings.risk_on_label} windows delivered {ro:.1%} CAGR "
+                        f"versus {rf:.1%} during {settings.risk_off_label.lower()} periods."
+                    )
+
+    if payload["summary"] is None and notes:
+        payload["summary"] = notes[0]
+
+    if payload.get("notes"):
+        # Deduplicate notes while preserving insertion order
+        seen_notes: set[str] = set()
+        ordered_notes: list[str] = []
+        for note in payload["notes"]:
+            if note not in seen_notes:
+                ordered_notes.append(note)
+                seen_notes.add(note)
+        payload["notes"] = ordered_notes
+
+    return payload
+
+
+__all__ = [
+    "RegimeSettings",
+    "aggregate_performance_by_regime",
+    "build_regime_payload",
+    "compute_regimes",
+    "normalise_settings",
+]

--- a/src/trend_analysis/run_analysis.py
+++ b/src/trend_analysis/run_analysis.py
@@ -5,6 +5,8 @@ import inspect
 from pathlib import Path
 from typing import Any, cast
 
+import pandas as pd
+
 from . import api, export
 from .config import load
 from .constants import DEFAULT_OUTPUT_DIRECTORY, DEFAULT_OUTPUT_FORMATS
@@ -91,6 +93,14 @@ def main(argv: list[str] | None = None) -> int:
                 out_formats = DEFAULT_OUTPUT_FORMATS
             if out_dir and out_formats:  # pragma: no cover - file output
                 data = {"metrics": result.metrics}
+                regime_table = result.details.get("performance_by_regime")
+                if isinstance(regime_table, pd.DataFrame) and not regime_table.empty:
+                    data["performance_by_regime"] = regime_table
+                regime_notes = result.details.get("regime_notes")
+                if regime_notes:
+                    data["regime_notes"] = pd.DataFrame(
+                        {"note": list(regime_notes)}
+                    )
                 if any(
                     f.lower() in {"excel", "xlsx"} for f in out_formats
                 ):  # pragma: no cover - file I/O

--- a/tests/test_regimes.py
+++ b/tests/test_regimes.py
@@ -1,0 +1,72 @@
+import pandas as pd
+
+from trend_analysis.regimes import build_regime_payload
+
+
+def _sample_frame() -> pd.DataFrame:
+    dates = pd.date_range("2020-01-31", periods=6, freq="ME")
+    data = pd.DataFrame(
+        {
+            "Date": dates,
+            "FundA": [0.02, 0.03, -0.01, 0.01, 0.02, 0.015],
+            "FundB": [0.01, 0.02, -0.015, 0.0, 0.018, 0.012],
+            "RF": 0.0,
+            "SPX": [0.05, 0.04, -0.03, -0.04, 0.02, 0.03],
+        }
+    )
+    return data
+
+
+def test_build_regime_payload_produces_labels_and_table() -> None:
+    data = _sample_frame()
+    index = pd.DatetimeIndex(data["Date"])
+    returns_map = {
+        "User": data.set_index("Date")["FundA"],
+        "Equal-Weight": data.set_index("Date")["FundB"],
+    }
+    risk_free = pd.Series(0.0, index=index)
+    payload = build_regime_payload(
+        data=data,
+        out_index=index,
+        returns_map=returns_map,
+        risk_free=risk_free,
+        config={
+            "enabled": True,
+            "proxy": "SPX",
+            "lookback": 2,
+            "smoothing": 1,
+            "threshold": 0.0,
+            "min_observations": 1,
+        },
+        freq_code="M",
+        periods_per_year=12,
+    )
+    table = payload["table"]
+    assert not table.empty
+    assert ("User", "Risk-On") in table.columns
+    assert payload["labels"].dtype == "string"
+    assert payload["summary"]
+
+
+def test_build_regime_payload_notes_for_insufficient_observations() -> None:
+    data = _sample_frame()
+    index = pd.DatetimeIndex(data["Date"])
+    returns_map = {"User": data.set_index("Date")["FundA"]}
+    risk_free = pd.Series(0.0, index=index)
+    payload = build_regime_payload(
+        data=data,
+        out_index=index,
+        returns_map=returns_map,
+        risk_free=risk_free,
+        config={
+            "enabled": True,
+            "proxy": "SPX",
+            "lookback": 3,
+            "smoothing": 1,
+            "min_observations": 10,
+        },
+        freq_code="M",
+        periods_per_year=12,
+    )
+    notes = payload["notes"]
+    assert any("fewer than" in note.lower() for note in notes)

--- a/tests/test_run_analysis.py
+++ b/tests/test_run_analysis.py
@@ -166,3 +166,29 @@ def test_run_analysis_missing_policy_zero_keeps_asset():
     assert set(filled["selected_funds"]) == {"A", "B"}
     missing_meta = filled.get("preprocessing", {}).get("missing", {})
     assert missing_meta.get("dropped") == []
+
+
+def test_run_analysis_includes_regime_breakdown() -> None:
+    df = make_df()
+    df["SPX"] = [0.04, 0.03, -0.02, -0.01, 0.025, 0.03]
+    res = run_analysis(
+        df,
+        "2020-01",
+        "2020-03",
+        "2020-04",
+        "2020-06",
+        0.1,
+        0.0,
+        indices_list=["SPX"],
+        regime_cfg={
+            "enabled": True,
+            "proxy": "SPX",
+            "lookback": 2,
+            "smoothing": 1,
+            "min_observations": 1,
+        },
+    )
+    assert res is not None
+    table = res.get("performance_by_regime")
+    assert isinstance(table, pd.DataFrame)
+    assert ("User", "Risk-On") in table.columns

--- a/tests/test_unified_report.py
+++ b/tests/test_unified_report.py
@@ -26,6 +26,13 @@ def _make_result() -> RunResult:
         max_drawdown=-0.2,
         information_ratio=0.4,
     )
+    regime_table = pd.DataFrame(
+        {
+            ("User", "Risk-On"): [0.12, 1.1, -0.2, 0.62, 36],
+            ("User", "Risk-Off"): [0.04, 0.4, -0.1, 0.45, 18],
+        },
+        index=["CAGR", "Sharpe", "Max Drawdown", "Hit Rate", "Observations"],
+    )
     details = {
         "out_user_stats": stats,
         "out_ew_stats": stats,
@@ -34,6 +41,9 @@ def _make_result() -> RunResult:
             "turnover": turnover,
             "final_weights": final_weights,
         },
+        "performance_by_regime": regime_table,
+        "regime_summary": "Risk-On windows delivered 12.0% CAGR versus 4.0% in risk-off.",
+        "regime_notes": ["Synthetic regime sample"],
     }
     result = RunResult(metrics=metrics, details=details, seed=7, environment={})
     setattr(result, "portfolio", portfolio)
@@ -66,6 +76,7 @@ def test_generate_unified_report_produces_expected_sections() -> None:
     assert "Vol-Adj Trend Analysis Report" in artifacts.html
     assert "Executive summary" in artifacts.html
     assert "Turnover" in artifacts.html
+    assert "Performance by Regime" in artifacts.html
     assert "Parameter summary" in artifacts.html
     assert "Past performance does not guarantee future results" in artifacts.html
     assert artifacts.pdf_bytes is None


### PR DESCRIPTION
## Summary
- implement configurable regime tagging helpers and aggregate performance metrics by market regime
- integrate regime results into the analysis pipeline, CLI exports, and unified report outputs
- document the new regime configuration defaults and add focused unit tests

## Testing
- pytest tests/test_regimes.py tests/test_run_analysis.py tests/test_unified_report.py

------
https://chatgpt.com/codex/tasks/task_e_68e194c18b388331925b32947edd6a48