### PR TITLE
ci: enhance coverage trend artifacts

### DIFF
--- a/.github/workflows/reusable-96-ci-lite.yml
+++ b/.github/workflows/reusable-96-ci-lite.yml
@@ -124,9 +124,10 @@ jobs:
             --coverage-json "coverage.json"
             --baseline "${BASELINE_PATH}"
             --artifact-path "artifacts/coverage-trend.json"
+            --summary-path "artifacts/coverage-summary.md"
           )
           if [[ -n "${SUMMARY_PATH:-}" ]]; then
-            args+=(--summary-path "${SUMMARY_PATH}")
+            args+=(--job-summary "${SUMMARY_PATH}")
           fi
           if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
             args+=(--github-output "${GITHUB_OUTPUT}")

--- a/docs/coverage_trend_usage.md
+++ b/docs/coverage_trend_usage.md
@@ -7,7 +7,7 @@ This project tracks code coverage trends in CI so coverage regressions are surfa
 1. **Coverage parsing** – `tools/coverage_trend.py` reads `coverage.xml` (and falls back to `coverage.json`) to compute the latest line coverage.
 2. **Baseline comparison** – The script reads `config/coverage-baseline.json` to determine the expected baseline (`line`) and soft warning drop (`warn_drop`, in percentage points).
 3. **Job summary** – Every run appends a "Coverage Trend" section to the GitHub Actions job summary, listing the current coverage, baseline, delta, soft drop limit, and any configured hard minimum.
-4. **Artifacts** – The reusable workflow writes `artifacts/coverage-trend.json` (capturing the current coverage, baseline, delta, warn-drop tolerance, and configured hard minimum) and uploads the entire `coverage-summary-<python>` artifact so coverage snapshots can be inspected locally.
+4. **Artifacts** – The reusable workflow writes `artifacts/coverage-summary.md` (human-readable synopsis) alongside `artifacts/coverage-trend.json` (current coverage, baseline, delta, warn-drop tolerance, and configured hard minimum) and uploads them inside the `coverage-summary-<python>` artifact so coverage snapshots can be inspected locally.
 5. **Soft warnings** – On pull requests, if the coverage delta is lower than `-warn_drop`, the workflow posts or updates a 🔶 coverage alert comment (including the current baseline, run coverage, delta, and configured hard minimum) instead of failing CI, and removes the comment once coverage returns within tolerance.
 
 ## Updating the baseline
@@ -39,4 +39,4 @@ python tools/coverage_trend.py \
   --artifact-path tmp/coverage-trend.json
 ```
 
-The command prints nothing by default but will populate `tmp/coverage-trend.json` and append summary information if `--summary-path` or `--github-output` are supplied.
+The command prints nothing by default but will populate `tmp/coverage-trend.json` and append summary information if `--summary-path` (file output) and/or `--job-summary` (append to an existing summary file) are supplied.

--- a/tests/test_coverage_trend.py
+++ b/tests/test_coverage_trend.py
@@ -135,6 +135,7 @@ def test_main_generates_summary_and_artifacts(tmp_path: Path) -> None:
     baseline_path = tmp_path / "baseline.json"
     write_file(baseline_path, json.dumps({"line": 90.0, "warn_drop": 1.5}))
     summary_path = tmp_path / "summary.md"
+    job_summary_path = tmp_path / "job_summary.md"
     artifact_path = tmp_path / "artifact.json"
     output_path = tmp_path / "github.txt"
 
@@ -148,6 +149,8 @@ def test_main_generates_summary_and_artifacts(tmp_path: Path) -> None:
             str(baseline_path),
             "--summary-path",
             str(summary_path),
+            "--job-summary",
+            str(job_summary_path),
             "--artifact-path",
             str(artifact_path),
             "--github-output",
@@ -177,3 +180,7 @@ def test_main_generates_summary_and_artifacts(tmp_path: Path) -> None:
     assert "status=ok" in github_output
     assert "minimum=85.00" in github_output
     assert all(not line.startswith("comment<<EOF") for line in github_output)
+
+    job_summary = job_summary_path.read_text(encoding="utf-8").strip().splitlines()
+    assert job_summary[0] == "### Coverage Trend"
+    assert any("Trend: 90.00% → 90.00%" in line for line in job_summary)


### PR DESCRIPTION
## Summary
- emit a reusable Markdown summary alongside coverage trend data for the CI-lite workflow
- surface coverage trend details in both the job summary and uploaded artifact
- document the updated coverage trend CLI options and extend regression tests

## Testing
- ./scripts/dev_check.sh --changed --fix
- ./scripts/validate_fast.sh --fix
- source .venv/bin/activate && pytest tests/test_coverage_trend.py