### PR TITLE
Rename reusable workflow slugs to WFv1 numbering

### DIFF
--- a/.github/workflows/pr-10-ci-python.yml
+++ b/.github/workflows/pr-10-ci-python.yml
@@ -1,7 +1,7 @@
 name: PR 10 CI Python
 
 # Temporary compatibility wrapper (Issue #1345): preserves legacy "CI" check name
-# while branch protection still expects it. Delegates to unified reusable-ci-python.yml.
+# while branch protection still expects it. Delegates to unified reusable-90-ci-python.yml.
 # Remove after updating protection rules to reference granular jobs directly.
 
 on:
@@ -52,7 +52,7 @@ jobs:
   tests:
     name: main / tests
     needs: formatting-fast
-    uses: ./.github/workflows/reusable-ci-python.yml
+    uses: ./.github/workflows/reusable-90-ci-python.yml
     with:
       python-versions: ${{ vars.CI_PY_VERSIONS || '["3.11"]' }}
       coverage-min: ${{ vars.COV_MIN || '70' }}

--- a/.github/workflows/reusable-90-ci-python.yml
+++ b/.github/workflows/reusable-90-ci-python.yml
@@ -1,4 +1,4 @@
-name: Reusable CI Python
+name: Reusable 90 CI Python
 
 # Clean rebuilt reusable workflow with debug instrumentation retained from strict-lint branch.
 # Inputs are feature flags controlling optional artifacts and gates.

--- a/.github/workflows/reusable-92-autofix.yml
+++ b/.github/workflows/reusable-92-autofix.yml
@@ -1,4 +1,4 @@
-name: Reusable Autofix
+name: Reusable 92 Autofix
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-94-legacy-ci-python.yml
+++ b/.github/workflows/reusable-94-legacy-ci-python.yml
@@ -1,4 +1,4 @@
-name: Reusable Legacy CI Python
+name: Reusable 94 Legacy CI Python
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-99-selftest.yml
+++ b/.github/workflows/reusable-99-selftest.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       python-versions:
         description: >-
-          JSON array of Python versions forwarded to `reusable-ci-python.yml`. Leave empty to
+          JSON array of Python versions forwarded to `reusable-90-ci-python.yml`. Leave empty to
           exercise the default 3.11 matrix used by Maint 90 Selftest.
         required: false
         type: string
@@ -62,7 +62,7 @@ jobs:
             coverage-alert-drop: '2'
     steps:
       - name: Invoke reusable CI (matrix scenario)
-        uses: stranske/Trend_Model_Project/.github/workflows/reusable-ci-python.yml@phase-2-dev
+        uses: stranske/Trend_Model_Project/.github/workflows/reusable-90-ci-python.yml@phase-2-dev
         with:
           python-versions: ${{ inputs.python-versions }}
           artifact-prefix: "sf-${{ matrix.name }}-"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains experiments and utilities for analyzing volatility-adju
 
 For a beginner-friendly overview, see [docs/UserGuide.md](docs/UserGuide.md).
 
-📦 **Reusable CI & Automation**: Standardise tests, autofix, and agent automation across repositories using the reusable workflows documented in [docs/ci_reuse.md](docs/ci_reuse.md). Consumers call `reusable-ci-python.yml`, `reusable-autofix.yml`, and the unified agents toolkit (`agents-70-orchestrator.yml` → `reusable-70-agents.yml`).
+📦 **Reusable CI & Automation**: Standardise tests, autofix, and agent automation across repositories using the reusable workflows documented in [docs/ci_reuse.md](docs/ci_reuse.md). Consumers call `reusable-90-ci-python.yml`, `reusable-92-autofix.yml`, and the unified agents toolkit (`agents-70-orchestrator.yml` → `reusable-70-agents.yml`).
 
 🧭 **Workflow topology & agent routing**: Learn how workflow buckets, naming, post-CI summaries, and agent labels fit together in [docs/WORKFLOW_GUIDE.md](docs/WORKFLOW_GUIDE.md).
 

