### PR TITLE
feat: restore agents consumer with JSON inputs

### DIFF
--- a/.github/workflows/agents-consumer.yml
+++ b/.github/workflows/agents-consumer.yml
@@ -1,0 +1,163 @@
+name: Agents Consumer
+
+on:
+  schedule:
+    - cron: '15 * * * *'
+  workflow_dispatch:
+    inputs:
+      params_json:
+        description: >-
+          JSON configuration for the agents toolkit (example: {"enable_readiness":true,"readiness_agents":"copilot,codex","enable_watchdog":true})
+        required: false
+        default: '{"enable_readiness":false,"enable_watchdog":true,"bootstrap_issues_label":"agent:codex","draft_pr":false}'
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: agents-consumer
+  cancel-in-progress: false
+
+jobs:
+  resolve-params:
+    name: Resolve Parameters
+    runs-on: ubuntu-latest
+    outputs:
+      enable_readiness: ${{ steps.parse.outputs.enable_readiness }}
+      readiness_agents: ${{ steps.parse.outputs.readiness_agents }}
+      custom_logins: ${{ steps.parse.outputs.custom_logins }}
+      require_all: ${{ steps.parse.outputs.require_all }}
+      enable_preflight: ${{ steps.parse.outputs.enable_preflight }}
+      codex_user: ${{ steps.parse.outputs.codex_user }}
+      codex_command_phrase: ${{ steps.parse.outputs.codex_command_phrase }}
+      enable_verify_issue: ${{ steps.parse.outputs.enable_verify_issue }}
+      verify_issue_number: ${{ steps.parse.outputs.verify_issue_number }}
+      enable_watchdog: ${{ steps.parse.outputs.enable_watchdog }}
+      bootstrap_issues_label: ${{ steps.parse.outputs.bootstrap_issues_label }}
+      draft_pr: ${{ steps.parse.outputs.draft_pr }}
+      options_json: ${{ steps.parse.outputs.options_json }}
+    steps:
+      - name: Parse params_json
+        id: parse
+        uses: actions/github-script@v7
+        with:
+          params_json: ${{ inputs.params_json || '' }}
+          script: |
+            const defaults = {
+              enable_readiness: false,
+              readiness_agents: 'copilot,codex',
+              custom_logins: '',
+              require_all: false,
+              enable_preflight: false,
+              codex_user: '',
+              codex_command_phrase: '',
+              enable_verify_issue: false,
+              verify_issue_number: '',
+              enable_watchdog: true,
+              bootstrap_issues_label: 'agent:codex',
+              draft_pr: false,
+              options_json: '{}',
+            };
+
+            const raw = core.getInput('params_json');
+            let parsed = {};
+            if (raw && raw.trim()) {
+              try {
+                parsed = JSON.parse(raw);
+              } catch (error) {
+                core.warning(`Invalid params_json payload (${error.message}). Falling back to defaults.`);
+              }
+            }
+
+            const asString = (value, fallback = '') => {
+              if (value === undefined || value === null) {
+                return fallback;
+              }
+              if (Array.isArray(value)) {
+                return value.map((item) => String(item).trim()).filter(Boolean).join(',');
+              }
+              return String(value);
+            };
+
+            const asBoolString = (value, fallback) => {
+              const candidate = value === undefined ? fallback : value;
+              if (typeof candidate === 'boolean') {
+                return candidate ? 'true' : 'false';
+              }
+              if (typeof candidate === 'number') {
+                return candidate !== 0 ? 'true' : 'false';
+              }
+              if (typeof candidate === 'string') {
+                const norm = candidate.trim().toLowerCase();
+                if (['true', '1', 'yes', 'y', 'on'].includes(norm)) {
+                  return 'true';
+                }
+                if (['false', '0', 'no', 'n', 'off', ''].includes(norm)) {
+                  return 'false';
+                }
+              }
+              return fallback ? 'true' : 'false';
+            };
+
+            const get = (key) => parsed[key] ?? defaults[key];
+
+            const readinessAgents = asString(get('readiness_agents'), defaults.readiness_agents);
+            const customLogins = asString(get('custom_logins'), defaults.custom_logins);
+            const codexUser = asString(get('codex_user'), defaults.codex_user);
+            const codexCommandPhrase = asString(get('codex_command_phrase'), defaults.codex_command_phrase);
+            const bootstrapLabel = asString(get('bootstrap_issues_label'), defaults.bootstrap_issues_label);
+            const verifyIssueNumber = asString(get('verify_issue_number'), defaults.verify_issue_number).trim();
+            const optionsJson = asString(get('options_json'), defaults.options_json) || '{}';
+
+            const outputs = {
+              enable_readiness: asBoolString(get('enable_readiness'), defaults.enable_readiness),
+              readiness_agents: readinessAgents,
+              custom_logins: customLogins,
+              require_all: asBoolString(get('require_all'), defaults.require_all),
+              enable_preflight: asBoolString(get('enable_preflight'), defaults.enable_preflight),
+              codex_user: codexUser,
+              codex_command_phrase: codexCommandPhrase,
+              enable_verify_issue: asBoolString(
+                get('enable_verify_issue'),
+                defaults.enable_verify_issue || verifyIssueNumber !== ''
+              ),
+              verify_issue_number: verifyIssueNumber,
+              enable_watchdog: asBoolString(get('enable_watchdog'), defaults.enable_watchdog),
+              bootstrap_issues_label: bootstrapLabel,
+              draft_pr: asBoolString(get('draft_pr'), defaults.draft_pr),
+              options_json: optionsJson.trim() ? optionsJson : '{}',
+            };
+
+            for (const [key, value] of Object.entries(outputs)) {
+              core.setOutput(key, value);
+            }
+
+            const summary = core.summary;
+            summary.addHeading('Agents Consumer Parameters');
+            summary.addTable([
+              [{ data: 'Key', header: true }, { data: 'Value', header: true }],
+              ...Object.entries(outputs).map(([key, value]) => [key, String(value)])
+            ]);
+            await summary.write();
+  dispatch:
+    name: Dispatch Agents Toolkit
+    needs: resolve-params
+    uses: ./.github/workflows/reuse-agents.yml
+    secrets: inherit
+    with:
+      enable_readiness: ${{ needs.resolve-params.outputs.enable_readiness }}
+      readiness_agents: ${{ needs.resolve-params.outputs.readiness_agents }}
+      custom_logins: ${{ needs.resolve-params.outputs.custom_logins }}
+      require_all: ${{ needs.resolve-params.outputs.require_all }}
+      enable_preflight: ${{ needs.resolve-params.outputs.enable_preflight }}
+      codex_user: ${{ needs.resolve-params.outputs.codex_user }}
+      codex_command_phrase: ${{ needs.resolve-params.outputs.codex_command_phrase }}
+      enable_verify_issue: ${{ needs.resolve-params.outputs.enable_verify_issue }}
+      verify_issue_number: ${{ needs.resolve-params.outputs.verify_issue_number }}
+      enable_watchdog: ${{ needs.resolve-params.outputs.enable_watchdog }}
+      bootstrap_issues_label: ${{ needs.resolve-params.outputs.bootstrap_issues_label }}
+      draft_pr: ${{ needs.resolve-params.outputs.draft_pr }}
+      options_json: ${{ needs.resolve-params.outputs.options_json }}

