### PR TITLE
docs: refresh workflow catalog quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ thresholds, and the annualisation flag under the new `regime` section in
 
 🧭 **Workflow topology & agent routing**: Learn how workflow buckets, naming, post-CI summaries, and agent labels fit together in [docs/WORKFLOW_GUIDE.md](docs/WORKFLOW_GUIDE.md).
 
-� **Workflow catalog & naming policy**: See [docs/ci/WORKFLOWS.md](docs/ci/WORKFLOWS.md) for the authoritative workflow list, naming conventions, local style gate, and agents JSON schema.
+🗂️ **Workflow catalog & naming policy**: See [docs/ci/WORKFLOWS.md](docs/ci/WORKFLOWS.md) for the authoritative workflow list, naming conventions, contributor quick start, and agents JSON schema.
 
 �🔁 **Layered Test Workflow (Phases 1–3)**: The staged metrics → history/classification → coverage delta reusable workflow implemented in this repository is documented in [docs/ci-workflow.md](docs/ci-workflow.md). All advanced phases are disabled by default for back‑compat.
 

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -1,98 +1,169 @@
-# Workflow Naming & Inventory (Issue #2190)
+# Workflow Catalog & Contributor Quick Start
 
-This document tracks the acceptance criteria for Issue #2190. Use it as the authoritative reference for the remaining workflows.
+Use this page as the canonical reference for CI workflow naming, inventory, and
+local guardrails. It consolidates the requirements from Issues #2190 and #2202
+and adds guidance for contributors who need to stage new workflows or dispatch
+the agents toolkit.
 
-## Naming Policy
-- Filenames follow `<area>-<NN>-<slug>.yml` with 10-point spacing per family (`pr-1x`, `maint-0x/3x/4x/9x`, `agents-7x`, `reusable-7x/9x`).
-- The workflow `name:` matches the filename rendered in Title Case (`pr-10-ci-python.yml` → `PR 10 CI Python`).
-- `tests/test_workflow_naming.py` enforces the policy; rerun `pytest tests/test_workflow_naming.py` after editing workflows.
+## Naming Policy & Number Ranges
 
-## Visible Workflows (Actions Tab)
-| Filename | `name:` | Purpose |
-|----------|---------|---------|
-| `.github/workflows/pr-10-ci-python.yml` | `PR 10 CI Python` | Unified job that runs Black, Ruff, mypy, pytest with coverage, uploads diagnostics, and enforces coverage minimums. |
-| `.github/workflows/pr-12-docker-smoke.yml` | `PR 12 Docker Smoke` | Deterministic Docker build + smoke tests. |
-| `.github/workflows/maint-02-repo-health.yml` | `Maint 02 Repo Health` | Weekly sweep that reports stale branches and unassigned issues in the run summary. |
-| `.github/workflows/maint-30-post-ci-summary.yml` | `Maint 30 Post CI Summary` | Publishes CI/Docker run summaries to the workflow run log on `workflow_run`. |
-| `.github/workflows/maint-32-autofix.yml` | `Maint 32 Autofix` | Applies autofix commits after CI completes. |
-| `.github/workflows/maint-33-check-failure-tracker.yml` | `Maint 33 Check Failure Tracker` | Manages CI failure tracker issues. |
-| `.github/workflows/maint-36-actionlint.yml` | `Maint 36 Actionlint` | Sole workflow-lint gate (actionlint via reviewdog). |
-| `.github/workflows/maint-40-ci-signature-guard.yml` | `Maint 40 CI Signature Guard` | Validates signed CI manifests. |
-| `.github/workflows/maint-90-selftest.yml` | `Maint 90 Selftest` | Manual/weekly caller for `reusable-99-selftest.yml`. |
-| `.github/workflows/agents-43-codex-issue-bridge.yml` | `Agents 43 Codex Issue Bridge` | Issue label trigger that bootstraps Codex branches/PRs automatically. |
-| `.github/workflows/agents-70-orchestrator.yml` | `Agents 70 Orchestrator` | Unified agents toolkit entry point. |
+- Store workflows under `.github/workflows/` and follow the
+  `<area>-<NN>-<slug>.yml` convention.
+- Reserve number bands per area so future additions remain grouped:
 
