### PR TITLE
feat: enrich cosmetic repair workflow reporting

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -75,6 +75,7 @@ All others use default `GITHUB_TOKEN`.
 | `maint-36-actionlint.yml` | pull_request (workflows), push (`phase-2-dev`), schedule, workflow_dispatch | Workflow schema lint with reviewdog annotations.
 | `maint-40-ci-signature-guard.yml` | pull_request/push (`phase-2-dev`) | Validates the signed job manifest for `pr-10-ci-python.yml`.
 | `maint-41-chatgpt-issue-sync.yml` | workflow_dispatch | Curated topic lists (e.g. `Issues.txt`) → labeled GitHub issues.
+| `cosmetic-repair.yml` | workflow_dispatch | Manual pytest + cosmetic fixer that raises guard-gated PRs for tolerated drift.
 | `agents-43-codex-issue-bridge.yml` | issues, workflow_dispatch | Prepares Codex-ready branches/PRs when an `agent:codex` label is applied.
 | `agents-70-orchestrator.yml` | schedule (*/20), workflow_dispatch | Unified agents toolkit entry point delegating to `reusable-70-agents.yml`.
 | `reusable-70-agents.yml` | workflow_call | Composite implementing readiness, bootstrap, diagnostics, and watchdog jobs.

--- a/.github/workflows/cosmetic-repair.yml
+++ b/.github/workflows/cosmetic-repair.yml
@@ -68,6 +68,26 @@ jobs:
           echo "Running: ${cmd[*]}"
           "${cmd[@]}"
 
+      - name: Capture cosmetic summary outputs
+        if: always()
+        id: cosmetic-summary
+        run: |
+          if [ -f .cosmetic-repair-summary.json ]; then
+            python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+summary = Path('.cosmetic-repair-summary.json')
+data = json.loads(summary.read_text(encoding='utf-8'))
+with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as handle:
+    for key in ('status', 'branch', 'pr_url'):
+        value = data.get(key)
+        if value:
+            handle.write(f"{key}={value}\n")
+PY
+          fi
+
       - name: Upload pytest report
         if: always()
         uses: actions/upload-artifact@v4
@@ -80,7 +100,39 @@ jobs:
       - name: Summarise outcome
         if: always()
         run: |
