### PR TITLE
docs: add quick workflow validation commands

### DIFF
--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -42,4 +42,9 @@ Only these workflows appear in the Actions UI; everything else is a reusable com
 - [x] Tests updated (`tests/test_workflow_agents_consolidation.py`) to guard the new structure.
 - [x] Documentation updated (`docs/agent-automation.md`, `docs/ops/codex-bootstrap-facts.md`, `docs/WORKFLOW_GUIDE.md`, `WORKFLOW_AUDIT_TEMP.md`).
 
+## Quick Validation Commands
+- `pytest tests/test_workflow_naming.py` — Ensures filenames and `name:` fields stay aligned with the WFv1 convention.
+- `pytest tests/test_automation_workflows.py -k agents` — Spot-checks the agents orchestrator wiring after edits.
+- `gh workflow list --limit 20` — Confirm the Actions tab only exposes the workflows listed above.
+
 Run `pytest tests/test_workflow_naming.py` after any workflow change to ensure the guardrails stay green.


### PR DESCRIPTION
## Summary
- document quick validation commands in docs/ci/WORKFLOWS.md to verify the Issue #2190 workflow roster

## Testing
- pytest tests/test_workflow_naming.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e1ee14d6408331b9aa3d03dc304d95