### PR TITLE
Restrict self-test workflow to manual dispatch

### DIFF
--- a/.github/workflows/selftest-81-reusable-ci.yml
+++ b/.github/workflows/selftest-81-reusable-ci.yml
@@ -1,25 +1,12 @@
-name: Reusable 99 Selftest
+name: Selftest 81 Reusable CI
 
 on:
-  workflow_call:
-    inputs:
-      python-versions:
-        description: >-
-          JSON array of Python versions forwarded to `reusable-10-ci-python.yml`.
-          Leave empty to exercise the default 3.11 matrix used by Maint 90 Selftest.
-        required: false
-        type: string
-        default: '["3.11"]'
-  schedule:
-    - cron: '0 6 * * 1'
-      # Weekly low-traffic window (Mondays at 06:00 UTC) to detect reusable stack drift
-      # without consuming PR minutes or blocking contributor workflows.
   workflow_dispatch:
     inputs:
       python-versions:
         description: >-
           JSON array of Python versions forwarded to `reusable-10-ci-python.yml`.
-          Leave empty to exercise the default 3.11 matrix used by Maint 90 Selftest.
+          Leave empty to exercise the default 3.11 matrix used by Selftest 81 Reusable CI.
         required: false
         default: '["3.11"]'
 

--- a/WORKFLOW_AUDIT_TEMP.md
+++ b/WORKFLOW_AUDIT_TEMP.md
@@ -48,7 +48,11 @@ This list mirrors the canonical catalogue in `docs/ci/WORKFLOWS.md` after the Is
 | `reusable-10-ci-python.yml` | `workflow_call` | General-purpose Python CI composite consumed by Gate and downstream repositories. |
 | `reusable-12-ci-docker.yml` | `workflow_call` | Docker smoke reusable consumed by Gate and external callers. |
 | `reusable-92-autofix.yml` | `workflow_call` | Autofix composite shared by `autofix.yml` and `maint-30-post-ci.yml`. |
-| `reusable-99-selftest.yml` | `workflow_call` | Scenario matrix validating the reusable CI executor. |
+
+### Manual Self-Tests
+| Workflow | Triggers | Notes |
+|----------|----------|-------|
+| `selftest-81-reusable-ci.yml` | `workflow_dispatch` | Manual example that exercises the reusable CI matrix across feature toggles. |
 
 ## Removed in Issue #2466
 | Workflow | Status |

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -13,7 +13,7 @@ bootstrap runs.
 | `maint-` | Post-CI maintenance and self-tests | `maint-30-post-ci.yml`, `maint-33-check-failure-tracker.yml`, `maint-34-cosmetic-repair.yml`, `maint-90-selftest.yml` |
 | `health-` | Repository health & policy checks | `health-40-repo-selfcheck.yml`, `health-41-repo-health.yml`, `health-42-actionlint.yml`, `health-43-ci-signature-guard.yml`, `health-44-gate-branch-protection.yml` |
 | `agents-` | Agent orchestration entry points | `agents-70-orchestrator.yml` |
-| `reusable-` | Reusable composites invoked by other workflows | `reusable-10-ci-python.yml`, `reusable-12-ci-docker.yml`, `reusable-92-autofix.yml`, `reusable-70-agents.yml`, `reusable-99-selftest.yml` |
+| `reusable-` | Reusable composites invoked by other workflows | `reusable-10-ci-python.yml`, `reusable-12-ci-docker.yml`, `reusable-92-autofix.yml`, `reusable-70-agents.yml` |
 | `autofix-` assets | Shared configuration for autofix tooling | `autofix-versions.env` |
 
 **Naming checklist**
@@ -52,7 +52,7 @@ Tests under `tests/test_workflow_naming.py` enforce the naming policy and invent
 - **`reusable-12-ci-docker.yml`** — Docker smoke reusable invoked by Gate and external consumers.
 - **`reusable-92-autofix.yml`** — Autofix harness used by `maint-30-post-ci.yml` and `autofix.yml`.
 - **`reusable-70-agents.yml`** — Reusable agent automation stack.
