### PR TITLE
chore: enforce formatter pins via shared env file

### DIFF
--- a/.github/actions/autofix/action.yml
+++ b/.github/actions/autofix/action.yml
@@ -25,7 +25,21 @@ runs:
     - name: Load tool versions
       shell: bash
       run: |
-        cat .github/workflows/autofix-versions.env >> $GITHUB_ENV
+        set -euo pipefail
+        pin_file=".github/workflows/autofix-versions.env"
+        if [[ ! -f "${pin_file}" ]]; then
+          echo "Missing ${pin_file}; aborting." >&2
+          exit 1
+        fi
+        # shellcheck disable=SC1090
+        source "${pin_file}"
+        for var in RUFF_VERSION BLACK_VERSION ISORT_VERSION DOCFORMATTER_VERSION MYPY_VERSION; do
+          if [[ -z "${!var:-}" ]]; then
+            echo "${pin_file} is missing a value for ${var}" >&2
+            exit 1
+          fi
+        done
+        cat "${pin_file}" >> "${GITHUB_ENV}"
     - name: Install fixers
       shell: bash
       run: |

--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -1,3 +1,5 @@
+# Shared formatter/type checker pins consumed by CI workflows and local scripts.
+# Update in lock-step when bumping tooling and keep values in sync with autofix images.
 RUFF_VERSION=0.6.3
 BLACK_VERSION=24.8.0
 ISORT_VERSION=5.12.0

--- a/.github/workflows/pr-10-ci-python.yml
+++ b/.github/workflows/pr-10-ci-python.yml
@@ -25,11 +25,24 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Load tool versions
+      - name: Load formatter pins
+        shell: bash
         run: |
-          if [ -f .github/workflows/autofix-versions.env ]; then
-            cat .github/workflows/autofix-versions.env >> "$GITHUB_ENV"
+          set -euo pipefail
+          pin_file=".github/workflows/autofix-versions.env"
+          if [[ ! -f "${pin_file}" ]]; then
+            echo "Missing ${pin_file}; aborting." >&2
+            exit 1
           fi
+          # shellcheck disable=SC1090
+          source "${pin_file}"
+          for var in RUFF_VERSION BLACK_VERSION MYPY_VERSION; do
+            if [[ -z "${!var:-}" ]]; then
+              echo "${pin_file} is missing a value for ${var}" >&2
+              exit 1
+            fi
+          done
+          cat "${pin_file}" >> "${GITHUB_ENV}"
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -98,50 +111,37 @@ jobs:
           # checkout time from ~8 minutes to a few seconds on CI runners.
           fetch-depth: 2
 
-      - name: Load tool versions
+      - name: Load formatter pins
+        shell: bash
         run: |
-          if [ -f .github/workflows/autofix-versions.env ]; then
-            cat .github/workflows/autofix-versions.env >> "$GITHUB_ENV"
+          set -euo pipefail
+          pin_file=".github/workflows/autofix-versions.env"
+          if [[ ! -f "${pin_file}" ]]; then
+            echo "Missing ${pin_file}; aborting." >&2
+            exit 1
           fi
+          # shellcheck disable=SC1090
+          source "${pin_file}"
+          for var in RUFF_VERSION BLACK_VERSION MYPY_VERSION; do
+            if [[ -z "${!var:-}" ]]; then
+              echo "${pin_file} is missing a value for ${var}" >&2
+              exit 1
+            fi
+          done
+          cat "${pin_file}" >> "${GITHUB_ENV}"
 
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
-      - name: Resolve latest mypy version
-        run: |
-          latest=$(python - <<'PY'
-          import json
-          import sys
-          import urllib.request
-
-          URL = "https://pypi.org/pypi/mypy/json"
-          try:
-              with urllib.request.urlopen(URL, timeout=30) as response:
-                  payload = json.load(response)
-              version = payload.get("info", {}).get("version")
-          except Exception as exc:  # pragma: no cover - network failure fallback
-              print(f"Failed to resolve latest mypy version: {exc}", file=sys.stderr)
-              version = None
-
-          if version:
-              print(version)
-          PY
-          )
-          if [ -n "$latest" ]; then
-            echo "Resolved mypy version $latest" >&2
-            echo "MYPY_VERSION=$latest" >> "$GITHUB_ENV"
-          else
-            echo "Using fallback mypy version ${MYPY_VERSION:-system default}" >&2
-          fi
-
       - name: Cache mypy
         uses: actions/cache@v4
         with:
           path: .mypy_cache
