### PR TITLE
docs: highlight Gate merge requirement in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thank you for contributing to the Trend Model Project.
 Pull requests flow through a single required check and a consolidated
 post-processing workflow:
 
+- Passing the Gate check is required to merge.
 - **Required check** – `Gate / gate` (defined in
   [`.github/workflows/pr-00-gate.yml`](.github/workflows/pr-00-gate.yml)) must
   pass before merges. Branch protection blocks the default branch until


### PR DESCRIPTION
## Summary
- add an explicit reminder that the Gate check must pass before merging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec2c57b5448331a72cecdb5e030874