### PR TITLE
Fix shell quoting in reusable CI workflow

### DIFF
--- a/.github/workflows/reusable-96-ci-lite.yml
+++ b/.github/workflows/reusable-96-ci-lite.yml
@@ -101,14 +101,17 @@ jobs:
         shell: bash
         run: |
           source .venv/bin/activate
-          marker_flag=""
+          pytest_args=(
+            "--junitxml=pytest-junit.xml"
+            "--cov=src"
+            "--cov-report=xml:coverage.xml"
+            "--cov-report=term-missing"
+            "--cov-report=json:coverage.json"
+          )
           if [[ -n "${PYTEST_MARKER}" ]]; then
-            marker_flag="-m ${PYTEST_MARKER}"
+            pytest_args+=("-m" "${PYTEST_MARKER}")
           fi
-          pytest --junitxml=pytest-junit.xml \
-            --cov=src --cov-report=xml:coverage.xml \
-            --cov-report=term-missing --cov-report=json:coverage.json \
-            ${marker_flag}
+          pytest "${pytest_args[@]}"
 
       - name: Capture artifacts
         if: always()


### PR DESCRIPTION
## Summary
- ensure pytest arguments are passed via an array in the reusable CI workflow
- prevent unquoted marker flags from triggering shellcheck warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e538808f8c8331b69f234c2bf75039