+          summary_file=".cosmetic-repair-summary.json"
           {
-            echo "### Cosmetic repair summary";
-            git status --short || true;
+            echo "### Cosmetic repair summary"
+            echo
+            if [ -f "$summary_file" ]; then
+              python - <<'PY'
+import json
+from pathlib import Path
+
+data = json.loads(Path('.cosmetic-repair-summary.json').read_text(encoding='utf-8'))
+status = data.get('status', 'unknown')
+print(f"- Status: **{status}**")
+changed = data.get('changed_files') or []
+if changed:
+    print(f"- Changed files ({len(changed)}):")
+    for path in changed:
+        print(f"  - `{path}`")
+else:
+    print("- No file changes detected.")
+pr_url = data.get('pr_url')
+if pr_url:
+    print(f"- PR: {pr_url}")
+instructions = data.get('instructions') or []
+if instructions:
+    print("- Instructions processed:")
+    for entry in instructions:
+        kind = entry.get('kind', 'unknown')
+        path = entry.get('path', '?')
+        guard = entry.get('guard', '')
+        extra = f" ({guard})" if guard else ""
+        print(f"  - `{kind}` → `{path}`{extra}")
+PY
+            else
+              git status --short || true
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 .pytest_cache/
+.cosmetic-repair-summary.json
 *.pyc
 *.py[cod]
 

--- a/WORKFLOW_AUDIT_TEMP.md
+++ b/WORKFLOW_AUDIT_TEMP.md
@@ -29,6 +29,7 @@ Only the workflows listed below remain visible in the Actions tab. Reusable comp
 | `maint-36-actionlint.yml` | pull_request, push, schedule, workflow_dispatch | Sole workflow lint gate (actionlint via reviewdog).
 | `maint-40-ci-signature-guard.yml` | pull_request, push | Verifies signed CI manifests to guard against tampering.
 | `maint-41-chatgpt-issue-sync.yml` | workflow_dispatch | Fans out curated topic lists (e.g. `Issues.txt`) into GitHub issues with automatic labeling. |
+| `cosmetic-repair.yml` | workflow_dispatch | Manual pytest run that feeds `scripts/ci_cosmetic_repair.py` to patch guard-gated tolerances/snapshots and open labelled PRs. |
 
 ### Agents
 | Workflow | Triggers | Notes |

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -35,6 +35,7 @@ Tests under `tests/test_workflow_naming.py` enforce the naming policy and invent
 - **`maint-36-actionlint.yml`** — Sole workflow-lint gate. Runs actionlint via reviewdog on PR edits, pushes, weekly cron, and manual dispatch.
 - **`maint-40-ci-signature-guard.yml`** — Guards the CI manifest with signed fixture checks.
 - **`maint-90-selftest.yml`** — Manual/weekly caller that delegates to `reusable-99-selftest.yml`.
+- **`cosmetic-repair.yml`** — Manual dispatch utility that runs `pytest -q`, applies guard-gated cosmetic fixes via `scripts/ci_cosmetic_repair.py`, and opens a labelled PR when changes exist.
 
 ### Agents
 - **`agents-70-orchestrator.yml`** — Hourly + manual dispatch entry point for readiness, Codex bootstrap, issue verification, and watchdog sweeps. Delegates to `reusable-70-agents.yml` and accepts extended options via `options_json`.

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -52,6 +52,7 @@ listen to their `workflow_run` events.
 | `maint-36-actionlint.yml` (`Maint 36 Actionlint`) | `pull_request`, weekly cron, manual | Sole workflow-lint gate (actionlint via reviewdog).
 | `maint-40-ci-signature-guard.yml` (`Maint 40 CI Signature Guard`) | `push`/`pull_request` targeting `phase-2-dev` | Validates the signed job manifest for `pr-10-ci-python.yml`.
 | `maint-41-chatgpt-issue-sync.yml` (`Maint 41 ChatGPT Issue Sync`) | `workflow_dispatch` (manual) | Fans out curated topic lists (e.g. `Issues.txt`) into labeled GitHub issues. ⚠️ Repository policy: do not remove without a functionally equivalent replacement. |
+| `cosmetic-repair.yml` (`Cosmetic Repair`) | `workflow_dispatch` | Manual pytest + guardrail fixer that applies tolerance/snapshot updates and opens a labelled PR when drift is detected. |
 
 ### Agent automation entry points
 

--- a/docs/ops/cosmetic-repair.md
+++ b/docs/ops/cosmetic-repair.md
@@ -31,7 +31,9 @@ standard fix PR instead.
 5. When changes exist, the script commits them on a branch named
    `autofix/cosmetic-repair-<timestamp>` (or with the provided suffix), pushes
 the branch, and opens a pull request labelled `testing` and `autofix:applied`.
-6. The workflow summary lists touched files and links to the created PR.
+6. The workflow writes `.cosmetic-repair-summary.json`, which feeds the job
+   summary with the execution status, changed files, and PR link (when one is
+   created).
 
 If re-run after the drift is already repaired, the script exits cleanly without
 creating a new branch or PR.

--- a/docs/planning/issue-2381-cosmetic-repair.md
+++ b/docs/planning/issue-2381-cosmetic-repair.md
@@ -28,12 +28,12 @@
    - Provide instructions for running the repair script locally (including prerequisites) and how to simulate the workflow behavior.
 
 ## Initial Task Checklist
-- [ ] Audit existing CI helpers to reuse environment bootstrap logic (actions, scripts, or caching patterns).
-- [ ] Design repairable-case inventory (identify fixture files, tolerance definitions, formatting targets) and codify guard comment conventions.
-- [ ] Implement `scripts/ci_cosmetic_repair.py` with CLI flags for `--dry-run`, `--apply`, and logging verbosity.
-- [ ] Write targeted unit tests for the repair script under `tests/` (include at least one success and one refusal scenario).
-- [ ] Create `.github/workflows/cosmetic-repair.yml` with dispatch inputs (e.g., optional branch name suffix, dry-run toggle) and integrate the script + pytest run.
-- [ ] Ensure the workflow sets the required labels when opening PRs and posts a concise job summary (detected issues, files changed).
-- [ ] Document usage in `docs/ops/cosmetic-repair.md` (or equivalent) and link from contributor guides if necessary.
-- [ ] Validate idempotency by running the script twice on synthetic drift and confirming the second run exits cleanly.
-- [ ] Perform end-to-end dry run (locally or via workflow) to confirm branch naming, labeling, and guard comments meet expectations.
+- [x] Audit existing CI helpers to reuse environment bootstrap logic (actions, scripts, or caching patterns).
+- [x] Design repairable-case inventory (identify fixture files, tolerance definitions, formatting targets) and codify guard comment conventions.
+- [x] Implement `scripts/ci_cosmetic_repair.py` with CLI flags for `--dry-run`, `--apply`, and logging verbosity.
+- [x] Write targeted unit tests for the repair script under `tests/` (include at least one success and one refusal scenario).
+- [x] Create `.github/workflows/cosmetic-repair.yml` with dispatch inputs (e.g., optional branch name suffix, dry-run toggle) and integrate the script + pytest run.
+- [x] Ensure the workflow sets the required labels when opening PRs and posts a concise job summary (detected issues, files changed).
+- [x] Document usage in `docs/ops/cosmetic-repair.md` (or equivalent) and link from contributor guides if necessary.
+- [x] Validate idempotency by running the script twice on synthetic drift and confirming the second run exits cleanly.
+- [x] Perform end-to-end dry run (locally or via workflow) to confirm branch naming, labeling, and guard comments meet expectations.

--- a/tests/test_ci_cosmetic_repair.py
+++ b/tests/test_ci_cosmetic_repair.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from xml.sax.saxutils import escape
 
@@ -10,6 +11,12 @@ pytestmark = pytest.mark.filterwarnings(
 )
 
 from scripts import ci_cosmetic_repair
+
+
+def _read_summary(repo_root: Path) -> dict[str, object]:
+    summary_path = repo_root / ci_cosmetic_repair.SUMMARY_FILE
+    assert summary_path.exists(), "summary file should be created"
+    return json.loads(summary_path.read_text(encoding="utf-8"))
 
 
 def _write_junit(tmp_path: Path, message: str) -> Path:
@@ -38,14 +45,14 @@ def test_cosmetic_repair_updates_guarded_value(tmp_path: Path) -> None:
         "EXPECTED_ALPHA = 1.23450  # cosmetic-repair: float EXPECTED_ALPHA\n",
         encoding="utf-8",
     )