--- a/.github/workflows/reusable-70-agents.yml
+++ b/.github/workflows/reusable-70-agents.yml
@@ -286,12 +286,15 @@ jobs:
               per_page: 30
             });
             const ready = issues.filter(i => !i.pull_request && !i.title.toLowerCase().includes('wip'));
-            core.setOutput('issue_numbers', ready.map(r => r.number).join(','));
+            const numbers = ready.map(r => r.number);
+            core.setOutput('issue_numbers', numbers.join(','));
+            core.setOutput('issue_numbers_json', JSON.stringify(numbers));
+            core.setOutput('first_issue', numbers.length ? String(numbers[0]) : '');
       - name: Bootstrap First Issue (if any)
-        if: steps.ready.outputs.issue_numbers != ''
+        if: steps.ready.outputs.first_issue != ''
         uses: ./.github/actions/codex-bootstrap-lite
         with:
-          issue: ${{ fromJSON(format('[{0}]', steps.ready.outputs.issue_numbers))[0] }}
+          issue: ${{ steps.ready.outputs.first_issue }}
           service_bot_pat: ${{ secrets.service_bot_pat || '' }}
           draft: ${{ inputs.draft_pr }}
 

--- a/.github/workflows/reuse-agents.yml
+++ b/.github/workflows/reuse-agents.yml
@@ -1,0 +1,97 @@
+name: Reuse Agents
+
+on:
+  workflow_call:
+    inputs:
+      enable_readiness:
+        description: 'Run readiness probe (true/false)'
+        required: false
+        default: 'false'
+        type: string
+      readiness_agents:
+        description: 'Comma-separated agent keys (copilot,codex)'
+        required: false
+        default: 'copilot,codex'
+        type: string
+      custom_logins:
+        description: 'Comma-separated custom logins to probe in readiness'
+        required: false
+        default: ''
+        type: string
+      require_all:
+        description: 'Fail readiness when any requested actor missing (true/false)'
+        required: false
+        default: 'false'
+        type: string
+      enable_preflight:
+        description: 'Run Codex preflight diagnostics (true/false)'
+        required: false
+        default: 'false'
+        type: string
+      codex_user:
+        description: 'Override Codex connector login for preflight'
+        required: false
+        default: ''
+        type: string
+      codex_command_phrase:
+        description: 'Command phrase to post during preflight'
+        required: false
+        default: ''
+        type: string
+      enable_verify_issue:
+        description: 'Verify a specific issue assignment (true/false)'
+        required: false
+        default: 'false'
+        type: string
+      verify_issue_number:
+        description: 'Issue number to verify when enable_verify_issue is true'
+        required: false
+        default: ''
+        type: string
+      enable_watchdog:
+        description: 'Run watchdog checks (true/false)'
+        required: false
+        default: 'true'
+        type: string
+      bootstrap_issues_label:
+        description: 'Label used to locate Codex-ready issues'
+        required: false
+        default: 'agent:codex'
+        type: string
+      draft_pr:
+        description: 'Create Codex bootstrap PRs as draft (true/false)'
+        required: false
+        default: 'false'
+        type: string
+      options_json:
+        description: 'Optional JSON settings forwarded to reusable toolkit'
+        required: false
+        default: '{}'
+        type: string
+    secrets:
+      service_bot_pat:
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  call:
+    uses: ./.github/workflows/reusable-70-agents.yml
+    secrets: inherit
+    with:
+      enable_readiness: ${{ inputs.enable_readiness }}
+      readiness_agents: ${{ inputs.readiness_agents }}
+      readiness_custom_logins: ${{ inputs.custom_logins }}
+      require_all: ${{ inputs.require_all }}
+      enable_preflight: ${{ inputs.enable_preflight }}
+      codex_user: ${{ inputs.codex_user }}
+      codex_command_phrase: ${{ inputs.codex_command_phrase }}
+      enable_verify_issue: ${{ inputs.enable_verify_issue }}
+      verify_issue_number: ${{ inputs.verify_issue_number }}
+      enable_watchdog: ${{ inputs.enable_watchdog }}
+      bootstrap_issues_label: ${{ inputs.bootstrap_issues_label }}
+      draft_pr: ${{ inputs.draft_pr }}
+      options_json: ${{ inputs.options_json }}