--- a/WORKFLOW_AUDIT_TEMP.md
+++ b/WORKFLOW_AUDIT_TEMP.md
@@ -13,7 +13,7 @@ Only the workflows listed below remain visible in the Actions tab. Reusable comp
 ### PR Checks
 | Workflow | Triggers | Notes |
 |----------|----------|-------|
-| `pr-10-ci-python.yml` | pull_request, push | Wrapper around `reusable-ci-python.yml` that preserves the full CI matrix + style/type gates.
+| `pr-10-ci-python.yml` | pull_request, push | Wrapper around `reusable-90-ci-python.yml` that preserves the full CI matrix + style/type gates.
 | `pr-12-docker-smoke.yml` | pull_request, push, workflow_call | Deterministic Docker build + smoke test harness.
 
 ### Maintenance & Governance
@@ -37,9 +37,9 @@ Only the workflows listed below remain visible in the Actions tab. Reusable comp
 |----------|----------|-------|
 | `reusable-70-agents.yml` | workflow_call | Reusable agents stack used by `agents-70-orchestrator.yml`.
 | `reusable-99-selftest.yml` | workflow_call | Matrix smoke-test for the reusable CI executor.
-| `reusable-ci-python.yml` | workflow_call | Primary reusable CI implementation.
-| `reusable-autofix.yml` | workflow_call | Autofix composite consumed by `maint-32-autofix.yml`.
-| `reusable-legacy-ci-python.yml` | workflow_call | Legacy CI contract retained for downstream consumers.
+| `reusable-90-ci-python.yml` | workflow_call | Primary reusable CI implementation.
+| `reusable-92-autofix.yml` | workflow_call | Autofix composite consumed by `maint-32-autofix.yml`.
+| `reusable-94-legacy-ci-python.yml` | workflow_call | Legacy CI contract retained for downstream consumers.
 
 ## Removed in Issue #2190
 | Workflow | Status |

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -10,7 +10,7 @@ This guide describes the slimmed-down GitHub Actions footprint after Issue #2190
 | `pr-` | Pull-request CI wrappers | `pr-10-ci-python.yml`, `pr-12-docker-smoke.yml` |
 | `maint-` | Maintenance, governance, and self-tests | `maint-02-repo-health.yml`, `maint-30-post-ci-summary.yml`, `maint-32-autofix.yml`, `maint-33-check-failure-tracker.yml`, `maint-36-actionlint.yml`, `maint-40-ci-signature-guard.yml`, `maint-90-selftest.yml` |
 | `agents-` | Agent orchestration entry points | `agents-70-orchestrator.yml` |
-| `reusable-` | Reusable composites invoked by other workflows | `reusable-ci-python.yml`, `reusable-legacy-ci-python.yml`, `reusable-autofix.yml`, `reusable-70-agents.yml`, `reusable-99-selftest.yml` |
+| `reusable-` | Reusable composites invoked by other workflows | `reusable-90-ci-python.yml`, `reusable-94-legacy-ci-python.yml`, `reusable-92-autofix.yml`, `reusable-70-agents.yml`, `reusable-99-selftest.yml` |
 | `autofix-` assets | Shared configuration for autofix tooling | `autofix-versions.env` |
 
 **Naming checklist**
@@ -24,7 +24,7 @@ Tests under `tests/test_workflow_naming.py` enforce the naming policy and invent
 ## Final Workflow Set
 
 ### PR Checks
-- **`pr-10-ci-python.yml`** — Unified CI wrapper that calls `reusable-ci-python.yml`. Jobs include tests, coverage, style/type gates, and the `gate / all-required-green` fan-in.
+- **`pr-10-ci-python.yml`** — Unified CI wrapper that calls `reusable-90-ci-python.yml`. Jobs include tests, coverage, style/type gates, and the `gate / all-required-green` fan-in.
 - **`pr-12-docker-smoke.yml`** — Docker build and smoke test pipeline. Keeps deterministic caching and publishes summary logs.
 
 ### Maintenance & Governance