-    message = (
-        "COSMETIC_TOLERANCE "
-        "{"\
-        "\"path\": \"tests/fixtures/baseline.py\", "
-        "\"guard\": \"float\", "
-        "\"key\": \"EXPECTED_ALPHA\", "
-        "\"actual\": 1.23456, "
-        "\"digits\": 5}"
+    message = "COSMETIC_TOLERANCE " + json.dumps(
+        {
+            "path": "tests/fixtures/baseline.py",
+            "guard": "float",
+            "key": "EXPECTED_ALPHA",
+            "actual": 1.23456,
+            "digits": 5,
+        }
     )
     report = _write_junit(repo_root, message)
 
@@ -64,6 +71,12 @@ def test_cosmetic_repair_updates_guarded_value(tmp_path: Path) -> None:
     updated = target.read_text(encoding="utf-8")
     assert "1.23456" in updated
     assert updated.endswith("\n")
+    summary = _read_summary(repo_root)
+    assert summary["status"] == "applied-no-pr"
+    assert summary["mode"] == "apply"
+    assert summary.get("changed_files") == ["tests/fixtures/baseline.py"]
+    instructions = summary.get("instructions")
+    assert isinstance(instructions, list) and instructions
 
 
 def test_cosmetic_repair_refuses_without_guard(tmp_path: Path) -> None:
@@ -71,14 +84,14 @@ def test_cosmetic_repair_refuses_without_guard(tmp_path: Path) -> None:
     target = repo_root / "tests" / "fixtures" / "baseline.py"
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text("EXPECTED_ALPHA = 1.23\n", encoding="utf-8")
-    message = (
-        "COSMETIC_TOLERANCE "
-        "{"\
-        "\"path\": \"tests/fixtures/baseline.py\", "
-        "\"guard\": \"float\", "
-        "\"key\": \"EXPECTED_ALPHA\", "
-        "\"actual\": 1.23456, "
-        "\"digits\": 5}"
+    message = "COSMETIC_TOLERANCE " + json.dumps(
+        {
+            "path": "tests/fixtures/baseline.py",
+            "guard": "float",
+            "key": "EXPECTED_ALPHA",
+            "actual": 1.23456,
+            "digits": 5,
+        }
     )
     report = _write_junit(repo_root, message)
 
@@ -93,3 +106,121 @@ def test_cosmetic_repair_refuses_without_guard(tmp_path: Path) -> None:
                 "--skip-pr",
             ]
         )
