### PR TITLE
Fix formatting in workflow guard tests

### DIFF
--- a/tests/test_workflow_agents_consolidation.py
+++ b/tests/test_workflow_agents_consolidation.py
@@ -42,9 +42,7 @@ def test_reusable_agents_workflow_structure():
         "enable_verify_issue",
         "enable_watchdog",
     ]:
-        assert (
-            f"{key}:" in text
-        ), f"Reusable agents workflow must expose input: {key}"
+        assert f"{key}:" in text, f"Reusable agents workflow must expose input: {key}"
 
 
 def test_legacy_agent_workflows_removed():

--- a/tests/test_workflow_autofix_guard.py
+++ b/tests/test_workflow_autofix_guard.py
@@ -47,6 +47,7 @@ def test_autofix_workflow_uses_repo_commit_prefix() -> None:
     assert "AUTOFIX_COMMIT_PREFIX" in prefix_expr
     assert "chore(autofix):" in prefix_expr
 
+
 def test_reusable_autofix_guard_applies_to_all_steps() -> None:
     data = _load_yaml("reusable-92-autofix.yml")
     steps = data["jobs"]["autofix"]["steps"]

--- a/tests/test_workflow_naming.py
+++ b/tests/test_workflow_naming.py
@@ -49,6 +49,8 @@ def test_workflow_names_match_filename_convention():
         if actual != expected:
             mismatches[path.name] = actual
     assert not mismatches, f"Workflow name mismatch detected: {mismatches}"
+
+
 EXPECTED_NAMES = {
     "agents-70-orchestrator.yml": "Agents 70 Orchestrator",
     "maint-02-repo-health.yml": "Maint 02 Repo Health",
@@ -66,4 +68,3 @@ EXPECTED_NAMES = {
     "reusable-94-legacy-ci-python.yml": "Reusable 94 Legacy CI Python",
     "reusable-99-selftest.yml": "Reusable 99 Selftest",
 }
-


### PR DESCRIPTION
## Summary
- apply Black formatting to the workflow guard tests so style checks pass

## Testing
- `pytest tests/test_workflow_naming.py -q`
- `pytest tests/test_workflow_agents_consolidation.py -q`
- `pytest tests/test_workflow_autofix_guard.py -q`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_68e1f0f8ec508331b71939bf75de7b4d