### PR TITLE
Ensure sanitized run results stringify regime columns

### DIFF
--- a/src/trend_analysis/api.py
+++ b/src/trend_analysis/api.py
@@ -266,7 +266,7 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
                 return value
             if isinstance(value, tuple):
                 parts = [_stringify_key(part) for part in value]
-                return " / ".join("" if part is None else str(part) for part in parts)
+                return " / ".join(str(part) for part in parts)
             try:
                 iso = getattr(value, "isoformat")
             except AttributeError:


### PR DESCRIPTION
## Summary
- normalise keys in the run_simulation sanitised payload so multi-level regime columns are converted to JSON-friendly strings
- extend the API sanitisation test to cover regime tables and assert the stringified column names

## Testing
- pytest tests/test_api_run_simulation_extra.py
- pytest tests/test_regimes.py tests/test_export_formatter.py tests/test_run_analysis.py tests/test_unified_report.py

------
https://chatgpt.com/codex/tasks/task_e_68e1eb7afe388331ab1e3cd5d77b9cc0