@@ -40,9 +40,9 @@ Tests under `tests/test_workflow_naming.py` enforce the naming policy and invent
 - **`agents-70-orchestrator.yml`** — Hourly + manual dispatch entry point for readiness, Codex bootstrap, issue verification, and watchdog sweeps. Delegates to `reusable-70-agents.yml` and accepts extended options via `options_json`.
 
 ### Reusable Composites
-- **`reusable-ci-python.yml`** — Reusable CI implementation consumed by `pr-10-ci-python.yml` and self-test scenarios.
-- **`reusable-legacy-ci-python.yml`** — Compatibility shim retained for downstream repositories yet to migrate.
-- **`reusable-autofix.yml`** — Autofix harness used by `maint-32-autofix.yml`.
+- **`reusable-90-ci-python.yml`** — Reusable CI implementation consumed by `pr-10-ci-python.yml` and self-test scenarios.
+- **`reusable-94-legacy-ci-python.yml`** — Compatibility shim retained for downstream repositories yet to migrate.
+- **`reusable-92-autofix.yml`** — Autofix harness used by `maint-32-autofix.yml`.
 - **`reusable-70-agents.yml`** — Reusable agent automation stack.
 - **`reusable-99-selftest.yml`** — Matrix self-test covering reusable CI feature flags.
 

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -110,7 +110,7 @@ name: Project CI
 on: [push, pull_request]
 jobs:
   ci:
-    uses: owner-or-fork/Trend_Model_Project/.github/workflows/reusable-ci-python.yml@phase-2-dev
+    uses: owner-or-fork/Trend_Model_Project/.github/workflows/reusable-90-ci-python.yml@phase-2-dev
     with:
       python-versions: '["3.11", "3.12"]'
       coverage-min: '72'

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -26,9 +26,9 @@ Only these workflows appear in the Actions UI; everything else is a reusable com
 ## Reusable Composites
 | Filename | `name:` | Notes |
 |----------|---------|-------|
-| `.github/workflows/reusable-ci-python.yml` | `Reusable CI Python` | Matrix CI executor used by the PR workflows and self-test matrix. |
-| `.github/workflows/reusable-legacy-ci-python.yml` | `Reusable Legacy CI Python` | Compatibility shim for downstream consumers. |
-| `.github/workflows/reusable-autofix.yml` | `Reusable Autofix` | Autofix harness consumed by `maint-32-autofix.yml`. |
+| `.github/workflows/reusable-90-ci-python.yml` | `Reusable 90 CI Python` | Matrix CI executor used by the PR workflows and self-test matrix. |
+| `.github/workflows/reusable-94-legacy-ci-python.yml` | `Reusable 94 Legacy CI Python` | Compatibility shim for downstream consumers. |
+| `.github/workflows/reusable-92-autofix.yml` | `Reusable 92 Autofix` | Autofix harness consumed by `maint-32-autofix.yml`. |
 | `.github/workflows/reusable-70-agents.yml` | `Reusable 70 Agents` | Readiness, Codex bootstrap, verification, watchdog jobs. |
 | `.github/workflows/reusable-99-selftest.yml` | `Reusable 99 Selftest` | Matrix smoke-test of reusable CI features. |
 

--- a/docs/ci_reuse.md
+++ b/docs/ci_reuse.md
@@ -5,13 +5,13 @@ building blocks that thin wrappers (or downstream repositories) can consume.
 
 | Reusable Workflow | File | Purpose |
 | ------------------ | ---- | ------- |
