### PR TITLE
Ensure failure tracker tags PRs and auto-resolves on success

### DIFF
--- a/.github/workflows/maint-46-post-ci.yml
+++ b/.github/workflows/maint-46-post-ci.yml
@@ -1739,7 +1739,8 @@ jobs:
                 body = `Healing threshold: ${HEAL_THRESHOLD_DESC}\n${body}`;
               }
 
-              if (prLine && !new RegExp(`Tracked PR:\\s*#${prNumber}`, 'i').test(body)) {
+              const escapedPr = String(prNumber).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              if (prLine && !new RegExp(`Tracked PR:\\s*#${escapedPr}`, 'i').test(body)) {
                 if (/Healing threshold:/i.test(body)) {
                   body = body.replace(/Healing threshold:.*?(?:\n|$)/i, (match) => {
                     const trimmed = match.replace(/\s+$/, '');
@@ -1962,16 +1963,12 @@ jobs:
               const issue_number = item.number;
               const issue = await github.rest.issues.get({ owner, repo, issue_number });
               let body = issue.data.body || '';
-              body = body.replace(/^Resolved:.*$/gim, '').replace(/\n{3,}/g, '\n\n');
-              if (/Last seen:/i.test(body)) {
-                body = body.replace(/Last seen:.*?(?:\n|$)/i, (match) => {
-                  const trimmed = match.replace(/\s+$/, '');
-                  return `${trimmed}\nResolved: ${nowIso}\n`;
-                });
-              } else {
-                body = `Resolved: ${nowIso}\n${body}`;
-              }
-              body = body.replace(/\n{3,}/g, '\n\n').replace(/^\n+/, '').replace(/\s+$/, '');
+              body = body
+                .replace(/^Resolved:.*$/gim, '')
+                .replace(/\n{3,}/g, '\n\n')
+                .replace(/^\n+/, '')
+                .replace(/\s+$/, '');
+              body = `Resolved: ${nowIso}\n${body}`.replace(/\n{3,}/g, '\n\n').replace(/\s+$/, '');
               if (body) {
                 body = `${body}\n`;
               }


### PR DESCRIPTION
## Summary
- Attach the pull request number and a hidden tracked-pr marker to failure tracker issues so the post-CI workflow can update them deterministically.
- Update the failure tracker script to reuse the new metadata when rebuilding issue bodies and to comment/close the issue automatically once the Gate run succeeds.
- Extend the workflow regression tests and harness coverage to assert the new tagging and resolution paths, and document the verification details in the hygiene plan.

## Testing
- pytest tests/test_post_ci_summary.py tests/test_failure_tracker_workflow_scope.py

------
https://chatgpt.com/codex/tasks/task_e_68edeb9234d883318b7242bb70f6dd72