### PR TITLE
Add CI coverage trend monitoring with soft alerts

### DIFF
--- a/.github/workflows/reusable-96-ci-lite.yml
+++ b/.github/workflows/reusable-96-ci-lite.yml
@@ -163,17 +163,89 @@ jobs:
           COVERAGE_COMMENT: ${{ steps.coverage_trend.outputs.comment }}
         with:
           script: |
-            const body = process.env.COVERAGE_COMMENT || '';
-            if (!body.trim()) {
+            const body = (process.env.COVERAGE_COMMENT || '').trim();
+            if (!body) {
               core.info('No coverage alert comment to post.');
               return;
             }
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
+            const marker = '🔶 Coverage drop alert';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner,
+                repo,
+                issue_number,
+                per_page: 100,
+              },
+            );
+            const existing = comments.find(
+              (comment) =>
+                comment.body &&
+                comment.body.startsWith(marker) &&
+                comment.user &&
+                comment.user.type === 'Bot',
+            );
+            if (existing) {
+              if (existing.body.trim() === body) {
+                core.info(`Coverage alert comment ${existing.id} already up to date.`);
+              } else {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body,
+                });
+                core.info(`Updated coverage alert comment ${existing.id}.`);
+              }
+            } else {
+              const response = await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+              core.info(`Created coverage alert comment ${response.data.id}.`);
+            }
+
+      - name: Remove resolved coverage alert
+        if: >
+          always() &&
+          github.event_name == 'pull_request' &&
+          (steps.coverage_trend.outputs.status != 'warn' || steps.coverage_trend.outputs.comment == '')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '🔶 Coverage drop alert';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner,
+                repo,
+                issue_number,
+                per_page: 100,
+              },
+            );
+            const existing = comments.find(
+              (comment) =>
+                comment.body &&
+                comment.body.startsWith(marker) &&
+                comment.user &&
+                comment.user.type === 'Bot',
+            );
+            if (!existing) {
+              core.info('No coverage alert comment to remove.');
+              return;
+            }
+            await github.rest.issues.deleteComment({
+              owner,
+              repo,
+              comment_id: existing.id,
             });
+            core.info(`Removed coverage alert comment ${existing.id}.`);
 
       - name: Enforce coverage minimum
         run: |

--- a/docs/coverage_trend_usage.md
+++ b/docs/coverage_trend_usage.md
@@ -8,7 +8,7 @@ This project tracks code coverage trends in CI so coverage regressions are surfa
 2. **Baseline comparison** – The script reads `config/coverage-baseline.json` to determine the expected baseline (`line`) and soft warning drop (`warn_drop`, in percentage points).
 3. **Job summary** – Every run appends a "Coverage Trend" section to the GitHub Actions job summary, listing the current coverage, baseline, delta, soft drop limit, and any configured hard minimum.
 4. **Artifacts** – The reusable workflow writes `artifacts/coverage-trend.json` and uploads the entire `coverage-summary-<python>` artifact so coverage snapshots can be inspected locally.
-5. **Soft warnings** – On pull requests, if the coverage delta is lower than `-warn_drop`, the workflow posts a 🔶 coverage alert comment instead of failing CI.
+5. **Soft warnings** – On pull requests, if the coverage delta is lower than `-warn_drop`, the workflow posts or updates a 🔶 coverage alert comment instead of failing CI, and removes the comment once coverage returns within tolerance.
 
 ## Updating the baseline
 


### PR DESCRIPTION
## Summary
- add a reusable `tools/coverage_trend.py` helper that parses coverage outputs, compares them with the stored baseline, and emits job summaries, artifacts, and GitHub output
- extend the reusable CI-lite workflow to run the helper, upload a `coverage-summary` artifact, and manage a reusable soft warning comment when coverage drops beyond the configured limit
- version a baseline configuration, document soft alert operations, and add unit tests covering the parsing and output utilities

## Testing
- pytest tests/test_coverage_trend.py
- pytest tests/test_automation_workflows.py::TestAutomationWorkflowCoverage::test_ci_workflow_enforces_coverage_threshold -q
- pytest tests/test_automation_workflows.py::TestAutomationWorkflowCoverage::test_workflow_conditions_do_not_reintroduce_marker_expression -q
- pytest tests/test_automation_workflows.py::TestAutomationWorkflowCoverage::test_workflows_do_not_define_invalid_marker_filters -q

------
https://chatgpt.com/codex/tasks/task_e_68e973f15e948331bafe48abb312c7e8