### PR TITLE
Restrict self-test workflow to manual dispatch

### DIFF
--- a/.github/workflows/selftest-81-reusable-ci.yml
+++ b/.github/workflows/selftest-81-reusable-ci.yml
@@ -3,6 +3,12 @@ name: Selftest 81 Reusable CI
 on:
   workflow_dispatch:
     inputs:
+      reason:
+        description: >-
+          Short note describing why the self-test is running. Appears in the
+          run summary for future reference.
+        required: false
+        default: Manual verification
       python-versions:
         description: >-
           JSON array of Python versions forwarded to `reusable-10-ci-python.yml`.
@@ -98,6 +104,7 @@ jobs:
           {
             echo "## Self-Test Matrix Summary"
             echo "Scenario job result: ${{ needs.scenario.result }}"
+            echo "Dispatch reason: ${{ inputs.reason }}"
             echo "Scenarios executed: ${SCENARIO_LIST}"
             echo "Workflow dispatch input (python-versions): ${{ inputs.python-versions }}"
             echo "Each reusable run uploads artifacts prefixed with \`sf-<scenario>-\`."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,18 @@ post-processing workflow:
   remains available when the JSON `params_json` interface is required and now
   forwards inputs to the same reusable workflow.
 
+## Manual Self-Test Workflows
+
+Self-tests provide an opt-in regression net that mirrors production CI behaviour without polluting regular pull request status
+checks. Trigger them from the **Actions** tab by running `Selftest 81 Reusable CI` via **Run workflow** and supply a short reason
+for the dispatch (for example, "Verifying coverage delta after config tweak"). The workflow defaults to the pinned Python
+matrix used by CI, but you can override the JSON `python-versions` input to exercise additional interpreters when debugging.
+
+Each run posts a concise summary in the workflow run log describing the matrix outcome, dispatch reason, and scenarios executed.
+Download the `selftest-report` artifact to inspect the scenario-by-scenario inventory that the aggregate verification job
+validates. Missing artifacts or unexpected uploads indicate a drift between reusable job expectations and scenario outputs; fix
+the offending scenario before re-running the self-test.
+
 ## Quick Checklist (Before Every Push)
 
 1. Fast dev validation (changed files only):


### PR DESCRIPTION
## Summary
- add a dispatch reason input to the `selftest-81` workflow and surface it in the run summary for traceability
- document how to manually trigger the self-test workflow and interpret its artifact report in `CONTRIBUTING.md`

## Testing
- not run (documentation and workflow metadata only)


------
https://chatgpt.com/codex/tasks/task_e_68ec97a68c8c8331b80f262249f8f631