-Only these workflows appear in the Actions UI; everything else is a reusable composite.
+  | Prefix | Number slots | Usage | Notes |
+  |--------|--------------|-------|-------|
+  | `pr-` | `10–19` | Pull-request gates | `pr-10-ci-python.yml` is the primary style/test gate; keep space for specialised PR jobs (Docker, docs).
+  | `maint-` | `00–49` and `90s` | Scheduled/background maintenance | Low numbers for repo hygiene, 30s/40s for post-CI and guards, 90 for self-tests calling reusable matrices.
+  | `agents-` | `40s` & `70s` | Agent bootstrap/orchestration | `43` bridges issues to Codex; `70` is the manual/scheduled orchestrator.
+  | `reusable-` | `70s` & `90s` | Composite workflows invoked by others | Keep 90s for CI executors, 70s for agent composites.
 
-## Reusable Composites
-| Filename | `name:` | Notes |
-|----------|---------|-------|
-| `.github/workflows/reusable-90-ci-python.yml` | `Reusable 90 CI Python` | Legacy matrix executor retained for self-tests while consumers migrate to the single-job workflow. |
-| `.github/workflows/reusable-94-legacy-ci-python.yml` | `Reusable 94 Legacy CI Python` | Compatibility shim for downstream consumers. |
-| `.github/workflows/reusable-92-autofix.yml` | `Reusable 92 Autofix` | Autofix harness consumed by `maint-32-autofix.yml`. |
-| `.github/workflows/reusable-70-agents.yml` | `Reusable 70 Agents` | Readiness, Codex bootstrap, verification, watchdog jobs. |
-| `.github/workflows/reusable-99-selftest.yml` | `Reusable 99 Selftest` | Matrix smoke-test of reusable CI features. |
+- Match the `name:` field to the filename rendered in Title Case
+  (`pr-10-ci-python.yml` → `PR 10 CI Python`).
+- `tests/test_workflow_naming.py` enforces this policy—rerun it after modifying
+  or adding workflows.
+- When introducing a new workflow choose the lowest unused slot inside the
+  appropriate band, update this document, and add the workflow to the relevant
+  section below.
+
+## Workflow Inventory
+
+### Required PR gates (block merges by default)
+
+| Workflow | Trigger(s) | Why it matters |
+|----------|------------|----------------|
+| `pr-10-ci-python.yml` (`PR 10 CI Python`) | `pull_request`, `workflow_dispatch` | Unified style/type/test gate (Black, Ruff, mypy, pytest + coverage upload).
+| `pr-12-docker-smoke.yml` (`PR 12 Docker Smoke`) | `pull_request`, `workflow_dispatch` | Deterministic Docker build followed by image smoke tests.
+
+These jobs must stay green for PRs to merge. The post-CI maintenance jobs below
+listen to their `workflow_run` events.
+
+### Maintenance & observability (scheduled/optional reruns)
+
+| Workflow | Trigger(s) | Purpose |
+|----------|------------|---------|
+| `maint-02-repo-health.yml` (`Maint 02 Repo Health`) | Weekly cron, manual | Reports stale branches & unassigned issues.
+| `maint-30-post-ci-summary.yml` (`Maint 30 Post CI Summary`) | `workflow_run` (PR 10/12) | Publishes consolidated CI status for active PRs.
+| `maint-32-autofix.yml` (`Maint 32 Autofix`) | `workflow_run` (PR 10/12 & Maint 90) | Applies formatter/type-hygiene autofixes after CI completes.
+| `maint-33-check-failure-tracker.yml` (`Maint 33 Check Failure Tracker`) | `workflow_run` (PR 10/12 & Maint 90) | Manages CI failure-tracker issues.
+| `maint-36-actionlint.yml` (`Maint 36 Actionlint`) | `pull_request`, weekly cron, manual | Sole workflow-lint gate (actionlint via reviewdog).
+| `maint-40-ci-signature-guard.yml` (`Maint 40 CI Signature Guard`) | `push`/`pull_request` targeting `phase-2-dev` | Validates the signed job manifest for `pr-10-ci-python.yml`.
+| `maint-90-selftest.yml` (`Maint 90 Selftest`) | Weekly cron, manual | Thin wrapper that dispatches the reusable CI self-test matrix.
+
+### Agent automation entry points
+
+| Workflow | Trigger(s) | Purpose |
+|----------|------------|---------|
+| `agents-43-codex-issue-bridge.yml` (`Agents 43 Codex Issue Bridge`) | `issues`, manual | Prepares Codex-ready branches/PRs when an `agent:codex` label is applied.
+| `agents-70-orchestrator.yml` (`Agents 70 Orchestrator`) | 20-minute cron, manual | Unified agents toolkit (readiness probes, Codex bootstrap, watchdogs) delegating to `reusable-70-agents.yml`.
+
+### Reusable composites
+
+| Workflow | Consumed by | Notes |
+|----------|-------------|-------|
+| `reusable-70-agents.yml` (`Reusable 70 Agents`) | `agents-70-orchestrator.yml` | Implements readiness, bootstrap, diagnostics, and watchdog jobs.
+| `reusable-90-ci-python.yml` (`Reusable 90 CI Python`) | `maint-90-selftest.yml` | Legacy matrix executor retained for self-tests while consumers migrate to the single-job workflow.
+| `reusable-92-autofix.yml` (`Reusable 92 Autofix`) | `maint-32-autofix.yml` | Autofix harness invoked after CI gates finish.
+| `reusable-94-legacy-ci-python.yml` (`Reusable 94 Legacy CI Python`) | Downstream consumers | Compatibility shim for repositories that still need the old matrix layout.
+| `reusable-99-selftest.yml` (`Reusable 99 Selftest`) | `maint-90-selftest.yml` | Matrix smoke-test covering reusable CI feature combinations.
+
+## Contributor Quick Start
+
+Follow this sequence before pushing workflow changes or large code edits:
+
+1. **Install tooling** – run `./scripts/setup_env.sh` once to create a virtual
+   environment with repository requirements.
+2. **Mirror the CI style gate locally** – execute:
+
+   ```bash
+   ./scripts/style_gate_local.sh
+   ```
+
+   The script sources `.github/workflows/autofix-versions.env`, installs the
+   pinned formatter/type versions, runs Ruff/Black, and finishes with a mypy pass
+   over `src/trend_analysis` and `src/trend_portfolio_app`. Fix any reported
+   issues to keep `PR 10 CI Python` green.
+3. **Targeted tests** – add `pytest tests/test_workflow_naming.py` after editing
+   workflow files to ensure naming conventions hold. For agents changes, also run
+   `pytest tests/test_automation_workflows.py -k agents`.
+4. **Optional smoke** – `gh workflow list --limit 20` validates that only the
+   documented workflows surface in the Actions tab.
+
+## Adding or Renumbering Workflows
+
+1. Pick the correct prefix/number band (see Naming Policy) and choose the lowest
+   unused slot.
+2. Place the workflow in `.github/workflows/` with the matching Title Case
+   `name:`.
+3. Update any trigger dependencies (`workflow_run` consumers) so maintenance jobs
+   continue to listen to the correct producers.
+4. Document the change in this file (inventory tables + bands) and in
+   `docs/WORKFLOW_GUIDE.md` if the topology shifts.
+5. Run the validation commands listed above before opening a PR.
 
 ## Formatter & Type Checker Pins