-| Python CI | `.github/workflows/reusable-ci-python.yml` | Tests + coverage gate + optional feature flags.
-| Legacy Python CI | `.github/workflows/reusable-legacy-ci-python.yml` | Compatibility contract for consumers still on the pre-WFv1 interface.
-| Autofix | `.github/workflows/reusable-autofix.yml` | Formatting / lint autofix harness used by `maint-32-autofix.yml`.
+| Python CI | `.github/workflows/reusable-90-ci-python.yml` | Tests + coverage gate + optional feature flags.
+| Legacy Python CI | `.github/workflows/reusable-94-legacy-ci-python.yml` | Compatibility contract for consumers still on the pre-WFv1 interface.
+| Autofix | `.github/workflows/reusable-92-autofix.yml` | Formatting / lint autofix harness used by `maint-32-autofix.yml`.
 | Agents Toolkit | `.github/workflows/reusable-70-agents.yml` | Readiness, Codex bootstrap, verification, and watchdog routines.
 | Self-Test Matrix | `.github/workflows/reusable-99-selftest.yml` | Exercises the reusable CI executor across feature combinations.
 
-## 1. Python CI (`reusable-ci-python.yml`)
+## 1. Python CI (`reusable-90-ci-python.yml`)
 Consumer example:
 
 ```yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   core:
-    uses: ./.github/workflows/reusable-ci-python.yml
+    uses: ./.github/workflows/reusable-90-ci-python.yml
     with:
       python-versions: '["3.11"]'
       enable-metrics: 'true'
@@ -33,7 +33,7 @@ jobs:
 Key inputs include optional coverage gates, history/metrics toggles, and the Python version matrix. The workflow emits gate,
 coverage, and summary jobs that downstream consumers can depend upon.
 
-## 2. Autofix (`reusable-autofix.yml`)
+## 2. Autofix (`reusable-92-autofix.yml`)
 Used by `maint-32-autofix.yml` to apply hygiene fixes once CI succeeds. Inputs gate behaviour behind opt-in labels and allow
 custom commit prefixes. The composite enforces size/path heuristics before pushing changes with `SERVICE_BOT_PAT`.
 

--- a/docs/ci_reuse_consolidation_plan.md
+++ b/docs/ci_reuse_consolidation_plan.md
@@ -6,7 +6,7 @@ Issue #2190 completed the consolidation roadmap that began in #1166/#1259. The r
 workflows required by the trimmed automation surface.
 
 ## Current State
-- Only five reusable workflows remain (`reusable-ci-python.yml`, `reusable-legacy-ci-python.yml`, `reusable-autofix.yml`,
+- Only five reusable workflows remain (`reusable-90-ci-python.yml`, `reusable-94-legacy-ci-python.yml`, `reusable-92-autofix.yml`,
   `reusable-70-agents.yml`, `reusable-99-selftest.yml`).
 - Visible workflows in the Actions tab were reduced to the final set documented in `WORKFLOW_AUDIT_TEMP.md` and `docs/ci/WORKFLOWS.md`.
 - All auxiliary wrappers (gate orchestrators, labelers, watchdog forwards, etc.) were deleted.
@@ -24,7 +24,7 @@ workflows required by the trimmed automation surface.
 - `docs/ci/WORKFLOWS.md` is the authoritative description of the remaining automation footprint.
 
 ## Future Considerations
-1. Monitor downstream consumers of `reusable-legacy-ci-python.yml`; retire it once all repos migrate to the WFv1 interface.
+1. Monitor downstream consumers of `reusable-94-legacy-ci-python.yml`; retire it once all repos migrate to the WFv1 interface.
 2. Keep `maint-90-selftest.yml` schedule under review—switch to manual-only if weekly coverage is unnecessary.
 3. Revisit CodeQL or dependency review if security tooling is reintroduced in a dedicated follow-up issue.
 

--- a/tests/test_automation_workflows.py
+++ b/tests/test_automation_workflows.py
@@ -131,7 +131,7 @@ class TestAutomationWorkflowCoverage(unittest.TestCase):
         tests_job = jobs["tests"]
         self.assertEqual(
             tests_job.get("uses"),
-            "./.github/workflows/reusable-ci-python.yml",
+            "./.github/workflows/reusable-90-ci-python.yml",
             "CI tests job should delegate to reusable stack",
         )
         inputs = tests_job.get("with", {})
@@ -310,7 +310,7 @@ class TestAutomationWorkflowCoverage(unittest.TestCase):
                         )
 
     def test_reusable_ci_runs_tests_and_mypy(self) -> None:
-        workflow = self._read_workflow("reusable-ci-python.yml")
+        workflow = self._read_workflow("reusable-90-ci-python.yml")
         jobs = workflow.get("jobs", {})
         self.assertIn("tests", jobs)
         self.assertIn("mypy", jobs)
@@ -343,7 +343,7 @@ class TestAutomationWorkflowCoverage(unittest.TestCase):
         )
 
     def test_coverage_soft_gate_checks_out_repo_before_python(self) -> None:
-        workflow = self._read_workflow("reusable-ci-python.yml")
+        workflow = self._read_workflow("reusable-90-ci-python.yml")
         jobs = workflow["jobs"]
 
         def _assert_checkout_precedes_python(job_name: str) -> None:
@@ -380,7 +380,7 @@ class TestAutomationWorkflowCoverage(unittest.TestCase):
     def test_coverage_soft_gate_preserves_classification_and_summary_steps(
         self,
     ) -> None:
-        workflow = self._read_workflow("reusable-ci-python.yml")
+        workflow = self._read_workflow("reusable-90-ci-python.yml")
         steps = workflow["jobs"]["coverage_soft_gate"].get("steps", [])
         names = {
             step.get("name")
@@ -400,7 +400,7 @@ class TestAutomationWorkflowCoverage(unittest.TestCase):
         )
 
     def test_cosmetic_followup_job_depends_on_soft_gate_outputs(self) -> None:
-        workflow = self._read_workflow("reusable-ci-python.yml")
+        workflow = self._read_workflow("reusable-90-ci-python.yml")
         job = workflow["jobs"]["cosmetic_followup"]
         condition = job.get("if", "")
         self.assertIn(

--- a/tests/test_workflow_autofix_guard.py
+++ b/tests/test_workflow_autofix_guard.py
@@ -48,7 +48,7 @@ def test_autofix_workflow_uses_repo_commit_prefix() -> None:
     assert "chore(autofix):" in prefix_expr
 
 def test_reusable_autofix_guard_applies_to_all_steps() -> None:
-    data = _load_yaml("reusable-autofix.yml")
+    data = _load_yaml("reusable-92-autofix.yml")
     steps = data["jobs"]["autofix"]["steps"]
     missing = _guarded_follow_up_steps(steps)
     assert not missing, f"Reusable autofix steps missing guard condition: {missing}"

--- a/tests/test_workflow_naming.py
+++ b/tests/test_workflow_naming.py
@@ -61,9 +61,9 @@ EXPECTED_NAMES = {
     "pr-10-ci-python.yml": "PR 10 CI Python",
     "pr-12-docker-smoke.yml": "PR 12 Docker Smoke",
     "reusable-70-agents.yml": "Reusable 70 Agents",
+    "reusable-90-ci-python.yml": "Reusable 90 CI Python",
+    "reusable-92-autofix.yml": "Reusable 92 Autofix",
+    "reusable-94-legacy-ci-python.yml": "Reusable 94 Legacy CI Python",
     "reusable-99-selftest.yml": "Reusable 99 Selftest",
-    "reusable-autofix.yml": "Reusable Autofix",
-    "reusable-ci-python.yml": "Reusable CI Python",
-    "reusable-legacy-ci-python.yml": "Reusable Legacy CI Python",
 }
 


### PR DESCRIPTION
## Summary
- rename the CI, autofix, and legacy reusable workflows to WFv1 `reusable-9x-*` slugs and update their `name:` headers
- point PR CI, the reusable self-test matrix, and repository docs at the new workflow filenames
- refresh workflow guard tests to enforce the renumbered inventory

## Testing
- pytest tests/test_workflow_naming.py -q
- pytest tests/test_automation_workflows.py -q
- pytest tests/test_workflow_agents_consolidation.py -q
- pytest tests/test_workflow_autofix_guard.py tests/test_workflow_autofix_remote.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e1eaa298bc8331a7455d6dc3f55371