### PR TITLE
ci: restore nightly selftest reusable workflow

### DIFF
--- a/.github/workflows/selftest-reusable-ci.yml
+++ b/.github/workflows/selftest-reusable-ci.yml
@@ -1,0 +1,263 @@
+name: Selftest Reusable CI
+
+on:
+  schedule:
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why are you running this self-test?'
+        required: false
+        default: 'nightly verification'
+      python_versions:
+        description: >-
+          JSON array of Python versions forwarded to the reusable CI workflow.
+          Leave empty to exercise the default nightly configuration.
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  scenario:
+    name: Scenario - ${{ matrix.name }}
+    uses: ./.github/workflows/reusable-10-ci-python.yml
+    secrets: inherit
+    with:
+      python-versions: ${{ inputs.python_versions && inputs.python_versions != '' && inputs.python_versions || '["3.11"]' }}
+      artifact-prefix: 'sf-${{ matrix.name }}-'
+      enable-metrics: ${{ matrix.enable-metrics }}
+      enable-history: ${{ matrix.enable-history }}
+      enable-classification: ${{ matrix.enable-classification }}
+      enable-coverage-delta: ${{ matrix.enable-coverage-delta }}
+      enable-soft-gate: ${{ matrix.enable-soft-gate }}
+      baseline-coverage: ${{ matrix.baseline-coverage || '0' }}
+      coverage-alert-drop: ${{ matrix.coverage-alert-drop || '1' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: minimal
+            enable-metrics: false
+            enable-history: false
+            enable-classification: false
+            enable-coverage-delta: false
+            enable-soft-gate: false
+          - name: metrics_only
+            enable-metrics: true
+            enable-history: false
+            enable-classification: false
+            enable-coverage-delta: false
+            enable-soft-gate: false
+          - name: metrics_history
+            enable-metrics: true
+            enable-history: true
+            enable-classification: false
+            enable-coverage-delta: false
+            enable-soft-gate: false
+          - name: classification_only
+            enable-metrics: false
+            enable-history: false
+            enable-classification: true
+            enable-coverage-delta: false
+            enable-soft-gate: false
+          - name: coverage_delta
+            enable-metrics: false
+            enable-history: false
+            enable-classification: false
+            enable-coverage-delta: true
+            enable-soft-gate: false
+            baseline-coverage: '65'
+            coverage-alert-drop: '2'
+          - name: full_soft_gate
+            enable-metrics: true
+            enable-history: true
+            enable-classification: true
+            enable-coverage-delta: true
+            enable-soft-gate: true
+            baseline-coverage: '65'
+            coverage-alert-drop: '2'
+
+  aggregate:
+    name: Aggregate Verification
+    if: ${{ always() }}
+    needs: scenario
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      verification_table: ${{ steps.verify.outputs.table }}
+      failures: ${{ steps.verify.outputs.failures }}
+      run_id: ${{ steps.run_metadata.outputs.run_id }}
+    env:
+      SCENARIO_LIST: minimal, metrics_only, metrics_history, classification_only, coverage_delta, full_soft_gate
+      PYTHON_VERSIONS: ${{ inputs.python_versions && inputs.python_versions != '' && inputs.python_versions || '["3.11"]' }}
+      DISPATCH_REASON: ${{ inputs.reason || '' }}
+      TRIGGER_EVENT: ${{ github.event_name }}
+    steps:
+      - name: Summarize matrix execution
+        run: |
+          reason="${DISPATCH_REASON}"
+          if [ -z "${reason}" ]; then
+            if [ "${TRIGGER_EVENT}" = "schedule" ]; then
+              reason="scheduled run"
+            else
+              reason="(not provided)"
+            fi
+          fi
+
+          {
+            echo "## Self-Test Matrix Summary"
+            echo "Workflow result: ${{ needs.scenario.result }}"
+            echo "Trigger: ${TRIGGER_EVENT}"
+            echo "Dispatch reason: ${reason}"
+            echo "Requested python-versions: ${PYTHON_VERSIONS}"
+            echo "Scenarios: ${SCENARIO_LIST}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Capture run metadata
+        id: run_metadata
+        run: |
+          echo "run_id=${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify artifact expectations
+        id: verify
+        uses: actions/github-script@v7
+        env:
+          PYTHON_VERSIONS: ${{ env.PYTHON_VERSIONS }}
+          SCENARIO_LIST: ${{ env.SCENARIO_LIST }}
+        with:
+          script: |
+            const defaultPythonVersions = ['3.11'];
+            let pythonVersions = defaultPythonVersions;
+            const rawPythonVersions = process.env.PYTHON_VERSIONS;
+
+            if (rawPythonVersions && rawPythonVersions.trim()) {
+              try {
+                const parsed = JSON.parse(rawPythonVersions.trim());
+                if (Array.isArray(parsed) && parsed.length) {
+                  pythonVersions = parsed.map(String);
+                } else {
+                  core.warning(`Parsed python_versions input is empty; falling back to ${defaultPythonVersions.join(', ')}`);
+                }
+              } catch (error) {
+                core.warning(`Unable to parse python_versions input (${rawPythonVersions}); using ${defaultPythonVersions.join(', ')}. Error: ${error}`);
+              }
+            }
+
+            const scenarios = process.env.SCENARIO_LIST.split(',').map((name) => name.trim()).filter(Boolean);
+            const scenarioDefinitions = scenarios.map((name) => {
+              switch (name) {
+                case 'minimal':
+                  return { name, metrics:false, history:false, classification:false, covDelta:false, soft:false };
+                case 'metrics_only':
+                  return { name, metrics:true, history:false, classification:false, covDelta:false, soft:false };
+                case 'metrics_history':
+                  return { name, metrics:true, history:true, classification:false, covDelta:false, soft:false };
+                case 'classification_only':
+                  return { name, metrics:false, history:false, classification:true, covDelta:false, soft:false };
+                case 'coverage_delta':
+                  return { name, metrics:false, history:false, classification:false, covDelta:true, soft:false };
+                case 'full_soft_gate':
+                  return { name, metrics:true, history:true, classification:true, covDelta:true, soft:true };
+                default:
+                  core.warning(`Unknown scenario '${name}' discovered; treating as minimal.`);
+                  return { name, metrics:false, history:false, classification:false, covDelta:false, soft:false };
+              }
+            });
+
+            const run_id = context.runId;
+            const { owner, repo } = context.repo;
+
+            async function listArtifacts() {
+              const collected = [];
+              let page = 1;
+              while (true) {
+                const resp = await github.rest.actions.listWorkflowRunArtifacts({ owner, repo, run_id, per_page: 100, page });
+                const batch = resp.data.artifacts || [];
+                collected.push(...batch);
+                if (batch.length < 100) {
+                  break;
+                }
+                page += 1;
+              }
+              return collected;
+            }
+
+            const artifacts = await listArtifacts();
+            const names = new Set(artifacts.map((artifact) => artifact.name));
+
+            function expectedFor(s) {
+              const prefix = (suffix) => `sf-${s.name}-${suffix}`;
+              const expected = [];
+
+              pythonVersions.forEach((version) => {
+                expected.push(prefix(`coverage-${version}`));
+              });
+
+              if (s.metrics) expected.push(prefix('ci-metrics'));
+              if (s.history) expected.push(prefix('metrics-history'));
+              if (s.classification) expected.push(prefix('classification'));
+              if (s.covDelta) expected.push(prefix('coverage-delta'));
+              if (s.soft) {
+                expected.push(prefix('coverage-summary'));
+                expected.push(prefix('coverage-trend'));
+                expected.push(prefix('coverage-trend-history'));
+              }
+              return expected;
+            }
+
+            const expectedGlobal = new Set();
+            scenarioDefinitions.forEach((scenario) => expectedFor(scenario).forEach((name) => expectedGlobal.add(name)));
+
+            const rows = ['| Scenario | Expected Artifacts | Missing | Unexpected Present | Status |', '|---|---|---|---|---|'];
+            const report = [];
+            let failures = 0;
+
+            for (const scenario of scenarioDefinitions) {
+              const expected = expectedFor(scenario);
+              const missing = expected.filter((name) => !names.has(name));
+              const prefix = `sf-${scenario.name}-`;
+              const actual = [...names].filter((name) => name.startsWith(prefix));
+              const unexpected = actual.filter((name) => !expected.includes(name));
+              const ok = missing.length === 0 && unexpected.length === 0;
+              if (!ok) {
+                failures += 1;
+              }
+              rows.push(`| ${scenario.name} | ${expected.join('<br>')} | ${missing.join('<br>') || '—'} | ${unexpected.join('<br>') || '—'} | ${ok ? '✅' : '❌'} |`);
+              report.push({ scenario: scenario.name, expected, missing, unexpected, ok });
+            }
+
+            const stray = [...names].filter((name) => name.startsWith('sf-') && !expectedGlobal.has(name));
+            if (stray.length) {
+              rows.push(`| (stray) | (n/a) | (n/a) | ${stray.join('<br>')} | ❌ |`);
+              report.push({ scenario: '_stray_', expected: [], missing: [], unexpected: stray, ok: false });
+              failures += 1;
+            }
+
+            core.setOutput('table', rows.join('\n'));
+            core.setOutput('failures', String(failures));
+            const summary = { run_id, artifact_count: artifacts.length, failures, scenarios: report };
+            require('fs').writeFileSync('selftest-report.json', JSON.stringify(summary, null, 2));
+
+      - name: Append verification table
+        run: |
+          {
+            echo "### Artifact Verification"
+            echo "${{ steps.verify.outputs.table }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload self-test report
+        uses: actions/upload-artifact@v4
+        with:
+          name: selftest-report
+          path: selftest-report.json
+
+      - name: Fail on verification errors
+        if: ${{ steps.verify.outputs.failures != '0' }}
+        run: |
+          echo "Artifact expectation mismatches detected." >&2
+          exit 1


### PR DESCRIPTION
## Summary
- add a scheduled `.github/workflows/selftest-reusable-ci.yml` wrapper that runs the reusable Python CI matrix via `jobs.scenario.uses`, fans into the nightly scenarios, and aggregates artifacts with verification outputs
- extend the workflow consolidation tests to cover the new reusable entry point, dispatch contract, scenario matrix wiring, and aggregation safeguards

## Testing
- pytest tests/test_workflow_selftest_consolidation.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f16c2b98508331865be9535b6f29e1