### PR TITLE
Fix heredoc syntax in mypy verification guard

### DIFF
--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -188,25 +188,26 @@ jobs:
             echo "::error file=pyproject.toml::pyproject.toml is required to verify the mypy python_version pin"
             exit 1
           fi
-          pinned_version="$(python - <<'PY'
-            import sys
-            import tomllib
-            from pathlib import Path
+          pinned_version="$(
+            python - <<'PY'
+import sys
+import tomllib
+from pathlib import Path
 
-            pyproject = Path("pyproject.toml")
-            try:
-                data = tomllib.loads(pyproject.read_text())
-            except tomllib.TOMLDecodeError as exc:  # pragma: no cover - workflow guard
-                print(f"::error file=pyproject.toml::Failed to parse pyproject.toml: {exc}")
-                sys.exit(1)
+pyproject = Path("pyproject.toml")
+try:
+    data = tomllib.loads(pyproject.read_text())
+except tomllib.TOMLDecodeError as exc:  # pragma: no cover - workflow guard
+    print(f"::error file=pyproject.toml::Failed to parse pyproject.toml: {exc}")
+    sys.exit(1)
 
-            pin = data.get("tool", {}).get("mypy", {}).get("python_version")
-            if pin is None:
-                print("::error file=pyproject.toml::[tool.mypy].python_version is not configured; cannot gate mypy execution")
-                sys.exit(1)
+pin = data.get("tool", {}).get("mypy", {}).get("python_version")
+if pin is None:
+    print("::error file=pyproject.toml::[tool.mypy].python_version is not configured; cannot gate mypy execution")
+    sys.exit(1)
 
-            print(pin)
-            PY
+print(pin)
+PY
           )"
           if [ -z "${pinned_version}" ]; then
             echo "::error::Unable to determine mypy python_version pin from pyproject.toml"


### PR DESCRIPTION
## Summary
- adjust the reusable CI workflow to wrap the mypy pin verification python snippet in a subshell without here-doc indentation issues
- ensure the heredoc terminator is flush so shellcheck no longer reports parsing errors

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68eeae9d29488331939003ca9cb28c79