### PR TITLE
Add planning notes for doc-only CI workflow

### DIFF
--- a/docs/ci/doc_only_ci_workflow_plan.md
+++ b/docs/ci/doc_only_ci_workflow_plan.md
@@ -1,0 +1,24 @@
+# Doc-Only CI Workflow Planning Notes
+
+## Scope and Key Constraints
+- Implement a GitHub Actions workflow that runs only for pull requests modifying documentation-specific paths (`**/*.md`, `docs/**`, `assets/**`).
+- The workflow must detect doc-only diffs by combining `paths` filters with a guard that prevents execution when other file types are present.
+- Use `actions/github-script@v7` within the job to author a single pull request comment summarizing the doc-only detection result.
+- Keep the workflow lightweight: avoid checkout or dependency installs, and complete within seconds to act as a quick signal.
+- Ensure the workflow is non-disruptive to existing CI by using a distinct job name (`docs-only`) and by exiting early when the change set includes non-doc files.
+
+## Acceptance Criteria / Definition of Done
+- A GitHub Actions workflow file exists under `.github/workflows/` defining the `docs-only` job.
+- The job triggers for pull request events and is limited by `paths` and `paths-ignore` filters so it runs only on doc-only changes.
+- When executed, the workflow posts exactly one comment on the pull request containing the message: `Doc-only change detected; gate skipped by path filters.`
+- The workflow avoids posting duplicate comments if rerun on the same PR by updating an existing comment or ensuring idempotent logic.
+- The workflow has been linted/validated (e.g., via `act -n` or GitHub Actions workflow syntax check) to confirm there are no YAML or logic errors.
+- Documentation describing the workflow purpose and limitations is added to the repository.
+
+## Initial Task Checklist
+- [ ] Draft workflow YAML (`.github/workflows/doc-only-comment.yml`) with appropriate event triggers and path filters.
+- [ ] Implement `actions/github-script@v7` step that locates any previous automation comment and updates/creates the doc-only notification.
+- [ ] Add inline comments explaining how the doc-only detection works and how to modify paths if documentation scope evolves.
+- [ ] Document the workflow in `docs/ci/` (summary, triggers, comment behavior, and maintenance tips).
+- [ ] Run a workflow linter or `act -n` dry run to validate syntax and guard conditions.
+- [ ] Request review/approval and confirm comment appears as expected on a doc-only PR.


### PR DESCRIPTION
## Summary
- document scope, acceptance criteria, and checklist for the planned doc-only CI workflow

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68e94bc9ce888331837958256fbe1869