### PR TITLE
docs: refresh CI documentation for orchestrator topology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,13 +23,20 @@ post-processing workflow:
   issues when hygiene regressions persist. Treat that consolidated
   comment as the canonical health dashboard; rerun Gate or Maint
   Post-CI if you need the summary refreshed.
-- **Agent automation** – Scheduled (cron) and on-demand dispatchers
-  ([`agents-70-orchestrator.yml`](.github/workflows/agents-70-orchestrator.yml)
-  and [`agents-consumer.yml`](.github/workflows/agents-consumer.yml))
-  invoke [`reuse-agents.yml`](.github/workflows/reuse-agents.yml) to run
-  readiness checks, watchdogs, and Codex bootstrapping. Applying the
-  `agent:codex` label flags an issue for bootstrap handling in the next
-  run; remove the label to opt out before the dispatcher cycles.
+- **Recommended local mirrors** – Run
+  [`./scripts/style_gate_local.sh`](scripts/style_gate_local.sh) for the
+  exact formatter/type checks used by Gate, and
+  [`./scripts/quality_gate.sh --full`](scripts/quality_gate.sh) to
+  mirror the full gate (style + fast validate + branch checks) before
+  requesting review.
+- **Agent automation** – Scheduled (cron) and on-demand runs of
+  [`agents-70-orchestrator.yml`](.github/workflows/agents-70-orchestrator.yml)
+  invoke the reusable agents toolkit for readiness checks, diagnostics, and
+  Codex bootstrapping. Applying the `agent:codex` label flags an issue for
+  bootstrap handling in the next run; remove the label to opt out before the
+  dispatcher cycles. Manual dispatch lives under **Actions → Agents 70
+  Orchestrator → Run workflow** – supply `enable_bootstrap: true` and an
+  optional `bootstrap_issues_label` in the inputs when seeding Codex PRs.
 
 ## Quick Checklist (Before Every Push)
 

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -1,22 +1,27 @@
 # Workflow Catalog & Contributor Quick Start
 
 Use this page as the canonical reference for CI workflow naming, inventory, and
-local guardrails. It consolidates the requirements from Issues #2190 and #2202
-and adds guidance for contributors who need to stage new workflows or dispatch
-the agents toolkit. The quick catalog below spells out **purpose, triggers,
-required permissions, and status/label effects** for every merge gate and agent
-automation entry point currently in service.
+local guardrails. It consolidates the requirements from Issues #2190, #2202, and
+#2466. The Gate workflow remains the required merge check for every pull
+request, and **Agents 70 Orchestrator** is now the **only** entry point for
+agent automation (readiness sweeps, Codex bootstrap, diagnostics).
 
 ## CI & agents quick catalog
 
-| Workflow | File | What it does | When it runs | Required secrets / permissions | Status outputs & labels |
+| Workflow | File | What it does | When it runs | Permissions | Required status checks |
 | --- | --- | --- | --- | --- | --- |
