### PR TITLE
Regime tagging and breakdown table - Source Issue #1686: 

### DIFF
--- a/src/trend_analysis/regimes.py
+++ b/src/trend_analysis/regimes.py
@@ -358,6 +358,11 @@ def aggregate_performance_by_regime(
                 max_drawdown(subset_all)
             )
             table.loc["Hit Rate", (portfolio, "All")] = _format_hit_rate(subset_all)
+        else:
+            notes.append(
+                f"All-period aggregate for {portfolio} has fewer than "
+                f"{settings.min_obs} observations; metrics shown as N/A."
+            )
 
     if notes:
         # Deduplicate while preserving order

--- a/tests/test_regimes.py
+++ b/tests/test_regimes.py
@@ -70,6 +70,7 @@ def test_build_regime_payload_notes_for_insufficient_observations() -> None:
     )
     notes = payload["notes"]
     assert any("fewer than" in note.lower() for note in notes)
+    assert any("all-period aggregate" in note.lower() for note in notes)
 
 
 def test_build_regime_payload_volatility_method() -> None:


### PR DESCRIPTION
**Summary**
* Added a volatility-based regime tagging path with configurable annualisation, frequency inference, and cache scoping so rolling-return and volatility filters share a unified payload builder.
* Surfaced the new `annualise_volatility` toggle in defaults and refreshed the README/User Guide to document both regime detection modes and tuning guidance.
* Extended the regime unit tests to exercise the volatility method alongside existing coverage.
* Flagged all-period aggregates with insufficient observations and asserted that the explanatory note is emitted so sparse histories are called out in reports.

**Testing**
* ✅ `pytest tests/test_regimes.py tests/test_run_analysis.py tests/test_unified_report.py`


------
https://chatgpt.com/codex/tasks/task_e_68e1a90e115c83319dab6a3a6a7ce960