### PR TITLE
Refine regime summary messaging for Issue #1686

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ For a beginner-friendly overview, see [docs/UserGuide.md](docs/UserGuide.md).
 
 Latest addition: the pipeline now tags market regimes (Risk-On / Risk-Off) via
 configurable rolling-return or volatility filters and adds a "Performance by
-Regime" table to the CLI, exports, and unified HTML/PDF report. Tweak lookback,
-smoothing, thresholds, and the annualisation flag under the new `regime` section
-in `config/defaults.yml` to align the analysis with your preferred market
-proxy.
+Regime" table to the CLI, exports, and unified HTML/PDF report. The narrative
+summary automatically calls out whichever regime outperforms (or notes when the
+strategy behaves similarly across regimes). Tweak lookback, smoothing,
+thresholds, and the annualisation flag under the new `regime` section in
+`config/defaults.yml` to align the analysis with your preferred market proxy.
 
 📦 **Reusable CI & Automation**: Standardise tests, autofix, and agent automation across repositories using the new reusable workflows documented in [docs/ci_reuse.md](docs/ci_reuse.md). Consumers call `reusable-ci-python.yml`, `reusable-autofix.yml`, and the unified agent orchestrator `agents-41-assign-and-watch.yml` (invoked via the lightweight wrappers `agents-41-assign.yml` / `agents-42-watchdog.yml`).
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -291,7 +291,10 @@ for the user-weight portfolio (and equal-weight baseline when available) across
 Risk-On, Risk-Off and aggregate windows. Any regime with fewer than
 `min_observations` samples is shown as `N/A` and annotated with a descriptive
 footnote. The unified report also appends a sentence to the executive summary
-and narrative highlighting the relative performance between regimes.
+and narrative highlighting the relative performance between regimes. When the
+strategy excels during Risk-Off periods, the copy explicitly calls out the
+outperformance; if both environments trade in line, the message notes that the
+regimes behaved similarly.
 
 The `regime_notes` entry in the result dictionary carries the collected
 footnotes; they are exported as a one-column table for easy auditing alongside


### PR DESCRIPTION
## Summary
- expand regime summary generation to compare CAGRs, highlight the leading regime, and handle near-ties or missing data gracefully
- document the improved narrative in the README and User Guide so users know the report calls out outperforming regimes
- add a regression test covering the risk-off outperformance path for the new summary helper

## Testing
- pytest tests/test_regimes.py tests/test_export_formatter.py tests/test_run_analysis.py tests/test_unified_report.py


------
https://chatgpt.com/codex/tasks/task_e_68e1e6da46c883318891abf3d65ff8d2