-| **Gate** | `.github/workflows/pr-gate.yml` | Fan-out orchestrator that reuses the Python CI matrix and Docker smoke reusable workflows, then enforces all downstream results. | `pull_request` (non-doc paths) and `workflow_dispatch`. | Default `GITHUB_TOKEN` (`contents: read`) for all jobs; delegated reusable workflows do not request additional scopes when called from Gate. | <ul><li>**Status checks:** `core tests (3.11)`, `core tests (3.12)`, `docker smoke`, aggregate `gate`.</li><li>**Labels:** _none_.</li></ul> |
-| **Autofix** | `.github/workflows/autofix.yml` | Lightweight formatting/type hygiene runner that auto-commits fixes for same-repo PRs or uploads a patch for forks. | `pull_request` (including label changes). | `contents: write`, `pull-requests: write`; inherits repository secrets but does not require extra PATs. | <ul><li>**Status checks:** top-level `apply` job delegating to the `autofix` composite.</li><li>**Labels:** `autofix`, `autofix:applied`/`autofix:patch`, mutually exclusive `autofix:clean` vs `autofix:debt`.</li></ul> |
-| **Repo Health (Maint 02)** | `.github/workflows/maint-02-repo-health.yml` | Weekly sweep that summarises stale branches and unassigned issues in the run summary. | Monday cron (`15 7 * * 1`) plus `workflow_dispatch`. | `contents: read`, `issues: read`; no secrets required. | <ul><li>**Status checks:** `Weekly repository health sweep`.</li><li>**Labels:** _none_.</li></ul> |
-| **Maint 35 Repo Health Self Check** | `.github/workflows/maint-35-repo-health-self-check.yml` | Read-only repository health probe that reports label coverage and branch-protection visibility via the step summary. | Weekly cron (`20 6 * * 1`) and `workflow_dispatch`. | `contents: read`, `issues: read`, `pull-requests: read`, `actions: read`. | <ul><li>**Status checks:** none – informational summary only.</li><li>**Labels:** _none_.</li></ul> |
-| **Agents Consumer** | `.github/workflows/agents-consumer.yml` | Hourly/adhoc entry point that parses JSON input then dispatches to the reusable agents toolkit for readiness, bootstrap, watchdog, and keepalive tasks. | Hourly cron (`15 * * * *`) and `workflow_dispatch` with `params_json`. | `contents`, `pull-requests`, `issues`: `write`; optional `service_bot_pat` forwarded to downstream jobs. | <ul><li>**Status checks:** `Resolve Parameters`, `Dispatch Agents Toolkit`, and whichever delegated runs are enabled (e.g., `Agent Readiness Probe`, `Codex Preflight`, `Bootstrap Codex PRs`, `Codex Keepalive Sweep`, `Agent Watchdog`).</li><li>**Labels:** Bootstrap runs add `agent:codex` to spawned PRs.</li></ul> |
-| **Reuse Agents** | `.github/workflows/reuse-agents.yml` | Workflow-call wrapper so other repositories or orchestrators can invoke the agents toolkit with consistent inputs. | `workflow_call` only. | Same as Agents Consumer (`contents`, `pull-requests`, `issues`: `write`) and can accept a `service_bot_pat` secret for Codex bootstrap. | <ul><li>**Status checks:** Top-level `call` job plus the same delegated checks from `Reusable 70 Agents` (readiness, preflight, bootstrap, watchdog, keepalive) when requested.</li><li>**Labels:** Mirrors `codex-bootstrap-lite` (e.g., `agent:codex` for created PRs).</li></ul> |
+| **Gate** | `.github/workflows/pr-gate.yml` | Fan-out orchestrator that reuses the Python CI matrix and Docker smoke reusable workflows, then enforces all downstream results. | `pull_request` (non-doc paths) and `workflow_dispatch`. | Defaults (`contents: read`). Delegated jobs inherit the same token scopes. | `core tests (3.11)`, `core tests (3.12)`, `docker smoke`, aggregate `gate`. |
+| **PR Docs Only** | `.github/workflows/pr-14-docs-only.yml` | Short-circuits the Gate for documentation-only diffs and posts a skip notice. | `pull_request` (docs paths). | `contents: read`. | `docs-only` (optional informational). |
+| **Autofix** | `.github/workflows/autofix.yml` | Formatting/type hygiene runner that auto-commits fixes for same-repo PRs or uploads a patch for forks. | `pull_request` (including label changes). | `contents: write`, `pull-requests: write`; inherits repository secrets, no PAT required. | `apply` job (optional — informative only). |
+| **Maint 02 Repo Health** | `.github/workflows/maint-02-repo-health.yml` | Weekly sweep that summarises stale branches and unassigned issues. | Monday cron (`15 7 * * 1`) plus `workflow_dispatch`. | `contents: read`, `issues: read`. | None (step summary only). |
+| **Maint Post CI** | `.github/workflows/maint-post-ci.yml` | Consolidated follower that reacts to Gate `workflow_run` events to publish summaries, apply safe autofix commits, and maintain the CI failure tracker. | `workflow_run` (Gate) and `workflow_dispatch`. | `contents: write`, `issues: write`, `pull-requests: write`. | None (reports via summary/comment). |
+| **Maint 33 Check Failure Tracker** | `.github/workflows/maint-33-check-failure-tracker.yml` | Compatibility shell that documents the delegation to `maint-post-ci.yml`. | `workflow_run` (Gate). | `contents: read`. | None. |
+| **Maint 35 Repo Health Self Check** | `.github/workflows/maint-35-repo-health-self-check.yml` | Read-only repository health probe surfacing label coverage and branch-protection visibility. | Weekly cron (`20 6 * * 1`) and `workflow_dispatch`. | `contents: read`, `issues: read`, `pull-requests: read`, `actions: read`. | None. |
+| **Maint 36 Actionlint** | `.github/workflows/maint-36-actionlint.yml` | Workflow lint gate (actionlint via reviewdog). | `pull_request`, weekly cron, `workflow_dispatch`. | `contents: read`, `pull-requests: write` (for reviewdog annotations). | `actionlint` (optional but recommended). |
+| **Maint 40 CI Signature Guard** | `.github/workflows/maint-40-ci-signature-guard.yml` | Validates the signed job manifest for `pr-gate.yml`. | `push`/`pull_request` targeting `phase-2-dev`. | `contents: read`. | `ci-signature-guard` (optional). |
+| **Maint 41 ChatGPT Issue Sync** | `.github/workflows/maint-41-chatgpt-issue-sync.yml` | Fans out curated topic lists (e.g., `Issues.txt`) into labelled GitHub issues. | `workflow_dispatch`. | `contents: write`, `issues: write`. | None. |
+| **Maint 45 Cosmetic Repair** | `.github/workflows/maint-45-cosmetic-repair.yml` | Manual pytest + guardrail fixer that opens a labelled PR when drift is detected. | `workflow_dispatch`. | `contents: write`, `pull-requests: write`. | None. |
+| **Agents 70 Orchestrator** | `.github/workflows/agents-70-orchestrator.yml` | Unified agents toolkit for readiness probes, Codex bootstrap, diagnostics, and keepalive sweeps. No other agent entry points remain. | 20-minute cron and `workflow_dispatch`. | `contents: write`, `issues: write`, `pull-requests: write`; optional `service_bot_pat` forwarded to reusable jobs. | `orchestrate` job (optional; failures block automation, not PR merges). |
 
 ## Naming Policy & Number Ranges
 
