### PR TITLE
docs: clarify doc-only workflow validation instructions

### DIFF
--- a/docs/ci/doc_only_ci_workflow_plan.md
+++ b/docs/ci/doc_only_ci_workflow_plan.md
@@ -9,10 +9,13 @@
 
 ## Acceptance Criteria / Definition of Done
 - A GitHub Actions workflow file exists under `.github/workflows/` defining the `docs-only` job.
-- The job triggers for pull request events and is limited by `paths` and `paths-ignore` filters so it runs only on doc-only changes.
+- The job triggers for pull request events and is limited by documentation path filters. A follow-on detection step keeps the
+  commenting job dormant when any non-doc files are present in the diff.
 - When executed, the workflow posts exactly one comment on the pull request containing the message: `Doc‑only change detected; gate skipped by path filters.`
 - The workflow avoids posting duplicate comments if rerun on the same PR by updating an existing comment or ensuring idempotent logic.
 - The workflow has been linted/validated (e.g., via `act -n` or GitHub Actions workflow syntax check) to confirm there are no YAML or logic errors.
+- When running the broader `scripts/workflow_lint.sh` helper, expect unrelated legacy findings; targeted invocations such as
+  `./.cache/actionlint/actionlint .github/workflows/pr-14-docs-only.yml` keep validation noise-free for this workflow.
 - Documentation describing the workflow purpose and limitations is added to the repository.
 
 ## Initial Task Checklist


### PR DESCRIPTION
## Summary
- clarify the doc-only CI workflow plan to highlight the detection guard for non-documentation diffs
- add guidance for running actionlint directly on the doc-only workflow when the global lint helper reports unrelated issues

## Testing
- ⚠️ `./scripts/workflow_lint.sh`
- ✅ `./.cache/actionlint/actionlint .github/workflows/pr-14-docs-only.yml`


------
https://chatgpt.com/codex/tasks/task_e_68e9586860ec833191123d803d014b2c