### PR TITLE
docs: align workflow documentation with orchestrator topology

### DIFF
--- a/ARCHIVE_WORKFLOWS.md
+++ b/ARCHIVE_WORKFLOWS.md
@@ -2,6 +2,16 @@
 
 This document records the archival and eventual deletion of legacy agent-related workflows now replaced by consolidated reusable pipelines. The most recent sweep (Issue #1419) retired the reusable agent matrix in favour of the focused assigner/watchdog pair. The follow-up sweep for Issue #1669 removed the on-disk archive directory so the history now lives exclusively in git along with this ledger.
 
+## Archived
+
+### Legacy agent watchdog
+- **Removed file**: `agent-watchdog.yml` (retired with the Issue #1419 consolidation sweep).
+- **Replacement**: watchdog logic now lives behind the `enable_watchdog` toggle inside `Agents 70 Orchestrator` so scheduled runs and manual dispatches both exercise the same path.
+
+### Retired self-tests
+- **Archived files**: `Old/workflows/maint-90-selftest.yml` and `Old/workflows/reusable-99-selftest.yml` remain in git history only; they were removed from active automation when the reusable matrix stabilised.
+- **Replacement**: manual verification flows route through the consolidated self-test entry points (`selftest-81` and related wrappers listed below) or reuse the Gate matrix when full coverage is required.
+
 ## Removed Legacy Files (Cleanup PR for Issue #1259)
 All deprecated agent automation workflows were deleted from `.github/workflows/` on 2025-09-21 once the stabilization window for the reusable equivalents closed. Historical copies formerly lived under `.github/workflows/archive/` but that directory was removed on 2026-10-07 as part of the Issue #1669 cleanup. Retrieve any prior YAML from git history when needed.
 

--- a/Agents.md
+++ b/Agents.md
@@ -129,6 +129,24 @@ Never touch notebooks living under any directory whose name ends in old/.
 
 ---
 
+## Automation entry points (Orchestrator → bridge → verification)
+
+### Agents 70 Orchestrator
+- **File**: `.github/workflows/agents-70-orchestrator.yml`.
+- **Triggers**: 20-minute cron plus on-demand `workflow_dispatch` inputs for readiness, bootstrap, verification, watchdog, and keepalive paths.
+- **Role**: single automation front door. Every scheduled sweep and manual run invokes `reusable-16-agents.yml`, passing the merged toggles (watchdog enabled by default, verification toggled via `enable_verify_issue`).
+- **Manual run**: Actions → **Agents 70 Orchestrator** → **Run workflow**. Supply booleans as strings (for example `true`) and optional JSON overrides in `options_json` when you need to bundle advanced switches in one payload.
+
+### Agents 63 Codex Issue Bridge
+- **File**: `.github/workflows/agents-63-codex-issue-bridge.yml`.
+- **Triggers**: reacts to issue events (opened, labeled, reopened) when the issue carries the `agent:codex`/`agents:codex` label set, and exposes `workflow_dispatch` inputs for manual testing, PR mode overrides, and forcing draft PRs.
+- **Role**: hydrates bootstrap PRs or invite flows for labeled issues, optionally posting the `@codex start` command. Manual dispatch requires `test_issue` so the bridge knows which issue to service.
+
+### Agents 64 Verify Agent Assignment
+- **File**: `.github/workflows/agents-64-verify-agent-assignment.yml`.
+- **Triggers**: reusable `workflow_call` with a required `issue_number` plus manual `workflow_dispatch` for spot checks.
+- **Role**: confirms that labeled issues still carry an agent assignee and emits a Markdown table + status outputs consumed by the orchestrator. Manual runs follow the same inputs—enter the issue number and review the generated run summary.
+
 ### 2025-06-27 UPDATE — RISK-METRICS EXPORT (SERIOUSLY, LEAVE THIS IN)
 
 Codex removed the pretty reporting layer once; it shall not happen again.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,15 @@ post-processing workflow:
   remains available when the JSON `params_json` interface is required and now
   forwards inputs to the same reusable workflow.
 
+### Manual workflow_dispatch quickstart
+
+- **Maintenance helper (Maint 45 Cosmetic Repair)** – Actions → **Maint 45 Cosmetic Repair** → **Run workflow**. Choose the base branch, interpreter, and whether to run in dry-run mode using the provided inputs before the workflow hydrates the cosmetic repair script.
+- **Agent automation (Agents 70 Orchestrator)** – Actions → **Agents 70 Orchestrator** → **Run workflow**. Supply booleans as strings (`true`/`false`) for readiness, watchdog, bootstrap, verification, and keepalive toggles or pass an advanced payload through `options_json` when you need to flip several paths at once.
+
+### Health self-check run summaries
+
+The `Health 40 Repo Selfcheck` job writes its status table into the GitHub Actions run summary so you can review label coverage, branch protection, and token usage without downloading artifacts. Open the workflow run and read the generated Markdown table in the **Summary** tab.
+
 ## Manual Self-Test Workflows
 
 Self-tests are strictly manual to avoid noisy or misleading status checks on day-to-day development branches. Trigger them from the **Actions** tab by selecting **Selftest 81 Reusable CI**, choosing **Run workflow**, and writing a brief reason for the dispatch (for example, "Verifying coverage delta after config tweak"). Providing a reason is required—the workflow will not start without it—and the text is echoed in the run summary so future readers can understand why the matrix was executed. The optional `python-versions` JSON input defaults to the pinned CI interpreter but can include additional versions when you need to chase cross-version issues.


### PR DESCRIPTION
## Summary
- document the current orchestrator, issue bridge, and verify workflows in Agents.md with their triggers and manual dispatch guidance
- add an Archived section that records the legacy watchdog retirement and the relocation of historical self-tests
- expand CONTRIBUTING.md with workflow_dispatch tips and a pointer to the health self-check run summary

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed90fcad548331a58a98f9b8a1df04