### PR TITLE
Codex bootstrap for #2201

### DIFF
--- a/.github/workflows/maint-40-ci-signature-guard.yml
+++ b/.github/workflows/maint-40-ci-signature-guard.yml
@@ -25,3 +25,12 @@ jobs:
         with:
           jobs-json: ${{ steps.read_signature.outputs.jobs_json }}
           expected-hash: ${{ steps.read_signature.outputs.expected_hash }}
+      - name: Reference documentation
+        if: always()
+        run: |
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          ## Maint 40 CI Signature Guard
+
+          Review the [CI signature guard docs](https://github.com/${{ github.repository }}/blob/phase-2-dev/docs/ci/WORKFLOWS.md#ci-signature-guard-fixtures)
+          for guidance on updating the fixtures when CI job definitions change.
+          EOF

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -63,6 +63,8 @@ The helper installs the pinned versions from `.github/workflows/autofix-versions
 
 When adding, removing, or renaming CI jobs intentionally, regenerate `basic_jobs.json` with the approved structure, compute the new hash (the composite action prints it when the comparison fails), and update both files in the same commit. The workflow should be rerun to confirm the new fixtures are accepted.
 
+To avoid noisy runs, the guard only triggers on pushes to `phase-2-dev` and on pull requests targeting that branch. Every run publishes a step summary with a direct link back to this section for quick reference while updating the fixtures.
+
 ## Formatter & Type Checker Pinning
 - The canonical formatter/type versions live in `.github/workflows/autofix-versions.env`. The file is sourced by CI workflows (`pr-10-ci-python.yml`, `reusable-90-ci-python.yml`, `maint-32-autofix.yml`) and the local mirror `scripts/style_gate_local.sh`.
 - Update the env file when bumping `black`, `ruff`, `mypy`, `isort`, or `docformatter`; commit the change with the workflow/doc updates in the same PR.


### PR DESCRIPTION
### Source Issue #2201: CI Signature Guard: reduce noise and document

Source: https://github.com/stranske/Trend_Model_Project/issues/2201

> Topic GUID: 15faf174-d285-5774-92fa-c45d03dbbab0
> 
> ## Why
> Body:
> Background
> maint-40-ci-signature-guard.yml validates expected jobs using fixtures and a composite action. Keep it, but limit branches to the ones you actually use and document. 
> GitHub
> 
> ## Tasks
> Confirm branch filters only include active ones (e.g., phase-2-dev and PRs). 
> GitHub
> 
>  Add a short section to docs/ci/WORKFLOWS.md explaining the signature files.
> 
> ## Acceptance criteria
> Guard runs only where relevant and has a link to docs.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18249944116).

---

## Summary
- publish a step summary from Maint 40 CI Signature Guard that links back to the workflow documentation for fixture updates
- expand the CI workflow guide with the guard's branch filters and the new step summary reference so maintainers know why it runs selectively

## Testing
- not run (workflow and documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e43069b388833197d79d1b4b90c95a