### PR TITLE
docs: refresh CI catalog and orchestrator params guidance

### DIFF
--- a/.github/workflows/agents-70-orchestrator.yml
+++ b/.github/workflows/agents-70-orchestrator.yml
@@ -41,8 +41,8 @@ on:
         description: 'Open bootstrap PRs as draft (true/false)'
         required: false
         default: 'false'
-      options_json:
-        description: 'Additional toggles as JSON (diagnostic_mode, readiness_custom_logins, codex_command_phrase, ... )'
+      params_json:
+        description: 'JSON payload for advanced toggles (diagnostic_mode, readiness_custom_logins, bootstrap overrides, keepalive)'
         required: false
         default: '{}'
 
@@ -56,34 +56,184 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  resolve-params:
+    name: Resolve Parameters
+    runs-on: ubuntu-latest
+    outputs:
+      enable_readiness: ${{ steps.merge.outputs.enable_readiness }}
+      readiness_agents: ${{ steps.merge.outputs.readiness_agents }}
+      readiness_custom_logins: ${{ steps.merge.outputs.readiness_custom_logins }}
+      require_all: ${{ steps.merge.outputs.require_all }}
+      enable_preflight: ${{ steps.merge.outputs.enable_preflight }}
+      codex_user: ${{ steps.merge.outputs.codex_user }}
+      codex_command_phrase: ${{ steps.merge.outputs.codex_command_phrase }}
+      enable_diagnostic: ${{ steps.merge.outputs.enable_diagnostic }}
+      diagnostic_attempt_branch: ${{ steps.merge.outputs.diagnostic_attempt_branch }}
+      diagnostic_dry_run: ${{ steps.merge.outputs.diagnostic_dry_run }}
+      enable_verify_issue: ${{ steps.merge.outputs.enable_verify_issue }}
+      verify_issue_number: ${{ steps.merge.outputs.verify_issue_number }}
+      enable_watchdog: ${{ steps.merge.outputs.enable_watchdog }}
+      enable_keepalive: ${{ steps.merge.outputs.enable_keepalive }}
+      enable_bootstrap: ${{ steps.merge.outputs.enable_bootstrap }}
+      bootstrap_issues_label: ${{ steps.merge.outputs.bootstrap_issues_label }}
+      draft_pr: ${{ steps.merge.outputs.draft_pr }}
+      options_json: ${{ steps.merge.outputs.options_json }}
+    steps:
+      - name: Merge dispatch inputs
+        id: merge
+        uses: actions/github-script@v7
+        env:
+          PARAMS_JSON: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.params_json || inputs.params_json || '{}' }}
+          BASE_ENABLE_READINESS: ${{ inputs.enable_readiness || 'false' }}
+          BASE_READINESS_AGENTS: ${{ inputs.readiness_agents || 'copilot,codex' }}
+          BASE_REQUIRE_ALL: ${{ inputs.require_all || 'false' }}
+          BASE_ENABLE_PREFLIGHT: ${{ inputs.enable_preflight || 'false' }}
+          BASE_CODEX_USER: ${{ inputs.codex_user || '' }}
+          BASE_ENABLE_VERIFY_ISSUE: ${{ inputs.enable_verify_issue || 'false' }}
+          BASE_VERIFY_ISSUE_NUMBER: ${{ inputs.verify_issue_number || '' }}
+          BASE_ENABLE_WATCHDOG: ${{ inputs.enable_watchdog || 'true' }}
+          BASE_DRAFT_PR: ${{ inputs.draft_pr || 'false' }}
+        with:
+          script: |
+            const core = require('@actions/core');
+
+            const defaults = {
+              enable_readiness: process.env.BASE_ENABLE_READINESS || 'false',
+              readiness_agents: process.env.BASE_READINESS_AGENTS || 'copilot,codex',
+              readiness_custom_logins: '',
+              require_all: process.env.BASE_REQUIRE_ALL || 'false',
+              enable_preflight: process.env.BASE_ENABLE_PREFLIGHT || 'false',
+              codex_user: process.env.BASE_CODEX_USER || '',
+              codex_command_phrase: '',
+              enable_verify_issue: process.env.BASE_ENABLE_VERIFY_ISSUE || 'false',
+              verify_issue_number: process.env.BASE_VERIFY_ISSUE_NUMBER || '',
+              enable_watchdog: process.env.BASE_ENABLE_WATCHDOG || 'true',
+              enable_keepalive: 'true',
+              enable_bootstrap: 'false',
+              bootstrap_issues_label: 'agent:codex',
+              draft_pr: process.env.BASE_DRAFT_PR || 'false',
+              options_json: '{}',
+              diagnostic_mode: 'off',
+            };
+
+            const asString = (value, fallback = '') => {
+              if (value === undefined || value === null) {
+                return fallback;
+              }
+              if (Array.isArray(value)) {
+                return value.map((item) => String(item).trim()).filter(Boolean).join(',');
+              }
+              return String(value);
+            };
+
+            const asBoolString = (value, fallback) => {
+              const candidate = value === undefined ? fallback : value;
+              if (typeof candidate === 'boolean') {
+                return candidate ? 'true' : 'false';
+              }
+              if (typeof candidate === 'number') {
+                return candidate !== 0 ? 'true' : 'false';
+              }
+              if (typeof candidate === 'string') {
+                const norm = candidate.trim().toLowerCase();
+                if (['true', '1', 'yes', 'y', 'on'].includes(norm)) {
+                  return 'true';
+                }
+                if (['false', '0', 'no', 'n', 'off', ''].includes(norm)) {
+                  return 'false';
+                }
+              }
+              return fallback === 'true' || fallback === true ? 'true' : 'false';
+            };
+
+            const raw = process.env.PARAMS_JSON || '';
+            let parsed = {};
+            if (raw.trim()) {
+              try {
+                parsed = JSON.parse(raw);
+              } catch (error) {
+                core.warning(`Invalid params_json payload (${error.message}). Falling back to defaults.`);
+              }
+            }
+
+            const nested = (value) => (value && typeof value === 'object' ? value : {});
+
+            const bootstrap = nested(parsed.bootstrap);
+            const keepalive = nested(parsed.keepalive);
+
+            const readinessAgents = asString(parsed.readiness_agents, defaults.readiness_agents);
+            const readinessCustom = asString(parsed.readiness_custom_logins ?? parsed.custom_logins, defaults.readiness_custom_logins);
+            const codexUser = asString(parsed.codex_user, defaults.codex_user);
+            const codexCommand = asString(parsed.codex_command_phrase, defaults.codex_command_phrase);
+            const verifyIssueNumber = asString(parsed.verify_issue_number, defaults.verify_issue_number).trim();
+            const optionsJson = asString(parsed.options_json, defaults.options_json) || '{}';
+
+            const diagnosticModeRaw = asString(parsed.diagnostic_mode, defaults.diagnostic_mode).trim().toLowerCase();
+            const diagnosticMode = ['full', 'dry-run'].includes(diagnosticModeRaw) ? diagnosticModeRaw : 'off';
+
+            const enableBootstrap = asBoolString(parsed.enable_bootstrap ?? bootstrap.enable, defaults.enable_bootstrap);
+            const bootstrapLabel = asString(parsed.bootstrap_issues_label ?? bootstrap.label, defaults.bootstrap_issues_label);
+
+            const enableKeepalive = asBoolString(parsed.enable_keepalive ?? keepalive.enabled, defaults.enable_keepalive);
+
+            const enableVerifyIssue = asBoolString(
+              parsed.enable_verify_issue,
+              defaults.enable_verify_issue === 'true' || verifyIssueNumber !== '' ? 'true' : 'false'
+            );
+
+            const outputs = {
+              enable_readiness: asBoolString(parsed.enable_readiness, defaults.enable_readiness),
+              readiness_agents: readinessAgents || defaults.readiness_agents,
+              readiness_custom_logins: readinessCustom,
+              require_all: asBoolString(parsed.require_all, defaults.require_all),
+              enable_preflight: asBoolString(parsed.enable_preflight, defaults.enable_preflight),
+              codex_user: codexUser,
+              codex_command_phrase: codexCommand,
+              enable_diagnostic: diagnosticMode === 'off' ? 'false' : 'true',
+              diagnostic_attempt_branch: diagnosticMode === 'full' ? 'true' : 'false',
+              diagnostic_dry_run: diagnosticMode === 'full' ? 'false' : 'true',
+              enable_verify_issue,
+              verify_issue_number: verifyIssueNumber,
+              enable_watchdog: asBoolString(parsed.enable_watchdog, defaults.enable_watchdog),
+              enable_keepalive: enableKeepalive,
+              enable_bootstrap: enableBootstrap,
+              bootstrap_issues_label: bootstrapLabel,
+              draft_pr: asBoolString(parsed.draft_pr, defaults.draft_pr),
+              options_json: optionsJson,
+            };
+
+            for (const [key, value] of Object.entries(outputs)) {
+              core.setOutput(key, value);
+            }
+
+            const summary = core.summary;
+            summary.addHeading('Agents orchestrator parameters');
+            summary.addTable([
+              [{ data: 'Key', header: true }, { data: 'Value', header: true }],
+              ...Object.entries(outputs).map(([key, value]) => [key, String(value ?? '')])
+            ]);
+            await summary.write();
+
   orchestrate:
     name: Dispatch Agents Toolkit