@@ -28,16 +33,11 @@ automation entry point currently in service.
   |--------|--------------|-------|-------|
   | `pr-` | `10–19` | Pull-request gates | `pr-gate.yml` is the primary orchestrator; keep space for specialized PR jobs (docs, optional helpers).
   | `maint-` | `00–49` and `90s` | Scheduled/background maintenance | Low numbers for repo hygiene, 30s/40s for post-CI and guards, 90 for self-tests calling reusable matrices.
-  | `agents-` | `40s` & `70s` | Agent bootstrap/orchestration | `43` bridges issues to Codex; `70` is the manual/scheduled orchestrator.
+  | `agents-` | `70s` | Agent bootstrap/orchestration | `agents-70-orchestrator.yml` is the sole automation entry point post-Issue #2466.
   | `reusable-` | `70s` & `90s` | Composite workflows invoked by others | Keep 90s for CI executors, 70s for agent composites.
 
-- Match the `name:` field to the filename rendered in Title Case
-  (`pr-gate.yml` → `Gate`).
-- `tests/test_workflow_naming.py` enforces this policy—rerun it after modifying
-  or adding workflows.
-- When introducing a new workflow choose the lowest unused slot inside the
-  appropriate band, update this document, and add the workflow to the relevant
-  section below.
+- Match the `name:` field to the filename rendered in Title Case (`pr-gate.yml` → `Gate`).
+- `tests/test_workflow_naming.py` enforces this policy—rerun it after modifying or adding workflows.
 
 ## Workflow Inventory
 
@@ -45,148 +45,140 @@ automation entry point currently in service.
 
 | Workflow | Trigger(s) | Why it matters |
 |----------|------------|----------------|
-| `pr-gate.yml` (`Gate`) | `pull_request`, `workflow_dispatch` | Composite orchestrator that chains the reusable CI and Docker smoke jobs and enforces that every leg succeeds.
-| `pr-14-docs-only.yml` (`PR 14 Docs Only`) | `pull_request` (doc paths) | Detects documentation-only diffs and posts a friendly skip notice instead of running heavier gates.
-| `autofix.yml` (`Autofix`) | `pull_request` | Lightweight formatting/type-hygiene runner that auto-commits safe fixes or publishes a patch artifact for forked PRs.
+| `pr-gate.yml` (`Gate`) | `pull_request`, `workflow_dispatch` | Composite orchestrator that chains the reusable CI and Docker smoke jobs and enforces that every leg succeeds. |
+| `pr-14-docs-only.yml` (`PR 14 Docs Only`) | `pull_request` (doc paths) | Detects documentation-only diffs and posts a friendly skip notice instead of running heavier gates. |
+| `autofix.yml` (`Autofix`) | `pull_request` | Lightweight formatting/type-hygiene runner that auto-commits safe fixes or publishes a patch artifact for forked PRs. |
 
 **Operational details**
 - **Gate** – Permissions: defaults (read scope). Secrets: relies on `GITHUB_TOKEN` only. Status outputs: `core tests (3.11)`, `core tests (3.12)`, `docker smoke`, and the aggregator job `gate`, which fails if any dependency fails.