--- a/WORKFLOW_AUDIT_TEMP.md
+++ b/WORKFLOW_AUDIT_TEMP.md
@@ -31,13 +31,15 @@ Only the workflows listed below remain visible in the Actions tab. Reusable comp
 ### Agents
 | Workflow | Triggers | Notes |
 |----------|----------|-------|
+| `agents-consumer.yml` | schedule (hourly), workflow_dispatch | JSON-configurable wrapper that forwards options to `reuse-agents.yml`.
 | `agents-43-codex-issue-bridge.yml` | issues, workflow_dispatch | Restored Codex bootstrap automation for label-driven issue handling. |
 | `agents-70-orchestrator.yml` | schedule (*/20), workflow_dispatch | Unified agents toolkit entry point (readiness, preflight, verification, watchdog, Codex keepalive).
 
 ### Reusable Composites
 | Workflow | Triggers | Notes |
 |----------|----------|-------|
-| `reusable-70-agents.yml` | workflow_call | Reusable agents stack used by `agents-70-orchestrator.yml`.
+| `reuse-agents.yml` | workflow_call | Bridges consumer JSON payloads to the reusable stack.
+| `reusable-70-agents.yml` | workflow_call | Reusable agents stack used by `agents-70-orchestrator.yml` and `reuse-agents.yml`.
 | `reusable-99-selftest.yml` | workflow_call | Matrix smoke-test for the reusable CI executor.
 | `reusable-90-ci-python.yml` | workflow_call | Primary reusable CI implementation.
 | `reusable-92-autofix.yml` | workflow_call | Autofix composite consumed by `maint-32-autofix.yml`.
@@ -49,7 +51,7 @@ Only the workflows listed below remain visible in the Actions tab. Reusable comp
 | `agents-40-consumer.yml`, `agents-41-assign*.yml`, `agents-42-watchdog.yml`, `agents-44-copilot-readiness.yml`, `agents-45-verify-codex-bootstrap-matrix.yml` | Deleted; functionality consolidated into `agents-70-orchestrator.yml` + `reusable-70-agents.yml`.
 | `maint-31-autofix-residual-cleanup.yml`, `maint-34-quarantine-ttl.yml`, `maint-37-ci-selftest.yml`, `maint-38-cleanup-codex-bootstrap.yml`, `maint-43-verify-service-bot-pat.yml`, `maint-44-verify-ci-stack.yml`, `maint-45-merge-manager.yml`, `maint-48-selftest-reusable-ci.yml`, `maint-49-stale-prs.yml`, `maint-52-perf-benchmark.yml`, `maint-60-release.yml` | Deleted; maintenance roster trimmed to the Issue #2190 final set.
 | `pr-01-gate-orchestrator.yml`, `pr-02-label-agent-prs.yml`, `pr-18-workflow-lint.yml`, `pr-20-selftest-pr-comment.yml`, `pr-30-codeql.yml`, `pr-31-dependency-review.yml`, `pr-path-labeler.yml` | Deleted; PR checks narrowed to the two required pipelines.
