### PR TITLE
Update agents consumer workflow defaults

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -123,7 +123,9 @@ Two entry points now exist:
 
 - `agents-consumer.yml` – Hourly cron + manual dispatch wrapper that accepts a
   single `params_json` string, parses it, and forwards normalized values to
-  `reuse-agents.yml`.
+  `reuse-agents.yml`. Scheduled runs only execute readiness + watchdog probes;
+  set `enable_bootstrap` to `true` in the JSON payload to opt into Codex
+  bootstraps (preflight stays disabled unless explicitly enabled).
 - `agents-70-orchestrator.yml` – Unified scheduled/dispatch orchestrator for
   readiness probes, diagnostics, bootstrap, watchdog, and keepalive flows. It
   passes discrete inputs directly to `reusable-70-agents.yml`.
@@ -148,14 +150,17 @@ paste payload:
   "enable_verify_issue": false,
   "verify_issue_number": "",
   "enable_watchdog": true,
+  "enable_bootstrap": false,
   "bootstrap_issues_label": "agent:codex",
   "draft_pr": false,
-  "options_json": "{}"
+  "options_json": "{\"keepalive\":{\"enabled\":false}}"
 }
 ```
 
-Omit any keys to fall back to defaults. `options_json` remains available for
-advanced keepalive tuning (dry run, alternate labels, idle thresholds, etc.).
+Omit any keys to fall back to defaults. `enable_bootstrap: true` unlocks Codex
+PR bootstraps; leave it `false` for the minimal readiness + watchdog run.
+`options_json` remains available for advanced keepalive tuning (dry run,
+alternate labels, idle thresholds, etc.).
 
 The guard test `tests/test_workflow_agents_consolidation.py` enforces the
 reduced input surface and ensures the consumer continues to call the bridge

--- a/.github/workflows/agents-consumer.yml
+++ b/.github/workflows/agents-consumer.yml
@@ -9,7 +9,7 @@ on:
         description: >-
           JSON configuration for the agents toolkit (example: {"enable_readiness":true,"readiness_agents":"copilot,codex","enable_watchdog":true})
         required: false
-        default: '{"enable_readiness":false,"enable_watchdog":true,"bootstrap_issues_label":"agent:codex","draft_pr":false}'
+        default: '{"enable_readiness":true,"enable_watchdog":true,"enable_preflight":false,"enable_bootstrap":false,"bootstrap_issues_label":"agent:codex","draft_pr":false,"options_json":"{\\"keepalive\\":{\\"enabled\\":false}}"}'
         type: string
 
 permissions:
@@ -19,12 +19,13 @@ permissions:
 
 concurrency:
   group: agents-consumer
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   resolve-params:
     name: Resolve Parameters
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       enable_readiness: ${{ steps.parse.outputs.enable_readiness }}
       readiness_agents: ${{ steps.parse.outputs.readiness_agents }}
@@ -36,6 +37,7 @@ jobs:
       enable_verify_issue: ${{ steps.parse.outputs.enable_verify_issue }}
       verify_issue_number: ${{ steps.parse.outputs.verify_issue_number }}
       enable_watchdog: ${{ steps.parse.outputs.enable_watchdog }}
+      enable_bootstrap: ${{ steps.parse.outputs.enable_bootstrap }}
       bootstrap_issues_label: ${{ steps.parse.outputs.bootstrap_issues_label }}
       draft_pr: ${{ steps.parse.outputs.draft_pr }}
       options_json: ${{ steps.parse.outputs.options_json }}
@@ -48,11 +50,12 @@ jobs:
         with:
           script: |
             const defaults = {
-              enable_readiness: false,
+              enable_readiness: true,
               readiness_agents: 'copilot,codex',
               custom_logins: '',
               require_all: false,
               enable_preflight: false,
+              enable_bootstrap: false,
               codex_user: '',
               codex_command_phrase: '',
               enable_verify_issue: false,
@@ -60,7 +63,7 @@ jobs:
               enable_watchdog: true,
               bootstrap_issues_label: 'agent:codex',
               draft_pr: false,
-              options_json: '{}',
+              options_json: '{"keepalive":{"enabled":false}}',
             };
 
             const raw = process.env.PARAMS_JSON ?? '';
@@ -109,7 +112,9 @@ jobs:
             const customLogins = asString(get('custom_logins'), defaults.custom_logins);
             const codexUser = asString(get('codex_user'), defaults.codex_user);
             const codexCommandPhrase = asString(get('codex_command_phrase'), defaults.codex_command_phrase);
-            const bootstrapLabel = asString(get('bootstrap_issues_label'), defaults.bootstrap_issues_label);
+            const bootstrapEnabled = asBoolString(get('enable_bootstrap'), defaults.enable_bootstrap);
+            const bootstrapLabelRaw = asString(get('bootstrap_issues_label'), defaults.bootstrap_issues_label);
+            const bootstrapLabel = bootstrapEnabled === 'true' ? bootstrapLabelRaw : '';
             const verifyIssueNumber = asString(get('verify_issue_number'), defaults.verify_issue_number).trim();
             const optionsJson = asString(get('options_json'), defaults.options_json) || '{}';
 
@@ -127,6 +132,7 @@ jobs:
               ),
               verify_issue_number: verifyIssueNumber,
               enable_watchdog: asBoolString(get('enable_watchdog'), defaults.enable_watchdog),
+              enable_bootstrap: bootstrapEnabled,
               bootstrap_issues_label: bootstrapLabel,
               draft_pr: asBoolString(get('draft_pr'), defaults.draft_pr),
               options_json: optionsJson.trim() ? optionsJson : '{}',
@@ -148,6 +154,7 @@ jobs:
     needs: resolve-params
     uses: ./.github/workflows/reuse-agents.yml
     secrets: inherit
+    timeout-minutes: 60
     with:
       enable_readiness: ${{ needs.resolve-params.outputs.enable_readiness }}
       readiness_agents: ${{ needs.resolve-params.outputs.readiness_agents }}


### PR DESCRIPTION
## Summary
- ensure the agents-consumer workflow cancels overlapping runs and applies job timeouts
- default the JSON payload to readiness/watchdog only, adding an explicit bootstrap opt-in and disabling keepalive unless requested
- document the bootstrap opt-in flow in the workflows README so operators know how to enable it

## Testing
- not run (workflow and documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e551012d808331bd582c64749d1457