### PR TITLE
Fix formatting for regime reporting modules

### DIFF
--- a/src/trend/reporting/unified.py
+++ b/src/trend/reporting/unified.py
@@ -578,12 +578,16 @@ def _render_html(context: Mapping[str, Any]) -> str:
     regime_table_html = context["regime_html"]
     regime_summary_text = context.get("regime_summary") or ""
     regime_summary_html = (
-        f"    <p>{html.escape(regime_summary_text)}</p>\n" if regime_summary_text else ""
+        f"    <p>{html.escape(regime_summary_text)}</p>\n"
+        if regime_summary_text
+        else ""
     )
     regime_notes = context.get("regime_notes", [])
     regime_notes_html = ""
     if regime_notes:
-        items = "\n".join(f"      <li>{html.escape(note)}</li>" for note in regime_notes)
+        items = "\n".join(
+            f"      <li>{html.escape(note)}</li>" for note in regime_notes
+        )
         regime_notes_html = f"    <ul>\n{items}\n    </ul>\n"
     params_rows = "\n".join(
         f"      <tr><th>{html.escape(k)}</th><td>{html.escape(v)}</td></tr>"
@@ -862,11 +866,17 @@ def generate_unified_report(
         else {}
     )
     raw_regime_table = details_mapping.get("performance_by_regime")
-    regime_table = raw_regime_table if isinstance(raw_regime_table, pd.DataFrame) else pd.DataFrame()
+    regime_table = (
+        raw_regime_table
+        if isinstance(raw_regime_table, pd.DataFrame)
+        else pd.DataFrame()
+    )
     regime_html, regime_text = _format_regime_table(regime_table)
     regime_notes = list(details_mapping.get("regime_notes", []))
     regime_summary = details_mapping.get("regime_summary")
-    narrative = _narrative(backtest, regime_summary if isinstance(regime_summary, str) else None)
+    narrative = _narrative(
+        backtest, regime_summary if isinstance(regime_summary, str) else None
+    )
     turnover_chart = _turnover_chart(backtest)
     exposure_chart = _exposure_chart(backtest)
     footer = "Past performance does not guarantee future results."

--- a/src/trend_analysis/regimes.py
+++ b/src/trend_analysis/regimes.py
@@ -62,7 +62,9 @@ def normalise_settings(cfg: Mapping[str, Any] | None) -> RegimeSettings:
     if proxy is not None:
         proxy = str(proxy).strip() or None
 
-    method_raw = str(cfg.get("method", "rolling_return") or "rolling_return").strip().lower()
+    method_raw = (
+        str(cfg.get("method", "rolling_return") or "rolling_return").strip().lower()
+    )
     method_lookup = {
         "rolling_return": "rolling_return",
         "rolling": "rolling_return",
@@ -83,9 +85,9 @@ def normalise_settings(cfg: Mapping[str, Any] | None) -> RegimeSettings:
 
     risk_on_label = str(cfg.get("risk_on_label", "Risk-On") or "Risk-On").strip()
     risk_off_label = str(cfg.get("risk_off_label", "Risk-Off") or "Risk-Off").strip()
-    default_label = (
-        str(cfg.get("default_label", risk_on_label) or risk_on_label).strip()
-    )
+    default_label = str(
+        cfg.get("default_label", risk_on_label) or risk_on_label
+    ).strip()
     if not risk_on_label:
         risk_on_label = "Risk-On"
     if not risk_off_label:
@@ -110,7 +112,9 @@ def normalise_settings(cfg: Mapping[str, Any] | None) -> RegimeSettings:
     )
 
 
-def _rolling_return_signal(series: pd.Series, *, window: int, smoothing: int) -> pd.Series:
+def _rolling_return_signal(
+    series: pd.Series, *, window: int, smoothing: int
+) -> pd.Series:
     """Return rolling compounded returns smoothed by ``smoothing`` window."""
 
     if window <= 0:
@@ -227,9 +231,7 @@ def _compute_regime_series(
         f"smooth{smoothing}_band{settings.neutral_band:.6f}"
     )
     if settings.method == "volatility":
-        method_tag = (
-            f"{method_tag}_annual{int(settings.annualise_volatility)}"
-        )
+        method_tag = f"{method_tag}_annual{int(settings.annualise_volatility)}"
         if periods:
             method_tag = f"{method_tag}_ppy{periods:.6f}"
 
@@ -330,12 +332,16 @@ def aggregate_performance_by_regime(
         return pd.DataFrame(), []
 
     if regimes.empty:
-        return pd.DataFrame(), ["Regime labels were unavailable for the analysis window."]
+        return pd.DataFrame(), [
+            "Regime labels were unavailable for the analysis window."
+        ]
 
     # Ensure string dtype for comparisons and align to returns index
     regimes = regimes.astype("string")
 
-    portfolios = {str(name): series.astype(float) for name, series in returns_map.items()}
+    portfolios = {
+        str(name): series.astype(float) for name, series in returns_map.items()
+    }
     all_index = pd.Index([])
     for series in portfolios.values():
         all_index = all_index.union(series.index)
@@ -384,12 +390,16 @@ def aggregate_performance_by_regime(
                 annual_return(subset.dropna(), periods_per_year=int(periods_per_year))
             )
             table.loc["Sharpe", (portfolio, regime)] = float(
-                sharpe_ratio(subset.dropna(), rf_subset, periods_per_year=int(periods_per_year))
+                sharpe_ratio(
+                    subset.dropna(), rf_subset, periods_per_year=int(periods_per_year)
+                )
             )
             table.loc["Max Drawdown", (portfolio, regime)] = float(
                 max_drawdown(subset.dropna())
             )
-            table.loc["Hit Rate", (portfolio, regime)] = _format_hit_rate(subset.dropna())
+            table.loc["Hit Rate", (portfolio, regime)] = _format_hit_rate(
+                subset.dropna()
+            )
 
         # All periods aggregate
         subset_all = aligned.dropna()
@@ -456,7 +466,9 @@ def build_regime_payload(
         return payload
 
     if not settings.proxy:
-        payload["notes"] = ["Regime proxy column not specified; skipping regime analysis."]
+        payload["notes"] = [
+            "Regime proxy column not specified; skipping regime analysis."
+        ]
         return payload
 
     if settings.proxy not in data.columns:

--- a/src/trend_analysis/run_analysis.py
+++ b/src/trend_analysis/run_analysis.py
@@ -98,9 +98,7 @@ def main(argv: list[str] | None = None) -> int:
                     data["performance_by_regime"] = regime_table
                 regime_notes = result.details.get("regime_notes")
                 if regime_notes:
-                    data["regime_notes"] = pd.DataFrame(
-                        {"note": list(regime_notes)}
-                    )
+                    data["regime_notes"] = pd.DataFrame({"note": list(regime_notes)})
                 if any(
                     f.lower() in {"excel", "xlsx"} for f in out_formats
                 ):  # pragma: no cover - file I/O


### PR DESCRIPTION
## Summary
- format regime reporting helpers to satisfy Black linting
- keep CLI exports consistent by simplifying regime notes dataframe construction

## Testing
- `pytest tests/test_regimes.py tests/test_export_formatter.py tests/test_run_analysis.py tests/test_unified_report.py`


------
https://chatgpt.com/codex/tasks/task_e_68e1e99c5b0c8331a945a0bd55438de1