### PR TITLE
Implement gate orchestration workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,114 @@
+name: Reusable CI
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: Python version to use for the job
+        required: true
+        type: string
+      marker:
+        description: Optional pytest marker expression
+        required: false
+        default: ''
+        type: string
+    secrets:
+      pypi-token:
+        description: Optional token for private dependencies
+        required: false
+
+jobs:
+  tests:
+    name: python ${{ inputs.python-version }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements.lock
+            pyproject.toml
+
+      - name: Install dependencies
+        env:
+          PRIVATE_PYPI_TOKEN: ${{ secrets.pypi-token }}
+        run: |
+          set -euo pipefail
+          if [ -n "${PRIVATE_PYPI_TOKEN:-}" ]; then
+            export PIP_INDEX_URL="https://__token__:${PRIVATE_PYPI_TOKEN}@pypi.org/simple"
+          fi
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
+          if [ -f requirements.lock ]; then
+            pip install -r requirements.lock || true
+          fi
+          if [ -f pyproject.toml ]; then
+            pip install -e . || pip install .
+          fi
+          pip install ruff mypy pytest pytest-cov
+
+      - name: Ruff (lint)
+        run: |
+          ruff check --output-format github .
+
+      - name: Mypy (type check)
+        run: |
+          set -euo pipefail
+          args=()
+          if [ -f pyproject.toml ]; then
+            args+=("--config-file" "pyproject.toml")
+          fi
+          target="src"
+          if [ ! -d "$target" ]; then
+            target="."
+          fi
+          mypy "${args[@]}" "$target"
+
+      - name: Cache pytest state
+        uses: actions/cache@v4
+        with:
+          path: .pytest_cache
+          key: pytest-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            pytest-${{ runner.os }}-${{ inputs.python-version }}-
+            pytest-${{ runner.os }}-
+
+      - name: Pytest (unit tests with coverage)
+        env:
+          PYTEST_MARKER: ${{ inputs.marker }}
+        run: |
+          set -euo pipefail
+          coverage_target="src"
+          if [ ! -d "$coverage_target" ]; then
+            coverage_target="."
+          fi
+          args=("--junitxml=pytest-junit.xml" "--cov=${coverage_target}" "--cov-report=xml:coverage.xml" "--cov-report=term-missing" "--cov-report=json:coverage.json")
+          if [ -n "${PYTEST_MARKER}" ]; then
+            args=("-m" "${PYTEST_MARKER}" "${args[@]}")
+          fi
+          pytest "${args[@]}"
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ inputs.python-version }}
+          path: |
+            coverage.xml
+            coverage.json
+            pytest-junit.xml
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,56 @@
+name: Reusable Docker Smoke
+
+on:
+  workflow_call:
+    inputs:
+      debug-build:
+        description: Enable verbose smoke test output
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  docker-smoke:
+    name: docker smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      REGISTRY: ${{ vars.REGISTRY || 'ghcr.io' }}
+      IMAGE_NAME: ${{ vars.IMAGE_NAME || format('{0}/{1}', github.repository_owner, 'trend-model') }}
+      HEALTH_PORT: ${{ vars.HEALTH_PORT || '8000' }}
+      HEALTH_PATH: ${{ vars.HEALTH_PATH || '/health' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        run: |
+          docker buildx build --load -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr .
+
+      - name: Smoke test container
+        env:
+          DEBUG_BUILD: ${{ inputs.debug-build }}
+        run: |
+          set -euo pipefail
+          container_name="trend-model-smoke"
+          docker rm -f "$container_name" >/dev/null 2>&1 || true
+          docker run -d --rm --name "$container_name" -p "${HEALTH_PORT}:${HEALTH_PORT}" "${REGISTRY}/${IMAGE_NAME}:pr" >/dev/null
+          trap 'docker rm -f "$container_name" >/dev/null 2>&1 || true' EXIT
+          for attempt in $(seq 1 10); do
+            if curl --fail --silent --max-time 2 "http://127.0.0.1:${HEALTH_PORT}${HEALTH_PATH}" >/dev/null; then
+              echo "Health check passed"
+              exit 0
+            fi
+            echo "Waiting for container (attempt ${attempt})"
+            sleep 3
+          done
+          echo "Container failed health check" >&2
+          if [ "${DEBUG_BUILD}" = "true" ]; then
+            docker logs "$container_name" || true
+          fi
+          exit 1

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -1,0 +1,80 @@
+name: gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'assets/**'
+  workflow_dispatch:
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number || github.ref_name }}-gate
+  cancel-in-progress: true
+
+jobs:
+  core-tests-311:
+    name: core tests (3.11)
+    uses: ./.github/workflows/ci.yml
+    with:
+      python-version: '3.11'
+      marker: "not quarantine and not slow"
+
+  core-tests-312:
+    name: core tests (3.12)
+    uses: ./.github/workflows/ci.yml
+    with:
+      python-version: '3.12'
+      marker: "not quarantine and not slow"
+
+  docker-smoke:
+    name: docker smoke
+    uses: ./.github/workflows/docker.yml
+
+  gate:
+    name: gate
+    needs:
+      - core-tests-311
+      - core-tests-312
+      - docker-smoke
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download coverage (3.11)
+        if: ${{ needs.core-tests-311.result == 'success' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-3.11
+          path: coverage/core-tests-311
+
+      - name: Download coverage (3.12)
+        if: ${{ needs.core-tests-312.result == 'success' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-3.12
+          path: coverage/core-tests-312
+
+      - name: Summarize results
+        run: |
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          ### Gate status
+          | Job | Result |
+          | --- | ------ |
+          | core-tests-311 | ${{ needs.core-tests-311.result }} |
+          | core-tests-312 | ${{ needs.core-tests-312.result }} |
+          | docker-smoke | ${{ needs.docker-smoke.result }} |
+          EOF
+
+          if [ "${{ needs.core-tests-311.result }}" != "success" ]; then
+            echo "core-tests-311 did not succeed" >&2
+            exit 1
+          fi
+          if [ "${{ needs.core-tests-312.result }}" != "success" ]; then
+            echo "core-tests-312 did not succeed" >&2
+            exit 1
+          fi
+          if [ "${{ needs.docker-smoke.result }}" != "success" ]; then
+            echo "docker-smoke did not succeed" >&2
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add a reusable CI workflow that runs Ruff, mypy, and pytest with coverage artifacts and caching
- provide a reusable Docker smoke workflow for gate orchestration
- introduce a gate workflow that fans out to CI and Docker jobs, applies concurrency, and aggregates results

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e489f6cf20833197223c9e4d2a21f2