### PR TITLE
Codex bootstrap for #2462

### DIFF
--- a/agents/codex-2462.md
+++ b/agents/codex-2462.md
@@ -1,1 +1,20 @@
 <!-- bootstrap for codex on issue #2462 -->
+
+## Scope / Key Constraints
+- Touch only the orchestration workflows involved in delegating to `reusable-70-agents.yml` (`.github/workflows/reuse-agents.yml` and the reusable workflow itself) plus related documentation (`docs/ci_reuse.md`).
+- Remove the disallowed `timeout-minutes` attribute from the caller job; GitHub Actions forbids timeouts on jobs that use another workflow.
+- Reintroduce equivalent or tighter per-job timeouts inside `reusable-70-agents.yml`, keeping each long-running job within a 15–30 minute ceiling and preserving existing behaviour.
+- Preserve workflow inputs, secrets pass-through, permissions, and job names so downstream automation continues to function.
+- Updates must maintain YAML validity (passes `actionlint`/workflow schema) and align with existing repository conventions for documentation tone and formatting.
+
+## Acceptance Criteria / Definition of Done
+- `.github/workflows/reuse-agents.yml` validates without “Unexpected value 'timeout-minutes'” or other structural errors when linted or parsed by GitHub Actions.
+- `.github/workflows/reusable-70-agents.yml` defines explicit `timeout-minutes` values for every long-running job (readiness probe, preflight, diagnostic/bootstrap, keepalive variants, watchdog) within the agreed 15–30 minute window.
+- Running the **Agents 70 Orchestrator** workflow via `workflow_dispatch` completes end-to-end, invoking the reusable workflow without YAML validation errors.
+- Documentation in `docs/ci_reuse.md` explains where timeouts live (within the reusable workflow) and how to adjust them going forward.
+
+## Initial Task Checklist
+- [ ] Inspect the existing `reuse-agents.yml` job definition and remove the top-level `timeout-minutes` property from the `uses` job.
+- [ ] Audit `reusable-70-agents.yml` to confirm each long-running job has an explicit timeout; add or adjust values to stay within 15–30 minutes as appropriate.
+- [ ] Update `docs/ci_reuse.md` to describe the timeout placement and modification process.
+- [ ] Trigger or document the plan for a `workflow_dispatch` run of Agents 70 Orchestrator to verify the YAML loads successfully (include evidence or follow-up instructions).


### PR DESCRIPTION
### Source Issue #2462: Repair reuse-agents.yml invalid syntax (timeout on a uses: job)

Source: https://github.com/stranske/Trend_Model_Project/issues/2462

> Topic GUID: 4f9feac2-77d0-5b92-87e9-db9ec247f223
> 
> ## Why
> Rationale: timeout-minutes is set on a job that uses another workflow, which is not allowed. Evidence: the workflow run shows “Unexpected value 'timeout-minutes'” on the call job. 
> GitHub
> Title: Fix reuse-agents.yml by removing invalid timeout-minutes and pushing timeouts into the reusable workflow
> 
> ## Tasks
> _Not provided._
> 
> ## Acceptance criteria
> .github/workflows/reuse-agents.yml validates; no “Invalid workflow file” annotation in Actions.
> 
> Timeouts are enforced inside .github/workflows/reusable-70-agents.yml per job instead of at the caller job level.
> 
> A manual workflow_dispatch of Agents 70 Orchestrator that delegates through reuse-agents completes the orchestration path without YAML errors.
> 
> Task list
> 
>  Remove timeout-minutes from .github/workflows/reuse-agents.yml where the job uses ./.github/workflows/reusable-70-agents.yml.
> 
>  Add timeout-minutes: to the long‑running jobs in .github/workflows/reusable-70-agents.yml (e.g., readiness probe, bootstrap, keepalive, watchdog) with sensible bounds (15–30 min).
> 
>  Trigger a workflow_dispatch of Agents 70 Orchestrator to exercise the path and confirm the absence of the prior annotation.
> 
>  Document the timeout location in docs/ci_reuse.md.
> 
> ## Implementation notes
> Timeouts on called jobs are the portable way to bound reusable workflows. Keep per-job timeouts near actual worst-case plus ~25%.
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18438793377).

### Follow-up update
- Documented scope, acceptance criteria, and execution checklist for the timeout migration in `agents/codex-2462.md` to guide the repair effort.


------
https://chatgpt.com/codex/tasks/task_e_68eb2700f9308331a63be744a917106f