+
+
+def test_second_run_detects_no_changes(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    target = repo_root / "tests" / "fixtures" / "baseline.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        "EXPECTED_ALPHA = 1.23450  # cosmetic-repair: float EXPECTED_ALPHA\n",
+        encoding="utf-8",
+    )
+    message = "COSMETIC_TOLERANCE " + json.dumps(
+        {
+            "path": "tests/fixtures/baseline.py",
+            "guard": "float",
+            "key": "EXPECTED_ALPHA",
+            "actual": 1.23456,
+            "digits": 5,
+        }
+    )
+    report = _write_junit(repo_root, message)
+
+    first_exit = ci_cosmetic_repair.main(
+        [
+            "--apply",
+            "--report",
+            str(report),
+            "--root",
+            str(repo_root),
+            "--skip-pr",
+        ]
+    )
+    assert first_exit == 0
+    first_summary = _read_summary(repo_root)
+    assert first_summary["status"] == "applied-no-pr"
+
+    second_exit = ci_cosmetic_repair.main(
+        [
+            "--apply",
+            "--report",
+            str(report),
+            "--root",
+            str(repo_root),
+            "--skip-pr",
+        ]
+    )
+    assert second_exit == 0
+    second_summary = _read_summary(repo_root)
+    assert second_summary["status"] == "no-changes"
+
+
+def test_cosmetic_snapshot_updates_file(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    target = repo_root / "tests" / "fixtures" / "snapshot.txt"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("old snapshot\n# cosmetic-repair: snapshot baseline\n", encoding="utf-8")
+    replacement = "new snapshot\n# cosmetic-repair: snapshot baseline\n"
+    message = "COSMETIC_SNAPSHOT " + json.dumps(
+        {
+            "path": "tests/fixtures/snapshot.txt",
+            "guard": "snapshot",
+            "replacement": replacement,
+        }
+    )
+    report = _write_junit(repo_root, message)
+
+    exit_code = ci_cosmetic_repair.main(
+        [
+            "--apply",
+            "--report",
+            str(report),
+            "--root",
+            str(repo_root),
+            "--skip-pr",
+        ]
+    )
+
+    assert exit_code == 0
+    assert target.read_text(encoding="utf-8") == replacement
+    summary = _read_summary(repo_root)
+    assert summary["status"] == "applied-no-pr"
+    assert summary.get("changed_files") == ["tests/fixtures/snapshot.txt"]
+    assert summary.get("instructions")[0]["kind"] == "snapshot"
+
+
+def test_dry_run_writes_summary(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    target = repo_root / "tests" / "fixtures" / "baseline.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        "EXPECTED_ALPHA = 1.23450  # cosmetic-repair: float EXPECTED_ALPHA\n",
+        encoding="utf-8",
+    )
+    message = "COSMETIC_TOLERANCE " + json.dumps(
+        {
+            "path": "tests/fixtures/baseline.py",
+            "guard": "float",
+            "key": "EXPECTED_ALPHA",
+            "actual": 1.23456,
+            "digits": 5,
+        }
+    )
+    report = _write_junit(repo_root, message)
+
+    exit_code = ci_cosmetic_repair.main(
+        [
+            "--dry-run",
+            "--report",
+            str(report),
+            "--root",
+            str(repo_root),
+        ]
+    )
+
+    assert exit_code == 0
+    summary = _read_summary(repo_root)
+    assert summary["status"] == "dry-run"
+    assert summary["mode"] == "dry-run"
+    assert summary.get("instructions")


### PR DESCRIPTION
## Summary
- extend `ci_cosmetic_repair.py` to capture execution summaries, emit `.cosmetic-repair-summary.json`, and surface PR metadata
- update the cosmetic repair workflow to publish summary details, expose outputs, and ignore the generated summary artefact
- document the manual workflow across the CI inventory and expand unit tests for snapshot fixes, idempotency, and dry-run coverage

## Testing
- pytest tests/test_ci_cosmetic_repair.py -q
- python -m compileall scripts/ci_cosmetic_repair.py

------
https://chatgpt.com/codex/tasks/task_e_68e55498778c8331b1653f618bea0aa0