-- **Autofix** – Permissions: `contents: write`, `pull-requests: write`. Secrets: inherits `GITHUB_TOKEN` (sufficient for label + comment updates). Status outputs: `autofix` job; labels applied include `autofix`, `autofix:applied`/`autofix:patch`, and cleanliness toggles (`autofix:clean`/`autofix:debt`).
+- **Autofix** – Permissions: `contents: write`, `pull-requests: write`. Secrets: inherits `GITHUB_TOKEN` (sufficient for label + comment updates). Status outputs: `apply` job; labels applied include `autofix`, `autofix:applied`/`autofix:patch`, and cleanliness toggles (`autofix:clean`/`autofix:debt`).
 
-These jobs must stay green for PRs to merge. The post-CI maintenance jobs below
-listen to their `workflow_run` events.
+These jobs must stay green for PRs to merge. The post-CI maintenance jobs below listen to their `workflow_run` events and post summaries whenever the Gate aggregator fails.
 
 ### Maintenance & observability (scheduled/optional reruns)
 
 | Workflow | Trigger(s) | Purpose |
 |----------|------------|---------|
-| `maint-02-repo-health.yml` (`Maint 02 Repo Health`) | Weekly cron, manual | Reports stale branches & unassigned issues.
-| `maint-post-ci.yml` (`Maint Post CI`) | `workflow_run` (Gate) | Consolidated follower that posts Gate summaries, applies low-risk autofix commits, and owns CI failure-tracker updates.
-| `maint-33-check-failure-tracker.yml` (`Maint 33 Check Failure Tracker`) | `workflow_run` (Gate) | Lightweight compatibility shell that documents the delegation to `maint-post-ci.yml`.
-| `maint-35-repo-health-self-check.yml` (`Maint 35 Repo Health Self Check`) | Weekly cron, manual | Read-only repo health pulse that surfaces missing labels or branch-protection visibility gaps in the step summary.
-| `maint-36-actionlint.yml` (`Maint 36 Actionlint`) | `pull_request`, weekly cron, manual | Sole workflow-lint gate (actionlint via reviewdog).
-| `maint-40-ci-signature-guard.yml` (`Maint 40 CI Signature Guard`) | `push`/`pull_request` targeting `phase-2-dev` | Validates the signed job manifest for `pr-gate.yml`.
-| `maint-41-chatgpt-issue-sync.yml` (`Maint 41 ChatGPT Issue Sync`) | `workflow_dispatch` (manual) | Fans out curated topic lists (e.g. `Issues.txt`) into labeled GitHub issues. ⚠️ Repository policy: do not remove without a functionally equivalent replacement. |
-| `maint-45-cosmetic-repair.yml` (`Maint 45 Cosmetic Repair`) | `workflow_dispatch` | Manual pytest + guardrail fixer that applies tolerance/snapshot updates and opens a labelled PR when drift is detected. |
-
-**Operational details**
-- **Maint 02 Repo Health** – Permissions: `contents: read`, `issues: read`. Secrets: uses `GITHUB_TOKEN` only. Output: publishes a step summary (“Repository health weekly sweep”) with stale branches and unassigned-issue tables.
+| `maint-02-repo-health.yml` (`Maint 02 Repo Health`) | Weekly cron, manual | Reports stale branches & unassigned issues in a run-summary table. |
+| `maint-post-ci.yml` (`Maint Post CI`) | `workflow_run` (Gate) | Consolidated follower that posts Gate summaries, applies low-risk autofix commits, and owns CI failure-tracker updates. |
+| `maint-33-check-failure-tracker.yml` (`Maint 33 Check Failure Tracker`) | `workflow_run` (Gate) | Lightweight compatibility shell that documents the delegation to `maint-post-ci.yml`. |
+| `maint-35-repo-health-self-check.yml` (`Maint 35 Repo Health Self Check`) | Weekly cron, manual | Read-only repo health pulse that surfaces missing labels or branch-protection visibility gaps in the step summary. |
+| `maint-36-actionlint.yml` (`Maint 36 Actionlint`) | `pull_request`, weekly cron, manual | Sole workflow-lint gate (actionlint via reviewdog). |
+| `maint-40-ci-signature-guard.yml` (`Maint 40 CI Signature Guard`) | `push`/`pull_request` targeting `phase-2-dev` | Validates the signed job manifest for `pr-gate.yml`. |
+| `maint-41-chatgpt-issue-sync.yml` (`Maint 41 ChatGPT Issue Sync`) | `workflow_dispatch` | Manual sync that turns curated lists into labelled GitHub issues. |
+| `maint-45-cosmetic-repair.yml` (`Maint 45 Cosmetic Repair`) | `workflow_dispatch` | Manual pytest + guardrail fixer that opens a labelled PR when drift is detected. |
 
 ### Agent automation entry points
 
