### PR TITLE
Codex bootstrap for #2199

### DIFF
--- a/.github/workflows/pr-12-docker-smoke.yml
+++ b/.github/workflows/pr-12-docker-smoke.yml
@@ -141,8 +141,6 @@ jobs:
             "${REGISTRY}/${IMAGE_NAME}:latest")
           echo "Started container: $CONTAINER_ID"
 
-          HEALTH_PARSER_SCRIPT=$'import json\nimport os\nimport sys\n\npayload = os.environ.get("HEALTH_RESPONSE", "").strip()\nif not payload:\n    sys.exit(1)\n\nnormalized = payload.lower()\nif normalized in {"ok", "healthy", "pass", "passed", "up", "ready", "success"}:\n    sys.exit(0)\n\ntry:\n    data = json.loads(payload)\nexcept json.JSONDecodeError:\n    sys.exit(1)\n\nSUCCESS_VALUES = {"ok", "healthy", "pass", "passed", "true", "1", "up", "ready", "success"}\nKEYS_TO_CHECK = ("status", "state", "health", "message", "detail")\n\ndef is_success(value):\n    if isinstance(value, str):\n        return value.strip().lower() in SUCCESS_VALUES\n    if isinstance(value, bool):\n        return value\n    if isinstance(value, (int, float)):\n        return value == 1\n    if isinstance(value, dict):\n        for key in KEYS_TO_CHECK:\n            if key in value and is_success(value[key]):\n                return True\n        return any(is_success(v) for v in value.values())\n    if isinstance(value, (list, tuple, set)):\n        return any(is_success(item) for item in value)\n    return False\n\nsys.exit(0 if is_success(data) else 1)'
-
           max_attempts=5
           attempt=1
           health_ready=0
@@ -165,7 +163,7 @@ jobs:
 
             if [ "$curl_status" -eq 0 ]; then
               last_health_response="$curl_output"
-              if HEALTH_RESPONSE="$curl_output" python -c "$HEALTH_PARSER_SCRIPT"
+              if HEALTH_RESPONSE="$curl_output" python scripts/docker_health_response.py
               then
                 echo "Health check passed on attempt $attempt"
                 health_ready=1

--- a/agents/codex-2199.md
+++ b/agents/codex-2199.md
@@ -1,1 +1,19 @@
-<!-- bootstrap for codex on issue #2199 -->
+# Issue 2199 – Docker smoke workflow guard rails
+
+## Scope and constraints
+- Keep the existing buildx cache semantics. The restore step must always run and the save step stays disabled for pull requests.
+- Total runtime must remain short; the smoke job timeout cannot exceed 10 minutes and the health probe should fail within seconds when the container is unhealthy.
+- Changes apply to both CI (.github/workflows/pr-12-docker-smoke.yml) and the matching local helper (scripts/docker_smoke.sh).
+
+## Acceptance criteria
+- [x] A health check runs immediately after the image build, targeting `${HEALTH_PORT}${HEALTH_PATH}` and fails the job quickly when the service is unhealthy.
+- [x] The smoke job timeout is capped at 10 minutes or less.
+- [x] Cache saving only executes on non-pull_request events while restore always runs.
+
+## Implementation checklist
+- [x] Launch the container with a unique name and ensure cleanup even on failure.
+- [x] Poll the health endpoint with retry + backoff capped under 10 seconds total.
+- [x] Parse JSON/plain-text health responses and capture diagnostics on failure.
+- [x] Share the health-response parser between CI and the local smoke helper to avoid drift.
+- [x] Mirror the CI guard rails in scripts/docker_smoke.sh for local parity.
+- [x] Validate YAML syntax (`python -c 'yaml.safe_load(...)'`) and shell syntax (`bash -n scripts/docker_smoke.sh`).