+    needs: resolve-params
     uses: ./.github/workflows/reusable-70-agents.yml
-    # Job timeouts live inside reusable-70-agents.yml because workflow-call
-    # dispatchers cannot set timeout-minutes directly. See reusable workflow for
-    # the 30 minute ceiling that guards the downstream fan-out.
-    # options_json schema (strings, defaults shown):
-    # {
-    #   "diagnostic_mode": "off" | "dry-run" | "full",
-    #   "readiness_custom_logins": "login-a,login-b",
-    #   "codex_command_phrase": "@codex start"
-    # }
     with:
-      enable_readiness: ${{ inputs.enable_readiness || 'false' }}
-      readiness_agents: ${{ inputs.readiness_agents || 'copilot,codex' }}
-      readiness_custom_logins: ${{ fromJson(inputs.options_json || '{}').readiness_custom_logins || '' }}
-      require_all: ${{ inputs.require_all || 'false' }}
-      enable_preflight: ${{ inputs.enable_preflight || 'false' }}
-      codex_user: ${{ inputs.codex_user || '' }}
-      codex_command_phrase: ${{ fromJson(inputs.options_json || '{}').codex_command_phrase || '' }}
-      enable_diagnostic: ${{ (fromJson(inputs.options_json || '{}').diagnostic_mode || 'off') != 'off' && 'true' || 'false' }}
-      diagnostic_attempt_branch: ${{ (fromJson(inputs.options_json || '{}').diagnostic_mode || 'off') == 'full' && 'true' || 'false' }}
-      diagnostic_dry_run: ${{ (fromJson(inputs.options_json || '{}').diagnostic_mode || 'off') == 'full' && 'false' || 'true' }}
-      enable_verify_issue: ${{ inputs.enable_verify_issue || ((inputs.verify_issue_number || '') != '' && 'true' || 'false') }}
-      verify_issue_number: ${{ inputs.verify_issue_number || '' }}
-      enable_watchdog: ${{ inputs.enable_watchdog || 'true' }}
-      enable_keepalive: ${{ (fromJson(inputs.options_json || '{}').enable_keepalive == false || fromJson(inputs.options_json || '{}').enable_keepalive == 'false' || (fromJson(inputs.options_json || '{}').keepalive && (fromJson(inputs.options_json || '{}').keepalive.enabled == false || fromJson(inputs.options_json || '{}').keepalive.enabled == 'false'))) && 'false' || 'true' }}
-      enable_bootstrap: ${{ (fromJson(inputs.options_json || '{}').enable_bootstrap == true || fromJson(inputs.options_json || '{}').enable_bootstrap == 'true' || (fromJson(inputs.options_json || '{}').bootstrap && (fromJson(inputs.options_json || '{}').bootstrap.enable == true || fromJson(inputs.options_json || '{}').bootstrap.enable == 'true'))) && 'true' || 'false' }}
-      bootstrap_issues_label: ${{ fromJson(inputs.options_json || '{}').bootstrap_issues_label || (fromJson(inputs.options_json || '{}').bootstrap && fromJson(inputs.options_json || '{}').bootstrap.label) || 'agent:codex' }}
-      draft_pr: ${{ inputs.draft_pr || 'false' }}
-      options_json: ${{ inputs.options_json || '{}' }}
+      enable_readiness: ${{ needs.resolve-params.outputs.enable_readiness }}
+      readiness_agents: ${{ needs.resolve-params.outputs.readiness_agents }}
+      readiness_custom_logins: ${{ needs.resolve-params.outputs.readiness_custom_logins }}
+      require_all: ${{ needs.resolve-params.outputs.require_all }}
+      enable_preflight: ${{ needs.resolve-params.outputs.enable_preflight }}
+      codex_user: ${{ needs.resolve-params.outputs.codex_user }}
+      codex_command_phrase: ${{ needs.resolve-params.outputs.codex_command_phrase }}
+      enable_diagnostic: ${{ needs.resolve-params.outputs.enable_diagnostic }}
+      diagnostic_attempt_branch: ${{ needs.resolve-params.outputs.diagnostic_attempt_branch }}
+      diagnostic_dry_run: ${{ needs.resolve-params.outputs.diagnostic_dry_run }}
+      enable_verify_issue: ${{ needs.resolve-params.outputs.enable_verify_issue }}
+      verify_issue_number: ${{ needs.resolve-params.outputs.verify_issue_number }}
+      enable_watchdog: ${{ needs.resolve-params.outputs.enable_watchdog }}
+      enable_keepalive: ${{ needs.resolve-params.outputs.enable_keepalive }}
+      enable_bootstrap: ${{ needs.resolve-params.outputs.enable_bootstrap }}
+      bootstrap_issues_label: ${{ needs.resolve-params.outputs.bootstrap_issues_label }}
+      draft_pr: ${{ needs.resolve-params.outputs.draft_pr }}
+      options_json: ${{ needs.resolve-params.outputs.options_json }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ strategy behaves similarly across regimes). Tweak lookback, smoothing,
 thresholds, and the annualisation flag under the new `regime` section in
 `config/defaults.yml` to align the analysis with your preferred market proxy.
 
