### PR TITLE
Add timeouts to workflow entry jobs

### DIFF
--- a/.github/workflows/agents-70-orchestrator.yml
+++ b/.github/workflows/agents-70-orchestrator.yml
@@ -55,6 +55,7 @@ jobs:
   orchestrate:
     name: Dispatch Agents Toolkit
     uses: ./.github/workflows/reusable-70-agents.yml
+    timeout-minutes: 45
     # options_json schema (strings, defaults shown):
     # {
     #   "diagnostic_mode": "off" | "dry-run" | "full",

--- a/.github/workflows/agents-consumer.yml
+++ b/.github/workflows/agents-consumer.yml
@@ -175,6 +175,7 @@ jobs:
     name: Dispatch Agents Toolkit
     needs: resolve-params
     uses: ./.github/workflows/reuse-agents.yml
+    timeout-minutes: 45
     secrets: inherit
     with:
       enable_readiness: ${{ needs.resolve-params.outputs.enable_readiness }}

--- a/.github/workflows/reuse-agents.yml
+++ b/.github/workflows/reuse-agents.yml
@@ -90,6 +90,7 @@ permissions:
 jobs:
   call:
     uses: ./.github/workflows/reusable-70-agents.yml
+    timeout-minutes: 45
     secrets: inherit
     with:
       enable_readiness: ${{ inputs.enable_readiness }}


### PR DESCRIPTION
## Summary
- bound the agents consumer dispatch job with a timeout so reuse-agents invocations cannot run indefinitely
- set matching timeouts on the reuse-agents bridge and orchestrator entrypoint to enforce consistent runtime limits

## Testing
- pytest tests/test_workflow_agents_consolidation.py

------
https://chatgpt.com/codex/tasks/task_e_68e55ff02a4c8331b45d781f3cbf2ad1