### PR TITLE
Fix failure tracker trigger quoting and refresh maintenance docs

### DIFF
--- a/.github/workflows/maint-33-check-failure-tracker.yml
+++ b/.github/workflows/maint-33-check-failure-tracker.yml
@@ -1,6 +1,6 @@
 name: Maint 33 Check Failure Tracker
 
-"on":
+on:
   workflow_run:
     workflows: ["PR 10 CI Python", "PR 12 Docker Smoke", "Maint 90 Selftest"]
     types: [completed]

--- a/docs/ci-failure-tracker.md
+++ b/docs/ci-failure-tracker.md
@@ -3,7 +3,7 @@
 This document summarises the behaviour and configuration of the enhanced failure tracking workflow.
 
 ## Overview
-`maint-33-check-failure-tracker.yml` listens to completed runs of the primary CI workflows (`CI`, `Docker`, and the manual `CI Selftest`). On failure it:
+`maint-33-check-failure-tracker.yml` listens to completed runs of the primary CI workflows (`PR 10 CI Python`, `PR 12 Docker Smoke`, and the manual `Maint 90 Selftest`). On failure it:
 
 1. Enumerates failed jobs and the first failing step.
 2. Optionally extracts a stack token (first exception or error line) per failed job.
@@ -80,8 +80,8 @@ Workflow: `maint-40-ci-signature-guard.yml` runs on pushes / PRs and validates t
 
 ## Manual Self-Test
 You can manually validate behaviour:
-1. Dispatch `CI Selftest` (will create a failing issue).
-2. Rerun it but edit the `maint-37-ci-selftest.yml` workflow to succeed (or manually re-run jobs) to test auto-heal logic after adjusting `INACTIVITY_HOURS`.
+1. Dispatch `Maint 90 Selftest` (will create a failing issue).
+2. Rerun it but edit the `maint-90-selftest.yml` workflow to succeed (or manually re-run jobs) to test auto-heal logic after adjusting `INACTIVITY_HOURS`.
 
 ## Local Simulation Harness
 For a fast feedback loop without touching GitHub, run `node tools/simulate_failure_tracker.js`. The harness lifts the tracker script straight out of the workflow file and replays three sequential failures against an in-memory stub of the GitHub API. It asserts that:

--- a/docs/ops/maintenance-playbook.md
+++ b/docs/ops/maintenance-playbook.md
@@ -1,21 +1,11 @@
 # Maintenance Workflow Playbook
 
 This playbook explains how on-call responders should handle failures in the
-maint-3x maintenance series introduced for Issue 1664.
+maintenance workflows that remain after Issue 2190. The roster now consists of
+`maint-02`, `maint-30`, `maint-32`, `maint-33`, `maint-36`, `maint-40`, and
+`maint-90`.
 
-## maint-34-quarantine-ttl.yml
-
-1. **Check the job summary** — the step summary lists each expired ID and its
-   expiry date.
-2. **Decide the fix** — either update the underlying test so it can graduate
-   from quarantine or extend the TTL with a follow-up issue reference.
-3. **Verify locally** — run `python tools/validate_quarantine_ttl.py` (or the
-   smoke harness `python scripts/workflow_smoke_tests.py`) before re-pushing.
-4. **Gate impact** — the gate orchestrator fails the PR while expired entries
-   remain, so acknowledge the check in the PR discussion if additional work is
-   required.
-
-## maint-35-repo-health-self-check.yml
+## maint-02-repo-health.yml
 
 1. **Read the Ops issue update** — failures append to the canonical issue marked
    `<!-- repo-health-nightly -->`. If `OPS_HEALTH_ISSUE` is unset the workflow
@@ -27,20 +17,75 @@ maint-3x maintenance series introduced for Issue 1664.
    repository settings UI. For actionlint failures, follow the inline reviewdog
    comments on the relevant PR.
 