--- a/scripts/docker_health_response.py
+++ b/scripts/docker_health_response.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Shared health-response parser for Docker smoke checks.
+
+The script reads the HEALTH_RESPONSE environment variable and exits 0 when the
+payload represents a healthy state.  This mirrors the logic used by the CI
+smoke workflow and the local docker_smoke.sh helper.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Iterable, Mapping
+
+SUCCESS_VALUES = {"ok", "healthy", "pass", "passed", "true", "1", "up", "ready", "success"}
+KEYS_TO_CHECK = ("status", "state", "health", "message", "detail")
+
+
+def _normalize(value: str) -> str:
+    return value.strip().lower()
+
+
+def _is_success(value: object) -> bool:
+    if isinstance(value, str):
+        return _normalize(value) in SUCCESS_VALUES
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value == 1
+    if isinstance(value, Mapping):
+        for key in KEYS_TO_CHECK:
+            if key in value and _is_success(value[key]):
+                return True
+        return any(_is_success(v) for v in value.values())
+    if isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray)):
+        return any(_is_success(item) for item in value)
+    return False
+
+
+def main() -> int:
+    payload = os.environ.get("HEALTH_RESPONSE", "").strip()
+    if not payload:
+        return 1
+
+    normalized = _normalize(payload)
+    if normalized in SUCCESS_VALUES:
+        return 0
+
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError:
+        return 1
+
+    return 0 if _is_success(data) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/docker_smoke.sh
+++ b/scripts/docker_smoke.sh
@@ -41,8 +41,6 @@ CONTAINER_ID=$(docker run -d \
 echo "Container id: $CONTAINER_ID" >&2
 
 # Probe health endpoint with retries mirroring the CI workflow behaviour.
-HEALTH_PARSER_SCRIPT=$'import json\nimport os\nimport sys\n\npayload = os.environ.get("HEALTH_RESPONSE", "").strip()\nif not payload:\n    sys.exit(1)\n\nnormalized = payload.lower()\nif normalized in {"ok", "healthy", "pass", "passed", "up", "ready", "success"}:\n    sys.exit(0)\n\ntry:\n    data = json.loads(payload)\nexcept json.JSONDecodeError:\n    sys.exit(1)\n\nSUCCESS_VALUES = {"ok", "healthy", "pass", "passed", "true", "1", "up", "ready", "success"}\nKEYS_TO_CHECK = ("status", "state", "health", "message", "detail")\n\ndef is_success(value):\n    if isinstance(value, str):\n        return value.strip().lower() in SUCCESS_VALUES\n    if isinstance(value, bool):\n        return value\n    if isinstance(value, (int, float)):\n        return value == 1\n    if isinstance(value, dict):\n        for key in KEYS_TO_CHECK:\n            if key in value and is_success(value[key]):\n                return True\n        return any(is_success(v) for v in value.values())\n    if isinstance(value, (list, tuple, set)):\n        return any(is_success(item) for item in value)\n    return False\n\nsys.exit(0 if is_success(data) else 1)'
-
 max_attempts=5
 attempt=1
 last_curl_status=0
@@ -66,7 +64,7 @@ while [[ $attempt -le $max_attempts ]]; do
 
   if [[ $curl_status -eq 0 ]]; then
     last_health_response="$curl_output"
-    if HEALTH_RESPONSE="$curl_output" python -c "$HEALTH_PARSER_SCRIPT"
+    if HEALTH_RESPONSE="$curl_output" python "$ROOT_DIR/scripts/docker_health_response.py"
     then
       echo "Smoke health check passed on attempt $attempt" >&2
       echo "Docker smoke: PASS" >&2


### PR DESCRIPTION
### Source Issue #2199: Docker smoke: keep caching, add guard rails

Source: https://github.com/stranske/Trend_Model_Project/issues/2199

> Topic GUID: 61b6b089-78ae-59cc-a62d-4cfe4b30a235
> 
> ## Why
> Body:
> Background
> pr-12-docker-smoke.yml is sound: hadolint, buildx cache keyed on requirements.lock, path‑ignores, optional registry login on push. Add a couple of safety checks. 
> GitHub
> 
> ## Tasks
> Add an explicit health check step using ${{ env.HEALTH_PORT }} and ${{ env.HEALTH_PATH }} after the build to fail fast if the app doesn’t come up.
> 
>  Ensure job‐level timeout stays ≤10 min.
> 
>  Make the cache save step conditional on non‑PR events (already present). 
> GitHub
> 
> ## Acceptance criteria
> Smoke job fails in seconds on a bad image rather than minutes later.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18249944116).

—
PR created automatically to engage Codex.