-📦 **Reusable CI & Automation**: Standardise tests, autofix, and agent automation across repositories using the new reusable workflows documented in [docs/ci_reuse.md](docs/ci_reuse.md). Consumers call `reusable-10-ci-python.yml`, `reusable-autofix.yml`, and the consolidated `agents-70-orchestrator.yml` entry point (which delegates to `reusable-70-agents.yml`).
+📦 **Reusable CI & Automation**: Standardise tests, autofix, and agent automation across repositories using the new reusable workflows documented in [docs/ci_reuse.md](docs/ci_reuse.md). Consumers rely on `pr-00-gate.yml` for pull-request orchestration and call `reusable-10-ci-python.yml`, `reusable-12-ci-docker.yml`, `reusable-92-autofix.yml`, and the consolidated `agents-70-orchestrator.yml` entry point (which delegates to `reusable-70-agents.yml`).
 
 🧭 **Workflow topology & agent routing**: Learn how workflow buckets, naming, post-CI summaries, and agent labels fit together in [docs/WORKFLOW_GUIDE.md](docs/WORKFLOW_GUIDE.md).
 🛠️ **Workflow catalog, automation inventory, contributor quick-start & naming policy**: See [docs/ci/WORKFLOWS.md](docs/ci/WORKFLOWS.md) for the canonical workflow list, quick status/permission catalog (purpose, triggers, secrets, and labels), naming ranges, required vs optional gates, local style-gate instructions, naming conventions, contributor quick start, and agents JSON schema.

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -42,8 +42,7 @@ Tests under `tests/test_workflow_naming.py` enforce the naming policy and invent
 - **`maint-34-cosmetic-repair.yml`** — Manual dispatch utility that runs `pytest -q`, applies guard-gated cosmetic fixes via `scripts/ci_cosmetic_repair.py`, and opens a labelled PR when changes exist.
 
 ### Agents