-- `.github/workflows/autofix-versions.env` is the single source of truth for formatter/type tooling versions (Ruff, Black, isort, docformatter, mypy).
-- `pr-10-ci-python.yml`, `reusable-90-ci-python.yml`, and the autofix composite action all load and validate this env file before installing tools; they will fail fast if the file is missing or incomplete.
-- Local mirrors (`scripts/style_gate_local.sh`, `scripts/dev_check.sh`, `scripts/validate_fast.sh`) `source` the same env file so contributors run the identical versions before pushing. These scripts now fail fast if the env file is missing or incomplete to keep the pins authoritative.
-- When bumping any formatter, update the env file first, rerun `./scripts/style_gate_local.sh`, and let CI confirm the new version. This keeps CI, autofix, and local developer flows in lock-step.
 
-### Local style gate quickstart
-
-Run the same style/type bundle that CI enforces with:
-
-```bash
-./scripts/style_gate_local.sh
-```
-
-The helper installs the pinned versions from `.github/workflows/autofix-versions.env`, runs Black/Ruff checks, and finishes with a mypy pass over `src/trend_analysis` and `src/trend_portfolio_app`. Fix any reported issues locally before pushing to keep `pr-10-ci-python.yml` green.
-
-## Trigger Dependencies
-- `maint-30-post-ci-summary.yml` listens for `workflow_run` events from `PR 10 CI Python` and `PR 12 Docker Smoke`, writing a consolidated status block to the run summary for the active PR head.
-- `maint-32-autofix.yml` and `maint-33-check-failure-tracker.yml` subscribe to the same CI workflows and also monitor the manual `Maint 90 Selftest` caller.
-- `Agents 70 Orchestrator` dispatches to `Reusable 70 Agents` and parses extended options via `options_json` to stay under GitHub's 10 input limit.
-- `Agents 43 Codex Issue Bridge` acts on `agent:codex` issue labels or manual dispatch to prepare Codex-ready branches and PRs.
+- `.github/workflows/autofix-versions.env` is the single source of truth for
+  formatter/type tooling versions (Ruff, Black, isort, docformatter, mypy).
+- `pr-10-ci-python.yml`, `reusable-90-ci-python.yml`, and the autofix composite
+  action all load and validate this env file before installing tools; they fail
+  fast if the file is missing or incomplete.
+- Local mirrors (`scripts/style_gate_local.sh`, `scripts/dev_check.sh`,
+  `scripts/validate_fast.sh`) source the same env file so contributors run the
+  identical versions before pushing.
+- When bumping any formatter, update the env file first, rerun
+  `./scripts/style_gate_local.sh`, and let CI confirm the new version to keep
+  automation and local flows aligned.
 
 ## CI Signature Guard Fixtures
