### PR TITLE
Fix YAML parsing error in smoke workflow health probe

### DIFF
--- a/.github/workflows/pr-12-docker-smoke.yml
+++ b/.github/workflows/pr-12-docker-smoke.yml
@@ -163,28 +163,20 @@ jobs:
 
             if [ "$curl_status" -eq 0 ]; then
               last_health_response="$curl_output"
-              if (
-                HEALTH_RESPONSE="$curl_output" python - <<'PY'
-import json
-import os
-import sys
-
-payload = os.environ.get("HEALTH_RESPONSE", "").strip()
-if not payload:
-    sys.exit(1)
-
-if payload.lower() == "ok":
-    sys.exit(0)
-
-try:
-    data = json.loads(payload)
-except json.JSONDecodeError:
-    sys.exit(1)
-
-status = str(data.get("status", "")).lower()
-sys.exit(0 if status == "ok" else 1)
-PY
-              ); then
+              if printf '%s\n' \
+                "import json, os, sys" \
+                "payload = os.environ.get(\"HEALTH_RESPONSE\", \"\").strip()" \
+                "if not payload:" \
+                "    sys.exit(1)" \
+                "if payload.lower() == \"ok\":" \
+                "    sys.exit(0)" \
+                "try:" \
+                "    data = json.loads(payload)" \
+                "except json.JSONDecodeError:" \
+                "    sys.exit(1)" \
+                "status = str(data.get(\"status\", \"\")).lower()" \
+                "sys.exit(0 if status == \"ok\" else 1)" \
+                | HEALTH_RESPONSE="$curl_output" python -; then
                 echo "Health check passed on attempt $attempt"
                 health_ready=1
                 break


### PR DESCRIPTION
## Summary
- replace the smoke health probe heredoc with a printf-piped Python snippet so the workflow remains valid YAML
- retain the same health response parsing logic while avoiding indentation that broke actionlint

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e42ba88c708331a91c1a5baf62d604