-- **`agents-70-orchestrator.yml`** — Hourly + manual dispatch entry point for readiness, Codex bootstrap, diagnostics, and keepalive sweeps. Delegates to `reusable-70-agents.yml` and accepts extended options via `options_json`. All prior consumer-style wrappers have been retired.
-- **`agents-62-consumer.yml`** — Manual-only JSON bridge that normalises inputs before calling `reusable-70-agents.yml`.
+- **`agents-70-orchestrator.yml`** — Hourly + manual dispatch entry point for readiness, Codex bootstrap, diagnostics, and keepalive sweeps. Delegates to `reusable-70-agents.yml` and accepts extended options via the `params_json` payload. All prior consumer-style wrappers have been retired.
 - **`agents-63-chatgpt-issue-sync.yml`** — Manual issue fan-out that mirrors curated topic lists into GitHub issues.
 - **`agents-64-verify-agent-assignment.yml`** — Workflow-call validator ensuring `agent:codex` issues remain assigned to approved automation accounts.
 
@@ -65,13 +64,15 @@ Tests under `tests/test_workflow_naming.py` enforce the naming policy and invent
 - Escalations apply the `priority: high` label once the same signature fires three times.
 
 ## Agent Operations
-- Use **Agents 70 Orchestrator** for every automation task (readiness checks, Codex bootstrap, diagnostics, keepalive). No other entry points remain.
-- Optional flags beyond the standard inputs belong in the `options_json` payload; the orchestrator parses it with `fromJson()` and forwards toggles to `reusable-70-agents.yml`.
+- Use **Agents 70 Orchestrator** for every automation task (readiness checks, Codex bootstrap, diagnostics, keepalive). No other entry points remain beyond deprecated compatibility shims.
+- Optional flags beyond the standard inputs belong in the `params_json` payload; the orchestrator parses it with `fromJson()` and forwards toggles to `reusable-70-agents.yml`. Include an `options_json` string inside the payload for nested keepalive or cleanup settings when required.
 - Provide a PAT when bootstrap needs to push branches. The orchestrator honours PAT priority (`OWNER_PR_PAT` → `SERVICE_BOT_PAT` → `GITHUB_TOKEN`) via the reusable composite.
+
+> **Deprecated compatibility wrappers:** `agents-62-consumer.yml` and `agents-consumer.yml` persist only for callers migrating from the historical JSON schema. They remain manual-only and should be phased out in favour of the orchestrator.
 
 ### Manual dispatch quick steps
 1. Open **Actions → Agents 70 Orchestrator → Run workflow**.
-2. Supply inputs such as `enable_bootstrap: true` and `bootstrap_issues_label: agent:codex` either via dedicated fields or inside `options_json`.
+2. Supply inputs such as `enable_bootstrap: true` and `bootstrap_issues_label: agent:codex` either via dedicated fields or inside `params_json`.
 3. Review the `orchestrate` job summary for readiness tables, bootstrap planner output, and links to spawned PRs. Failures provide direct links for triage.
 
 ### Troubleshooting signals

--- a/docs/agent-automation.md
+++ b/docs/agent-automation.md
@@ -21,7 +21,7 @@ Manual dispatch / 20-minute schedule ──▶ agents-70-orchestrator.yml
 - No automatic label forwarding remains. Maintainers trigger the orchestrator directly from the Actions tab (manual
   `workflow_dispatch`) or allow the hourly schedule to run readiness + watchdog checks.
 - Codex keepalive now runs as part of the orchestrator invocation. Configure thresholds or disable it entirely via the
-  `options_json` payload (e.g. `{ "enable_keepalive": false }`).
+  `params_json` payload (e.g. `{ "enable_keepalive": false }`).
 - Bootstrap PR creation, diagnostics, and stale issue escalation now live entirely inside `agents-70-orchestrator.yml` and the
   `reusable-70-agents.yml` composite it calls. Historical wrappers (`agents-41-assign*.yml`, `agents-42-watchdog.yml`, etc.) were
   deleted.
@@ -32,7 +32,7 @@ Manual dispatch / 20-minute schedule ──▶ agents-70-orchestrator.yml
 
 - **Triggers:** `schedule` (every 20 minutes) and manual `workflow_dispatch` with curated inputs.
 - **Inputs:** `enable_readiness`, `readiness_agents`, `require_all`, `enable_preflight`, `codex_user`,
-  `enable_verify_issue`, `verify_issue_number`, `enable_watchdog`, `draft_pr`, plus an extensible `options_json` string for long
+  `enable_verify_issue`, `verify_issue_number`, `enable_watchdog`, `draft_pr`, plus an extensible `params_json` string for long
   tail toggles (currently `diagnostic_mode`, `readiness_custom_logins`, `codex_command_phrase`, `enable_keepalive`,
   `keepalive_idle_minutes`, `keepalive_repeat_minutes`, `keepalive_labels`, `keepalive_command`).
 - **Behaviour:** delegates directly to `reusable-70-agents.yml`, which orchestrates readiness probes, Codex bootstrap, issue
@@ -48,7 +48,7 @@ Manual dispatch / 20-minute schedule ──▶ agents-70-orchestrator.yml
 
 - exposes a `workflow_call` interface so the orchestrator can exercise readiness, preflight, verification, and watchdog routines.
 - keeps compatibility inputs such as `readiness_custom_logins`, `require_all`, `enable_preflight`, `enable_verify_issue`,
