### PR TITLE
Fix reusable agents verify workflow reference

### DIFF
--- a/.github/workflows/reusable-70-agents.yml
+++ b/.github/workflows/reusable-70-agents.yml
@@ -263,7 +263,7 @@ jobs:
 
   verify_issue:
     if: inputs.enable_verify_issue == 'true' && inputs.verify_issue_number != ''
-    uses: ./.github/workflows/verify-agent-assignment.yml
+    uses: ./.github/workflows/agents-44-verify-agent-assignment.yml
     secrets: inherit
     with:
       issue_number: ${{ inputs.verify_issue_number }}


### PR DESCRIPTION
## Summary
- point the reusable agents workflow to the existing agents-44 verify assignment job so actionlint can resolve it

## Testing
- not run (workflow reference fix)


------
https://chatgpt.com/codex/tasks/task_e_68e9e882e9d88331868bcf472f177816