### PR TITLE
Add Gate branch protection snapshot capture tooling

### DIFF
--- a/agents/codex-2495.md
+++ b/agents/codex-2495.md
@@ -7,6 +7,6 @@
 - [ ] Validation draft PR evidence captured (see runbook).
 
 ## Next Actions
-1. Repository owner runs `tools/enforce_gate_branch_protection.py --check` with an admin token to confirm the live settings.
-2. Follow `docs/runbooks/gate-branch-protection-validation.md` to produce validation PR evidence and attach it to issue #2495.
+1. Repository owner runs `tools/enforce_gate_branch_protection.py --check --snapshot docs/evidence/gate-branch-protection/pre.json` with an admin token to confirm the live settings.
+2. Follow `docs/runbooks/gate-branch-protection-validation.md` to produce validation PR evidence (including snapshot files) and attach it to issue #2495.
 3. Mark the final checkbox above once validation artifacts are archived.

--- a/docs/evidence/README.md
+++ b/docs/evidence/README.md
@@ -1,0 +1,14 @@
+# Gate Branch Protection Evidence Archive
+
+Store validation artifacts for issue #2495 in this folder. Suggested layout:
+
+```
+gate-branch-protection/
+  pre-enforcement.json     # Snapshot captured before running --apply
+  enforcement.json         # Snapshot captured during enforcement run
+  post-enforcement.json    # Snapshot captured after the Gate check passes
+```
+
+Include the JSON snapshots referenced in the runbook alongside any screenshots from
+the validation pull request so auditors can confirm the Gate check blocks merges
+when failing and allows merges when passing.

--- a/docs/gate_protection_plan.md
+++ b/docs/gate_protection_plan.md
@@ -33,6 +33,8 @@
   respect `GITHUB_TOKEN`, `GH_TOKEN`, and `GITHUB_API_URL` when flags are omitted.
 - The helper defaults to `GITHUB_REPOSITORY`/`DEFAULT_BRANCH` and can run in dry-run mode to audit the current contexts before
   applying changes.
+- Maintainers can add `--snapshot <path>` to the helper to emit a JSON evidence bundle that records the current, desired, and
+  post-enforcement status checks for audit trails.
 - Contributors without direct settings access can now request an owner to run the script with a fine-grained `GITHUB_TOKEN`
   instead of navigating the UI, ensuring infrastructure as code parity for the protection rule.
 - Scheduled automation (`.github/workflows/health-44-gate-branch-protection.yml`) executes the helper nightly and on-demand,
