### PR TITLE
Add workflow_call trigger to reusable selftest

### DIFF
--- a/.github/workflows/reusable-99-selftest.yml
+++ b/.github/workflows/reusable-99-selftest.yml
@@ -1,6 +1,7 @@
 name: Reusable 99 Selftest
 
 on:
+  workflow_call:
   workflow_dispatch:
   schedule:
     # Nightly verification run at 02:30 UTC to keep the reusable workflow healthy without


### PR DESCRIPTION
## Summary
- add a workflow_call trigger to reusable-99-selftest so it can be invoked by maint-90-selftest

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e1a87dff3483318690a5f0ad2d0a82