-  `enable_watchdog`, `draft_pr`, and the pass-through `options_json` for additional toggles.
+  `enable_watchdog`, `draft_pr`, and the pass-through `options_json` (embedded via `params_json`) for additional toggles.
 - emits a Codex keepalive sweep that looks for stalled checklists on `agent:codex` PRs and republishes the
   `@codex plan-and-execute` command when the agent has been idle longer than the configured threshold (defaults: 10 minute
   idle threshold, 30 minute cooldown between nudges).
@@ -71,7 +71,7 @@ While the agent wrappers were removed, maintenance automation still supports the
 
 1. Use the **Agents 70 Orchestrator** workflow to run readiness checks, Codex bootstrap diagnostics, keepalive sweeps, or
   watchdog checks on demand.
-2. Supply additional toggles via `options_json`, for example:
+2. Supply additional toggles via `params_json`, for example:
    ```json
    {
      "readiness_custom_logins": "my-bot,backup-bot",
@@ -95,8 +95,8 @@ While the agent wrappers were removed, maintenance automation still supports the
 
 ## Future Enhancements
 
-- Extend `options_json` to cover any additional toggles without growing the dispatch form.
-- Consider adding a lightweight CLI wrapper that posts curated `options_json` payloads for common scenarios.
+- Extend `params_json` to cover any additional toggles without growing the dispatch form (embed an `options_json` string when nested structures are required).
+- Consider adding a lightweight CLI wrapper that posts curated `params_json` payloads for common scenarios.
 - Monitor usage; if the hourly schedule proves redundant, convert it to manual-only to further reduce background noise.
 
 For questions or updates, open an issue labeled `agent:codex` describing the desired change.

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -3,9 +3,9 @@
 Use this page as the canonical reference for CI workflow naming, inventory, and
 local guardrails. It consolidates the requirements from Issues #2190, #2202, and
 #2466. The Gate workflow remains the required merge check for every pull
-request. Agents automation now exposes two entry points: the scheduled
-**Agents 70 Orchestrator** and the manual-only **Agents Consumer** wrapper that
-directly dispatches the reusable toolkit.
+request. Agents automation now exposes a single entry point: the scheduled and
+manually dispatchable **Agents 70 Orchestrator**. Deprecated compatibility
+wrappers are listed later in this guide for historical context only.
 
 ## CI & agents quick catalog
 
@@ -27,8 +27,6 @@ Use the matrix below as the authoritative roster of active workflows. Each row c
 | **Enforce Gate Branch Protection** | `.github/workflows/health-44-gate-branch-protection.yml` | Cron (`0 6 * * *`), `workflow_dispatch` | `contents: read`, `pull-requests: read`; optional `BRANCH_PROTECTION_TOKEN` | No | Validates branch protection settings via helper script; no-ops if PAT absent. |
 | **Agents 43 Codex Issue Bridge** | `.github/workflows/agents-43-codex-issue-bridge.yml` | `issues`, `workflow_dispatch` | `contents: write`, `pull-requests: write`, `issues: write`; optional `service_bot_pat` | No | Label-driven helper that prepares Codex bootstrap issues/PRs and optionally comments `@codex start`. |
 | **Agents 70 Orchestrator** | `.github/workflows/agents-70-orchestrator.yml` | Cron (`*/20 * * * *`), `workflow_dispatch` | `contents: write`, `pull-requests: write`, `issues: write`; optional `service_bot_pat` | No | Primary automation entry point dispatching readiness, bootstrap, diagnostics, and keepalive routines. |
-| **Agents 62 Consumer** | `.github/workflows/agents-62-consumer.yml` | `workflow_dispatch` | `contents: write`, `pull-requests: write`, `issues: write`; optional `service_bot_pat` | No | Manual dispatcher that proxies inputs directly to `reusable-70-agents.yml`, supports advanced overrides via `options_json`, and enforces concurrency guard (`agents-62-consumer-${ref_name}`). |
-| **Agents Consumer (compat)** | `.github/workflows/agents-consumer.yml` | `workflow_dispatch` | `contents: write`, `pull-requests: write`, `issues: write`; optional `service_bot_pat` | No | Legacy shim retained for downstream callers; forwards string inputs directly to `reusable-70-agents.yml`, supports advanced overrides via `options_json`, and enforces concurrency guard (`agents-consumer-${ref_name}`). |
 | **Agents 44 Verify Agent Assignment** | `.github/workflows/agents-64-verify-agent-assignment.yml` | `workflow_call`, `workflow_dispatch` | `issues: read` | No | Reusable issue-verification helper used by the orchestrator and available for ad-hoc checks. |
 | **Reusable CI** | `.github/workflows/reusable-10-ci-python.yml` | `workflow_call` | Inherits caller permissions | No | Python lint/type/test reusable consumed by Gate and downstream repositories. |
 | **Reusable Docker Smoke** | `.github/workflows/reusable-12-ci-docker.yml` | `workflow_call` | Inherits caller permissions | No | Docker build + smoke reusable consumed by Gate and external callers. |
@@ -46,7 +44,7 @@ Use the matrix below as the authoritative roster of active workflows. Each row c
   |--------|--------------|-------|-------|
   | `pr-` | `10–19` | Pull-request gates | `pr-00-gate.yml` is the primary orchestrator; keep space for specialized PR jobs (docs, optional helpers).
   | `maint-` | `00–49` and `90s` | Scheduled/background maintenance | Low numbers for repo hygiene, 30s/40s for post-CI and guards, 90 for self-tests calling reusable matrices.
-  | `agents-` | `70s` | Agent bootstrap/orchestration | `agents-70-orchestrator.yml` handles automation cadences; `agents-consumer.yml` is manual-only dispatch.
+  | `agents-` | `70s` | Agent bootstrap/orchestration | `agents-70-orchestrator.yml` handles automation cadences; legacy consumers remain manual-only for compatibility.
   | `reusable-` | `70s` & `90s` | Composite workflows invoked by others | Keep 90s for CI executors, 70s for agent composites.
 
 - Match the `name:` field to the filename rendered in Title Case
@@ -71,6 +69,15 @@ Use the matrix below as the authoritative roster of active workflows. Each row c
 - **Gate** – Permissions: defaults (read scope). Secrets: relies on `GITHUB_TOKEN` only. Status outputs: `core tests (3.11)`, `core tests (3.12)`, `docker smoke`, and the aggregator job `gate`, which fails if any dependency fails.
 - **Autofix** – Permissions: `contents: write`, `pull-requests: write`. Secrets: inherits `GITHUB_TOKEN` (sufficient for label + comment updates). Status outputs: `apply` job; labels applied include `autofix`, `autofix:applied`/`autofix:patch`, and cleanliness toggles (`autofix:clean`/`autofix:debt`).
 
+**Gate job map**
+
+| Job | Role | Artifacts / Outputs |
+| --- | ---- | ------------------- |
+| `core-tests-311` | Python 3.11 lint/type/test run via `reusable-10-ci-python.yml`. | Uploads `coverage-3.11` artifact (coverage XML + HTML summary). |
+| `core-tests-312` | Python 3.12 lint/type/test run via `reusable-10-ci-python.yml`. | Uploads `coverage-3.12` artifact mirroring 3.11 contents. |
+| `docker-smoke` | Container build + smoke test via `reusable-12-ci-docker.yml`. | No artifacts; emits build + smoke logs in job summary. |
+| `gate` | Final enforcement job that downloads coverage artifacts, posts the summary table, and fails if any upstream job failed. | Adds `Gate status` table to the workflow summary and surfaces missing artifacts in the log. |
+
 These jobs must stay green for PRs to merge. The post-CI maintenance jobs below listen to their `workflow_run` events and post summaries whenever the Gate aggregator fails.
 
 ### Maintenance & observability (scheduled/optional reruns)
@@ -87,6 +94,10 @@ These jobs must stay green for PRs to merge. The post-CI maintenance jobs below 
 | `agents-63-chatgpt-issue-sync.yml` (`Maint 41 ChatGPT Issue Sync`) | `workflow_dispatch` (manual) | Fans out curated topic lists (e.g. `Issues.txt`) into labeled GitHub issues. ⚠️ Repository policy: do not remove without a functionally equivalent replacement. |
 | `maint-34-cosmetic-repair.yml` (`Maint 45 Cosmetic Repair`) | `workflow_dispatch` | Manual pytest + guardrail fixer that applies tolerance/snapshot updates and opens a labelled PR when drift is detected. |
 
+**Repo health troubleshooting**
+- If `Maint 02 Repo Health` fails with `Resource not accessible by integration`, the `GITHUB_TOKEN` lacks `issues: read` scope. Update the workflow's fine-grained token permissions (Repository → Settings → Actions → General) to grant `issues: read`, or rerun manually with a PAT stored in `SERVICE_BOT_PAT` that includes `repo` read scopes.
+- Confirm the repository allows GitHub Actions to read all branches. Private forks that disable default token scopes can also trigger the same error; re-enable the default permissions or provide an explicit PAT.
+
 ### CI failure rollup issue
 
 `Maint Post CI` maintains **one** open issue labelled `ci-failure` that aggregates "CI failures in the last 24 h". The failure-tracker job updates the table in place with each Gate failure, links the offending workflow run, and closes the issue automatically once the inactivity threshold elapses. The issue carries labels `ci`, `devops`, and `priority: medium`; escalations add `priority: high` when the same signature trips three times. Use this issue for a quick dashboard of outstanding CI problems instead of scanning individual PR timelines.
@@ -94,12 +105,12 @@ These jobs must stay green for PRs to merge. The post-CI maintenance jobs below 
 ### Agent automation entry points
 
 `agents-70-orchestrator.yml` (`Agents 70 Orchestrator`) is the scheduled automation entry point. It runs on an hourly cron and can also be dispatched manually. Both methods call the reusable agents toolkit to perform readiness probes, Codex bootstrap, diagnostics, and keepalive sweeps.
-`.github/workflows/agents-62-consumer.yml` exposes a numbered manual bridge that proxies JSON overrides directly to `reusable-70-agents.yml`. The restored `.github/workflows/agents-consumer.yml` accepts direct string inputs and forwards them to the same reusable workflow, using its own concurrency guard.
+Deprecated compatibility wrappers (`agents-62-consumer.yml`, `agents-consumer.yml`) remain available for curated manual runs that require the historical JSON schema; they are not part of the supported flow and should be referenced only when migrating older automations.
 The Codex Issue Bridge is only a label-driven helper for seeding bootstrap PRs. `agents-64-verify-agent-assignment.yml` exposes the verification logic as a reusable workflow-call entry point.
 
 **Operational details**
 - Provide required write scopes via the default `GITHUB_TOKEN`. Supply `service_bot_pat` when bootstrap jobs must push branches or leave comments.
-- Use the `options_json` input to enable bootstrap (`{"enable_bootstrap": true}`) or pass extra labels such as `{"bootstrap_issues_label": "agent:codex"}` when dispatching manually. The orchestrator parses the JSON via `fromJson()` and forwards toggles to `reusable-70-agents.yml`.
+- Use the `params_json` payload to enable bootstrap (`{"enable_bootstrap": true}`) or pass extra labels such as `{"bootstrap_issues_label": "agent:codex"}` when dispatching manually. The orchestrator parses the JSON via `fromJson()` and forwards toggles to `reusable-70-agents.yml`.
 - Readiness, preflight, bootstrap, and keepalive diagnostics appear in the job summary. Failures bubble up through the single `orchestrate` job; Maint Post CI will echo the failing run link in the CI failure-tracker issue when the Gate is affected.
 
 ### Manual Orchestrator Dispatch
@@ -107,52 +118,30 @@ The Codex Issue Bridge is only a label-driven helper for seeding bootstrap PRs. 
 1. Navigate to **Actions → Agents 70 Orchestrator → Run workflow**.
 2. Provide inputs:
    - **Branch**: default (`phase-2-dev`) unless testing a feature branch.
-   - **Enable bootstrap**: set to `true` when seeding Codex PRs.
-   - **Bootstrap issues label**: usually `agent:codex`.
-   - **Options JSON**: example payload
+   - Flip the toggle inputs as needed (`enable_readiness`, `enable_preflight`, `enable_watchdog`, etc.).
+   - **Params JSON**: bundle less common overrides (custom logins, diagnostics, bootstrap switches) inside the JSON payload. Example:
      ```json
      {
        "enable_bootstrap": true,
        "bootstrap_issues_label": "agent:codex",
-       "enable_readiness": true,
-       "require_all": true
+       "diagnostic_mode": "dry-run",
+       "readiness_custom_logins": "backup-bot",
+       "options_json": "{\"enable_keepalive\":false,\"keepalive\":{\"enabled\":false}}"
      }
      ```
 3. Click **Run workflow**. The orchestrator calls `reusable-70-agents.yml`; job summaries include readiness tables, bootstrap status, and links to spawned PRs.
-
-### Manual Consumer Dispatch
-
-Use the **Agents 62 Consumer** workflow when you need a lightweight manual trigger without the orchestrator cron context. The legacy **Agents Consumer** workflow stays wired for callers pinned to the historical slug.
-
-1. Navigate to **Actions → Agents 62 Consumer → Run workflow**.
-2. Flip the high-level toggles (`enable_readiness`, `enable_preflight`, diagnostics, watchdog, bootstrap) as needed. Advanced overrides—custom readiness lists, Codex command phrase, diagnostic dry-run mode, bootstrap label, etc.—go inside `options_json` as a JSON object.
-3. Example payload:
-   ```json
-   {
-     "readiness_agents": "copilot,codex",
-     "require_all": "true",
-     "codex_user": "chatgpt-codex-connector",
-     "bootstrap_issues_label": "agent:codex"
-   }
+4. CLI dispatch example (same `params_json` schema):
+   ```bash
+   gh workflow run agents-70-orchestrator.yml \
+     --ref phase-2-dev \
+     --raw-field enable_watchdog=true \
+     --raw-field params_json='{"enable_bootstrap":true,"bootstrap_issues_label":"agent:codex","diagnostic_mode":"dry-run"}'
    ```
