### PR TITLE
Add coverage minimum metadata to trend outputs

### DIFF
--- a/tests/test_coverage_trend.py
+++ b/tests/test_coverage_trend.py
@@ -86,12 +86,14 @@ def test_dump_artifact_and_outputs(tmp_path: Path) -> None:
         "baseline": 90.0,
         "delta": -2.0,
         "warn_drop": 1.0,
+        "minimum": 85.0,
         "status": "warn",
     }
     output_path = tmp_path / "output.txt"
     write_github_output(output_path, result)
     output = output_path.read_text(encoding="utf-8").strip().splitlines()
     assert "status=warn" in output
+    assert "minimum=85.00" in output
     assert any(line.startswith("comment<<EOF") for line in output)
 
 
@@ -136,7 +138,9 @@ def test_main_generates_summary_and_artifacts(tmp_path: Path) -> None:
     artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
     assert artifact["status"] == "ok"
     assert artifact["delta"] == pytest.approx(0.0, abs=1e-9)
+    assert artifact["minimum"] == pytest.approx(85.0)
 
     github_output = output_path.read_text(encoding="utf-8").strip().splitlines()
     assert "status=ok" in github_output
+    assert "minimum=85.00" in github_output
     assert all(not line.startswith("comment<<EOF") for line in github_output)

--- a/tools/coverage_trend.py
+++ b/tools/coverage_trend.py
@@ -177,6 +177,7 @@ def dump_artifact(path: Path, result: TrendResult) -> None:
         "baseline": result.baseline,
         "delta": result.delta,
         "warn_drop": result.warn_drop,
+        "minimum": result.minimum,
         "status": result.status,
     }
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -194,6 +195,8 @@ def write_github_output(path: Optional[Path], result: TrendResult) -> None:
     if result.delta is not None:
         outputs.append(f"delta={result.delta:.2f}")
     outputs.append(f"warn_drop={result.warn_drop:.2f}")
+    if result.minimum is not None:
+        outputs.append(f"minimum={result.minimum:.2f}")
     outputs.append(f"status={result.status}")
     comment = result.comment_body()
     if comment:


### PR DESCRIPTION
## Summary
- include the configured coverage minimum in the coverage trend artifact and GitHub outputs
- extend the coverage trend unit tests to cover the new metadata

## Testing
- pytest tests/test_coverage_trend.py

------
https://chatgpt.com/codex/tasks/task_e_68e977c33df883318d98ec9a59b4632b