### PR TITLE
Rename Codex issue bridge workflow to agents-63

### DIFF
--- a/.github/workflows/agents-63-codex-issue-bridge.yml
+++ b/.github/workflows/agents-63-codex-issue-bridge.yml
@@ -1,4 +1,4 @@
-name: Agents 43 Codex Issue Bridge
+name: Agents 63 Codex Issue Bridge
 
 on:
   issues:

--- a/WORKFLOW_AUDIT_TEMP.md
+++ b/WORKFLOW_AUDIT_TEMP.md
@@ -34,7 +34,7 @@ This list mirrors the canonical catalogue in `docs/ci/WORKFLOWS.md` after the Is
 | Workflow | Triggers | Notes |
 |----------|----------|-------|
 | `agents-62-consumer.yml` | workflow_dispatch | Manual-only JSON bridge that calls `reusable-70-agents.yml`; concurrency guard `agents-62-consumer-${{ github.ref_name }}` prevents back-to-back dispatch collisions. |
-| `agents-43-codex-issue-bridge.yml` | issues, workflow_dispatch | Restored Codex bootstrap automation for label-driven issue handling. |
+| `agents-63-codex-issue-bridge.yml` | issues, workflow_dispatch | Restored Codex bootstrap automation for label-driven issue handling. |
 | `agents-64-verify-agent-assignment.yml` | workflow_call, workflow_dispatch | Validates that `agent:codex` issues remain assigned to an approved agent account before automation runs. |
 | `agents-70-orchestrator.yml` | schedule (*/20), workflow_dispatch | Unified agents toolkit entry point (readiness, diagnostics, Codex keepalive). |
 

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -45,7 +45,7 @@ Tests under `tests/test_workflow_naming.py` enforce the naming policy and invent
 
 ### Agents
 - **`agents-70-orchestrator.yml`** — 20-minute cron plus manual dispatch entry point for readiness, Codex bootstrap, diagnostics, verification, and keepalive sweeps. Delegates to `reusable-70-agents.yml` and accepts extended options via `options_json`.
-- **`agents-43-codex-issue-bridge.yml`** — Label-driven helper that seeds Codex bootstrap PRs and can optionally auto-comment `@codex start`.
+- **`agents-63-codex-issue-bridge.yml`** — Label-driven helper that seeds Codex bootstrap PRs and can optionally auto-comment `@codex start`.
 - **`agents-63-chatgpt-issue-sync.yml`** — Manual issue fan-out that mirrors curated topic lists into GitHub issues.
 - **`agents-64-verify-agent-assignment.yml`** — Workflow-call validator ensuring `agent:codex` issues remain assigned to approved automation accounts.
 - **`agents-62-consumer.yml`** — *Deprecated compatibility shim.* Accepts a `params_json` blob and forwards the resolved inputs to the orchestrator for callers that have not yet migrated.

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -62,7 +62,7 @@ flowchart TD
 | Workflow | File | Trigger(s) | Permissions | Required? | Purpose |
 | --- | --- | --- | --- | --- | --- |
 | **Agents 70 Orchestrator** | `.github/workflows/agents-70-orchestrator.yml` | Cron (`*/20 * * * *`), `workflow_dispatch` | `contents: write`, `pull-requests: write`, `issues: write`; optional `service_bot_pat` | No | Single supported entry point dispatching readiness, bootstrap, diagnostics, verification, and keepalive routines. |
-| **Agents 43 Codex Issue Bridge** | `.github/workflows/agents-43-codex-issue-bridge.yml` | `issues`, `workflow_dispatch` | `contents: write`, `pull-requests: write`, `issues: write` | No | Label-driven helper that seeds Codex bootstrap PRs and can auto-comment `@codex start`. |
+| **Agents 63 Codex Issue Bridge** | `.github/workflows/agents-63-codex-issue-bridge.yml` | `issues`, `workflow_dispatch` | `contents: write`, `pull-requests: write`, `issues: write` | No | Label-driven helper that seeds Codex bootstrap PRs and can auto-comment `@codex start`. |
 | **Agents 64 Verify Agent Assignment** | `.github/workflows/agents-64-verify-agent-assignment.yml` | `workflow_call`, `workflow_dispatch` | `issues: read` | No | Reusable issue-verification helper consumed by the orchestrator and available for ad-hoc checks. |
 | **Agents 63 ChatGPT Issue Sync** | `.github/workflows/agents-63-chatgpt-issue-sync.yml` | `workflow_dispatch` | `contents: read`, `issues: write` | No | Manual sync that turns curated topic lists (e.g. `Issues.txt`) into labelled GitHub issues. |
 

--- a/docs/ci/workflow_renaming_plan.md
+++ b/docs/ci/workflow_renaming_plan.md
@@ -2,7 +2,7 @@
 
 ## Scope and Key Constraints
 - **Workflows covered**: All YAML files under `.github/workflows/`, including reusable components, must follow the new numbering-based naming scheme described in Issue #2492.
-- **Rename map fidelity**: File moves must exactly match the provided mapping, including deletions (e.g., removing `agent-watchdog.yml` if confirmed obsolete) and handling already compliant files (e.g., `agents-43-codex-issue-bridge.yml`).
+- **Rename map fidelity**: File moves must exactly match the provided mapping, including deletions (e.g., removing `agent-watchdog.yml` if confirmed obsolete) and handling already compliant files (e.g., `agents-63-codex-issue-bridge.yml`).
 - **Display names preserved**: Workflow `name:` fields should remain unchanged to avoid disrupting recognizable labels in the GitHub UI.
 - **Documentation alignment**: Any documentation referencing the old filenames (README, workflow guides, CI docs) must be updated in lockstep with the renames.
 - **Compatibility**: Downstream workflow callers (especially `pr-00-gate.yml`) must reference the new filenames so that automation continues to run without interruption.