-| Workflow | Trigger(s) | Purpose |
-|----------|------------|---------|
-| `agents-consumer.yml` (`Agents Consumer`) | Hourly cron, manual | Consolidated wrapper that accepts a JSON payload and calls `reuse-agents.yml` to run readiness, preflight, verification, and bootstrap flows.
-| `agents-43-codex-issue-bridge.yml` (`Agents 43 Codex Issue Bridge`) | `issues`, manual | Prepares Codex-ready branches/PRs when an `agent:codex` label is applied.
-| `agents-44-verify-agent-assignment.yml` (`Agents 44 Verify Agent Assignment`) | `workflow_call`, manual | Checks that `agent:codex` issues remain assigned to an approved automation account before downstream workflows act.
-| `agents-70-orchestrator.yml` (`Agents 70 Orchestrator`) | 20-minute cron, manual | Unified agents toolkit (readiness probes, Codex bootstrap, watchdogs) delegating to `reusable-70-agents.yml`.
+`agents-70-orchestrator.yml` (`Agents 70 Orchestrator`) is the **sole** entry point for automation. Hourly cron and manual dispatch both call the reusable agents toolkit to perform readiness probes, Codex bootstrap, diagnostics, and keepalive sweeps. Legacy wrappers (e.g., `agents-consumer.yml`, agent watchdog flows, unconstrained consumers) have been removed.
 
 **Operational details**
-- **Agents Consumer** – Permissions: `contents: write`, `pull-requests: write`, `issues: write`. Secrets: inherits `GITHUB_TOKEN` and forwards `secrets.SERVICE_BOT_PAT` when available so downstream automation may push branches/comments. Output: emits `Resolve Parameters` summary and a `Dispatch Agents Toolkit` reusable call that surfaces Codex readiness/watchdog diagnostics.
-- **Agents 70 Orchestrator** – Uses `options_json` to layer advanced toggles without adding dispatch inputs; set `enable_bootstrap: true` (and optionally `bootstrap_issues_label`) to fan bootstrap jobs through the reusable workflow during manual runs.
+- Provide required write scopes via the default `GITHUB_TOKEN`. Supply `service_bot_pat` when bootstrap jobs must push branches or leave comments.
+- Use the `options_json` input to enable bootstrap (`{"enable_bootstrap": true}`) or pass extra labels such as `{"bootstrap_issues_label": "agent:codex"}` when dispatching manually. The orchestrator parses the JSON via `fromJson()` and forwards toggles to `reusable-70-agents.yml`.
+- Readiness, preflight, bootstrap, and keepalive diagnostics appear in the job summary. Failures bubble up through the single `orchestrate` job; Maint Post CI will echo the failing run link in the CI failure-tracker issue when the Gate is affected.
+
+### Manual Orchestrator Dispatch
+
+1. Navigate to **Actions → Agents 70 Orchestrator → Run workflow**.
+2. Provide inputs:
+   - **Branch**: default (`phase-2-dev`) unless testing a feature branch.
+   - **Enable bootstrap**: set to `true` when seeding Codex PRs.
+   - **Bootstrap issues label**: usually `agent:codex`.
+   - **Options JSON**: example payload
+     ```json
+     {
+       "enable_bootstrap": true,
+       "bootstrap_issues_label": "agent:codex",
+       "enable_readiness": true,
+       "require_all": true
+     }
+     ```
+3. Click **Run workflow**. The orchestrator calls `reusable-70-agents.yml`; job summaries include readiness tables, bootstrap status, and links to spawned PRs.
+
+### Agent troubleshooting: bootstrap & readiness signals
+
+| Symptom | Likely cause | Where to look | Remedy |
+| ------- | ------------ | ------------- | ------ |
+| Readiness probe fails immediately | Missing PAT or permissions | `orchestrate` job summary → “Authentication” step | Provide `SERVICE_BOT_PAT` secret or rerun with reduced scope. |
+| Bootstrap skipped despite `enable_bootstrap` | No matching labelled issues | Job summary → “Bootstrap Planner” table | Add `agent:codex` label (or configured label) to target issues, rerun. |
+| Bootstrap run exits with “Repository dirty” | Prior automation left branches open | Job log → `cleanup` step | Manually close stale branches or enable cleanup via `options_json` toggle before rerun. |
+| Readiness succeeds but Codex PR creation fails | Repository protections blocking pushes | Job log → `Create bootstrap branch` step | Ensure branch protection rules allow the automation account or supply a PAT with required scopes. |
+
+Escalate persistent failures by linking the failing run URL in the CI failure-tracker issue managed by Maint Post CI.
+
+### Gate pipeline overview
+
+| Stage | Job ID (Gate) | Failure visibility |
+|-------|---------------|--------------------|
+| Python quality (3.11) | `core tests (3.11)` | Surfaces Ruff, mypy, pytest failures in the job log and step summary with direct links to offending tests. |
+| Python quality (3.12) | `core tests (3.12)` | Mirrors the 3.11 leg; investigate parity regressions here first. |
+| Docker smoke | `docker smoke` | Logs Docker build output and runtime smoke tests; summary links point to failing commands. |
+| Aggregator | `gate` | Fails if any upstream job fails and posts a consolidated summary link. Maint Post CI consumes this status to update the CI failure-tracker issue. |
 
 ### Reusable composites
 
 | Workflow | Consumed by | Notes |
 |----------|-------------|-------|
