### PR TITLE
docs: capture verify assignee defaults and manual run steps

### DIFF
--- a/docs/agent-automation.md
+++ b/docs/agent-automation.md
@@ -63,6 +63,8 @@ label is present, validates that one of the configured valid assignees is assign
 documenting the outcome. `reusable-16-agents.yml` now delegates its issue verification job to this workflow so the same checks
 are available for ad-hoc dispatches from the Actions tab.
 
+The default valid assignee roster includes `copilot`, `chatgpt-codex-connector`, and `stranske-automation-bot`; provide a comma-separated override when onboarding additional automation accounts or running spot checks against bespoke actors.
+
 ## Related Automation
 
 While the agent wrappers were removed, maintenance automation still supports the broader workflow stack:

--- a/docs/agent_assignment_verification_plan.md
+++ b/docs/agent_assignment_verification_plan.md
@@ -6,7 +6,7 @@
 - **Execution context**: Job must run with `issues: read` permissions only; avoid actions that implicitly demand broader scopes (e.g., GraphQL mutations, issue write operations).
 - **Input focus**: Single required `issue_number` integer input. Downstream steps resolve repository context automatically via `github.repository` to keep invocation friction low.
 - **Eligibility check**: Guard clause exits early unless the referenced issue currently carries the `agent:codex` label; no-op success keeps audit noise low when mis-triggered.
-- **Assignee validation**: Treat `copilot` and `chatgpt-codex-connector` as the only valid automated assignees for now. Flag absence of both as a hard failure and surface human-readable guidance.
+- **Assignee validation**: Treat `copilot`, `chatgpt-codex-connector`, and `stranske-automation-bot` as the canonical automated assignees. Flag absence of all three as a hard failure and surface human-readable guidance.
 - **Output channel**: Summaries and failure detail should land both in job logs and as a markdown table via `core.summary` so reusable consumers get consistent presentation.
 - **Idempotence**: Multiple dispatches against the same issue should produce identical outputs unless the issue metadata changes; avoid stateful artifacts that persist between runs.
 
@@ -16,7 +16,7 @@
 - Manual `workflow_dispatch` entry point remains available either directly in the same file or via a thin wrapper job.
 - Workflow fetches issue metadata using the GitHub REST API with only read permissions and logs the resolved title, URL, labels, and assignees.
 - Run terminates early with a success summary when the target issue lacks the `agent:codex` label.
-- Run fails with exit code and summary table message when neither `copilot` nor `chatgpt-codex-connector` is assigned, including explicit remediation guidance.
+- Run fails with exit code and summary table message when none of `copilot`, `chatgpt-codex-connector`, or `stranske-automation-bot` are assigned, including explicit remediation guidance.
 - On success (valid assignee present), workflow publishes a single-row markdown table summarising issue number, title, label presence, and matched assignee.
 - Summary table always renders, even in failure scenarios, and links back to the inspected issue for fast triage.
 - Logging clearly distinguishes API errors (e.g., 404, permissions) from logical validation failures, aiding debugging without revealing tokens.

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -177,6 +177,7 @@ The Codex Issue Bridge is a label-driven helper for seeding bootstrap PRs, while
    - **Enable bootstrap**: set to `true` when seeding Codex PRs; leave `false` for readiness-only sweeps.
    - **Options JSON**: supply nested overrides (for example `{ "bootstrap": { "label": "agent:codex" }, "diagnostic_mode": "dry-run", "require_all": true }`).
 3. Click **Run workflow**. The orchestrator fan-outs through `reusable-16-agents.yml`; job summaries include readiness tables, bootstrap status, verification notes, and links to spawned PRs.
+4. When verification is enabled and succeeds, the `verify-assignment-summary` step appends the matched assignee and status to the run summary so operators can confirm which automation satisfied the check.
 
 **Programmatic dispatch (`options_json` example).** Tooling can post the JSON payload directly through the orchestrator’s `options_json` input or hand it to the deprecated consumer wrapper while you migrate clients—the wrapper parses `params_json`, normalises the keys, and forwards the derived `options_json` payload to the orchestrator.
 

--- a/docs/evidence/agents-orchestrator/manual-run-issue-2566.md
+++ b/docs/evidence/agents-orchestrator/manual-run-issue-2566.md
@@ -1,0 +1,58 @@
+# Manual Orchestrator Run — Issue #2566 Verification Sweep
+
+> **Status:** Pending execution — requires a GitHub Actions run using repository credentials.
+
+## Dispatch Parameters
+
+Use the following payload when triggering **Agents 70 Orchestrator** manually:
+
+```json
+{
+  "enable_verify_issue": "true",
+  "verify_issue_number": "<replace-with-controlled-issue-number>",
+  "verify_issue_valid_assignees": "copilot,chatgpt-codex-connector,stranske-automation-bot"
+}
+```
+
+### GitHub CLI
+
+```bash
+BRANCH="phase-2-dev"
+ISSUE="<replace-with-controlled-issue-number>"
+
+cat <<'JSON' > orchestrator-verify.json
+{
+  "enable_verify_issue": true,
+  "verify_issue_number": "${ISSUE}",
+  "verify_issue_valid_assignees": "copilot,chatgpt-codex-connector,stranske-automation-bot"
+}
+JSON
+
+gh workflow run agents-70-orchestrator.yml \
+  --ref "${BRANCH}" \
+  --raw-field params_json="$(cat orchestrator-verify.json)"
+```
+
+### REST API
+
+```bash
+curl -X POST \
+  -H "Authorization: token ${GITHUB_TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  -H "Content-Type: application/json" \
+  https://api.github.com/repos/stranske/Trend_Model_Project/actions/workflows/agents-70-orchestrator.yml/dispatches \
+  -d @<(jq -nc --arg ref "phase-2-dev" --arg params "$(cat orchestrator-verify.json)" '{ref: $ref, inputs: {params_json: $params}}')
+```
+
+## Run Log
+
+Once dispatched, record the resulting Actions run URL below so future audits can confirm the `verify-assignment-summary` step logged the matched assignee. Replace `<RUN_URL>` with the actual link and add the assignee details captured in the summary.
+
+- **Run:** `<RUN_URL>`
+- **Matched assignee:** `<matched-login>`
+- **Status:** `pass`
+
+## Notes
+
+- The orchestrator now forwards `verify_issue_valid_assignees` to both the reusable toolkit and verification workflow so `stranske-automation-bot` satisfies the check when label rules require automation involvement.
+- The reusable verification workflow publishes the matched assignee via outputs and step summary; ensure the run summary includes the appended section before closing out Issue #2566.


### PR DESCRIPTION
## Summary
- document the expanded default verify assignee list, including stranske-automation-bot, across automation guides
- update the verification plan to reflect the new assignee roster
- add manual orchestrator run instructions and placeholders for recording the required verification sweep
- highlight that successful verify runs append the matched assignee to the orchestrator summary

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68eddc2d7724833199ae2c60503e01c8