-          key: mypy-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('src/**.py') }}
+          key: mypy-${{ runner.os }}-${{ env.MYPY_VERSION }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('src/**.py') }}
           restore-keys: |
+            mypy-${{ runner.os }}-${{ env.MYPY_VERSION }}-
             mypy-${{ runner.os }}-
 
       - name: Install lint deps

--- a/.github/workflows/reusable-90-ci-python.yml
+++ b/.github/workflows/reusable-90-ci-python.yml
@@ -278,6 +278,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Load formatter pins
+        shell: bash
+        run: |
+          set -euo pipefail
+          pin_file=".github/workflows/autofix-versions.env"
+          if [[ ! -f "${pin_file}" ]]; then
+            echo "Missing ${pin_file}; aborting." >&2
+            exit 1
+          fi
+          # shellcheck disable=SC1090
+          source "${pin_file}"
+          if [[ -z "${MYPY_VERSION:-}" ]]; then
+            echo "${pin_file} is missing a value for MYPY_VERSION" >&2
+            exit 1
+          fi
+          cat "${pin_file}" >> "${GITHUB_ENV}"
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -290,7 +306,7 @@ jobs:
           source .venv/bin/activate
           pip install -U pip
           pip install -r requirements.txt
-          pip install mypy
+          pip install "mypy==${MYPY_VERSION}"
       - name: Run mypy
         run: mypy src || (echo 'mypy failed' && exit 1)
 

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -33,6 +33,12 @@ Only these workflows appear in the Actions UI; everything else is a reusable com
 | `.github/workflows/reusable-70-agents.yml` | `Reusable 70 Agents` | Readiness, Codex bootstrap, verification, watchdog jobs. |
 | `.github/workflows/reusable-99-selftest.yml` | `Reusable 99 Selftest` | Matrix smoke-test of reusable CI features. |
 
+## Formatter & Type Checker Pins
+- `.github/workflows/autofix-versions.env` is the single source of truth for formatter/type tooling versions (Ruff, Black, isort, docformatter, mypy).
+- `pr-10-ci-python.yml`, `reusable-90-ci-python.yml`, and the autofix composite action all load and validate this env file before installing tools; they will fail fast if the file is missing or incomplete.
+- Local mirrors (`scripts/style_gate_local.sh`, `scripts/dev_check.sh`, `scripts/validate_fast.sh`) `source` the same env file so contributors run the identical versions before pushing.
+- When bumping any formatter, update the env file first, rerun `./scripts/style_gate_local.sh`, and let CI confirm the new version. This keeps CI, autofix, and local developer flows in lock-step.
+
 ## Trigger Dependencies
 - `maint-30-post-ci-summary.yml`, `maint-32-autofix.yml`, and `maint-33-check-failure-tracker.yml` listen for `workflow_run` events from `PR 10 CI Python`, `PR 12 Docker Smoke`, and `Maint 90 Selftest`.
 - `Agents 70 Orchestrator` dispatches to `Reusable 70 Agents` and parses extended options via `options_json` to stay under GitHub's 10 input limit.


### PR DESCRIPTION
## Summary
- validate and export the shared formatter/type-checker pins before CI or autofix jobs run
- reuse the pinned mypy version across PR and reusable workflows, updating cache keys accordingly
- document the new env-file workflow for contributors keeping local tooling aligned with CI

## Testing
- ./scripts/style_gate_local.sh
- pytest tests/test_workflow_naming.py


------
https://chatgpt.com/codex/tasks/task_e_68e3be9499d48331896ebecf5567b3fa