### PR TITLE
Align CI followers with the Issue #2190 workflow roster

### DIFF
--- a/.github/workflows/maint-30-post-ci-summary.yml
+++ b/.github/workflows/maint-30-post-ci-summary.yml
@@ -2,7 +2,7 @@ name: Maint 30 Post CI Summary
 
 on:
   workflow_run:
-    workflows: ["PR 10 CI Python", "PR 12 Docker Smoke"]
+    workflows: ["PR 10 CI Python", "PR 12 Docker Smoke", "Maint 90 Selftest"]
     types: [completed]
 
 concurrency:
@@ -53,6 +53,7 @@ jobs:
             const defaultWorkflowTargets = [
               { key: 'ci', display_name: 'CI', workflow_path: '.github/workflows/pr-10-ci-python.yml' },
               { key: 'docker', display_name: 'Docker', workflow_path: '.github/workflows/pr-12-docker-smoke.yml' },
+              { key: 'selftest', display_name: 'Maint Selftest', workflow_path: '.github/workflows/maint-90-selftest.yml' },
             ];
 
             const workflowTargetsRaw = process.env.WORKFLOW_TARGETS_JSON;

--- a/.github/workflows/maint-32-autofix.yml
+++ b/.github/workflows/maint-32-autofix.yml
@@ -2,7 +2,7 @@ name: Maint 32 Autofix
 
 on:
   workflow_run:
-    workflows: ["PR 10 CI Python"]
+    workflows: ["PR 10 CI Python", "PR 12 Docker Smoke", "Maint 90 Selftest"]
     types: [completed]
 
 permissions:

--- a/agents/codex-1205.md
+++ b/agents/codex-1205.md
@@ -39,7 +39,7 @@ Establish automated lifecycle management for inactive pull requests so queues st
 - Confirm the canonical label names for "stale" and "keep open" to match repository conventions.
 - Determine whether draft PRs should be exempt by default or receive a separate TTL clock.
 - Decide on localization/templating strategy for reminder + closure comments (single template vs. separate markdown partials).
-- Align with existing cleanup workflows (e.g., `maint-38-cleanup-codex-bootstrap.yml`) to avoid overlapping responsibilities.
+- Align with existing cleanup workflows (e.g., `maint-32-autofix.yml` and `maint-33-check-failure-tracker.yml`) to avoid overlapping responsibilities.
 
 ## Definition of done
 - Scheduled workflow merged on `phase-2-dev`, documented in `docs/ops/codex-bootstrap-facts.md` (automation inventory) and `docs/agent-automation.md` if necessary.

--- a/agents/codex-1666.md
+++ b/agents/codex-1666.md
@@ -3,7 +3,7 @@
 ## Task checklist
 
 ### Discovery
-- [x] Review consolidated CI orchestrator and Docker workflows to capture the current required job manifest (`.github/workflows/pr-10-ci-python.yml`, `maint-44-verify-ci-stack.yml`, `pr-01-gate-orchestrator.yml`, `pr-12-docker-smoke.yml`).
+- [x] Review consolidated CI/self-test workflows to capture the current required job manifest (`.github/workflows/pr-10-ci-python.yml`, `.github/workflows/pr-12-docker-smoke.yml`, `.github/workflows/maint-90-selftest.yml`).
 - [x] Confirm hashed fields and guard flow by inspecting `.github/workflows/maint-40-ci-signature-guard.yml` and `tools/test_failure_signature.py`.
 
 ### Fixture refresh

--- a/docs/quarantine_ttl_monitoring.md
+++ b/docs/quarantine_ttl_monitoring.md
@@ -1,5 +1,8 @@
 # Quarantine TTL Monitoring (maint-34)
 
+> **Status:** Workflow retired during Issue #2190. The notes below remain for
+> historical context should a replacement hygiene check be reintroduced.
+
 `maint-34-quarantine-ttl.yml` enforces the "quarantine entries must expire"
 policy by linting `tests/quarantine.yml` on a schedule and during relevant PRs.
 It uses the shared validator `tools/validate_quarantine_ttl.py` so automation

--- a/docs/workflow-chatgpt-issue-sync.md
+++ b/docs/workflow-chatgpt-issue-sync.md
@@ -2,6 +2,9 @@
 
 _Last updated: 2025-09-20_
 
+> **Status:** Workflow removed as part of Issue #2190. Documentation retained
+> for historical troubleshooting and potential future reinstatement.
+
 This document explains how to use and operate the `maint-41-chatgpt-issue-sync.yml` GitHub Actions workflow that ingests ChatGPT topic lists and synchronizes them to GitHub Issues with strong normalization, diagnostics, and fallback behavior.
 
 ## Purpose


### PR DESCRIPTION
## Summary
- ensure the post-CI summary and autofix followers watch the Maint 90 Selftest run alongside the PR CI workflows
- refresh agent automation docs so checklists reference the renamed workflow roster
- flag retired maintenance workflows in the historical documentation for clarity

## Testing
- pytest tests/test_workflow_naming.py -q
- pytest tests/test_workflow_agents_consolidation.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e1e72479cc8331bdfc6e2c50b06d1e