### PR TITLE
Clarify gate check requirement in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,10 @@ post-processing workflow:
 
 - **Required check** – `Gate / gate` (defined in
   [`.github/workflows/pr-gate.yml`](.github/workflows/pr-gate.yml)) must
-  pass before merges. It fans out to the Python 3.11/3.12 test lanes and
-  the Docker smoke job.
+  pass before merges. Branch protection blocks the default branch until
+  this check succeeds; treat the gate status as the final merge blocker.
+  It fans out to the Python 3.11/3.12 test lanes and the Docker smoke
+  job.
 - **Autofix lane** – The
   [Autofix workflow](.github/workflows/autofix.yml) runs on every
   non-draft PR event. Drafts are ignored unless you opt in by adding the


### PR DESCRIPTION
## Summary
- clarify that branch protection blocks merges until the Gate / gate check passes
- emphasize that contributors should treat the gate status as the final merge blocker

## Testing
- not run (documentation change only)


------
https://chatgpt.com/codex/tasks/task_e_68eb3271a300833193caba3be5047651