### PR TITLE
test: guard failure tracker label & comment flow

### DIFF
--- a/tests/test_failure_tracker_workflow_scope.py
+++ b/tests/test_failure_tracker_workflow_scope.py
@@ -94,6 +94,7 @@ def test_post_ci_failure_tracker_handles_failure_path() -> None:
     assert label_step["uses"].startswith("actions/github-script@")
     label_script = label_step.get("with", {}).get("script", "")
     assert "'ci-failure'" in label_script
+    assert "github.rest.issues.addLabels" in label_script
 
     tracker_script = tracker_step.get("with", {}).get("script", "")
     assert "github.rest.issues.update({" in tracker_script
@@ -124,3 +125,16 @@ def test_post_ci_failure_tracker_handles_success_path() -> None:
     assert remove_label_step["uses"].startswith("actions/github-script@")
     remove_script = remove_label_step.get("with", {}).get("script", "")
     assert "ci-failure" in remove_script
+    assert "github.rest.issues.removeLabel" in remove_script
+
+
+def test_post_comment_job_upserts_single_pr_comment() -> None:
+    workflow = _load_workflow(POST_CI_PATH)
+    job = workflow["jobs"]["post-comment"]
+
+    comment_step = _get_step(job, "Upsert consolidated PR comment")
+    script = comment_step.get("with", {}).get("script", "")
+
+    assert "<!-- maint-post-ci: DO NOT EDIT -->" in script
+    assert "github.rest.issues.updateComment" in script
+    assert "github.rest.issues.createComment" in script


### PR DESCRIPTION
## Summary
- extend the failure tracker workflow regression checks to ensure the consolidated job applies ci-failure labels via addLabels and removes them with removeLabel
- add coverage verifying the consolidated maint-post-ci workflow upserts (update or create) the single PR comment marker

## Testing
- pytest tests/test_failure_tracker_workflow_scope.py tests/test_workflow_naming.py


------
https://chatgpt.com/codex/tasks/task_e_68ea75215e4483319404b23c6f11fca3