### PR TITLE
Clean up Gate docs-only marker comment when code changes resume

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -223,6 +223,42 @@ jobs:
             core.setOutput('state', 'success');
             core.setOutput('description', message);
 
+      - name: Remove stale docs-only marker
+        if: needs.detect.outputs.doc_only != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- gate-docs-only -->';
+
+            if (context.eventName !== 'pull_request') {
+              core.info('Not a pull_request event; nothing to clean up.');
+              return;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(comment =>
+              typeof comment.body === 'string' && comment.body.includes(marker)
+            );
+
+            if (!existing) {
+              core.info('No docs-only fast-pass marker found to remove.');
+              return;
+            }
+
+            await github.rest.issues.deleteComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+            });
+
+            core.info(`Removed stale docs-only marker comment ${existing.id}.`);
+
       - name: Download coverage (3.11)
         if: ${{ needs.detect.outputs.doc_only != 'true' && needs.core-tests-311.result != 'skipped' }}
         continue-on-error: true


### PR DESCRIPTION
## Summary
- remove the docs-only fast-pass marker comment when a PR now includes code changes so reviewers do not see stale messaging
- extend the Gate workflow coverage tests to assert the cleanup step exists and calls the GitHub API to delete the marker

## Testing
- pytest tests/test_workflow_naming.py tests/test_automation_workflows.py

------
https://chatgpt.com/codex/tasks/task_e_68f291067ae88331b5a54cb3d8acde1c