### PR TITLE
Add regression coverage for similar regime performance summary

### DIFF
--- a/tests/test_regimes.py
+++ b/tests/test_regimes.py
@@ -1,6 +1,10 @@
 import pandas as pd
 
-from trend_analysis.regimes import build_regime_payload
+from trend_analysis.regimes import (
+    RegimeSettings,
+    _summarise_regime_outcome,
+    build_regime_payload,
+)
 
 
 def _sample_frame() -> pd.DataFrame:
@@ -175,4 +179,17 @@ def test_regime_summary_highlights_stronger_regime() -> None:
     summary = payload["summary"]
     assert isinstance(summary, str)
     assert "outperformed" in summary.lower()
+    assert "risk-off" in summary.lower()
+
+
+def test_regime_summary_identifies_similar_performance() -> None:
+    settings = RegimeSettings(risk_on_label="Risk-On", risk_off_label="Risk-Off")
+    risk_on = pd.Series({"CAGR": 0.105, "Sharpe": 1.1})
+    risk_off = pd.Series({"CAGR": 0.1045, "Sharpe": 0.9})
+
+    summary = _summarise_regime_outcome(settings, risk_on, risk_off)
+
+    assert isinstance(summary, str)
+    assert "similar" in summary.lower()
+    assert "risk-on" in summary.lower()
     assert "risk-off" in summary.lower()


### PR DESCRIPTION
## Summary
- add regression coverage to ensure the regime summary calls out similar performance when risk-on and risk-off CAGRs converge
- import the regime summary helper in the test suite so we can validate the tolerance logic directly

## Testing
- pytest tests/test_regimes.py tests/test_export_formatter.py tests/test_run_analysis.py tests/test_unified_report.py tests/test_api_run_simulation_extra.py

------
https://chatgpt.com/codex/tasks/task_e_68e1f9faee488331b8edc7b1e75999d6