### PR TITLE
Harden PR autofix workflow concurrency and fork handling

### DIFF
--- a/.github/workflows/pr-02-autofix.yml
+++ b/.github/workflows/pr-02-autofix.yml
@@ -14,7 +14,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: pr-02-autofix-${{ github.event.pull_request.number || github.run_id }}
+  group: pr-02-autofix-${{ github.event.pull_request.head.ref || github.head_ref || github.ref_name || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/reusable-18-autofix.yml
+++ b/.github/workflows/reusable-18-autofix.yml
@@ -19,7 +19,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: pr-02-autofix-${{ github.event.pull_request.number || github.run_id }}
+  group: pr-02-autofix-${{ github.event.pull_request.head.ref || github.head_ref || github.ref_name || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -423,8 +423,8 @@ jobs:
             ].join('\n');
             await github.rest.issues.create({ owner: context.repo.owner, repo: context.repo.repo, title: issueTitle, body, labels:['autofix:regression'] });
 
-      - name: Emit JSON report
-        if: steps.guard.outputs.skip != 'true'
+      - name: Emit JSON report (same-repo)
+        if: steps.guard.outputs.skip != 'true' && steps.same_repo.outputs.same == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -444,7 +444,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Upload JSON report
-        if: steps.guard.outputs.skip != 'true'
+        if: steps.guard.outputs.skip != 'true' && steps.same_repo.outputs.same == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: autofix-report-pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- scope the PR autofix concurrency group to the pull request head ref so only one run executes per branch
- skip JSON report artifacts for forked pull requests to avoid leaking data while keeping same-repo behaviour unchanged

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68efde72fc5c8331a12fb892a25ea911