-`maint-40-ci-signature-guard.yml` enforces a manifest "signature" for the PR Python workflow by comparing two fixture files stored in `.github/signature-fixtures/`:
 
-- `basic_jobs.json` – canonical list of jobs (name, concurrency label, and selected metadata) that must exist in `pr-10-ci-python.yml`.
-- `basic_hash.txt` – precomputed hash of the JSON payload used by the composite action `.github/actions/signature-verify` to detect unauthorized job changes.
+`maint-40-ci-signature-guard.yml` enforces a manifest signature for the PR Python
+workflow by comparing two fixture files stored in `.github/signature-fixtures/`:
 
-When adding, removing, or renaming CI jobs intentionally, regenerate `basic_jobs.json` with the approved structure, compute the new hash (the composite action prints it when the comparison fails), and update both files in the same commit. The workflow should be rerun to confirm the new fixtures are accepted.
+- `basic_jobs.json` – canonical list of jobs (name, concurrency label, metadata)
+  that must exist in `pr-10-ci-python.yml`.
+- `basic_hash.txt` – precomputed hash of the JSON payload used by
+  `.github/actions/signature-verify` to detect unauthorized job changes.
 
-Use `tools/test_failure_signature.py` to derive the hash locally while refreshing the fixtures:
+When intentionally editing CI jobs, regenerate `basic_jobs.json`, compute the new
+hash, and update both files in the same commit. Use
+`tools/test_failure_signature.py` locally to recompute and verify the hash before
+pushing. The guard only runs on pushes/PRs targeting `phase-2-dev` and publishes
+ a step summary linking back here.
 
