### PR TITLE
Enforce gate branch protection automation for #2465

### DIFF
--- a/.github/workflows/enforce-gate-branch-protection.yml
+++ b/.github/workflows/enforce-gate-branch-protection.yml
@@ -1,0 +1,45 @@
+name: Enforce Gate Branch Protection
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  ENFORCE_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN }}
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip when enforcement token is not configured
+        if: env.ENFORCE_TOKEN == ''
+        run: |
+          echo "BRANCH_PROTECTION_TOKEN is not configured; skipping enforcement run."
+          echo "Configure a fine-grained PAT with branch protection admin scope to enable this workflow."
+          exit 0
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        if: env.ENFORCE_TOKEN != ''
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+
+      - name: Enforce gate branch protection
+        if: env.ENFORCE_TOKEN != ''
+        env:
+          GITHUB_TOKEN: ${{ env.ENFORCE_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          python tools/enforce_gate_branch_protection.py --apply

--- a/docs/gate_protection_plan.md
+++ b/docs/gate_protection_plan.md
@@ -33,6 +33,17 @@
   applying changes.
 - Contributors without direct settings access can now request an owner to run the script with a fine-grained `GITHUB_TOKEN`
   instead of navigating the UI, ensuring infrastructure as code parity for the protection rule.
+- Scheduled automation (`.github/workflows/enforce-gate-branch-protection.yml`) executes the helper nightly and on-demand,
+  applying fixes whenever the optional `BRANCH_PROTECTION_TOKEN` secret is configured.
+
+## Automation Requirements
+
+- Create a fine-grained PAT with the **Administration: Branches** scope (repo → settings → developer settings → fine-grained
+  personal access tokens). Attach it to the repository as the `BRANCH_PROTECTION_TOKEN` secret so the enforcement workflow can
+  manage branch protection.
+- The workflow runs on a nightly cron and via the `workflow_dispatch` trigger. When the secret is absent the job exits early
+  with an informational log, allowing maintainers to opt in when they are ready to enforce gate automatically.
+- Manual runs surface the audit diff in the workflow logs, mirroring the script's dry-run output before applying updates.
 
 ## Usage Notes
 

--- a/tests/tools/test_enforce_gate_branch_protection.py
+++ b/tests/tools/test_enforce_gate_branch_protection.py
@@ -1,0 +1,98 @@
+import pytest
+
+from tools.enforce_gate_branch_protection import (
+    BranchProtectionError,
+    StatusCheckState,
+    diff_contexts,
+    format_contexts,
+    normalise_contexts,
+    parse_contexts,
+    fetch_status_checks,
+    update_status_checks,
+)
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, payload: dict | None = None, text: str = "") -> None:
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class DummySession:
+    def __init__(self, response: DummyResponse) -> None:
+        self._response = response
+        self.last_payload: dict | None = None
+
+    def get(self, *_args, **_kwargs) -> DummyResponse:
+        return self._response
+
+    def patch(self, *_args, json: dict, **_kwargs) -> DummyResponse:
+        self.last_payload = json
+        return self._response
+
+
+def test_parse_contexts_defaults_to_gate_when_missing() -> None:
+    assert parse_contexts(None) == ["Gate / gate"]
+    assert parse_contexts([""]) == ["Gate / gate"]
+
+
+def test_parse_contexts_preserves_non_empty_values() -> None:
+    assert parse_contexts([" Gate / gate ", "Extra"]) == ["Gate / gate", "Extra"]
+
+
+def test_normalise_contexts_deduplicates_and_sorts() -> None:
+    assert normalise_contexts(["Extra", "Gate / gate", "Gate / gate"]) == ["Extra", "Gate / gate"]
+
+
+def test_diff_contexts_returns_expected_differences() -> None:
+    to_add, to_remove = diff_contexts(["Gate / gate"], ["Gate / gate", "Extra"])
+    assert to_add == ["Extra"]
+    assert to_remove == []
+
+    to_add, to_remove = diff_contexts(["Legacy"], ["Gate / gate"])
+    assert to_add == ["Gate / gate"]
+    assert to_remove == ["Legacy"]
+
+
+def test_format_contexts_handles_empty_and_multiple_values() -> None:
+    assert format_contexts([]) == "(none)"
+    assert format_contexts(["Gate / gate", "Extra"]) == "Gate / gate, Extra"
+
+
+def test_fetch_status_checks_raises_for_missing_rule() -> None:
+    session = DummySession(DummyResponse(404))
+    with pytest.raises(BranchProtectionError):
+        fetch_status_checks(session, "owner/repo", "main")
+
+
+def test_fetch_status_checks_returns_state() -> None:
+    response = DummyResponse(200, {"strict": True, "contexts": ["Gate / gate"]})
+    session = DummySession(response)
+    state = fetch_status_checks(session, "owner/repo", "main")
+    assert state == StatusCheckState(strict=True, contexts=["Gate / gate"])
+
+
+def test_update_status_checks_submits_payload_and_returns_state() -> None:
+    response = DummyResponse(200, {"strict": True, "contexts": ["Gate / gate"]})
+    session = DummySession(response)
+
+    state = update_status_checks(
+        session,
+        "owner/repo",
+        "main",
+        contexts=["Gate / gate"],
+        strict=True,
+    )
+
+    assert session.last_payload == {"contexts": ["Gate / gate"], "strict": True}
+    assert state == StatusCheckState(strict=True, contexts=["Gate / gate"])
+
+
+def test_update_status_checks_raises_on_failure() -> None:
+    session = DummySession(DummyResponse(500, text="error"))
+    with pytest.raises(BranchProtectionError):
+        update_status_checks(session, "owner/repo", "main", contexts=["Gate / gate"], strict=True)


### PR DESCRIPTION
## Summary
- add a scheduled enforcement workflow that runs the gate branch protection helper using an opt-in PAT
- expand the gate protection plan with automation requirements for the workflow
- cover the helper’s parsing and API plumbing with unit tests to guard regressions

## Testing
- pytest tests/tools/test_enforce_gate_branch_protection.py

------
https://chatgpt.com/codex/tasks/task_e_68eb350dbfd88331871a005b50828989