-4. The single **Dispatch reusable agents toolkit** job calls `reusable-70-agents.yml`. A concurrency group (`agents-62-consumer-${ref_name}`) cancels any previous run on the same branch before starting. The compatibility slug reuses the same `ref_name` guard.
+   The CLI invocation mirrors the manual form—`params_json` is optional but provides a single string for complex settings.
 
-### Legacy Agents Consumer Dispatch
+### Deprecated manual wrappers
 
-Use the **Agents Consumer** workflow when you need a compatibility shim that accepts the historical slug and direct string inputs.
-
-1. Navigate to **Actions → Agents Consumer → Run workflow**.
-2. Populate the high-level toggles or provide overrides via `options_json` as needed (readiness agents, Codex command phrase, diagnostic modes, bootstrap label, etc.).
-3. Example payload:
-   ```json
-   {
-     "readiness_agents": "copilot,codex",
-     "require_all": "true",
-     "codex_user": "chatgpt-codex-connector",
-     "bootstrap_issues_label": "agent:codex"
-   }
-   ```
-4. The **Dispatch reusable agents toolkit** job forwards the request to `reusable-70-agents.yml`. A concurrency group (`agents-consumer-${ref_name}`) prevents overlapping manual retries on the same branch.
+`agents-62-consumer.yml` and `agents-consumer.yml` remain in the repository for callers pinned to their historical interfaces. Both are manual-only, forward to `reusable-70-agents.yml`, and accept the same `params_json` payload documented above. Prefer the orchestrator for all new automation.
 
 ### Agent troubleshooting: bootstrap & readiness signals
 