-- **`reusable-99-selftest.yml`** — Matrix self-test covering reusable CI feature flags.
+- **`selftest-81-reusable-ci.yml`** — Manual self-test covering reusable CI feature flags; dispatch via `workflow_dispatch` when verification is needed.
 
 ## Trigger Wiring Tips
 1. When renaming a workflow, update any `workflow_run` consumers. In this roster that includes `maint-30-post-ci.yml`, `autofix.yml`, and `maint-33-check-failure-tracker.yml`.

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -36,7 +36,7 @@ Use the matrix below as the authoritative roster of active workflows. Each row c
 | **Reusable 92 Autofix** | `.github/workflows/reusable-92-autofix.yml` | `workflow_call` | `contents: write`, `pull-requests: write` | No | Autofix harness shared by `autofix.yml` and `maint-post-ci.yml`. |
 | **Reusable 70 Agents** | `.github/workflows/reusable-70-agents.yml` | `workflow_call` | `contents: write`, `pull-requests: write`, `issues: write`; optional `service_bot_pat` | No | Implements readiness, bootstrap, diagnostics, and keepalive jobs for orchestrator callers. |
 | **Reusable 71 Agents Dispatch** | `.github/workflows/reusable-71-agents-dispatch.yml` | `workflow_call` | `contents: write`, `pull-requests: write`, `issues: write`; optional `service_bot_pat` | No | Fan-out dispatcher that selects the appropriate toolkit run list for numbered orchestrators and manual consumers. |
-| **Reusable 99 Selftest** | `.github/workflows/reusable-99-selftest.yml` | `workflow_call` | `contents: read` | No | Scenario matrix validating the reusable CI executor. |
+| **Selftest 81 Reusable CI** | `.github/workflows/selftest-81-reusable-ci.yml` | `workflow_dispatch` | `contents: read`, `actions: read` | No | Manual self-test that exercises the reusable CI matrix and must be dispatched explicitly. |
 
 ## Naming Policy & Number Ranges
 
@@ -191,12 +191,19 @@ Manual-only status means maintainers should review the Actions list during that 
 | `reusable-71-agents-dispatch.yml` (`Reuse Agents`) | `agents-70-orchestrator.yml`, downstream repositories | Bridges dispatch inputs to the reusable toolkit while preserving defaults.
 | `reusable-70-agents.yml` (`Reusable 70 Agents`) | `agents-70-orchestrator.yml`, `reusable-71-agents-dispatch.yml` | Implements readiness, bootstrap, diagnostics, and watchdog jobs.
 | `reusable-92-autofix.yml` (`Reusable 92 Autofix`) | `maint-30-post-ci.yml`, `autofix.yml` | Autofix harness used both by the PR-time autofix workflow and the post-CI maintenance listener.
-| `reusable-99-selftest.yml` (`Reusable 99 Selftest`) | `maint-` self-test orchestration | Scenario matrix that validates the reusable CI executor and artifact inventory.
 | `reusable-10-ci-python.yml` (`Reusable CI`) | Gate, downstream repositories | Single source for Python lint/type/test coverage runs.
 | `reusable-12-ci-docker.yml` (`Reusable Docker Smoke`) | Gate, downstream repositories | Docker build + smoke reusable consumed by Gate and external callers.
 
 **Operational details**
 - **Reuse Agents** – Permissions: `contents: write`, `pull-requests: write`, `issues: write`. Secrets: optional `service_bot_pat` (forwarded to `reusable-70-agents`) plus `GITHUB_TOKEN`. Outputs: single `call` job exposes reusable outputs such as `triggered` keepalive lists and orchestrator diagnostics for upstream callers.
+
+### Manual self-test examples
+
+| Workflow | Notes |
+|----------|-------|
+| `selftest-81-reusable-ci.yml` (`Selftest 81 Reusable CI`) | Manual-only dispatch that runs the reusable CI matrix across the documented feature toggles and uploads verification summaries/artifacts for humans to inspect. |
+
+> Self-test workflows are intended as reference exercises for maintainers. They are quiet by default—run them via `workflow_dispatch` when you need a fresh artifact inventory check or to validate reusable CI changes, and expect no automated runs in Actions history.
 
 ### Archived self-test workflows
 

--- a/docs/ci_reuse.md
+++ b/docs/ci_reuse.md
@@ -1,7 +1,6 @@
 # Reusable CI & Automation Workflows
 