+## maint-30-post-ci-summary.yml
+
+1. **Check the comment thread** — the workflow edits/creates a single summary
+   comment per head SHA. Read the consolidated status to understand which jobs
+   failed.
+2. **Re-run after fixes** — once the underlying CI run passes, manually re-run
+   the workflow (or re-run the source CI) to refresh the summary comment.
+3. **Keep paths aligned** — if this workflow starts failing to locate artifacts
+   ensure `pr-10-ci-python.yml` and `pr-12-docker-smoke.yml` still expose the
+   expected outputs.
+
+## maint-32-autofix.yml
+
+1. **Inspect the uploaded patch** — on failure the workflow attaches the patch
+   bundle to the run. Download it and review the diff locally.
+2. **Mind the exit conditions** — the job fails only when the autofix could not
+   be pushed automatically. Apply the patch locally, re-run formatting, and push
+   manually.
+3. **Update labels if needed** — the workflow relies on PR labels to decide
+   whether autofix should attempt a commit. Confirm the labels are present when
+   debugging skipped runs.
+
+## maint-33-check-failure-tracker.yml
+
+1. **Review the issue comment** — failures create or update the CI failure
+   tracker issue with signature details. Follow the links to the failing jobs.
+2. **Respect cooldowns** — the workflow enforces rate limits to prevent spam.
+   When testing fixes, wait for the cooldown or adjust the environment variables
+   in a fork.
+3. **Confirm auto-heal** — after the offending workflow run passes, trigger the
+   tracker again to ensure the issue closes (or the comment updates to show the
+   heal state).
+
 ## maint-36-actionlint.yml
 
 1. **PR context** — reviewdog publishes annotations directly on the offending
    workflow file. Open the "Files changed" tab to see inline comments.
 2. **Scheduled run** — when the weekly cron fails, inspect the workflow logs to
-   identify the offending file and push a corrective PR. The gate orchestrator
-   runs the same lint, so broken syntax will also block merges.
+   identify the offending file and push a corrective PR. Actionlint failures
+   will also block merges via the CI gate.
 3. **Version drift** — actionlint is pinned; if you need a newer version, update
-  both `maint-36-actionlint.yml` and `pr-01-gate-orchestrator.yml` in the same PR and
-   record the change in `docs/workflow`.
+   the pinned release in both this workflow and the reusable composites that run
+   actionlint.
+
+## maint-40-ci-signature-guard.yml
+
+1. **Check signature metadata** — the summary highlights which manifest failed
+   verification. Validate the signature locally using the instructions in
+   `docs/ci-signature-guard.md`.
+2. **Re-issue manifests** — regenerate the signed manifest or rotate the key
+   material as required. Ensure the updated signature is committed before
+   re-running the workflow.
+3. **Watch branch filters** — this workflow only runs on `phase-2-dev` and
+   branches prefixed `feat/` or `chore/`. If it appears missing, confirm the
+   branch naming matches the allow list.
+
+## maint-90-selftest.yml
+
+1. **Treat it as a smoke harness** — the workflow invokes
+   `reusable-99-selftest.yml` to exercise the reusable CI matrix.
+2. **Verify inputs** — ensure the forwarded `python-version` input matches the
+   expected matrix before debugging downstream failures.
+3. **Secrets passthrough** — the workflow forwards secrets to the reusable call.
+   When adding new secrets to the reusable workflow remember to surface them
+   here as well.
 
 ## Common tooling
 
-- `python scripts/workflow_smoke_tests.py` exercises the repo-health probe and
-  quarantine TTL validator offline.
-- All three workflows append Markdown to `$GITHUB_STEP_SUMMARY`, making it easy
+- `python scripts/workflow_smoke_tests.py` exercises the repo-health probe
+  offline.
+- All workflows append Markdown to `$GITHUB_STEP_SUMMARY`, making it easy
   to snapshot their state in dashboards or incident notes.

--- a/docs/repo_health_self_check.md
+++ b/docs/repo_health_self_check.md
@@ -1,6 +1,6 @@
-# Repository Health Self-Check Workflow (maint-35)
+# Repository Health Workflow (maint-02)
 
-The `maint-35-repo-health-self-check.yml` workflow keeps the repository's
+The `maint-02-repo-health.yml` workflow keeps the repository's
 baseline governance assets (labels, secrets, and Ops issue plumbing) healthy.
 It runs nightly with a weekly deep-dive, can be dispatched manually, and
 re-executes automatically whenever the probe or workflow definition changes in a
@@ -22,7 +22,8 @@ PR.
 - **workflow_dispatch** — Manual runs for smoke tests or post-incident
   verification.
 - **Scoped PR / push triggers** — Changes to `tools/repo_health_probe.py` or the
-  workflow definition automatically re-run the probe.
+  workflow definition automatically re-run the probe on the
+  `phase-2-dev` branch.
 
 ## Sample step summary
 


### PR DESCRIPTION
## Summary
- fix the `maint-33-check-failure-tracker.yml` trigger key so actionlint treats the workflow as valid
- refresh maintenance runbooks to reference the Issue #2190 workflow inventory and numbering
- update the failure tracker guide to cite `Maint 90 Selftest` instead of the removed self-test workflows

## Testing
- pytest tests/test_workflow_naming.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e1ab70e65c83319ac37ab70be5068a