### PR TITLE
Support bootstrapping gate branch protection

### DIFF
--- a/docs/gate_protection_plan.md
+++ b/docs/gate_protection_plan.md
@@ -32,7 +32,8 @@
 - The helper defaults to `GITHUB_REPOSITORY`/`DEFAULT_BRANCH` and can run in dry-run mode to audit the current contexts before
   applying changes.
 - Contributors without direct settings access can now request an owner to run the script with a fine-grained `GITHUB_TOKEN`
-  instead of navigating the UI, ensuring infrastructure as code parity for the protection rule.
+  instead of navigating the UI, ensuring infrastructure as code parity for the protection rule. When no protection rule exists,
+  the helper bootstraps one with the required status checks so teams can enable gate in a single `--apply` invocation.
 - Scheduled automation (`.github/workflows/enforce-gate-branch-protection.yml`) executes the helper nightly and on-demand,
   applying fixes whenever the optional `BRANCH_PROTECTION_TOKEN` secret is configured.
 
@@ -65,14 +66,16 @@ Desired 'require up to date': True
 No changes required.
 ```
 
-Apply corrections (if the dry run indicates drift):
+Apply corrections (if the dry run indicates drift or the rule is missing):
 
 ```bash
 GITHUB_TOKEN=ghp_xxx python tools/enforce_gate_branch_protection.py --repo stranske/Trend_Model_Project --branch main --apply
 ```
 
-The script patches `required_status_checks` in-place and leaves other branch protection toggles untouched. Use `--context` to
-temporarily allow additional contexts or `--no-clean` to preserve existing extras while asserting Gate.
+The script patches `required_status_checks` in-place and leaves other branch protection toggles untouched. When the rule is
+absent the helper creates one with GitHub’s default toggles (admins not enforced, reviews/restrictions unset) before ensuring
+`Gate / gate` is the required context. Use `--context` to temporarily allow additional contexts or `--no-clean` to preserve
+existing extras while asserting Gate.
 
 ## Validation Checklist
 

--- a/tests/tools/test_enforce_gate_branch_protection.py
+++ b/tests/tools/test_enforce_gate_branch_protection.py
@@ -1,8 +1,12 @@
+from typing import Sequence
+
 import pytest
 
 from tools.enforce_gate_branch_protection import (
     BranchProtectionError,
+    BranchProtectionMissingError,
     StatusCheckState,
+    bootstrap_branch_protection,
     diff_contexts,
     fetch_status_checks,
     format_contexts,
@@ -28,13 +32,18 @@ class DummyResponse:
 class DummySession:
     def __init__(self, response: DummyResponse) -> None:
         self._response = response
-        self.last_payload: dict | None = None
+        self.last_patch_payload: dict | None = None
+        self.last_put_payload: dict | None = None
 
     def get(self, *_args, **_kwargs) -> DummyResponse:
         return self._response
 
     def patch(self, *_args, json: dict, **_kwargs) -> DummyResponse:
-        self.last_payload = json
+        self.last_patch_payload = json
+        return self._response
+
+    def put(self, *_args, json: dict, **_kwargs) -> DummyResponse:
+        self.last_put_payload = json
         return self._response
 
 
@@ -71,7 +80,7 @@ def test_format_contexts_handles_empty_and_multiple_values() -> None:
 
 def test_fetch_status_checks_raises_for_missing_rule() -> None:
     session = DummySession(DummyResponse(404))
-    with pytest.raises(BranchProtectionError):
+    with pytest.raises(BranchProtectionMissingError):
         fetch_status_checks(session, "owner/repo", "main")
 
 
@@ -94,7 +103,7 @@ def test_update_status_checks_submits_payload_and_returns_state() -> None:
         strict=True,
     )
 
-    assert session.last_payload == {"contexts": ["Gate / gate"], "strict": True}
+    assert session.last_patch_payload == {"contexts": ["Gate / gate"], "strict": True}
     assert state == StatusCheckState(strict=True, contexts=["Gate / gate"])
 
 
@@ -104,6 +113,35 @@ def test_update_status_checks_raises_on_failure() -> None:
         update_status_checks(
             session, "owner/repo", "main", contexts=["Gate / gate"], strict=True
         )
+
+
+def test_bootstrap_branch_protection_creates_rule() -> None:
+    response = DummyResponse(
+        200,
+        {
+            "required_status_checks": {
+                "strict": True,
+                "contexts": ["Gate / gate"],
+            }
+        },
+    )
+    session = DummySession(response)
+
+    state = bootstrap_branch_protection(
+        session,
+        "owner/repo",
+        "main",
+        contexts=["Gate / gate"],
+        strict=True,
+    )
+
+    assert session.last_put_payload == {
+        "required_status_checks": {"strict": True, "contexts": ["Gate / gate"]},
+        "enforce_admins": False,
+        "required_pull_request_reviews": None,
+        "restrictions": None,
+    }
+    assert state == StatusCheckState(strict=True, contexts=["Gate / gate"])
 
 
 def test_main_reports_no_changes_in_dry_run(
@@ -244,6 +282,85 @@ def test_main_apply_with_no_clean_keeps_existing_contexts(
         "strict": True,
     }
     assert "Update successful." in captured.out
+
+
+def test_main_reports_missing_rule_in_dry_run(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(
+        "tools.enforce_gate_branch_protection._build_session",
+        lambda _token: object(),
+    )
+
+    def _raise_missing(*_args, **_kwargs):
+        raise BranchProtectionMissingError("missing")
+
+    monkeypatch.setattr(
+        "tools.enforce_gate_branch_protection.fetch_status_checks",
+        _raise_missing,
+    )
+
+    exit_code = main(["--repo", "owner/repo", "--branch", "main"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Would create branch protection" in captured.out
+
+
+def test_main_bootstraps_when_apply(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(
+        "tools.enforce_gate_branch_protection._build_session",
+        lambda _token: object(),
+    )
+
+    def _raise_missing(*_args, **_kwargs):
+        raise BranchProtectionMissingError("missing")
+
+    monkeypatch.setattr(
+        "tools.enforce_gate_branch_protection.fetch_status_checks",
+        _raise_missing,
+    )
+
+    captured_payload: dict[str, object] = {}
+
+    def fake_bootstrap(
+        _session: object,
+        repo: str,
+        branch: str,
+        *,
+        contexts: Sequence[str],
+        strict: bool,
+    ) -> StatusCheckState:
+        captured_payload.update(
+            {
+                "repo": repo,
+                "branch": branch,
+                "contexts": list(contexts),
+                "strict": strict,
+            }
+        )
+        return StatusCheckState(strict=True, contexts=list(contexts))
+
+    monkeypatch.setattr(
+        "tools.enforce_gate_branch_protection.bootstrap_branch_protection",
+        fake_bootstrap,
+    )
+
+    exit_code = main(["--repo", "owner/repo", "--branch", "main", "--apply"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured_payload == {
+        "repo": "owner/repo",
+        "branch": "main",
+        "contexts": ["Gate / gate"],
+        "strict": True,
+    }
+    assert "Created branch protection rule." in captured.out
 
 
 def test_main_surfaces_branch_protection_errors(


### PR DESCRIPTION
## Summary
- allow the gate branch-protection helper to create the required-status-check rule when it is missing while still normalising the enforced contexts
- cover the bootstrap flow in unit tests and ensure CLI dry-run/apply scenarios report the new behaviour
- document that the helper can bootstrap protection and clarify the apply instructions for missing rules

## Testing
- pytest tests/tools/test_enforce_gate_branch_protection.py
- python -m compileall tools/enforce_gate_branch_protection.py
- ruff check tools/enforce_gate_branch_protection.py tests/tools/test_enforce_gate_branch_protection.py

------
https://chatgpt.com/codex/tasks/task_e_68eb3d452f648331bc8aa1a85fd6da31