-Issues #2190 and #2466 leave five reusable GitHub Actions workflows in this repository. They provide CI, autofix, and agent
-automation building blocks that thin wrappers (or downstream repositories) can consume.
+Issues #2190 and #2466 leave four reusable GitHub Actions workflows in this repository plus a manual self-test example. They provide CI, autofix, and agent automation building blocks that thin wrappers (or downstream repositories) can consume.
 
 | Reusable Workflow | File | Purpose |
 | ------------------ | ---- | ------- |
@@ -10,7 +9,6 @@ automation building blocks that thin wrappers (or downstream repositories) can c
 | Legacy Python CI | `.github/workflows/reusable-94-legacy-ci-python.yml` | Compatibility contract for consumers still on the pre-WFv1 interface.
 | Autofix | `.github/workflows/reusable-92-autofix.yml` | Formatting / lint autofix harness used by `maint-30-post-ci.yml`.
 | Agents Toolkit | `.github/workflows/reusable-70-agents.yml` | Readiness, Codex bootstrap, verification, and watchdog routines.
-| Self-Test Matrix | `.github/workflows/reusable-99-selftest.yml` | Exercises the reusable CI executor across feature combinations.
 
 ## 1. Reusable CI (`reusable-10-ci-python.yml`)
 Consumer example (excerpt from `pr-00-gate.yml`):
@@ -73,11 +71,10 @@ To manually verify the orchestration chain after making changes, use **Actions â
 GitHub UI. This dispatches the orchestrator, which calls the reusable workflow and surfaces any YAML validation errors alongside
 the bounded job runs described above.
 
-## 5. Self-Test Matrix (`reusable-99-selftest.yml`)
-Exposes the matrix that validates the reusable CI executor across feature combinations (coverage delta, soft gate, metrics,
-history, classification). It declares manual (`workflow_dispatch`) and weekly schedule triggers so maintainers can run ad-hoc
-verification without PR noise. `maint-90-selftest.yml` remains the lightweight wrapper preserved in `Old/workflows/` for
-historical reference.
+## Manual Self-Test (`selftest-81-reusable-ci.yml`)
+Runs the matrix that validates the reusable CI executor across feature combinations (coverage delta, soft gate, metrics,
+history, classification). The workflow triggers only on `workflow_dispatch`, keeping Actions history quiet until a maintainer
+requests a run. `maint-90-selftest.yml` remains archived under `Old/workflows/` for historical reference.
 
 ## Adoption Notes
 1. Reference the files directly via `uses: stranske/Trend_Model_Project/.github/workflows/<file>@phase-2-dev` in external repos.

--- a/docs/ci_reuse_consolidation_plan.md
+++ b/docs/ci_reuse_consolidation_plan.md
@@ -6,8 +6,8 @@ Issue #2190 completed the consolidation roadmap that began in #1166/#1259. The r
 workflows required by the trimmed automation surface.
 
 ## Current State
-- Only five reusable workflows remain (`reusable-10-ci-python.yml`, `reusable-12-ci-docker.yml`, `reusable-92-autofix.yml`,
-  `reusable-70-agents.yml`, `reusable-99-selftest.yml`).
+- Four reusable workflows remain (`reusable-10-ci-python.yml`, `reusable-12-ci-docker.yml`, `reusable-92-autofix.yml`,
+  `reusable-70-agents.yml`). The self-test matrix now lives in the manual-only `selftest-81-reusable-ci.yml` workflow.
 - Visible workflows in the Actions tab were reduced to the final set documented in `WORKFLOW_AUDIT_TEMP.md` and `docs/ci/WORKFLOWS.md`.
 - All auxiliary wrappers (gate orchestrators, labelers, watchdog forwards, etc.) were deleted, with `agents-43-codex-issue-bridge.yml` later reinstated to restore label-driven Codex automation.
 
@@ -24,7 +24,8 @@ workflows required by the trimmed automation surface.
 - `docs/ci/WORKFLOWS.md` is the authoritative description of the remaining automation footprint.
 
 ## Future Considerations
-1. Keep `maint-90-selftest.yml` schedule under review—switch to manual-only if weekly coverage is unnecessary.
+1. The legacy `maint-90-selftest.yml` schedule is retired; dispatch `selftest-81-reusable-ci.yml` manually when reusable CI
+   verification is needed.
 2. Revisit CodeQL or dependency review if security tooling is reintroduced in a dedicated follow-up issue.
 3. Validate external consumers when adjusting inputs on `reusable-10-ci-python.yml` or `reusable-12-ci-docker.yml`.
 