@@ -56,7 +58,8 @@ Run a dry check to review the current branch protection rule (either export
 python tools/enforce_gate_branch_protection.py \
   --repo stranske/Trend_Model_Project \
   --branch main \
-  --token ghp_xxx
+  --token ghp_xxx \
+  --snapshot docs/evidence/gate-branch-protection/status.json
 ```
 
 Expected dry-run output when the rule is correct:
@@ -77,7 +80,8 @@ Apply corrections (if the dry run indicates drift):
 python tools/enforce_gate_branch_protection.py \
   --repo stranske/Trend_Model_Project \
   --branch main \
-  --token ghp_xxx --apply
+  --token ghp_xxx --apply \
+  --snapshot docs/evidence/gate-branch-protection/post-apply.json
 ```
 
 The script patches `required_status_checks` in-place and leaves other branch protection toggles untouched. Use `--context` to

--- a/docs/planning/gate-branch-protection-plan.md
+++ b/docs/planning/gate-branch-protection-plan.md
@@ -34,7 +34,8 @@
 - ✅ **Automation helper** – `tools/enforce_gate_branch_protection.py` provides dry-run, check, and apply modes for owners with the
   appropriate token to configure branch protection without leaving the command line. The helper accepts explicit `--token` and
   `--api-url` overrides for GitHub Enterprise Server usage. Unit tests in `tests/tools/test_enforce_gate_branch_protection.py`
-  cover the primary scenarios (initial bootstrap, drift detection, and clean enforcement).
+  cover the primary scenarios (initial bootstrap, drift detection, and clean enforcement). The CLI now supports `--snapshot` so
+  enforcement runs can emit JSON evidence of the before/after branch protection state for audit logs.
 - ✅ **Scheduled enforcement** – `.github/workflows/health-44-gate-branch-protection.yml` runs nightly and on demand. It applies the
   enforcement automatically whenever the optional `BRANCH_PROTECTION_TOKEN` secret is present, otherwise it exits early with a
   clear reminder to configure the token.

--- a/docs/runbooks/gate-branch-protection-validation.md
+++ b/docs/runbooks/gate-branch-protection-validation.md
@@ -11,7 +11,7 @@ updated or during periodic audits.
 - A scratch branch to use for the validation pull request.
 
 ## 1. Audit Current Protection Rule
-1. Export the status check configuration:
+1. Export the status check configuration and capture a JSON snapshot for the audit log:
    ```bash
    gh api repos/stranske/Trend_Model_Project/branches/main/protection/required_status_checks \
      --jq '{strict: .strict, contexts: .contexts}'
@@ -19,12 +19,14 @@ updated or during periodic audits.
    - Confirm the output shows `{"strict":true,"contexts":["Gate / gate"]}`.
    - If `gh` is unavailable, run the helper in dry-run mode. Provide a
      personal access token either by exporting `GITHUB_TOKEN`/`GH_TOKEN` or
-     by passing `--token` explicitly:
+     by passing `--token` explicitly and include `--snapshot` to write the
+     evidence file (for example, under `docs/evidence/`):
      ```bash
      python tools/enforce_gate_branch_protection.py \
        --repo stranske/Trend_Model_Project \
        --branch main \
-       --token ghp_xxx
+       --token ghp_xxx \
+       --snapshot docs/evidence/gate-branch-protection/pre-enforcement.json
      ```
      Ensure it prints `No changes required.`
 
@@ -32,9 +34,10 @@ updated or during periodic audits.
    ```bash
    python tools/enforce_gate_branch_protection.py \
      --repo stranske/Trend_Model_Project --branch main \
-     --token ghp_xxx --apply
-   ```
-   Record the console output in the issue log.
+     --token ghp_xxx --apply \
+     --snapshot docs/evidence/gate-branch-protection/enforcement.json
+  ```
+  Record the console output in the issue log.
 
 ## 2. Create Validation Pull Request
 1. Check out a new branch and make a trivial change (e.g., update a comment) so a pull request can be opened.
@@ -48,8 +51,9 @@ updated or during periodic audits.
 ## 3. Resolve the Failure
 1. Push a fix that allows the Gate workflow to pass (e.g., revert the failing test or re-run the cancelled job).
 2. Wait for the workflow to finish successfully.
-3. Verify the status area now shows **Required — Gate / gate** with a green check and the merge button becomes available.
-4. Update the issue or documentation with the pass/fail timestamps and the URL of the validation PR for traceability.
+3. Run the helper again with `--snapshot` to capture the post-fix configuration for the evidence bundle.
+4. Verify the status area now shows **Required — Gate / gate** with a green check and the merge button becomes available.
+5. Update the issue or documentation with the pass/fail timestamps, the URL of the validation PR, and paths to the snapshot files for traceability.
 
 ## 4. Close Out
 - Merge or close the draft PR without merging into `main` (if using a deliberately failing change, force-push to remove it).

--- a/tests/tools/test_enforce_gate_branch_protection.py
+++ b/tests/tools/test_enforce_gate_branch_protection.py
@@ -1,5 +1,6 @@
 import json
 from collections.abc import Sequence
+from pathlib import Path
 
 import pytest
 import requests
@@ -427,6 +428,102 @@ def test_main_surfaces_branch_protection_errors(
     captured = capsys.readouterr()
     assert exit_code == 1
     assert "error: boom" in captured.err
+
+
+def test_main_writes_snapshot_when_drift_detected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(
+        "tools.enforce_gate_branch_protection._build_session",
+        lambda _token: object(),
+    )
+    monkeypatch.setattr(
+        "tools.enforce_gate_branch_protection.fetch_status_checks",
+        lambda *_args, **_kwargs: StatusCheckState(
+            strict=False, contexts=["Legacy"]
+        ),
+    )
+
+    snapshot_file = tmp_path / "snapshots" / "state.json"
+    exit_code = main(
+        [
+            "--repo",
+            "owner/repo",
+            "--branch",
+            "main",
+            "--snapshot",
+            str(snapshot_file),
+        ]
+    )
+
+    assert exit_code == 0
+    data = json.loads(snapshot_file.read_text())
+    assert data["repository"] == "owner/repo"
+    assert data["branch"] == "main"
+    assert data["mode"] == "inspect"
+    assert data["current"] == {"strict": False, "contexts": ["Legacy"]}
+    assert data["desired"] == {"strict": True, "contexts": ["Gate / gate"]}
+    assert data["changes_required"] is True
+    assert data["changes_applied"] is False
+    assert "after" not in data
+
+
+def test_main_snapshot_updates_after_apply(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(
+        "tools.enforce_gate_branch_protection._build_session",
+        lambda _token: object(),
+    )
+    monkeypatch.setattr(
+        "tools.enforce_gate_branch_protection.fetch_status_checks",
+        lambda *_args, **_kwargs: StatusCheckState(
+            strict=False, contexts=["Legacy"]
+        ),
+    )
+
+    def fake_update(
+        _session: object,
+        repo: str,
+        branch: str,
+        *,
+        contexts: list[str],
+        strict: bool,
+        api_root: str = "",
+    ) -> StatusCheckState:
+        assert repo == "owner/repo"
+        assert branch == "main"
+        assert contexts == ["Gate / gate"]
+        assert strict is True
+        assert api_root == "https://api.github.com"
+        return StatusCheckState(strict=True, contexts=contexts)
+
+    monkeypatch.setattr(
+        "tools.enforce_gate_branch_protection.update_status_checks",
+        fake_update,
+    )
+
+    snapshot_file = tmp_path / "state.json"
+    exit_code = main(
+        [
+            "--repo",
+            "owner/repo",
+            "--branch",
+            "main",
+            "--apply",
+            "--snapshot",
+            str(snapshot_file),
+        ]
+    )
+
+    assert exit_code == 0
+    data = json.loads(snapshot_file.read_text())
+    assert data["mode"] == "apply"
+    assert data["changes_required"] is True
+    assert data["changes_applied"] is True
+    assert data["after"] == {"strict": True, "contexts": ["Gate / gate"]}
 
 
 def test_require_token_prefers_explicit_value(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tools/enforce_gate_branch_protection.py
+++ b/tools/enforce_gate_branch_protection.py
@@ -7,8 +7,11 @@ import argparse
 import os
 import sys
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any, Iterable, List, Mapping, Sequence
 
+import json
 import requests
 
 DEFAULT_API_ROOT = "https://api.github.com"
@@ -21,6 +24,8 @@ def resolve_api_root(explicit: str | None = None) -> str:
     if not candidate:
         return DEFAULT_API_ROOT
     return candidate.rstrip("/")
+
+
 DEFAULT_CONTEXT = "Gate / gate"
 
 
@@ -199,6 +204,14 @@ def require_token(explicit: str | None = None) -> str:
     return token
 
 
+def _write_snapshot(path: str, payload: Mapping[str, Any]) -> None:
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
 def diff_contexts(
     current: Sequence[str], desired: Sequence[str]
 ) -> tuple[list[str], list[str]]:
@@ -243,6 +256,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--snapshot",
+        help="Write a JSON snapshot of the current and desired branch protection state to this file.",
+    )
+    parser.add_argument(
         "--apply",
         action="store_true",
         help="Apply the changes instead of performing a dry run.",
@@ -271,6 +288,17 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     desired_contexts = normalise_contexts(parse_contexts(args.contexts))
 
+    snapshot: dict[str, Any] | None = None
+    if args.snapshot:
+        now = datetime.now(UTC).replace(microsecond=0)
+        snapshot = {
+            "repository": args.repo,
+            "branch": args.branch,
+            "mode": "apply" if args.apply else "check" if args.check else "inspect",
+            "generated_at": now.isoformat().replace("+00:00", "Z"),
+            "changes_applied": False,
+        }
+
     api_root = resolve_api_root(args.api_url)
     token = require_token(args.token)
     session = _build_session(token)
@@ -279,6 +307,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         current_state = fetch_status_checks(
             session, args.repo, args.branch, api_root=api_root
         )
+        if snapshot is not None:
+            snapshot["current"] = {
+                "strict": current_state.strict,
+                "contexts": list(current_state.contexts),
+            }
     except BranchProtectionMissingError:
         print(f"Repository: {args.repo}")
         print(f"Branch:     {args.branch}")
@@ -287,6 +320,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"{label}: {format_contexts(desired_contexts)}")
         print("Current 'require up to date': False")
         print("Desired 'require up to date': True")
+
+        if snapshot is not None:
+            snapshot.update(
+                {
+                    "current": None,
+                    "desired": {"strict": True, "contexts": list(desired_contexts)},
+                    "changes_required": True,
+                }
+            )
 
         if args.apply:
             try:
@@ -300,19 +342,37 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
             except BranchProtectionError as exc:
                 print(f"error: {exc}", file=sys.stderr)
+                if snapshot is not None:
+                    snapshot["error"] = str(exc)
+                    _write_snapshot(args.snapshot, snapshot)
                 return 1
 
             print("Created branch protection rule.")
             print(f"New contexts: {format_contexts(created_state.contexts)}")
             print(f"'Require up to date' enabled: {created_state.strict}")
+            if snapshot is not None:
+                snapshot["changes_applied"] = True
+                snapshot["after"] = {
+                    "strict": created_state.strict,
+                    "contexts": list(created_state.contexts),
+                }
+                _write_snapshot(args.snapshot, snapshot)
             return 0
 
         print("Would create branch protection.")
+        if snapshot is not None:
+            _write_snapshot(args.snapshot, snapshot)
         if args.check:
             return 1
         return 0
     except BranchProtectionError as exc:
         print(f"error: {exc}", file=sys.stderr)
+        if snapshot is not None:
+            snapshot["error"] = str(exc)
+            snapshot.setdefault(
+                "desired", {"strict": True, "contexts": list(desired_contexts)}
+            )
+            _write_snapshot(args.snapshot, snapshot)
         return 1
 
     target_contexts = (
@@ -323,6 +383,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     to_add, to_remove = diff_contexts(current_state.contexts, target_contexts)
     strict_change = not current_state.strict
+
+    if snapshot is not None:
+        snapshot["desired"] = {"strict": True, "contexts": list(target_contexts)}
 
     print(f"Repository: {args.repo}")
     print(f"Branch:     {args.branch}")
@@ -335,10 +398,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     no_changes_required = (
         not to_add and (args.no_clean or not to_remove) and not strict_change
     )
+    changes_required = not no_changes_required
+
+    if snapshot is not None:
+        snapshot["changes_required"] = changes_required
 
     if args.check or not args.apply:
         if no_changes_required:
             print("No changes required.")
+            if snapshot is not None:
+                _write_snapshot(args.snapshot, snapshot)
             return 0
 
         if to_add:
@@ -347,6 +416,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"Would remove contexts: {format_contexts(to_remove)}")
         if strict_change:
             print("Would enable 'require branches to be up to date'.")
+
+        if snapshot is not None:
+            _write_snapshot(args.snapshot, snapshot)
 
         if args.check:
             return 1
@@ -365,11 +437,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
     except BranchProtectionError as exc:
         print(f"error: {exc}", file=sys.stderr)
+        if snapshot is not None:
+            snapshot["error"] = str(exc)
+            snapshot["changes_required"] = True
+            _write_snapshot(args.snapshot, snapshot)
         return 1
 
     print("Update successful.")
     print(f"New contexts: {format_contexts(updated_state.contexts)}")
     print(f"'Require up to date' enabled: {updated_state.strict}")
+    if snapshot is not None:
+        snapshot["changes_required"] = changes_required
+        snapshot["changes_applied"] = bool(args.apply and changes_required)
+        snapshot["after"] = {
+            "strict": updated_state.strict,
+            "contexts": list(updated_state.contexts),
+        }
+        _write_snapshot(args.snapshot, snapshot)
     return 0
 
 


### PR DESCRIPTION
## Summary
- add a --snapshot option to the gate branch-protection helper so enforcement runs can write JSON evidence of the current, desired, and post-update states
- extend the CLI regression tests for the helper and document the snapshot workflow across the plan, runbook, and evidence archive

## Testing
- pytest tests/tools/test_enforce_gate_branch_protection.py

------
https://chatgpt.com/codex/tasks/task_e_68ec3704038883318dfd780601b1477f