### PR TITLE
Pass regime config through run_full and relax demo checks

### DIFF
--- a/src/trend_analysis/pipeline.py
+++ b/src/trend_analysis/pipeline.py
@@ -1315,6 +1315,7 @@ def run_full(cfg: Config) -> dict[str, object]:
         previous_weights=_section_get(portfolio_cfg, "previous_weights"),
         max_turnover=_section_get(portfolio_cfg, "max_turnover"),
         signal_spec=trend_spec,
+        regime_cfg=_cfg_section(cfg, "regime"),
     )
     return {} if res is None else res
 


### PR DESCRIPTION
## Summary
- ensure `pipeline.run_full` forwards the regime configuration into `_run_analysis` so demo runs populate risk-on/off tables and insights
- relax the demo pipeline validation to accept the new average-correlation columns, include the risk-free series when probing custom weights, and allow small tolerances when comparing normalised weights

## Testing
- `pytest tests/test_regimes.py tests/test_export_formatter.py tests/test_run_analysis.py tests/test_unified_report.py tests/test_api_run_simulation_extra.py`


------
https://chatgpt.com/codex/tasks/task_e_68e1f46fa7488331b991e9cd1a516c39