@@ -160,7 +149,7 @@ Use the **Agents Consumer** workflow when you need a compatibility shim that acc
 | ------- | ------------ | ------------- | ------ |
 | Readiness probe fails immediately | Missing PAT or permissions | `orchestrate` job summary → “Authentication” step | Provide `SERVICE_BOT_PAT` secret or rerun with reduced scope. |
 | Bootstrap skipped despite `enable_bootstrap` | No matching labelled issues | Job summary → “Bootstrap Planner” table | Add `agent:codex` label (or configured label) to target issues, rerun. |
-| Bootstrap run exits with “Repository dirty” | Prior automation left branches open | Job log → `cleanup` step | Manually close stale branches or enable cleanup via `options_json` toggle before rerun. |
+| Bootstrap run exits with “Repository dirty” | Prior automation left branches open | Job log → `cleanup` step | Manually close stale branches or enable cleanup via the `params_json` payload (set `{"options_json":"{\\"cleanup\\":{\\"force\\":true}}"}`). |
 | Readiness succeeds but Codex PR creation fails | Repository protections blocking pushes | Job log → `Create bootstrap branch` step | Ensure branch protection rules allow the automation account or supply a PAT with required scopes. |
 
 Escalate persistent failures by linking the failing run URL in the CI failure-tracker issue managed by Maint Post CI.