--- a/docs/ci_reuse_consolidation_plan.md
+++ b/docs/ci_reuse_consolidation_plan.md
@@ -9,12 +9,12 @@ workflows required by the trimmed automation surface.
 - Four reusable workflows remain (`reusable-10-ci-python.yml`, `reusable-12-ci-docker.yml`, `reusable-92-autofix.yml`,
   `reusable-70-agents.yml`). The self-test matrix now lives in the manual-only `selftest-81-reusable-ci.yml` workflow.
 - Visible workflows in the Actions tab were reduced to the final set documented in `WORKFLOW_AUDIT_TEMP.md` and `docs/ci/WORKFLOWS.md`.
-- All auxiliary wrappers (gate orchestrators, labelers, watchdog forwards, etc.) were deleted, with `agents-43-codex-issue-bridge.yml` later reinstated to restore label-driven Codex automation.
+- All auxiliary wrappers (gate orchestrators, labelers, watchdog forwards, etc.) were deleted, with `agents-63-codex-issue-bridge.yml` later reinstated to restore label-driven Codex automation.
 
 ## Completed Consolidation Actions
 | Area | Action |
 |------|--------|
-| Agent automation | Removed `agents-41*`, `agents-42-watchdog.yml`, `agents-44-copilot-readiness.yml`, and `agents-45-verify-codex-bootstrap-matrix.yml`; consolidated around `agents-70-orchestrator.yml` + `reusable-70-agents.yml`, then reinstated `agents-43-codex-issue-bridge.yml` to preserve label-driven Codex bootstraps.
+| Agent automation | Removed `agents-41*`, `agents-42-watchdog.yml`, `agents-44-copilot-readiness.yml`, and `agents-45-verify-codex-bootstrap-matrix.yml`; consolidated around `agents-70-orchestrator.yml` + `reusable-70-agents.yml`, then reinstated `agents-63-codex-issue-bridge.yml` to preserve label-driven Codex bootstraps.
 | Maintenance | Deleted legacy hygiene/self-test workflows (`maint-31`, `maint-34`, `maint-37`, `maint-38`, `maint-43`, `maint-44`, `maint-45`, `maint-48`, `maint-49`, `maint-52`, `maint-60`) and introduced `maint-90-selftest.yml` as the single self-test caller. `agents-63-chatgpt-issue-sync.yml` was later reinstated (2025-10-07) to preserve issue fan-out from curated topic lists and is now guarded by tests. |
 | PR checks | Removed auxiliary PR workflows (gate orchestrator, labeler, workflow lint, CodeQL, dependency review, path labeler) to align with the two final checks.
 

--- a/docs/ops/codex-bootstrap-facts.md
+++ b/docs/ops/codex-bootstrap-facts.md
@@ -26,7 +26,7 @@ remain true after the cleanup.
   variables to the reusable composite.
 
 ## Active Workflows & Actions
-- **Codex issue bridge:** `.github/workflows/agents-43-codex-issue-bridge.yml`
+- **Codex issue bridge:** `.github/workflows/agents-63-codex-issue-bridge.yml`
   - Reacts to `agent:codex` (and `agents:codex`) labels plus manual dispatch.
   - Creates or reuses Codex bootstrap branches/PRs and posts copyable issue snippets + `@codex start` instructions.
 - **Orchestrator:** `.github/workflows/agents-70-orchestrator.yml`

--- a/tests/test_workflow_agents_consolidation.py
+++ b/tests/test_workflow_agents_consolidation.py
@@ -81,10 +81,10 @@ def test_legacy_agent_workflows_removed():
 
 
 def test_codex_issue_bridge_present():
-    bridge = WORKFLOWS_DIR / "agents-43-codex-issue-bridge.yml"
+    bridge = WORKFLOWS_DIR / "agents-63-codex-issue-bridge.yml"
     assert (
         bridge.exists()
-    ), "agents-43-codex-issue-bridge.yml must exist after Codex bridge restoration"
+    ), "agents-63-codex-issue-bridge.yml must exist after Codex bridge restoration"
 
 
 def test_keepalive_job_present():

--- a/tests/test_workflow_naming.py
+++ b/tests/test_workflow_naming.py
@@ -98,7 +98,7 @@ def test_chatgpt_issue_sync_workflow_present_and_intact():
 
 
 EXPECTED_NAMES = {
-    "agents-43-codex-issue-bridge.yml": "Agents 43 Codex Issue Bridge",
+    "agents-63-codex-issue-bridge.yml": "Agents 63 Codex Issue Bridge",
     "agents-62-consumer.yml": "Agents Consumer",
     "agents-63-chatgpt-issue-sync.yml": "Maint 41 ChatGPT Issue Sync",
     "agents-64-verify-agent-assignment.yml": "Agents 44 Verify Agent Assignment",


### PR DESCRIPTION
## Summary
- rename the Codex issue bridge workflow to agents-63 and update its display name
- update workflow catalog documentation and guardrail tests to reference the new identifier

## Testing
- pytest tests/test_workflow_naming.py tests/test_workflow_agents_consolidation.py


------
https://chatgpt.com/codex/tasks/task_e_68ec96fd79d48331ac1230718021a5a0