--- a/docs/ops/maintenance-playbook.md
+++ b/docs/ops/maintenance-playbook.md
@@ -98,7 +98,7 @@ maintenance workflows that remain after Issue 2190. The roster now consists of
 ## maint-90-selftest.yml
 
 1. **Treat it as a smoke harness** — the workflow invokes
-   `reusable-99-selftest.yml` to exercise the reusable CI matrix.
+   `selftest-81-reusable-ci.yml` to exercise the reusable CI matrix.
 2. **Verify inputs** — ensure the forwarded `python-version` input matches the
    expected matrix before debugging downstream failures.
 3. **Secrets passthrough** — the workflow forwards secrets to the reusable call.

--- a/docs/selftest_81_reusable_ci_plan.md
+++ b/docs/selftest_81_reusable_ci_plan.md
@@ -1,7 +1,7 @@
-# reusable-99-selftest Workflow Rewrite Plan
+# Selftest 81 Reusable CI Workflow Plan
 
 ## Scope and Key Constraints
-- Replace step-level `uses` invocations in `.github/workflows/reusable-99-selftest.yml` with job-level `jobs.<id>.uses` calls targeting `.github/workflows/reusable-10-ci-python.yml`.
+- Replace step-level `uses` invocations in `.github/workflows/selftest-81-reusable-ci.yml` with job-level `jobs.<id>.uses` calls targeting `.github/workflows/reusable-10-ci-python.yml`.
 - Preserve the workflow's opt-in nature (manual `workflow_dispatch` and/or label trigger) while keeping existing inputs or labels functional.
 - Model the scenario execution as a matrix-driven reusable workflow job (`jobs.scenario`) that forwards scenario-specific inputs via `strategy.matrix.include` entries.
 - Maintain or improve aggregation logic that collates scenario results, handles required artifacts, and exposes outputs to downstream jobs without breaking current consumers.
@@ -9,7 +9,7 @@
 - Keep naming conventions, permissions, and environment protections aligned with repository workflow standards (see `docs/ci_reuse.md`).
 
 ## Acceptance Criteria / Definition of Done
-1. `.github/workflows/reusable-99-selftest.yml` dispatches reusable scenarios through a `jobs.scenario.uses` job referencing `reusable-10-ci-python.yml` with a clearly defined matrix of at least two scenarios.
+1. `.github/workflows/selftest-81-reusable-ci.yml` dispatches reusable scenarios through a `jobs.scenario.uses` job referencing `reusable-10-ci-python.yml` with a clearly defined matrix of at least two scenarios.
 2. Each matrix entry maps required inputs/needs (e.g., scenario identifier, environment, feature toggles) so the reusable workflow executes successfully for every scenario.
 3. Aggregator job (`jobs.aggregate`) consumes the matrix job outputs via `needs`, produces a concise summary (artifacts/log output), and validates the presence of expected artifacts from each scenario run.
 4. Workflow remains manually triggerable (e.g., `workflow_dispatch` or label-based trigger), and default branch protections are unchanged.
@@ -17,7 +17,7 @@
 6. CI dry-run or linting (if available) confirms the workflow syntax is valid (e.g., `act` or `workflow-lint` if part of repo tooling).
 
 ## Initial Task Checklist
-- [x] Inspect current `.github/workflows/reusable-99-selftest.yml` to capture existing triggers, inputs, scenario definitions, and artifact handling.
+- [x] Inspect current `.github/workflows/selftest-81-reusable-ci.yml` to capture existing triggers, inputs, scenario definitions, and artifact handling.
 - [x] Review `.github/workflows/reusable-10-ci-python.yml` to enumerate required inputs, outputs, and permissions for job-level reuse.
 - [x] Draft the new `jobs.scenario` matrix structure, mapping per-scenario inputs to the reusable workflow.
 - [x] Update the workflow file to replace step-level `uses` calls with `jobs.scenario.uses`, wiring matrix-provided values into the reusable workflow inputs.

--- a/tests/test_workflow_naming.py
+++ b/tests/test_workflow_naming.py
@@ -9,6 +9,7 @@ ALLOWED_PREFIXES = (
     "autofix",
     "enforce-",
     "health-",
+    "selftest-",
 )
 WORKFLOW_DIR = pathlib.Path(".github/workflows")
 
