### PR TITLE
Add regression tests for trend model CLI and spec utilities

### DIFF
--- a/docs/test_coverage_plan.md
+++ b/docs/test_coverage_plan.md
@@ -17,8 +17,8 @@
 
 ## Initial Task Checklist
 1. **Baseline Audit**
-   - [ ] Pull the latest coverage artifacts (HTML/JSON) from CI run 18016554334 to pinpoint modules <90%.
-   - [ ] Inventory existing tests by package to map gaps (CLI paths, data pipelines, config validation, etc.).
+   - [x] Pull the latest coverage artifacts (HTML/JSON) from CI run 18016554334 to pinpoint modules <90%.
+   - [x] Inventory existing tests by package to map gaps (CLI paths, data pipelines, config validation, etc.).
 
 2. **Prioritised Test Development**
    - [x] Draft targeted test cases for the lowest-coverage modules first (e.g., any files currently at 0%).
@@ -26,7 +26,7 @@
    - [x] Validate edge cases uncovered during planning (error handling, boundary inputs, config permutations).
 
 3. **Iterative Execution and Tracking**
-   - [ ] Run `pytest` with coverage locally to confirm incremental gains; adjust thresholds as needed.
+   - [x] Run `pytest` with coverage locally to confirm incremental gains; adjust thresholds as needed.
    - [ ] Update coverage tracking spreadsheet or issue checklist to reflect improvements per module.
    - [ ] Re-run CI (via existing workflows) to verify the aggregate coverage and file-level minimums.
 

--- a/tests/test_spec_loader.py
+++ b/tests/test_spec_loader.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
-from trend_model.spec import TrendRunSpec, ensure_run_spec, load_run_spec_from_file
+import pytest
+
+from trend_model import spec as spec_module
+from trend_model.spec import (
+    TrendRunSpec,
+    ensure_run_spec,
+    load_run_spec_from_file,
+    load_run_spec_from_mapping,
+)
 
 
 def test_load_run_spec_from_file() -> None:
@@ -15,6 +25,22 @@ def test_load_run_spec_from_file() -> None:
     assert spec.backtest.selection_mode == "rank"
     assert "annual_return" in spec.backtest.metrics
     assert spec.backtest.export_formats
+
+
+def test_load_run_spec_from_file_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    missing_path = tmp_path / "absent.toml"
+    with pytest.raises(FileNotFoundError):
+        load_run_spec_from_file(missing_path)
+
+    invalid_path = tmp_path / "invalid.toml"
+    invalid_path.write_text("ignored = true", encoding="utf-8")
+
+    monkeypatch.setattr(spec_module.tomllib, "load", lambda fh: [1, 2, 3])
+
+    with pytest.raises(TypeError):
+        load_run_spec_from_file(invalid_path)
 
 
 def test_ensure_run_spec_attaches_attributes() -> None:
@@ -46,3 +72,132 @@ def test_ensure_run_spec_attaches_attributes() -> None:
     assert hasattr(clone, "backtest_spec")
     assert clone.trend_spec.window == ensured.trend.window
     assert ensured.backtest.selection_mode == "rank"
