### PR TITLE
Codex bootstrap for #2197

### DIFF
--- a/.github/workflows/maint-30-post-ci-summary.yml
+++ b/.github/workflows/maint-30-post-ci-summary.yml
@@ -6,13 +6,12 @@ on:
     types: [completed]
 
 concurrency:
-  group: post-ci-summary-${{ github.event.workflow_run.head_sha }}
+  group: ${{ format('post-ci-summary-{0}', github.event.workflow_run.pull_requests && github.event.workflow_run.pull_requests[0] && github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_sha || github.event.workflow_run.id || github.run_id) }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: read
+  pull-requests: read
   actions: read
 
 jobs:

--- a/.github/workflows/maint-30-post-ci-summary.yml
+++ b/.github/workflows/maint-30-post-ci-summary.yml
@@ -18,7 +18,6 @@ jobs:
   summarize:
     if: >
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.name == 'PR 10 CI Python' &&
       github.event.workflow_run.pull_requests &&
       github.event.workflow_run.pull_requests[0] &&
       github.event.workflow_run.pull_requests[0].number

--- a/.github/workflows/maint-30-post-ci-summary.yml
+++ b/.github/workflows/maint-30-post-ci-summary.yml
@@ -2,7 +2,7 @@ name: Maint 30 Post CI Summary
 
 on:
   workflow_run:
-    workflows: ["PR 10 CI Python", "PR 12 Docker Smoke", "Maint 90 Selftest"]
+    workflows: ["PR 10 CI Python", "PR 12 Docker Smoke"]
     types: [completed]
 
 concurrency:
@@ -19,6 +19,9 @@ jobs:
   summarize:
     if: >
       github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.name == 'PR 10 CI Python' &&
+      github.event.workflow_run.pull_requests &&
+      github.event.workflow_run.pull_requests[0] &&
       github.event.workflow_run.pull_requests[0].number
     runs-on: ubuntu-latest
     steps:
@@ -53,7 +56,6 @@ jobs:
             const defaultWorkflowTargets = [
               { key: 'ci', display_name: 'CI', workflow_path: '.github/workflows/pr-10-ci-python.yml' },
               { key: 'docker', display_name: 'Docker', workflow_path: '.github/workflows/pr-12-docker-smoke.yml' },
-              { key: 'selftest', display_name: 'Maint Selftest', workflow_path: '.github/workflows/maint-90-selftest.yml' },
             ];
 
             const workflowTargetsRaw = process.env.WORKFLOW_TARGETS_JSON;
@@ -109,18 +111,23 @@ jobs:
             }
 
             async function loadJobs(runId) {
-              const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
-                owner,
-                repo,
-                run_id: runId,
-                per_page: 100,
-              });
-              return jobs.map(job => ({
-                name: job.name,
-                conclusion: job.conclusion,
-                status: job.status,
-                html_url: job.html_url,
-              }));
+              try {
+                const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                  owner,
+                  repo,
+                  run_id: runId,
+                  per_page: 100,
+                });
+                return jobs.map(job => ({
+                  name: job.name,
+                  conclusion: job.conclusion,
+                  status: job.status,
+                  html_url: job.html_url,
+                }));
+              } catch (error) {
+                core.warning(`Failed to load jobs for workflow run ${runId}: ${error}`);
+                return [];
+              }
             }
 
             async function resolveRun(target) {

--- a/WORKFLOW_AUDIT_TEMP.md
+++ b/WORKFLOW_AUDIT_TEMP.md
@@ -20,7 +20,7 @@ Only the workflows listed below remain visible in the Actions tab. Reusable comp
 | Workflow | Triggers | Notes |
 |----------|----------|-------|
 | `maint-02-repo-health.yml` | schedule, workflow_dispatch, pull_request, push | Nightly/weekly repository health probe with OPS issue updates.
-| `maint-30-post-ci-summary.yml` | workflow_run | Posts consolidated CI/Docker run summaries as PR comments.
+| `maint-30-post-ci-summary.yml` | workflow_run | Posts consolidated CI/Docker run summaries to the workflow step summary.
 | `maint-32-autofix.yml` | workflow_run | Follower that applies low-risk autofix commits after CI succeeds.
 | `maint-33-check-failure-tracker.yml` | workflow_run | Opens and resolves CI failure tracker issues based on run outcomes.
 | `maint-36-actionlint.yml` | pull_request, push, schedule, workflow_dispatch | Sole workflow lint gate (actionlint via reviewdog).

--- a/agents/codex-2197.md
+++ b/agents/codex-2197.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #2197 -->

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -29,7 +29,7 @@ Tests under `tests/test_workflow_naming.py` enforce the naming policy and invent
 
 ### Maintenance & Governance
 - **`maint-02-repo-health.yml`** — Nightly/weekly repository health probe with optional workflow_dispatch reruns.
-- **`maint-30-post-ci-summary.yml`** — Subscribes to `workflow_run` events from the PR and Docker workflows. Posts a single summary comment per head SHA.
+- **`maint-30-post-ci-summary.yml`** — Subscribes to `workflow_run` events from the PR and Docker workflows. Writes a single step-summary block per head SHA.
 - **`maint-32-autofix.yml`** — Follower that applies autofix commits or uploads patches after CI completes successfully or fails for lint-only reasons.
 - **`maint-33-check-failure-tracker.yml`** — Opens and resolves CI failure tracker issues using signatures derived from the two PR workflows and the self-test caller.
 - **`maint-36-actionlint.yml`** — Sole workflow-lint gate. Runs actionlint via reviewdog on PR edits, pushes, weekly cron, and manual dispatch.

--- a/docs/agent-automation.md
+++ b/docs/agent-automation.md
@@ -59,7 +59,7 @@ Manual dispatch / 20-minute schedule ──▶ agents-70-orchestrator.yml
 While the agent wrappers were removed, maintenance automation still supports the broader workflow stack:
 
 - `maint-32-autofix.yml` continues to follow the CI pipeline and apply low-risk fixes.
-- `maint-30-post-ci-summary.yml` posts consolidated run summaries once `pr-10-ci-python.yml` and `pr-12-docker-smoke.yml` finish.
+- `maint-30-post-ci-summary.yml` writes consolidated run summaries to the workflow step summary once `pr-10-ci-python.yml` and `pr-12-docker-smoke.yml` finish.
 - `maint-33-check-failure-tracker.yml` opens or resolves CI failure issues based on those runs.
 
 ## Operational Playbook

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -13,7 +13,7 @@ This document tracks the acceptance criteria for Issue #2190. Use it as the auth
 | `.github/workflows/pr-10-ci-python.yml` | `PR 10 CI Python` | Unified job that runs Black, Ruff, mypy, pytest with coverage, uploads diagnostics, and enforces coverage minimums. |
 | `.github/workflows/pr-12-docker-smoke.yml` | `PR 12 Docker Smoke` | Deterministic Docker build + smoke tests. |
 | `.github/workflows/maint-02-repo-health.yml` | `Maint 02 Repo Health` | Nightly/weekly repository health probe. |
-| `.github/workflows/maint-30-post-ci-summary.yml` | `Maint 30 Post CI Summary` | Posts CI/Docker run summaries on `workflow_run` (triggered by `PR 10 CI Python`). |
+| `.github/workflows/maint-30-post-ci-summary.yml` | `Maint 30 Post CI Summary` | Posts CI/Docker run summaries on `workflow_run` completions for `PR 10 CI Python` **and** `PR 12 Docker Smoke`. |
 | `.github/workflows/maint-32-autofix.yml` | `Maint 32 Autofix` | Applies autofix commits after CI completes. |
 | `.github/workflows/maint-33-check-failure-tracker.yml` | `Maint 33 Check Failure Tracker` | Manages CI failure tracker issues. |
 | `.github/workflows/maint-36-actionlint.yml` | `Maint 36 Actionlint` | Sole workflow-lint gate (actionlint via reviewdog). |
@@ -40,7 +40,7 @@ Only these workflows appear in the Actions UI; everything else is a reusable com
 - When bumping any formatter, update the env file first, rerun `./scripts/style_gate_local.sh`, and let CI confirm the new version. This keeps CI, autofix, and local developer flows in lock-step.
 
 ## Trigger Dependencies
-- `maint-30-post-ci-summary.yml` listens for `workflow_run` events from `PR 10 CI Python` (and aggregates the latest `PR 12 Docker Smoke` run data defensively).
+- `maint-30-post-ci-summary.yml` listens for `workflow_run` completions from both `PR 10 CI Python` and `PR 12 Docker Smoke`, aggregating their latest run data defensively.
 - `maint-32-autofix.yml` and `maint-33-check-failure-tracker.yml` listen for `workflow_run` events from `PR 10 CI Python`, `PR 12 Docker Smoke`, and `Maint 90 Selftest`.
 - `Agents 70 Orchestrator` dispatches to `Reusable 70 Agents` and parses extended options via `options_json` to stay under GitHub's 10 input limit.
 - `Agents 43 Codex Issue Bridge` acts on `agent:codex` issue labels or manual dispatch to prepare Codex-ready branches and PRs.

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -13,7 +13,7 @@ This document tracks the acceptance criteria for Issue #2190. Use it as the auth
 | `.github/workflows/pr-10-ci-python.yml` | `PR 10 CI Python` | Unified job that runs Black, Ruff, mypy, pytest with coverage, uploads diagnostics, and enforces coverage minimums. |
 | `.github/workflows/pr-12-docker-smoke.yml` | `PR 12 Docker Smoke` | Deterministic Docker build + smoke tests. |
 | `.github/workflows/maint-02-repo-health.yml` | `Maint 02 Repo Health` | Nightly/weekly repository health probe. |
-| `.github/workflows/maint-30-post-ci-summary.yml` | `Maint 30 Post CI Summary` | Posts CI/Docker run summaries on `workflow_run`. |
+| `.github/workflows/maint-30-post-ci-summary.yml` | `Maint 30 Post CI Summary` | Posts CI/Docker run summaries on `workflow_run` (triggered by `PR 10 CI Python`). |
 | `.github/workflows/maint-32-autofix.yml` | `Maint 32 Autofix` | Applies autofix commits after CI completes. |
 | `.github/workflows/maint-33-check-failure-tracker.yml` | `Maint 33 Check Failure Tracker` | Manages CI failure tracker issues. |
 | `.github/workflows/maint-36-actionlint.yml` | `Maint 36 Actionlint` | Sole workflow-lint gate (actionlint via reviewdog). |
@@ -40,7 +40,8 @@ Only these workflows appear in the Actions UI; everything else is a reusable com
 - When bumping any formatter, update the env file first, rerun `./scripts/style_gate_local.sh`, and let CI confirm the new version. This keeps CI, autofix, and local developer flows in lock-step.
 
 ## Trigger Dependencies
-- `maint-30-post-ci-summary.yml`, `maint-32-autofix.yml`, and `maint-33-check-failure-tracker.yml` listen for `workflow_run` events from `PR 10 CI Python`, `PR 12 Docker Smoke`, and `Maint 90 Selftest`.
+- `maint-30-post-ci-summary.yml` listens for `workflow_run` events from `PR 10 CI Python` (and aggregates the latest `PR 12 Docker Smoke` run data defensively).
+- `maint-32-autofix.yml` and `maint-33-check-failure-tracker.yml` listen for `workflow_run` events from `PR 10 CI Python`, `PR 12 Docker Smoke`, and `Maint 90 Selftest`.
 - `Agents 70 Orchestrator` dispatches to `Reusable 70 Agents` and parses extended options via `options_json` to stay under GitHub's 10 input limit.
 - `Agents 43 Codex Issue Bridge` acts on `agent:codex` issue labels or manual dispatch to prepare Codex-ready branches and PRs.
 

--- a/docs/ops/ci-status-summary.md
+++ b/docs/ops/ci-status-summary.md
@@ -1,12 +1,12 @@
 ## Automated Post-CI Status Summary
 
-The repository maintains a single, continuously updated pull-request comment
-that surfaces CI and Docker results once both workflows finish. The
+The repository maintains a continuously updated **step summary** that surfaces
+CI and Docker results once both workflows finish. The
 `maint-30-post-ci-summary.yml` follower reacts to `workflow_run` events for the
 `CI` and `Docker` workflows, downloads shared artifacts, and renders a unified
 Markdown block headed by `### Automated Status Summary`.
 
-### Comment Contents
+### Summary Contents
 
 Each refresh includes:
 
@@ -23,9 +23,9 @@ Each refresh includes:
   Markdown snippet published as the `coverage-summary` artifact.
 
 The helper stores the rendered Markdown as
-`summary_artifacts/comment_preview.md` so maintainers can inspect the message
-directly from the Actions UI. Re-runs overwrite the same preview file and update
-the existing PR comment in place.
+`summary_artifacts/summary_preview.md` so maintainers can inspect the message
+directly from the Actions UI. Re-runs overwrite the same preview file and append
+an updated block to the job summary output of the workflow run.
 
 ### Data sources
 
@@ -45,9 +45,8 @@ The workflow collects status data from three places:
 
 * The workflow uses a concurrency group keyed by the head SHA to cancel stale
   runs.
-* Comment discovery prefers the hidden `<!-- post-ci-summary:do-not-edit -->`
-  marker (with the heading as a fallback), so reruns patch the original comment
-  instead of posting duplicates.
+* Only the GitHub Actions job summary is updated; there are no PR comments,
+  status checks, or other side-channel notifications.
 * If neither CI nor Docker has produced artifacts yet, the helper still posts a
   pending table so reviewers can see progress.
 
@@ -67,4 +66,5 @@ The workflow collects status data from three places:
 
 Delete or rename `.github/workflows/maint-30-post-ci-summary.yml` to disable the
 follower. The consolidated helper is only invoked from that workflow, so no
-other automation will recreate the comment once the file is removed.
+other automation will append the CI/Docker status summary once the file is
+removed.

--- a/docs/ops/ci-status-summary.md
+++ b/docs/ops/ci-status-summary.md
@@ -43,8 +43,8 @@ The workflow collects status data from three places:
 
 ### Idempotency & Anti-Spam
 
-* The workflow uses a concurrency group keyed by the head SHA to cancel stale
-  runs.
+* The workflow uses a concurrency group keyed by the PR number (falling back to
+  the head SHA when the PR metadata is unavailable) to cancel stale runs.
 * Only the GitHub Actions job summary is updated; there are no PR comments,
   status checks, or other side-channel notifications.
 * If neither CI nor Docker has produced artifacts yet, the helper still posts a

--- a/docs/ops/maintenance-playbook.md
+++ b/docs/ops/maintenance-playbook.md
@@ -19,11 +19,11 @@ maintenance workflows that remain after Issue 2190. The roster now consists of
 
 ## maint-30-post-ci-summary.yml
 
-1. **Check the comment thread** — the workflow edits/creates a single summary
-   comment per head SHA. Read the consolidated status to understand which jobs
-   failed.
+1. **Check the job summary** — the workflow writes a single consolidated block
+   to the GitHub Actions step summary for the run. Read the rendered Markdown to
+   understand which jobs failed or are still pending.
 2. **Re-run after fixes** — once the underlying CI run passes, manually re-run
-   the workflow (or re-run the source CI) to refresh the summary comment.
+   the workflow (or re-run the source CI) to refresh the step summary output.
 3. **Keep paths aligned** — if this workflow starts failing to locate artifacts
    ensure `pr-10-ci-python.yml` and `pr-12-docker-smoke.yml` still expose the
    expected outputs.

--- a/docs/post_ci_summary_plan.md
+++ b/docs/post_ci_summary_plan.md
@@ -1,0 +1,24 @@
+# Post CI Summary Hardening Plan (Issue #2197)
+
+## Scope and Key Constraints
+- Maintain Post CI Summary workflow focus on summarizing workflow runs triggered by pull requests only.
+- Preserve support exclusively for `pr-10-ci-python.yml` and `pr-12-docker-smoke.yml` workflow targets in the summary payload.
+- Handle missing, cancelled, or in-progress workflow runs defensively without causing runtime failures.
+- Ensure the workflow emits information through the GitHub Actions step summary only (no PR comments, status checks, or external notifications).
+- Operate within existing repository automation policies—no additional secrets, services, or workflow permissions beyond current configuration.
+
+## Acceptance Criteria / Definition of Done
+- Workflow listens to `workflow_run` events and filters to pull-request-triggered executions only, preventing activation on push or manual runs.
+- Exactly one step summary is produced per PR, even across multiple reruns; no duplicate comments or summary loops occur.
+- Summary output gracefully notes absent or incomplete workflow runs without causing failures; succeeds even when one or both target workflows are missing.
+- Formatting of the step summary is consistent (tables or bullet lists) and tolerant of null or partial run metadata.
+- Automated tests or dry-run validations (where feasible) cover the new handling logic and document expected behaviors.
+- Documentation or inline comments explain the defensive checks and trigger scope.
+
+## Initial Task Checklist
+1. Review current Post CI Summary workflow implementation to confirm existing triggers, target workflows, and output behavior.
+2. Update workflow triggers to enforce PR-only execution via `workflow_run` filtering, adding safeguards for manual/other events.
+3. Implement defensive data retrieval for `pr-10-ci-python.yml` and `pr-12-docker-smoke.yml`, handling missing runs or unexpected statuses.
+4. Refine summary formatting to present partial data cleanly and ensure it always posts exactly one step summary.
+5. Add tests, validation scripts, or documented manual verification steps that cover missing-run scenarios and duplicate-prevention logic.
+6. Update workflow documentation (e.g., README or inline comments) with the new constraints and usage notes.

--- a/docs/post_ci_summary_plan.md
+++ b/docs/post_ci_summary_plan.md
@@ -16,9 +16,16 @@
 - Documentation or inline comments explain the defensive checks and trigger scope.
 
 ## Initial Task Checklist
-1. Review current Post CI Summary workflow implementation to confirm existing triggers, target workflows, and output behavior.
-2. Update workflow triggers to enforce PR-only execution via `workflow_run` filtering, adding safeguards for manual/other events.
-3. Implement defensive data retrieval for `pr-10-ci-python.yml` and `pr-12-docker-smoke.yml`, handling missing runs or unexpected statuses.
-4. Refine summary formatting to present partial data cleanly and ensure it always posts exactly one step summary.
-5. Add tests, validation scripts, or documented manual verification steps that cover missing-run scenarios and duplicate-prevention logic.
-6. Update workflow documentation (e.g., README or inline comments) with the new constraints and usage notes.
+1. ✅ Review current Post CI Summary workflow implementation to confirm existing triggers, target workflows, and output behavior.
+2. ✅ Update workflow triggers to enforce PR-only execution via `workflow_run` filtering, adding safeguards for manual/other events.
+3. ✅ Implement defensive data retrieval for `pr-10-ci-python.yml` and `pr-12-docker-smoke.yml`, handling missing runs or unexpected statuses.
+4. ✅ Refine summary formatting to present partial data cleanly and ensure it always posts exactly one step summary.
+5. ✅ Add tests, validation scripts, or documented manual verification steps that cover missing-run scenarios and duplicate-prevention logic.
+6. ✅ Update workflow documentation (e.g., README or inline comments) with the new constraints and usage notes.
+
+## Status Summary
+
+- Maint 30 Post CI Summary now runs exclusively for pull-request initiated completions of the CI and Docker workflows and uses a PR-scoped concurrency key to avoid duplicate summaries.
+- The renderer deduplicates target runs, tolerates missing metadata, and highlights required job groups with resilient fallbacks for absent jobs.
+- Regression tests cover deduplication, pending-run placeholders, CLI `$GITHUB_OUTPUT` append semantics, and validation of required job-group configuration parsing.
+- Operations documentation has been refreshed to steer maintainers toward the step-summary output and to explain the anti-spam guarantees.

--- a/tests/test_post_ci_summary.py
+++ b/tests/test_post_ci_summary.py
@@ -259,3 +259,99 @@ def test_load_required_groups_filters_incomplete_entries() -> None:
 
     parsed = _load_required_groups(json.dumps(custom))
     assert parsed == [{"label": "Lint", "patterns": [r"^lint /"]}]
+
+
+def test_build_summary_comment_prefers_present_runs_when_duplicates() -> None:
+    runs = [
+        {"key": "ci", "displayName": "CI", "present": False, "jobs": []},
+        {
+            "key": "ci",
+            "displayName": "CI",
+            "present": True,
+            "id": 55,
+            "conclusion": "success",
+            "html_url": "https://example.test/ci/55",
+            "jobs": [],
+        },
+        {"key": "docker", "displayName": "Docker", "present": False, "jobs": []},
+        {
+            "key": "docker",
+            "displayName": "Docker",
+            "present": True,
+            "id": 91,
+            "status": "in_progress",
+            "html_url": "https://example.test/docker/91",
+            "jobs": [],
+        },
+    ]
+
+    body = build_summary_comment(
+        runs=runs,
+        head_sha=None,
+        coverage_stats=None,
+        coverage_section=None,
+        required_groups_env=None,
+    )
+
+    latest_line = next(
+        (line for line in body.splitlines() if line.startswith("**Latest Runs:**")),
+        "",
+    )
+
+    assert "CI (#55)" in latest_line
+    assert "pending — CI" not in latest_line
+    assert "⏳ in progress — [Docker (#91)]" in latest_line
+
+
+def test_build_summary_comment_prefers_worse_state_for_duplicates() -> None:
+    runs = [
+        {
+            "key": "ci",
+            "displayName": "CI",
+            "present": True,
+            "id": 77,
+            "conclusion": "success",
+            "html_url": "https://example.test/ci/77",
+            "jobs": [
+                {
+                    "name": "ci / python",
+                    "conclusion": "success",
+                    "html_url": "https://example.test/ci/77/python",
+                }
+            ],
+        },
+        {
+            "key": "ci",
+            "displayName": "CI",
+            "present": True,
+            "id": 78,
+            "conclusion": "failure",
+            "html_url": "https://example.test/ci/78",
+            "jobs": [
+                {
+                    "name": "ci / python",
+                    "conclusion": "failure",
+                    "html_url": "https://example.test/ci/78/python",
+                }
+            ],
+        },
+    ]
+
+    body = build_summary_comment(
+        runs=runs,
+        head_sha=None,
+        coverage_stats=None,
+        coverage_section=None,
+        required_groups_env=None,
+    )
+
+    latest_line = next(
+        (line for line in body.splitlines() if line.startswith("**Latest Runs:**")),
+        "",
+    )
+
+    assert "❌ failure" in latest_line
+    assert "(#78)" in latest_line
+    assert "✅ success" not in latest_line
+    assert "| **CI / ci / python** | ❌ failure | [logs]" in body
+    assert "CI python: ❌ failure" in body

--- a/tests/test_post_ci_summary.py
+++ b/tests/test_post_ci_summary.py
@@ -80,8 +80,13 @@ def test_build_summary_comment_renders_expected_sections(
     assert "<!-- post-ci-summary:do-not-edit -->" in body
     assert "### Automated Status Summary" in body
     assert "**Head SHA:** abc123" in body
-    assert "**Latest Runs:** ✅ success — [CI (#101)](https://example.test/ci/101)" in body
-    assert "· ❌ failure — [Docker (#202 (attempt 2))](https://example.test/docker/202)" in body
+    assert (
+        "**Latest Runs:** ✅ success — [CI (#101)](https://example.test/ci/101)" in body
+    )
+    assert (
+        "· ❌ failure — [Docker (#202 (attempt 2))](https://example.test/docker/202)"
+        in body
+    )
     assert "CI python: ✅ success" in body
     assert "Docker: ❌ failure" in body
     assert "| CI / ci / python | ✅ success |" in body
@@ -237,7 +242,10 @@ def test_load_required_groups_handles_invalid_inputs() -> None:
     assert _load_required_groups("{invalid json}") == DEFAULT_REQUIRED_JOB_GROUPS
 
     # Non-list payloads also fall back to defaults.
-    assert _load_required_groups(json.dumps({"label": "ignored"})) == DEFAULT_REQUIRED_JOB_GROUPS
+    assert (
+        _load_required_groups(json.dumps({"label": "ignored"}))
+        == DEFAULT_REQUIRED_JOB_GROUPS
+    )
 
 
 def test_load_required_groups_filters_incomplete_entries() -> None:

--- a/tools/post_ci_summary.py
+++ b/tools/post_ci_summary.py
@@ -454,7 +454,9 @@ def main() -> None:
 
     output_path = os.environ.get("GITHUB_OUTPUT")
     if output_path:
-        Path(output_path).write_text(f"body<<EOF\n{body}\nEOF\n", encoding="utf-8")
+        handle_path = Path(output_path)
+        with handle_path.open("a", encoding="utf-8") as handle:
+            handle.write(f"body<<EOF\n{body}\nEOF\n")
     else:
         print(body)
 

--- a/tools/post_ci_summary.py
+++ b/tools/post_ci_summary.py
@@ -231,10 +231,17 @@ def _format_latest_runs(runs: Sequence[Mapping[str, object]]) -> str:
             or run.get("display_name")
             or run.get("key")
             or "workflow"
-        )
+        ).strip() or "workflow"
+
+        state = run.get("conclusion") or run.get("status")
+        state_str = str(state) if state is not None else None
+        badge = _badge(state_str)
+        state_display = _display_state(state_str)
+
         if not run.get("present"):