@@ -119,6 +120,6 @@ EXPECTED_NAMES = {
     "reusable-70-agents.yml": "Reusable 70 Agents",
     "reusable-71-agents-dispatch.yml": "Reuse Agents",
     "reusable-92-autofix.yml": "Reusable 92 Autofix",
-    "reusable-99-selftest.yml": "Reusable 99 Selftest",
+    "selftest-81-reusable-ci.yml": "Selftest 81 Reusable CI",
     "reuse-agents.yml": "Reuse Agents",
 }

--- a/tests/test_workflow_selftest_consolidation.py
+++ b/tests/test_workflow_selftest_consolidation.py
@@ -6,7 +6,7 @@ import yaml
 
 WORKFLOW_DIR = Path(".github/workflows")
 ARCHIVE_DIR = Path("Old/workflows")
-SELFTEST_PATH = WORKFLOW_DIR / "reusable-99-selftest.yml"
+SELFTEST_PATH = WORKFLOW_DIR / "selftest-81-reusable-ci.yml"
 
 
 def test_selftest_workflow_inventory() -> None:
@@ -16,8 +16,8 @@ def test_selftest_workflow_inventory() -> None:
         path.name for path in WORKFLOW_DIR.glob("*selftest*.yml")
     )
     assert selftest_workflows == [
-        "reusable-99-selftest.yml"
-    ], "Active self-test inventory drifted; expected only reusable-99-selftest.yml."
+        "selftest-81-reusable-ci.yml"
+    ], "Active self-test inventory drifted; expected only selftest-81-reusable-ci.yml."
 
 
 def test_selftest_triggers_are_manual_only() -> None:
@@ -28,8 +28,7 @@ def test_selftest_triggers_are_manual_only() -> None:
 
     disallowed_triggers = {"pull_request", "pull_request_target", "push"}
     required_manual_trigger = "workflow_dispatch"
-    optional_triggers = {"schedule", "workflow_call"}
-    allowed_triggers = {required_manual_trigger} | optional_triggers
+    allowed_triggers = {required_manual_trigger}
 
     for workflow_file in selftest_files:
         data = yaml.safe_load(workflow_file.read_text()) or {}
@@ -66,9 +65,9 @@ def test_selftest_triggers_are_manual_only() -> None:
             "Only workflow_dispatch, schedule, or workflow_call are permitted."
         )
 
-        assert required_manual_trigger in trigger_keys, (
-            f"{workflow_file.name} must provide a {required_manual_trigger} entry "
-            "so self-tests remain manually invokable."
+        assert trigger_keys == allowed_triggers and required_manual_trigger in trigger_keys, (
+            f"{workflow_file.name} must provide only a {required_manual_trigger} "
+            "trigger so self-tests remain strictly manual."
         )
 
 
@@ -144,7 +143,7 @@ def test_archived_selftests_retain_manual_triggers() -> None:
 def test_selftest_matrix_and_aggregate_contract() -> None:
     assert (
         SELFTEST_PATH.exists()
-    ), "reusable-99-selftest.yml is missing from .github/workflows/"
+    ), "selftest-81-reusable-ci.yml is missing from .github/workflows/"
 
     data = yaml.safe_load(SELFTEST_PATH.read_text())
     jobs = data.get("jobs", {})
@@ -152,7 +151,7 @@ def test_selftest_matrix_and_aggregate_contract() -> None:
     scenario_job = jobs.get("scenario")
     assert (
         scenario_job is not None
-    ), "Scenario job missing from reusable-99-selftest.yml"
+    ), "Scenario job missing from selftest-81-reusable-ci.yml"
     assert (
         scenario_job.get("uses") == "./.github/workflows/reusable-10-ci-python.yml"
     ), "Scenario job must invoke reusable-10-ci-python.yml via jobs.<id>.uses"


### PR DESCRIPTION
## Summary
- rename the self-test workflow to `selftest-81-reusable-ci.yml` and remove automated triggers so it only runs on manual dispatch
- update workflow guardrails to expect the new self-test filename and enforce manual-only triggers
- refresh workflow documentation to describe the self-test catalog as manual examples

## Testing
- pytest tests/test_workflow_selftest_consolidation.py tests/test_workflow_naming.py

------
https://chatgpt.com/codex/tasks/task_e_68ec37e52f508331b7a5f522d32c6db2