### PR TITLE
Regime tagging and breakdown table - Source Issue #1686

### DIFF
--- a/tests/test_export_formatter.py
+++ b/tests/test_export_formatter.py
@@ -193,6 +193,35 @@ def test_format_summary_text_basic():
     assert "fund" in text
 
 
+def test_format_summary_text_includes_regime_breakdown():
+    regime_table = pd.DataFrame(
+        {
+            ("User", "Risk-On"): [0.12, 1.2, -0.18, 0.58, 24],
+            ("User", "Risk-Off"): [0.03, 0.3, -0.25, 0.42, 8],
+        },
+        index=["CAGR", "Sharpe", "Max Drawdown", "Hit Rate", "Observations"],
+    )
+    res = {
+        "in_ew_stats": (1, 1, 1, 1, 1, 1),
+        "out_ew_stats": (2, 2, 2, 2, 2, 2),
+        "in_user_stats": (3, 3, 3, 3, 3, 3),
+        "out_user_stats": (4, 4, 4, 4, 4, 4),
+        "in_sample_stats": {"fund": (5, 5, 5, 5, 5, 5)},
+        "out_sample_stats": {"fund": (6, 6, 6, 6, 6, 6)},
+        "fund_weights": {"fund": 0.5},
+        "performance_by_regime": regime_table,
+        "regime_summary": "Risk-On windows delivered 12% CAGR versus 3% in risk-off.",
+        "regime_notes": ["Risk-Off windows have limited observations."],
+    }
+    text = format_summary_text(res, "a", "b", "c", "d")
+
+    assert "Performance by regime" in text
+    assert "Risk-On" in text
+    assert "Risk-Off" in text
+    assert "Regime insight:" in text
+    assert "Regime notes:" in text
+
+
 def test_export_to_excel_invokes_formatter(tmp_path):
     df = pd.DataFrame({"A": [1]})
     called = []


### PR DESCRIPTION
## Summary
- Added configurable regime detection, payload building, caching, and performance aggregation helpers to compute risk-on/off labels and metrics.
- Integrated regime outputs throughout the pipeline, API, CLI exports, and unified HTML/PDF reporting so reports and data exports surface the new breakdown with contextual notes.
- Documented defaults and usage guidance for regime analysis, expanded targeted tests, and surfaced regime insights in the CLI/text summary to highlight when the strategy excels or struggles.

## Testing
- `pytest tests/test_export_formatter.py tests/test_regimes.py tests/test_run_analysis.py tests/test_unified_report.py`


------
https://chatgpt.com/codex/tasks/task_e_68e1ac3dfc548331bf2b1b3177251bec