-| `reuse-agents.yml` (`Reuse Agents`) | `agents-consumer.yml` | Bridges `params_json` inputs to the reusable toolkit while preserving defaults.
-| `reusable-70-agents.yml` (`Reusable 70 Agents`) | `agents-70-orchestrator.yml`, `reuse-agents.yml` | Implements readiness, bootstrap, diagnostics, and watchdog jobs.
-| `reusable-92-autofix.yml` (`Reusable 92 Autofix`) | `maint-post-ci.yml`, `autofix.yml` | Autofix harness used both by the PR-time autofix workflow and the post-CI maintenance listener.
-| `reusable-99-selftest.yml` (`Reusable 99 Selftest`) | `maint-` self-test orchestration | Scenario matrix that validates the reusable CI executor and artifact inventory.
-| `reusable-ci.yml` (`Reusable CI`) | Gate, downstream repositories | Single source for Python lint/type/test coverage runs.
-| `reusable-docker.yml` (`Reusable Docker Smoke`) | Gate, downstream repositories | Docker build + smoke reusable consumed by Gate and external callers.
-
-**Operational details**
-- **Reuse Agents** – Permissions: `contents: write`, `pull-requests: write`, `issues: write`. Secrets: optional `service_bot_pat` (forwarded to `reusable-70-agents`) plus `GITHUB_TOKEN`. Outputs: single `call` job exposes reusable outputs such as `triggered` keepalive list and watchdog diagnostics for upstream orchestrators.
+| `reusable-70-agents.yml` (`Reusable 70 Agents`) | `agents-70-orchestrator.yml` | Implements readiness, bootstrap, diagnostics, and keepalive jobs. |
+| `reusable-92-autofix.yml` (`Reusable 92 Autofix`) | `maint-post-ci.yml`, `autofix.yml` | Autofix harness used by the PR-time autofix workflow and the post-CI maintenance follower. |
+| `reusable-99-selftest.yml` (`Reusable 99 Selftest`) | `maint-90-selftest.yml` | Scenario matrix that validates the reusable CI executor and artifact inventory. |
+| `reusable-ci.yml` (`Reusable CI`) | Gate, downstream repositories | Single source for Python lint/type/test coverage runs. |
+| `reusable-docker.yml` (`Reusable Docker Smoke`) | Gate, downstream repositories | Docker build + smoke reusable consumed by Gate and external callers. |
 
 ### Archived self-test workflows
 
-`Old/workflows/maint-90-selftest.yml` remains available as the historical wrapper that previously
-scheduled the self-test cron. The retired PR comment and maintenance wrappers listed below stay
-removed; consult git history if you need their YAML for archaeology:
+`Old/workflows/maint-90-selftest.yml` remains available as the historical wrapper that previously scheduled the self-test cron. The retired PR comment and maintenance wrappers listed below stay removed; consult git history if you need their YAML for archaeology:
 
 - `maint-43-selftest-pr-comment.yml` – deleted; previously posted PR comments summarising self-test matrices.
-- `maint-44-selftest-reusable-ci.yml` – deleted reusable-integration cron (matrix coverage moved to the
-  main CI jobs).
+- `maint-44-selftest-reusable-ci.yml` – deleted reusable-integration cron (matrix coverage moved to the main CI jobs).
 - `maint-48-selftest-reusable-ci.yml` – deleted; short-lived variant of the reusable matrix exerciser.
-- `pr-20-selftest-pr-comment.yml` – deleted; PR-triggered comment bot that duplicated the maintenance
-  wrapper.
+- `pr-20-selftest-pr-comment.yml` – deleted; PR-triggered comment bot that duplicated the maintenance wrapper.
 