-```bash
-# After updating basic_jobs.json with the new job manifest
-python tools/test_failure_signature.py \
-  --jobs "$(cat .github/signature-fixtures/basic_jobs.json)" \
-  > .github/signature-fixtures/basic_hash.txt
+## Agents `options_json` Schema
 
-# Sanity-check that both files agree before committing
-python tools/test_failure_signature.py \
-  --jobs "$(cat .github/signature-fixtures/basic_jobs.json)" \
-  --expected "$(cat .github/signature-fixtures/basic_hash.txt)"
+`agents-70-orchestrator.yml` accepts the standard dispatch inputs shown in the
+workflow plus an extensible JSON payload routed through `options_json`. The JSON
+is parsed with `fromJson()` and handed to the reusable agents workflow.
+
+```jsonc
+{
+  "diagnostic_mode": "off" | "dry-run" | "full",
+  "readiness_custom_logins": "login-a,login-b",
+  "codex_command_phrase": "@codex start"
+}
 ```
 
-To avoid noisy runs, the guard only triggers on pushes to `phase-2-dev` and on pull requests targeting that branch. It is further limited to changes that touch the signed workflow, fixture directory, or the composite verifier itself so unrelated commits on the branch do not run the guard. Every run publishes a step summary with a direct link back to this section for quick reference while updating the fixtures. The link resolves against the active branch or PR base automatically so maintainers always land on the correct documentation revision.
+- **`diagnostic_mode`** — `off` (default) disables diagnostics, `dry-run` keeps
+  bootstrap logic read-only, `full` allows branch creation and sets
+  `diagnostic_attempt_branch=true` in the reusable workflow.
+- **`readiness_custom_logins`** — optional comma-separated list of extra agent
+  logins to probe during readiness checks.
+- **`codex_command_phrase`** — overrides the PR comment phrase the orchestrator
+  looks for when confirming Codex bootstrap completion.
 
-## Formatter & Type Checker Pinning
-- The canonical formatter/type versions live in `.github/workflows/autofix-versions.env`. The file is sourced by CI workflows (`pr-10-ci-python.yml`, `reusable-90-ci-python.yml`, `maint-32-autofix.yml`) and the local mirror `scripts/style_gate_local.sh`.
-- Update the env file when bumping `black`, `ruff`, `mypy`, `isort`, or `docformatter`; commit the change with the workflow/doc updates in the same PR.
-- After editing the pins, run `./scripts/style_gate_local.sh` to confirm the local checks match CI output. CI workflows fail fast if the env file is missing or omits any required variable.
-
-## Verification Checklist
-- [x] Filenames and `name:` values verified.
-- [x] Redundant workflows removed (`agents-4x`, `maint-3x/4x/5x` variants, gate orchestrators, CodeQL, dependency review, labelers).
-- [x] Tests updated (`tests/test_workflow_agents_consolidation.py`) to guard the new structure.
-- [x] Documentation updated (`docs/agent-automation.md`, `docs/ops/codex-bootstrap-facts.md`, `docs/WORKFLOW_GUIDE.md`, `WORKFLOW_AUDIT_TEMP.md`).
+Extend the schema by adding new keys to the JSON object and updating both the
+orchestrator workflow and this documentation. Keep additional toggles in the
+JSON payload to avoid exceeding GitHub's 10 input limit on `workflow_dispatch`
+forms.
 
 ## Quick Validation Commands
-- `pytest tests/test_workflow_naming.py` — Ensures filenames and `name:` fields stay aligned with the WFv1 convention.
-- `pytest tests/test_automation_workflows.py -k agents` — Spot-checks the agents orchestrator wiring after edits.
-- `gh workflow list --limit 20` — Confirm the Actions tab only exposes the workflows listed above.
 
-Run `pytest tests/test_workflow_naming.py` after any workflow change to ensure the guardrails stay green.
+- `pytest tests/test_workflow_naming.py` — guard the naming convention.
+- `pytest tests/test_automation_workflows.py -k agents` — ensure agents inputs
+  (including `options_json`) parse correctly.
+- `gh workflow list --limit 20` — verify only the inventoried workflows are
+  visible in the Actions UI.
+
+Run the naming test after any workflow change to keep CI guardrails intact.

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -13,7 +13,7 @@ the agents toolkit.
 
   | Prefix | Number slots | Usage | Notes |
   |--------|--------------|-------|-------|
-  | `pr-` | `10–19` | Pull-request gates | `pr-10-ci-python.yml` is the primary style/test gate; keep space for specialised PR jobs (Docker, docs).
+  | `pr-` | `10–19` | Pull-request gates | `pr-10-ci-python.yml` is the primary style/test gate; keep space for specialized PR jobs (Docker, docs).
   | `maint-` | `00–49` and `90s` | Scheduled/background maintenance | Low numbers for repo hygiene, 30s/40s for post-CI and guards, 90 for self-tests calling reusable matrices.
   | `agents-` | `40s` & `70s` | Agent bootstrap/orchestration | `43` bridges issues to Codex; `70` is the manual/scheduled orchestrator.
   | `reusable-` | `70s` & `90s` | Composite workflows invoked by others | Keep 90s for CI executors, 70s for agent composites.

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -129,7 +129,7 @@ When intentionally editing CI jobs, regenerate `basic_jobs.json`, compute the ne
 hash, and update both files in the same commit. Use
 `tools/test_failure_signature.py` locally to recompute and verify the hash before
 pushing. The guard only runs on pushes/PRs targeting `phase-2-dev` and publishes
- a step summary linking back here.
+a step summary linking back here.
 
 ## Agents `options_json` Schema
 


### PR DESCRIPTION
## Summary
- reorganize `docs/ci/WORKFLOWS.md` to document numbering bands, required gates, contributor quick start, and agents dispatch schema
- update the README callout to point to the refreshed workflow catalog guidance

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e43729f64083319a9763ec0d5f0a78