### PR TITLE
Fix matrix fallback without coalesce in reusable CI workflow

### DIFF
--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -159,7 +159,7 @@ jobs:
             || format(
               '["{0}"]',
               (
-                inputs['python-version'] != '' && inputs['python-version']
+                inputs['python-version'] && inputs['python-version']
               )
               || '3.11'
             )


### PR DESCRIPTION
## Summary
- replace the unsupported `coalesce` helper in the matrix resolver with expression chaining supported by GitHub Actions
- default the matrix to the caller-provided `python-version` (or 3.11) when no explicit list is passed

## Testing
- Not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f2914e152483319bd9252401a0fe64