### PR TITLE
docs: clarify orchestrator watchdog guidance

### DIFF
--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -54,6 +54,7 @@ Tests under `tests/test_workflow_naming.py` enforce the naming policy and invent
 
 ## Agent Operations
 - All historical wrappers were removed. Use **Agents 70 Orchestrator** directly for readiness checks, Codex bootstrap, or watchdog sweeps.
+- The deprecated **`agent-watchdog.yml`** workflow has been retired; toggle watchdog diagnostics via the orchestrator's `enable_watchdog` input instead of dispatching a standalone job.
 - Optional flags beyond the standard inputs belong in the `options_json` payload; the orchestrator parses it with `fromJson()`.
 - The orchestrator maintains PAT priority (`OWNER_PR_PAT` → `SERVICE_BOT_PAT` → `GITHUB_TOKEN`) via the reusable composite.
 

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -83,6 +83,7 @@ listen to their `workflow_run` events.
 **Operational details**
 - **Agents Consumer** – Permissions: `contents: write`, `pull-requests: write`, `issues: write`. Secrets: inherits `GITHUB_TOKEN` and forwards `secrets.SERVICE_BOT_PAT` when available so downstream automation may push branches/comments. Output: emits `Resolve Parameters` summary and a `Dispatch Agents Toolkit` reusable call that surfaces Codex readiness/watchdog diagnostics.
 - **Agents 70 Orchestrator** – Uses `options_json` to layer advanced toggles without adding dispatch inputs; set `enable_bootstrap: true` (and optionally `bootstrap_issues_label`) to fan bootstrap jobs through the reusable workflow during manual runs.
+- The standalone `.github/workflows/agent-watchdog.yml` workflow has been removed; run watchdog checks by dispatching the orchestrator with `enable_watchdog: true` (default) or via the Agents Consumer/Reuse wrappers.
 
 ### Reusable composites
 


### PR DESCRIPTION
## Summary
- call out that the legacy `.github/workflows/agent-watchdog.yml` workflow has been retired
- direct contributors to dispatch the Agents 70 Orchestrator with `enable_watchdog` when watchdog diagnostics are required

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68eb2a119b0083319a02fe434413c8f4