-See [ARCHIVE_WORKFLOWS.md](../../ARCHIVE_WORKFLOWS.md) for the full ledger of retired workflows and
-rationale, including notes on the removed files.
+See [ARCHIVE_WORKFLOWS.md](../../ARCHIVE_WORKFLOWS.md) for the full ledger of retired workflows and rationale, including notes on the removed files.
 
 ## Contributor Quick Start
 
 Follow this sequence before pushing workflow changes or large code edits:
 
-1. **Install tooling** – run `./scripts/setup_env.sh` once to create a virtual
-   environment with repository requirements.
+1. **Install tooling** – run `./scripts/setup_env.sh` once to create a virtual environment with repository requirements.
 2. **Mirror the CI style gate locally** – execute:
 
    ```bash
    ./scripts/style_gate_local.sh
    ```
 
-   The script sources `.github/workflows/autofix-versions.env`, installs the
-   pinned formatter/type versions, runs Ruff/Black, and finishes with a mypy pass
-   over `src/trend_analysis` and `src/trend_portfolio_app`. Fix any reported
-   issues to keep the Gate workflow green.
-3. **Targeted tests** – add `pytest tests/test_workflow_naming.py` after editing
-   workflow files to ensure naming conventions hold. For agents changes, also run
-   `pytest tests/test_automation_workflows.py -k agents`.
-4. **Optional smoke** – `gh workflow list --limit 20` validates that only the
-   documented workflows surface in the Actions tab.
+   The script sources `.github/workflows/autofix-versions.env`, installs the pinned formatter/type versions, runs Ruff/Black, and finishes with a mypy pass over `src/trend_analysis` and `src/trend_portfolio_app`. Fix any reported issues to keep the Gate workflow green.
+3. **Targeted tests** – add `pytest tests/test_workflow_naming.py` after editing workflow files to ensure naming conventions hold. For agents changes, also run `pytest tests/test_automation_workflows.py -k agents`.
+4. **Optional smoke** – `gh workflow list --limit 20` validates that only the documented workflows surface in the Actions tab.
 
 ## Adding or Renumbering Workflows
 
-1. Pick the correct prefix/number band (see Naming Policy) and choose the lowest
-   unused slot.
-   - Treat the `NN` portion as a zero-padded two-digit identifier within the
-     band (`pr-10`, `maint-36`, etc.). Check the tables above before reusing a
-     number so future contributors can infer gaps at a glance.
-2. Place the workflow in `.github/workflows/` with the matching Title Case
-   `name:`.
-3. Update any trigger dependencies (`workflow_run` consumers) so maintenance jobs
-   continue to listen to the correct producers.
-4. Document the change in this file (inventory tables + bands) and in
-   `docs/WORKFLOW_GUIDE.md` if the topology shifts.
+1. Pick the correct prefix/number band (see Naming Policy) and choose the lowest unused slot.
+   - Treat the `NN` portion as a zero-padded two-digit identifier within the band (`pr-10`, `maint-36`, etc.). Check the tables above before reusing a number so future contributors can infer gaps at a glance.
+2. Place the workflow in `.github/workflows/` with the matching Title Case `name:`.
+3. Update any trigger dependencies (`workflow_run` consumers) so maintenance jobs continue to listen to the correct producers.
+4. Document the change in this file (inventory tables + bands) and in `docs/WORKFLOW_GUIDE.md` if the topology shifts.
 5. Run the validation commands listed above before opening a PR.
 
 ## Formatter & Type Checker Pins
 
-- `.github/workflows/autofix-versions.env` is the single source of truth for
-  formatter/type tooling versions (Ruff, Black, isort, docformatter, mypy).
-- `reusable-ci.yml`, `reusable-docker.yml`, and the autofix composite
-  action all load and validate this env file before installing tools; they fail
-  fast if the file is missing or incomplete.
-- Local mirrors (`scripts/style_gate_local.sh`, `scripts/dev_check.sh`,
-  `scripts/validate_fast.sh`) source the same env file so contributors run the
-  identical versions before pushing.
-- When bumping any formatter, update the env file first, rerun
-  `./scripts/style_gate_local.sh`, and let CI confirm the new version to keep
-  automation and local flows aligned.
+- `.github/workflows/autofix-versions.env` is the single source of truth for formatter/type tooling versions (Ruff, Black, isort, docformatter, mypy).
+- `reusable-ci.yml`, `reusable-docker.yml`, and the autofix composite action all load and validate this env file before installing tools; they fail fast if the file is missing or incomplete.
+- Local mirrors (`scripts/style_gate_local.sh`, `scripts/dev_check.sh`, `scripts/validate_fast.sh`) source the same env file so contributors run the identical versions before pushing.
+- When bumping any formatter, update the env file first, rerun `./scripts/style_gate_local.sh`, and let CI confirm the new version to keep automation and local flows aligned.
 
 ## CI Signature Guard Fixtures
 
