### PR TITLE
tests: fix docs-only handler assertions

### DIFF
--- a/tests/test_automation_workflows.py
+++ b/tests/test_automation_workflows.py
@@ -224,8 +224,8 @@ class TestAutomationWorkflowCoverage(unittest.TestCase):
 
         self.assertIn("const marker = '<!-- gate-docs-only -->';", script)
         self.assertIn("comment.body.includes(marker)", script)
-        self.assertIn("body: `${marker}\\n${message}`", script)
-        self.assertIn(".addRaw(`${message}\\n`)", script)
+        self.assertIn(r"body: `${marker}\n${message}`", script)
+        self.assertIn(r".addRaw(`${message}\n`)", script)
         self.assertIn("await core.summary", script)
         self.assertIn("core.setOutput('description', message);", script)
 


### PR DESCRIPTION
## Summary
- ensure the gate docs-only workflow test checks for literal `\n` sequences using raw strings

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68ef0f5e33548331a6175d8b8ecc1c47