+
+
+def test_ensure_run_spec_handles_failures() -> None:
+    class Explosive:
+        def __getattr__(self, name: str) -> Any:  # pragma: no cover - fallback guard
+            raise RuntimeError("boom")
+
+    assert ensure_run_spec(Explosive()) is None
+
+
+def test_ensure_run_spec_uses_object_setattr(monkeypatch: pytest.MonkeyPatch) -> None:
+    @dataclass(frozen=True)
+    class FrozenConfig:
+        signals: dict[str, Any]
+        sample_split: dict[str, str]
+        portfolio: dict[str, Any]
+
+    cfg = FrozenConfig(
+        signals={"window": 10, "lag": 1, "vol_adjust": True, "vol_target": 0.2},
+        sample_split={"in_start": "2020-01", "out_start": "2021-01"},
+        portfolio={}
+    )
+
+    ensured = ensure_run_spec(cfg)
+
+    assert ensured is not None
+    assert getattr(cfg, "trend_spec").vol_target == 0.2
+
+
+def test_helper_coercion_and_mapping_behaviour(tmp_path: Path) -> None:
+    class WithModelDump:
+        def model_dump(self) -> dict[str, Any]:
+            return {"a": 1}
+
+    class WithBadModelDump:
+        def model_dump(self) -> int:
+            return 5
+
+    class WithDict:
+        def __init__(self) -> None:
+            self.b = 2
+
+    assert spec_module._as_mapping({"key": "value"}) == {"key": "value"}
+    assert spec_module._as_mapping(WithModelDump()) == {"a": 1}
+    assert spec_module._as_mapping(WithBadModelDump()) == {}
+    assert spec_module._as_mapping(WithDict()) == {"b": 2}
+    assert spec_module._as_mapping(object()) == {}
+
+    assert spec_module._coerce_float(None) is None
+    assert spec_module._coerce_float("", default=1.2) == 1.2
+    assert spec_module._coerce_float("3.5") == 3.5
+    assert spec_module._coerce_float("bad", default=7.1) == 7.1
+
+    assert spec_module._as_tuple([1, 2, 3]) == (1, 2, 3)
+    assert spec_module._as_tuple(("x", "y")) == ("x", "y")
+    assert spec_module._as_tuple([1, 2], coerce=str) == ("1", "2")
+
+    base = tmp_path / "base"
+    base.mkdir()
+    rel = spec_module._maybe_path("relative.txt", base_path=base)
+    assert rel == (base / "relative.txt").resolve()
+    assert spec_module._maybe_path("", base_path=base) is None
+    absolute = spec_module._maybe_path(str(base / "abs.txt"), base_path=base)
+    assert absolute == (base / "abs.txt").resolve()
+
+
+def test_build_trend_and_backtest_specs(tmp_path: Path) -> None:
+    payload = {
+        "version": "1",
+        "data": {
+            "csv_path": "returns.csv",
+            "date_column": "Date",
+            "frequency": "ME",
+        },
+        "signals": {"window": 5, "lag": 2, "vol_adjust": False, "vol_target": 0.1, "min_periods": -5},
+        "vol_adjust": {"target_vol": 0.15, "floor_vol": 0.05, "warmup_periods": 0},
+        "sample_split": {
+            "in_start": "2020-01",
+            "in_end": "2020-12",
+            "out_start": "2021-01",
+            "out_end": "2021-12",
+        },
+        "portfolio": {
+            "selection_mode": "manual",
+            "rebalance_calendar": "NYSE",
+            "transaction_cost_bps": 10,
+            "max_turnover": 0.5,
+            "manual_list": ["A", "B"],
+            "indices_list": ("IDX",),
+            "rank": {"foo": "bar"},
+            "selector": {"name": "rank"},
+            "weighting": {"name": "equal"},
+            "custom_weights": {"A": 0.7},
+        },
+        "export": {"directory": "exports", "formats": ["csv"]},
+        "output": {"path": "report.html", "format": "csv"},
+        "run": {"seed": 7, "monthly_cost": "0.05"},
+        "metrics": {"registry": ("sharpe",)},
+        "benchmarks": {"spx": "SPX"},
+        "regime": {"enabled": True},
+    }
+
+    base = tmp_path / "cfg"
+    base.mkdir()
+    (base / "returns.csv").write_text("date,value\n2020-01,1\n", encoding="utf-8")
+
+    spec = load_run_spec_from_mapping(payload, base_path=base)
+
+    assert spec.trend.vol_target is None  # Disabled by vol_adjust False
+    assert spec.trend.min_periods is None
+    assert spec.backtest.manual_list == ("A", "B")
+    assert spec.backtest.indices_list == ("IDX",)
+    assert spec.backtest.export_directory == (base / "exports").resolve()
+    assert spec.backtest.output_path == (base / "report.html").resolve()
+    assert spec.backtest.export_formats == ("csv",)
+
+
+def test_temporary_cwd_creates_directory(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "dir"
+    original = Path.cwd()
+    try:
+        with spec_module._temporary_cwd(None):
+            assert Path.cwd() == original
+        with spec_module._temporary_cwd(target):
+            assert Path.cwd() == target
+    finally:
+        assert Path.cwd() == original
+
+

--- a/tests/test_trend_model_cli.py
+++ b/tests/test_trend_model_cli.py
@@ -41,6 +41,31 @@ def test_load_configuration_with_toml(
     assert Path.cwd() == original_cwd
 
 
+def test_load_configuration_with_yaml(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text("config: true", encoding="utf-8")
+
+    cfg_obj = SimpleNamespace(marker=True)
+    ensured: list[tuple[object, Path]] = []
+
+    monkeypatch.setattr(
+        cli,
+        "_load_yaml_configuration",
+        lambda path: (Path(path), cfg_obj),
+    )
+    monkeypatch.setattr(
+        cli,
+        "ensure_run_spec",
+        lambda cfg, base_path: ensured.append((cfg, base_path)),
+    )
+
+    resolved_path, resolved_cfg = cli._load_configuration(str(cfg_path))
+
+    assert resolved_path == cfg_path
+    assert resolved_cfg is cfg_obj
+    assert ensured == [(cfg_obj, cfg_path.parent)]
+
+
 def test_run_requires_artefacts_when_formats_supplied(tmp_path: Path) -> None:
     cfg_path = tmp_path / "config.yml"
     cfg_path.write_text("config", encoding="utf-8")
@@ -49,6 +74,29 @@ def test_run_requires_artefacts_when_formats_supplied(tmp_path: Path) -> None:
         cli.run(["--config", str(cfg_path), "--formats", "csv"])
 
     assert exc.value.code == 2
+
+
+def test_load_toml_payload_requires_table(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload_path = tmp_path / "broken.toml"
+    payload_path.write_text("ignored = true", encoding="utf-8")
+
+    stub_loader = SimpleNamespace(load=lambda fh: ["not", "a", "mapping"])
+    monkeypatch.setattr(cli, "_toml_module", stub_loader)
+
+    with pytest.raises(cli.TrendCLIError, match="top-level table"):
+        cli._load_toml_payload(payload_path)
+
+
+def test_load_toml_payload_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    payload_path = tmp_path / "config.toml"
+    payload_path.write_text("value = 1", encoding="utf-8")
+
+    stub_loader = SimpleNamespace(load=lambda fh: {"value": 1})
+    monkeypatch.setattr(cli, "_toml_module", stub_loader)
+
+    assert cli._load_toml_payload(payload_path) == {"value": 1}
 
 
 def test_run_success_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -110,3 +158,120 @@ def test_run_success_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
     assert (report_path).read_text(encoding="utf-8") == "<html></html>"
     assert (report_path.with_suffix(".pdf")).read_bytes() == b"pdf"
     assert written and written[0][0] == export_dir
+
+
+def test_run_without_artefacts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg_path = tmp_path / "config.yml"
+    cfg_path.write_text("config", encoding="utf-8")
+    returns_path = tmp_path / "returns.csv"
+    returns_path.write_text("date,value\n2024-01,1\n", encoding="utf-8")
+
+    monkeypatch.setattr(cli, "_load_configuration", lambda path: (Path(path), {}))
+    monkeypatch.setattr(cli, "_resolve_returns_path", lambda *_: returns_path)
+    monkeypatch.setattr(cli, "_ensure_dataframe", lambda *_: pd.DataFrame({"v": [1]}))
+    monkeypatch.setattr(cli, "_determine_seed", lambda *_: None)
+
+    export_calls: list[tuple[object | None, tuple[str, ...] | None]] = []
+
+    def fake_run_pipeline(*args, **kwargs):
+        return SimpleNamespace(), "run42", tmp_path / "log.jsonl"
+
+    monkeypatch.setattr(cli, "_run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(cli, "_print_summary", lambda *a, **k: None)
+    monkeypatch.setattr(
+        cli,
+        "_prepare_export_config",
+        lambda cfg, export_dir, formats: export_calls.append((export_dir, formats)),
+    )
+
+    report_path = tmp_path / "output" / "report.html"
+
+    class Artefacts:
+        html = "<html></html>"
+        pdf_bytes = None
+
+    monkeypatch.setattr(cli, "generate_unified_report", lambda *a, **k: Artefacts())
+    monkeypatch.setattr(
+        cli,
+        "_resolve_report_output_path",
+        lambda output, export_dir, run_id: report_path,
+    )
+
+    exit_code = cli.run(
+        [
+            "--config",
+            str(cfg_path),
+            "--returns",
+            str(returns_path),
+            "--output",
+            str(report_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert report_path.read_text(encoding="utf-8") == "<html></html>"
+    # The export configuration should see formats=None when artefacts are omitted.
+    assert export_calls == [(None, None)]
+
+
+def test_run_pdf_flag_requires_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cfg_path = tmp_path / "config.yml"
+    cfg_path.write_text("cfg", encoding="utf-8")
+
+    monkeypatch.setattr(cli, "_load_configuration", lambda path: (Path(path), {}))
+    monkeypatch.setattr(cli, "_resolve_returns_path", lambda *_: tmp_path / "returns.csv")
+    monkeypatch.setattr(cli, "_ensure_dataframe", lambda *_: pd.DataFrame({"v": [1]}))
+    monkeypatch.setattr(cli, "_determine_seed", lambda *_: None)
+    monkeypatch.setattr(
+        cli,
+        "_run_pipeline",
+        lambda *a, **k: (SimpleNamespace(), "run42", tmp_path / "log.jsonl"),
+    )
+    monkeypatch.setattr(cli, "_print_summary", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "_prepare_export_config", lambda *a, **k: None)
+    monkeypatch.setattr(
+        cli,
+        "_resolve_report_output_path",
+        lambda *_: tmp_path / "report.html",
+    )
+
+    class Artefacts:
+        html = "ok"
+        pdf_bytes = None
+
+    monkeypatch.setattr(cli, "generate_unified_report", lambda *a, **k: Artefacts())
+
+    exit_code = cli.run(["--config", str(cfg_path), "--pdf"])
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "PDF generation failed" in captured.err
+
+
+def test_run_trend_cli_error(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    def raise_error(*_):
+        raise cli.TrendCLIError("boom")
+
+    monkeypatch.setattr(cli, "_load_configuration", raise_error)
+
+    exit_code = cli.run(["--config", "foo.yml"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "boom" in captured.err
+
+
+def test_run_file_not_found(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    def raise_missing(*_):
+        raise FileNotFoundError("missing.yml")
+
+    monkeypatch.setattr(cli, "_load_configuration", raise_missing)
+
+    exit_code = cli.run(["--config", "missing.yml"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "missing.yml" in captured.err

--- a/tests/test_trend_model_sitecustomize.py
+++ b/tests/test_trend_model_sitecustomize.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import importlib.util
+import pytest
+
+from trend_model import _sitecustomize as site
+
+
+def test_maybe_apply_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(site.ENV_FLAG, raising=False)
+    called = []
+    monkeypatch.setattr(site, "apply", lambda: called.append(True))
+
+    site.maybe_apply()
+    assert called == []
+
+    monkeypatch.setenv(site.ENV_FLAG, "1")
+    site.maybe_apply()
+    assert called == [True]
+
+
+def test_bootstrap_and_apply(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(site, "SRC_DIR", Path.cwd())
+    monkeypatch.setattr(site.sys, "path", [])
+
+    site.bootstrap()
+    assert site.sys.path[0] == str(Path.cwd())
+
+    called = []
+    monkeypatch.setattr(site, "_ensure_src_on_sys_path", lambda: called.append("src"))
+    monkeypatch.setattr(site, "_ensure_joblib_external", lambda: called.append("joblib"))
+
+    site.apply()
+    assert called == ["src", "joblib"]
+
+
+def test_ensure_src_on_sys_path_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    temp_dir = Path.cwd()
+    monkeypatch.setattr(site, "SRC_DIR", temp_dir)
+    monkeypatch.setattr(site.sys, "path", ["existing"])
+
+    site._ensure_src_on_sys_path()
+    assert str(temp_dir) in site.sys.path
+
+    # Second invocation should not duplicate entries.
+    site._ensure_src_on_sys_path()
+    assert site.sys.path.count(str(temp_dir)) == 1
+
+
+def test_ensure_joblib_external_behaviour(monkeypatch: pytest.MonkeyPatch) -> None:
+    base = Path.cwd()
+
+    def fake_find_spec(name: str) -> SimpleNamespace | None:
+        if name == "joblib":
+            return SimpleNamespace(origin=str(base / "site-packages" / "joblib.py"))
+        return None
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    # Acceptable when resolving from site-packages.
+    site._ensure_joblib_external()
+
+    # Missing module should be ignored gracefully.
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+    site._ensure_joblib_external()
+
+    # Resolution within the repository should raise an error.
+    repo_stub = SimpleNamespace(origin=str(site.REPO_ROOT / "joblib.py"))
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: repo_stub)
+    with pytest.raises(ImportError, match="repository stub"):
+        site._ensure_joblib_external()
+
+    # Unexpected location without site-packages/dist-packages should raise.
+    elsewhere = SimpleNamespace(origin=str(Path("/tmp/joblib.py")))
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: elsewhere)
+    with pytest.raises(ImportError, match="should resolve"):
+        site._ensure_joblib_external()
+


### PR DESCRIPTION
## Summary
- add high-coverage tests for the trend model CLI including TOML handling, export behaviour, and error paths
- expand the trend model spec suite to exercise helper coercions, mapping loaders, and temporary working directory semantics
- cover the sitecustomize bootstrap logic and update the coverage improvement checklist to reflect local coverage execution

## Testing
- pytest tests/test_trend_model_cli.py tests/test_spec_loader.py tests/test_trend_model_sitecustomize.py tests/test_trend_model_app.py --cov=src/trend_model --cov-report=term


------
https://chatgpt.com/codex/tasks/task_e_68edfdafb43c83319af67312889be729