### PR TITLE
Adopt workflow naming/numbering + rename files to match - Source Issue #2190

### DIFF
--- a/.github/workflows/maint-90-selftest.yml
+++ b/.github/workflows/maint-90-selftest.yml
@@ -8,3 +8,4 @@ on:
 jobs:
   selftest:
     uses: ./.github/workflows/reusable-99-selftest.yml
+    secrets: inherit

--- a/.github/workflows/reusable-99-selftest.yml
+++ b/.github/workflows/reusable-99-selftest.yml
@@ -1,12 +1,15 @@
 name: Reusable 99 Selftest
 
 on:
-  workflow_dispatch:
-  schedule:
-    # Nightly verification run at 02:30 UTC to keep the reusable workflow healthy without
-    # overlapping with the main CI rush hour. No other triggers (e.g. pull_request) should run
-    # this workflow – Issue #1660 scopes it strictly to manual/nightly execution.
-    - cron: '30 02 * * *'
+  workflow_call:
+    inputs:
+      python-versions:
+        description: >-
+          JSON array of Python versions forwarded to `reusable-ci-python.yml`. Leave empty to
+          exercise the default 3.11 matrix used by Maint 90 Selftest.
+        required: false
+        type: string
+        default: '["3.11"]'
 
 jobs:
   # Matrix of feature scenarios exercising the reusable workflow with different flag combinations.
@@ -61,7 +64,7 @@ jobs:
       - name: Invoke reusable CI (matrix scenario)
         uses: stranske/Trend_Model_Project/.github/workflows/reusable-ci-python.yml@phase-2-dev
         with:
-          python-versions: '["3.11"]'
+          python-versions: ${{ inputs.python-versions }}
           artifact-prefix: "sf-${{ matrix.name }}-"
           enable-metrics: ${{ matrix.enable-metrics }}
           enable-history: ${{ matrix.enable-history }}

--- a/WORKFLOW_AUDIT_TEMP.md
+++ b/WORKFLOW_AUDIT_TEMP.md
@@ -36,7 +36,7 @@ Only the workflows listed below remain visible in the Actions tab. Reusable comp
 | Workflow | Triggers | Notes |
 |----------|----------|-------|
 | `reusable-70-agents.yml` | workflow_call | Reusable agents stack used by `agents-70-orchestrator.yml`.
-| `reusable-99-selftest.yml` | workflow_dispatch, schedule | Matrix smoke-test for the reusable CI executor.
+| `reusable-99-selftest.yml` | workflow_call | Matrix smoke-test for the reusable CI executor.
 | `reusable-ci-python.yml` | workflow_call | Primary reusable CI implementation.
 | `reusable-autofix.yml` | workflow_call | Autofix composite consumed by `maint-32-autofix.yml`.
 | `reusable-legacy-ci-python.yml` | workflow_call | Legacy CI contract retained for downstream consumers.

--- a/docs/ci_reuse.md
+++ b/docs/ci_reuse.md
@@ -60,8 +60,7 @@ The caller may also pass `options_json` (in the orchestration workflow) to layer
 input limit.
 
 ## 4. Self-Test Matrix (`reusable-99-selftest.yml`)
-Provides a nightly/manual matrix that validates the reusable CI executor across feature combinations (coverage delta, soft gate,
-metrics, history, classification). `maint-90-selftest.yml` is the thin caller for manual dispatches or weekly checks.
+Exposes the matrix that validates the reusable CI executor across feature combinations (coverage delta, soft gate, metrics, history, classification). The workflow no longer declares its own cron or manual triggers; `maint-90-selftest.yml` is the thin caller for ad-hoc dispatches or weekly checks.
 
 ## Adoption Notes
 1. Reference the files directly via `uses: stranske/Trend_Model_Project/.github/workflows/<file>@phase-2-dev` in external repos.


### PR DESCRIPTION
**Summary**
* Collapsed the Actions roster to the Issue #2190 final workflows, renaming the repo health monitor to `maint-02-repo-health.yml`, introducing the `maint-90-selftest` caller, and documenting the authoritative inventory in `docs/ci/WORKFLOWS.md`.
* Replaced the legacy agents automation stack with `agents-70-orchestrator.yml`, which parses `options_json` for advanced toggles and delegates to the renamed `reusable-70-agents.yml`, while refreshing the agent automation guide to explain the streamlined flow.
* Updated workflow documentation and archives (e.g., `docs/WORKFLOW_GUIDE.md`, `ARCHIVE_WORKFLOWS.md`) to reflect the trimmed workflow set and removal of merge/label tooling.
* Added a `workflow_call` contract to `reusable-99-selftest.yml`, updated `maint-90-selftest` to inherit secrets, and refreshed the workflow documentation so the self-test composite stays reusable-only.

**Testing**
* ✅ `pytest tests/test_workflow_naming.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68e1a8771da08331a99516eb7e046dc4