### PR TITLE
chore(codex): update helper prompt after start command

### DIFF
--- a/.github/workflows/agents-43-codex-issue-bridge.yml
+++ b/.github/workflows/agents-43-codex-issue-bridge.yml
@@ -206,7 +206,20 @@ jobs:
             const message = [
               `Opened PR #${prNumber} to engage Codex.`,
               '',
-              'Copy/paste the snippet below into the PR description if needed, then comment `@codex start` when you are ready for Codex to work:',
+              'Comment with `@codex start`, then paste the helper text below so Codex can draft the scope, acceptance criteria, and starter task list for you.',
+              '',
+              '```markdown',
+              '@codex start',
+              '',
+              'Codex, please derive and propose:',
+              '- Scope / key constraints',
+              '- Acceptance criteria / definition of done',
+              '- Initial task checklist to iterate through',
+              '',
+              'Use the issue context below to draft the plan, then continue with implementation.',
+              '```',
+              '',
+              'Issue context (optional: copy into the PR body if needed):',
               '',
               '```markdown',
               snippet,
@@ -272,7 +285,7 @@ jobs:
             const issueUrl = `https://github.com/${owner}/${repo}/issues/${issue_number}`;
             const header = `### Source Issue #${issue_number}: ${issueTitle}`;
             const quoted = (issueBody || '').split('\n').map(l => `> ${l}`).join('\n');
-            const suggestion = `${header}\n\nSource: ${issueUrl}\n\n${quoted}\n\n\n(After opening the PR, comment with \`@codex start\`.)`;
+            const suggestion = `${header}\n\nSource: ${issueUrl}\n\n${quoted}\n\n\n@codex start\n\nCodex, please derive and propose:\n- Scope / key constraints\n- Acceptance criteria / definition of done\n- Initial task checklist to iterate through\n\nUse the issue details above to draft the plan, then proceed with implementation.`;
             const compareUrl = `https://github.com/${owner}/${repo}/compare/${base}...${branch}?expand=1`;
             if (!issue_number) { core.setFailed('Resolved issue number missing; cannot post invite.'); return; }
             await github.rest.issues.createComment({ owner, repo, issue_number, body: `Branch \`${branch}\` created from \`${base}\`.\n\nOption 1 (Invite) is enforced on issue events. PR creation is disabled by design so you are the PR author. Codex only engages on human-authored PRs.\n\nPlease open the PR as the author so Codex can work on it:\n\n- Compare link: ${compareUrl}\n- Suggested title: \`Codex bootstrap for #${issue_number}\`\n- Suggested body (copy/paste):\n\n\n${'```markdown'}\n${suggestion}\n${'```'}` });

--- a/.github/workflows/agents-43-codex-issue-bridge.yml
+++ b/.github/workflows/agents-43-codex-issue-bridge.yml
@@ -215,8 +215,6 @@ jobs:
               '- Scope / key constraints',
               '- Acceptance criteria / definition of done',
               '- Initial task checklist to iterate through',
-              '',
-              'Use the issue context below to draft the plan, then continue with implementation.',
               '```',
               '',
               'Issue context (optional: copy into the PR body if needed):',
@@ -285,7 +283,7 @@ jobs:
             const issueUrl = `https://github.com/${owner}/${repo}/issues/${issue_number}`;
             const header = `### Source Issue #${issue_number}: ${issueTitle}`;
             const quoted = (issueBody || '').split('\n').map(l => `> ${l}`).join('\n');
-            const suggestion = `${header}\n\nSource: ${issueUrl}\n\n${quoted}\n\n\n@codex start\n\nCodex, please derive and propose:\n- Scope / key constraints\n- Acceptance criteria / definition of done\n- Initial task checklist to iterate through\n\nUse the issue details above to draft the plan, then proceed with implementation.`;
+            const suggestion = `${header}\n\nSource: ${issueUrl}\n\n${quoted}\n\n\n@codex start\n\nCodex, please derive and propose:\n- Scope / key constraints\n- Acceptance criteria / definition of done\n- Initial task checklist to iterate through`;
             const compareUrl = `https://github.com/${owner}/${repo}/compare/${base}...${branch}?expand=1`;
             if (!issue_number) { core.setFailed('Resolved issue number missing; cannot post invite.'); return; }
             await github.rest.issues.createComment({ owner, repo, issue_number, body: `Branch \`${branch}\` created from \`${base}\`.\n\nOption 1 (Invite) is enforced on issue events. PR creation is disabled by design so you are the PR author. Codex only engages on human-authored PRs.\n\nPlease open the PR as the author so Codex can work on it:\n\n- Compare link: ${compareUrl}\n- Suggested title: \`Codex bootstrap for #${issue_number}\`\n- Suggested body (copy/paste):\n\n\n${'```markdown'}\n${suggestion}\n${'```'}` });


### PR DESCRIPTION
## Summary\n- streamline the post-@codex start helper block in agents-43 by trimming extra instructions\n- ensure authors can copy the block so codex drafts scope, acceptance criteria, and initial task list\n- remove the wait-for-confirmation language to align with the new workflow\n\n## Testing\n- pre-commit hooks (yaml)