-`maint-40-ci-signature-guard.yml` enforces a manifest signature for the Gate
-workflow by comparing two fixture files stored in `.github/signature-fixtures/`:
+`maint-40-ci-signature-guard.yml` enforces a manifest signature for the Gate workflow by comparing two fixture files stored in `.github/signature-fixtures/`:
 
-- `basic_jobs.json` – canonical list of jobs (name, concurrency label, metadata)
-  that must exist in `pr-gate.yml`.
-- `basic_hash.txt` – precomputed hash of the JSON payload used by
-  `.github/actions/signature-verify` to detect unauthorized job changes.
+- `basic_jobs.json` – canonical list of jobs (name, concurrency label, metadata) that must exist in `pr-gate.yml`.
+- `basic_hash.txt` – precomputed hash of the JSON payload used by `.github/actions/signature-verify` to detect unauthorized job changes.
 
-When intentionally editing CI jobs, regenerate `basic_jobs.json`, compute the new
-hash, and update both files in the same commit. Use
-`tools/test_failure_signature.py` locally to recompute and verify the hash before
-pushing. The guard only runs on pushes/PRs targeting `phase-2-dev` and publishes
-a step summary linking back here.
+When intentionally editing CI jobs, regenerate `basic_jobs.json`, compute the new hash, and update both files in the same commit. Use `tools/test_failure_signature.py` locally to recompute and verify the hash before pushing. The guard only runs on pushes/PRs targeting `phase-2-dev` and publishes a step summary linking back here.
 
 ## Agents `options_json` Schema
 
-`agents-70-orchestrator.yml` accepts the standard dispatch inputs shown in the
-workflow plus an extensible JSON payload routed through `options_json`. The JSON
-is parsed with `fromJson()` and handed to the reusable agents workflow.
+`agents-70-orchestrator.yml` accepts the standard dispatch inputs shown in the workflow plus an extensible JSON payload routed through `options_json`. The JSON is parsed with `fromJson()` and handed to the reusable agents workflow.
 
 ```jsonc
 {
@@ -196,25 +188,8 @@ is parsed with `fromJson()` and handed to the reusable agents workflow.
 }
 ```
 
-- **`diagnostic_mode`** — `off` (default) disables diagnostics, `dry-run` keeps
-  bootstrap logic read-only, `full` allows branch creation and sets
-  `diagnostic_attempt_branch=true` in the reusable workflow.
-- **`readiness_custom_logins`** — optional comma-separated list of extra agent
-  logins to probe during readiness checks.
-- **`codex_command_phrase`** — overrides the PR comment phrase the orchestrator
-  looks for when confirming Codex bootstrap completion.
+- **`diagnostic_mode`** — `off` (default) disables diagnostics, `dry-run` keeps bootstrap logic read-only, `full` allows branch creation and sets `draft_pr: false` when Codex is seeded.
+- **`readiness_custom_logins`** — comma-separated list for additional readiness probes.
+- **`codex_command_phrase`** — phrase used when the orchestrator comments on issues or PRs to summon Codex.
 
-Extend the schema by adding new keys to the JSON object and updating both the
-orchestrator workflow and this documentation. Keep additional toggles in the
-JSON payload to avoid exceeding GitHub's 10 input limit on `workflow_dispatch`
-forms.
-
-## Quick Validation Commands
-
-- `pytest tests/test_workflow_naming.py` — guard the naming convention.
-- `pytest tests/test_automation_workflows.py -k agents` — ensure agents inputs
-  (including `options_json`) parse correctly.
-- `gh workflow list --limit 20` — verify only the inventoried workflows are
-  visible in the Actions UI.
-
-Run the naming test after any workflow change to keep CI guardrails intact.
+Keep this schema backward compatible; add new keys sparingly and document them in the table above when introduced.


### PR DESCRIPTION
## Summary
- update the workflow catalog to describe the Gate pipeline and Agents 70 Orchestrator as the only automation entry point
- align the workflow guide, reusable workflow reference, and contributing guide with the simplified orchestrator-driven topology
- add troubleshooting guidance and manual dispatch instructions for the agents orchestrator plus highlight local gate mirror scripts

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68eb2ce52bac833185aa39dbc89be705