### PR TITLE
Refine docs-only workflow detection

### DIFF
--- a/.github/workflows/docs-only.yml
+++ b/.github/workflows/docs-only.yml
@@ -25,9 +25,6 @@ jobs:
         with:
           script: |
             const core = require('@actions/core');
-            const minimatch = require('minimatch');
-
-            const allowedPatterns = ['**/*.md', 'docs/**', 'assets/**'];
 
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
@@ -36,9 +33,18 @@ jobs:
               per_page: 100,
             });
 
+            const classify = filename => {
+              const normalised = filename.toLowerCase();
+              return (
+                normalised.endsWith('.md') ||
+                normalised.startsWith('docs/') ||
+                normalised.startsWith('assets/')
+              );
+            };
+
             const nonDocFiles = files
               .map(file => file.filename)
-              .filter(filename => !allowedPatterns.some(pattern => minimatch(filename, pattern)));
+              .filter(filename => !classify(filename));
 
             const docOnly = nonDocFiles.length === 0;
 


### PR DESCRIPTION
## Summary
- keep the docs-only workflow focused on documentation paths without relying on external minimatch dependencies
- normalise file paths in the detection script so mixed case `.MD`, `docs/`, and `assets/` changes continue to qualify as documentation-only

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e94c7782c08331bd5d08da0e9b2532