@@ -264,20 +253,25 @@ Follow this sequence before pushing workflow changes or large code edits:
 
 When intentionally editing CI jobs, regenerate `basic_jobs.json`, compute the new hash, and update both files in the same commit. Use `tools/test_failure_signature.py` locally to recompute and verify the hash before pushing. The guard only runs on pushes/PRs targeting `phase-2-dev` and publishes a step summary linking back here.
 
-## Agents `options_json` Schema
+## Agents `params_json` Schema
 
-`agents-70-orchestrator.yml` accepts the standard dispatch inputs shown in the workflow plus an extensible JSON payload routed through `options_json`. The JSON is parsed with `fromJson()` and handed to the reusable agents workflow.
+`agents-70-orchestrator.yml` accepts the standard dispatch inputs shown in the workflow plus an extensible JSON payload routed through `params_json`. The JSON is parsed with `fromJson()` and handed to the reusable agents workflow. Nested automation knobs can be forwarded via the optional `options_json` string when the reusable composite expects more structured data.
 
 ```jsonc
 {
-  "diagnostic_mode": "off" | "dry-run" | "full",
+  "enable_bootstrap": true,
+  "bootstrap_issues_label": "agent:codex",
+  "diagnostic_mode": "dry-run",
   "readiness_custom_logins": "login-a,login-b",
-  "codex_command_phrase": "@codex start"
+  "codex_command_phrase": "@codex start",
+  "options_json": "{\"enable_keepalive\":false}"
 }
 ```
 
+- **`enable_bootstrap` / `bootstrap_issues_label`** — toggle Codex bootstrap and override the label scanned for candidate issues.
 - **`diagnostic_mode`** — `off` (default) disables diagnostics, `dry-run` keeps bootstrap logic read-only, `full` allows branch creation and sets `draft_pr: false` when Codex is seeded.
 - **`readiness_custom_logins`** — comma-separated list for additional readiness probes.
 - **`codex_command_phrase`** — phrase used when the orchestrator comments on issues or PRs to summon Codex.
+- **`options_json`** — pass-through blob for nested settings such as keepalive thresholds or cleanup toggles (see Gate troubleshooting table above).
 
-Keep this schema backward compatible; add new keys sparingly and document them in the table above when introduced.
+Keep this schema backward compatible; add new keys sparingly and document them here when introduced.

--- a/docs/ci_reuse.md
+++ b/docs/ci_reuse.md
@@ -51,10 +51,13 @@ jobs:
       enable_preflight: 'true'
       enable_bootstrap: 'true'
       bootstrap_issues_label: 'agent:codex'
+      options_json: '{"enable_keepalive":false}'
 ```
 
-The caller may also pass `options_json` to layer additional toggles without exceeding GitHub's input limit. `agents-70-orchestrator.yml`
-is the only supported wrapper inside this repository; downstream consumers should call the reusable workflow directly.
+The caller may also pass a `params_json` payload to layer additional toggles without exceeding GitHub's input limit. Include an `options_json`
+string inside the payload for nested keepalive or cleanup controls. `agents-70-orchestrator.yml`
+is the only supported wrapper inside this repository; downstream consumers should call the reusable workflow directly. Deprecated manual wrappers
+(`agents-62-consumer.yml`, `agents-consumer.yml`) persist solely for migration and are not part of the supported surface.
 
 Timeouts live inside the reusable workflow so the orchestrator avoids invalid syntax. Each automation path has a bound sized to
 its typical runtime plus roughly 25 percent headroom.
@@ -87,7 +90,7 @@ requests a run. `maint-90-selftest.yml` remains archived under `Old/workflows/` 
 | ---- | ------------- | ----- |
 | Coverage reporting | Chain an additional job that depends on the reusable CI job to upload coverage artifacts. | Keep job IDs stable when referencing outputs. |
 | Autofix heuristics | Update `autofix.yml` or `maint-30-post-ci.yml` to widen size limits or adjust glob filters. | Avoid editing the reusable composite unless behaviour must change globally. |
-| Agents options | Provide extra keys inside `options_json` and update the reusable workflow to honour them. | Remember GitHub only supports 10 dispatch inputs; keep new flags in JSON. |
+| Agents options | Provide extra keys inside `params_json` (and embed `options_json` when structured overrides are required) and update the reusable workflow to honour them. | Remember GitHub only supports 10 dispatch inputs; keep new flags in JSON. |
 
 ## Security & Permissions
 - CI workflows default to `permissions: contents: read`; escalate only when artifacts require elevated scopes.


### PR DESCRIPTION
## Summary
- align the CI catalog with the active workflow roster, add a Gate job map, and document repo-health troubleshooting
- switch the Agents 70 orchestrator to parse a params_json payload while marking consumer wrappers as deprecated in the docs
- refresh supporting guides and the README to reference pr-00-gate and the renamed reusable workflows

## Testing
- pytest tests/test_workflow_naming.py tests/test_automation_workflows.py -k agents

------
https://chatgpt.com/codex/tasks/task_e_68ec50135b148331afa2f260237b5c6e