-| `reuse-agents.yml` (renamed), `agents-consumer.yml` (renamed), `repo-health-self-check.yml` (renamed) | Superseded by the new naming scheme.
+| `reuse-agents.yml` (renamed), `agents-consumer.yml` (renamed), `repo-health-self-check.yml` (renamed) | Superseded by the new naming scheme. **2026-10 follow-up:** consumer + bridge reinstated with JSON interface to stay under dispatch limits.
 
 ## Verification
 - `pytest tests/test_workflow_*.py` validates naming compliance, inventory coverage, and agent orchestration wiring.

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -55,6 +55,7 @@ listen to their `workflow_run` events.
 
 | Workflow | Trigger(s) | Purpose |
 |----------|------------|---------|
+| `agents-consumer.yml` (`Agents Consumer`) | Hourly cron, manual | Consolidated wrapper that accepts a JSON payload and calls `reuse-agents.yml` to run readiness, preflight, verification, and bootstrap flows.
 | `agents-43-codex-issue-bridge.yml` (`Agents 43 Codex Issue Bridge`) | `issues`, manual | Prepares Codex-ready branches/PRs when an `agent:codex` label is applied.
 | `agents-70-orchestrator.yml` (`Agents 70 Orchestrator`) | 20-minute cron, manual | Unified agents toolkit (readiness probes, Codex bootstrap, watchdogs) delegating to `reusable-70-agents.yml`.
 
@@ -62,7 +63,8 @@ listen to their `workflow_run` events.
 
 | Workflow | Consumed by | Notes |
 |----------|-------------|-------|
-| `reusable-70-agents.yml` (`Reusable 70 Agents`) | `agents-70-orchestrator.yml` | Implements readiness, bootstrap, diagnostics, and watchdog jobs.
+| `reuse-agents.yml` (`Reuse Agents`) | `agents-consumer.yml` | Bridges `params_json` inputs to the reusable toolkit while preserving defaults.
+| `reusable-70-agents.yml` (`Reusable 70 Agents`) | `agents-70-orchestrator.yml`, `reuse-agents.yml` | Implements readiness, bootstrap, diagnostics, and watchdog jobs.
 | `reusable-90-ci-python.yml` (`Reusable 90 CI Python`) | `maint-90-selftest.yml` | Legacy matrix executor retained for self-tests while consumers migrate to the single-job workflow.
 | `reusable-92-autofix.yml` (`Reusable 92 Autofix`) | `maint-32-autofix.yml` | Autofix harness invoked after CI gates finish.
 | `reusable-94-legacy-ci-python.yml` (`Reusable 94 Legacy CI Python`) | Downstream consumers | Compatibility shim for repositories that still need the old matrix layout.

--- a/tests/test_workflow_naming.py
+++ b/tests/test_workflow_naming.py
@@ -1,6 +1,6 @@
 import pathlib
 
-ALLOWED_PREFIXES = ("pr-", "maint-", "agents-", "reusable-")
+ALLOWED_PREFIXES = ("pr-", "maint-", "agents-", "reusable-", "reuse-")
 WORKFLOW_DIR = pathlib.Path(".github/workflows")
 
 
@@ -88,8 +88,10 @@ def test_chatgpt_issue_sync_workflow_present_and_intact():
 
 
 EXPECTED_NAMES = {
+    "agents-consumer.yml": "Agents Consumer",
     "agents-43-codex-issue-bridge.yml": "Agents 43 Codex Issue Bridge",
     "agents-70-orchestrator.yml": "Agents 70 Orchestrator",
+    "reuse-agents.yml": "Reuse Agents",
     "maint-02-repo-health.yml": "Maint 02 Repo Health",
     "maint-30-post-ci-summary.yml": "Maint 30 Post CI Summary",
     "maint-32-autofix.yml": "Maint 32 Autofix",


### PR DESCRIPTION
## Summary
- add a rebuilt `agents-consumer.yml` workflow that accepts a single `params_json` payload and forwards parsed flags to the agents toolkit
- reintroduce `reuse-agents.yml` as a workflow_call bridge and update the reusable stack to emit structured ready-issue outputs
- refresh workflow inventory docs and tests for the new consumer/bridge names and dispatch contract

## Testing
- pytest tests/test_workflow_agents_consolidation.py tests/test_workflow_naming.py

------
https://chatgpt.com/codex/tasks/task_e_68e4f4a0920883319704836dff19670a