### PR TITLE
Restrict self-test workflows to manual dispatches

### DIFF
--- a/Old/workflows/maint-90-selftest.yml
+++ b/Old/workflows/maint-90-selftest.yml
@@ -2,8 +2,6 @@ name: Maint 90 Selftest
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 6 * * 1'
 
 jobs:
   selftest:

--- a/Old/workflows/reusable-99-selftest.yml
+++ b/Old/workflows/reusable-99-selftest.yml
@@ -10,9 +10,6 @@ on:
         required: false
         type: string
         default: '["3.11"]'
-  schedule:
-    - cron: '0 6 * * 1'
-      # Archived wrapper retains weekly coverage sweep to mirror the active workflow cadence.
   workflow_dispatch:
     inputs:
       python-versions:

--- a/tests/test_workflow_selftest_consolidation.py
+++ b/tests/test_workflow_selftest_consolidation.py
@@ -21,7 +21,7 @@ def test_selftest_workflow_inventory() -> None:
 
 
 def test_selftest_triggers_are_manual_only() -> None:
-    """Self-test workflows must only expose manual or scheduled triggers."""
+    """Self-test workflows must only expose manual dispatch triggers."""
 
     selftest_files = sorted(WORKFLOW_DIR.glob("*selftest*.yml"))
     assert selftest_files, "Expected at least one self-test workflow definition."
@@ -62,7 +62,7 @@ def test_selftest_triggers_are_manual_only() -> None:
         unsupported = sorted(trigger_keys - allowed_triggers)
         assert not unsupported, (
             f"{workflow_file.name} declares unsupported triggers: {unsupported}. "
-            "Only workflow_dispatch, schedule, or workflow_call are permitted."
+            "Only workflow_dispatch is permitted for active self-tests."
         )
 
         assert (
@@ -128,7 +128,7 @@ def test_archived_selftests_retain_manual_triggers() -> None:
 
     disallowed_triggers = {"pull_request", "pull_request_target", "push"}
     required_manual_trigger = "workflow_dispatch"
-    optional_triggers = {"schedule", "workflow_call"}
+    optional_triggers = {"workflow_call"}
     allowed_triggers = {required_manual_trigger} | optional_triggers
 
     for workflow_file in archived_files:
@@ -156,13 +156,13 @@ def test_archived_selftests_retain_manual_triggers() -> None:
         unexpected = sorted(trigger_keys & disallowed_triggers)
         assert not unexpected, (
             f"{workflow_file.name} exposes disallowed triggers: {unexpected}. "
-            "Archived self-tests should remain manual/cron only."
+            "Archived self-tests should remain manual-only entry points."
         )
 
         unsupported = sorted(trigger_keys - allowed_triggers)
         assert not unsupported, (
             f"{workflow_file.name} declares unsupported triggers: {unsupported}. "
-            "Only workflow_dispatch, schedule, or workflow_call are permitted."
+            "Only workflow_dispatch or workflow_call are permitted."
         )
 
         assert required_manual_trigger in trigger_keys, (


### PR DESCRIPTION
### Summary
- remove legacy cron triggers from archived self-test workflows so they cannot run automatically
- tighten regression tests to enforce manual-only triggers for both active and archived self-test definitions

### Testing
- `pytest tests/test_workflow_selftest_consolidation.py`


------
https://chatgpt.com/codex/tasks/task_e_68eceb824514833191e3847962370258