-            parts.append(f"{display}: pending")
+            parts.append(f"{badge} {state_display} — {display}")
             continue
+
         run_id = run.get("id")
         attempt = run.get("run_attempt")
         attempt_suffix = (
@@ -243,9 +250,9 @@ def _format_latest_runs(runs: Sequence[Mapping[str, object]]) -> str:
         label = f"{display} (#{run_id}{attempt_suffix})" if run_id else display
         url = run.get("html_url")
         if url:
-            parts.append(f"[{label}]({url})")
-        else:
-            parts.append(label)
+            label = f"[{label}]({url})"
+
+        parts.append(f"{badge} {state_display} — {label}")
     return " · ".join(parts)
 
 

--- a/tools/post_ci_summary.py
+++ b/tools/post_ci_summary.py
@@ -10,7 +10,7 @@ import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Mapping, MutableSequence, Sequence
+from typing import Any, Iterable, List, Mapping, MutableSequence, Sequence, TypedDict
 
 
 @dataclass(frozen=True)
@@ -32,9 +32,23 @@ class RunRecord:
     url: str | None
 
 
-DEFAULT_REQUIRED_JOB_GROUPS = [
+class RequiredJobGroup(TypedDict):
+    label: str
+    patterns: List[str]
+
+
+DEFAULT_REQUIRED_JOB_GROUPS: List[RequiredJobGroup] = [
     {"label": "CI python", "patterns": [r"^ci / python(?: /|$)"]},
 ]
+
+
+def _copy_required_groups(
+    groups: Sequence[RequiredJobGroup],
+) -> List[RequiredJobGroup]:
+    return [
+        {"label": group["label"], "patterns": list(group["patterns"])}
+        for group in groups
+    ]
 
 
 def _badge(state: str | None) -> str:
@@ -91,28 +105,32 @@ def _combine_states(states: Iterable[str | None]) -> str:
     return lowered[0]
 
 
-def _load_required_groups(env_value: str | None) -> List[Mapping[str, str]]:
+def _load_required_groups(env_value: str | None) -> List[RequiredJobGroup]:
     if not env_value:
-        return DEFAULT_REQUIRED_JOB_GROUPS.copy()
+        return _copy_required_groups(DEFAULT_REQUIRED_JOB_GROUPS)
     try:
         parsed = json.loads(env_value)
     except json.JSONDecodeError:
-        return DEFAULT_REQUIRED_JOB_GROUPS.copy()
+        return _copy_required_groups(DEFAULT_REQUIRED_JOB_GROUPS)
     if not isinstance(parsed, list):
-        return DEFAULT_REQUIRED_JOB_GROUPS.copy()
-    result: List[Mapping[str, str]] = []
+        return _copy_required_groups(DEFAULT_REQUIRED_JOB_GROUPS)
+    result: List[RequiredJobGroup] = []
     for item in parsed:
         if not isinstance(item, Mapping):
             continue
         label = str(item.get("label") or item.get("name") or "").strip()
         patterns = item.get("patterns")
-        if not label or not isinstance(patterns, Sequence):
+        if (
+            not label
+            or not isinstance(patterns, Sequence)
+            or isinstance(patterns, (str, bytes))
+        ):
             continue
-        cleaned = [p for p in patterns if isinstance(p, str) and p]
+        cleaned: List[str] = [p for p in patterns if isinstance(p, str) and p]
         if not cleaned:
             continue
         result.append({"label": label, "patterns": cleaned})
-    return result or DEFAULT_REQUIRED_JOB_GROUPS.copy()
+    return result or _copy_required_groups(DEFAULT_REQUIRED_JOB_GROUPS)
 
 
 def _build_job_rows(runs: Sequence[Mapping[str, object]]) -> List[JobRecord]:
@@ -179,7 +197,7 @@ def _format_jobs_table(rows: Sequence[JobRecord]) -> List[str]:
 
 def _collect_required_segments(
     runs: Sequence[Mapping[str, object]],
-    groups: Sequence[Mapping[str, Sequence[str]]],
+    groups: Sequence[RequiredJobGroup],
 ) -> List[str]:
     import re
 
@@ -190,8 +208,8 @@ def _collect_required_segments(
         jobs = ci_run.get("jobs")
         job_list = jobs if isinstance(jobs, Sequence) else []
         for group in groups:
-            label = group.get("label")
-            patterns = group.get("patterns") or []
+            label = group["label"].strip()
+            patterns = group["patterns"]
             regexes = []
             for pattern in patterns:
                 try:
@@ -200,13 +218,16 @@ def _collect_required_segments(
                     continue
             if not label or not regexes:
                 continue
-            matched_states = []
+            matched_states: List[str | None] = []
             for job in job_list:
                 if not isinstance(job, Mapping):
                     continue
                 name = str(job.get("name") or "")
                 if any(regex.search(name) for regex in regexes):
-                    matched_states.append(job.get("conclusion") or job.get("status"))
+                    state_value = job.get("conclusion") or job.get("status")
+                    matched_states.append(
+                        str(state_value) if state_value is not None else None
+                    )
             state = _combine_states(matched_states)
             segments.append(f"{label}: {_badge(state)} {_display_state(state)}")
     else:
@@ -214,8 +235,9 @@ def _collect_required_segments(
 
     docker_run = run_lookup.get("docker")
     if isinstance(docker_run, Mapping) and docker_run.get("present"):
-        state = docker_run.get("conclusion") or docker_run.get("status") or None
-        segments.append(f"Docker: {_badge(state)} {_display_state(state)}")
+        state_value = docker_run.get("conclusion") or docker_run.get("status")
+        state_str = str(state_value) if state_value is not None else None
+        segments.append(f"Docker: {_badge(state_str)} {_display_state(state_str)}")
     else:
         segments.append("Docker: ⏳ pending")
     return segments
@@ -226,12 +248,15 @@ def _format_latest_runs(runs: Sequence[Mapping[str, object]]) -> str:
     for run in runs:
         if not isinstance(run, Mapping):
             continue
-        display = str(
-            run.get("displayName")
-            or run.get("display_name")
-            or run.get("key")
+        display = (
+            str(
+                run.get("displayName")
+                or run.get("display_name")
+                or run.get("key")
+                or "workflow"
+            ).strip()
             or "workflow"
-        ).strip() or "workflow"
+        )
 
         state = run.get("conclusion") or run.get("status")
         state_str = str(state) if state is not None else None
@@ -260,13 +285,13 @@ def _format_coverage_lines(stats: Mapping[str, object] | None) -> List[str]:
     if not isinstance(stats, Mapping):
         return []
 
-    def fmt_percent(value: object) -> str | None:
+    def fmt_percent(value: Any) -> str | None:
         try:
             return f"{float(value):.2f}%"
         except (TypeError, ValueError):
             return None
 
-    def fmt_delta(value: object) -> str | None:
+    def fmt_delta(value: Any) -> str | None:
         try:
             number = float(value)
         except (TypeError, ValueError):


### PR DESCRIPTION
### Source Issue #2197: Harden Post CI Summary

Source: https://github.com/stranske/Trend_Model_Project/issues/2197

> Topic GUID: 4f365d70-42a3-5de9-815b-00db1429c8a6
> 
> ## Why
> Body:
> Background
> Post‑CI Summary enumerates target workflows by path and writes a PR summary. Keep the two stable targets and defensively handle missing runs. 
> GitHub
> 
> ## Tasks
> Keep targets: pr-10-ci-python.yml, pr-12-docker-smoke.yml.
> 
>  Robustify null checks and summary formatting; no PR comments, only step summary.
> 
>  Confirm it only runs for PR events via workflow_run filter. 
> GitHub
> 
> ## Acceptance criteria
> Exactly one summary per PR. No loops, no duplicate comments.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18249944116).

—
PR created automatically to engage Codex.