### PR TITLE
docs: sync autofix docs with refreshed workflow ranges

### DIFF
--- a/docs/autofix_type_hygiene.md
+++ b/docs/autofix_type_hygiene.md
@@ -4,8 +4,8 @@ This repository includes an extended **autofix** workflow that standardises styl
 
 ## What It Does (Scope)
 1. Code formatting & style
-   - Early `ruff check --fix --exit-zero` sweep that runs before the heavier composite so trivial whitespace/import issues are cleaned even when later phases short-circuit.【F:.github/workflows/reusable-18-autofix.yml†L96-L110】
-   - Full composite run covering `ruff`, `black`, `isort`, and `docformatter` with both safe and targeted lint passes.【F:.github/actions/autofix/action.yml†L33-L111】
+- Early `ruff check --fix --exit-zero` sweep that runs before the heavier composite so trivial whitespace/import issues are cleaned even when later phases short-circuit.【F:.github/workflows/reusable-18-autofix.yml†L121-L148】
+  - Full composite run covering `ruff`, `black`, `isort`, and `docformatter` with both safe and targeted lint passes.【F:.github/actions/autofix/action.yml†L34-L110】
    - `black` (code formatting)
    - `isort` (import sorting where unambiguous)
    - `docformatter` (docstring wrapping)
@@ -20,9 +20,9 @@ This repository includes an extended **autofix** workflow that standardises styl
 If any step produces changes, the workflow auto‑commits them back to the PR branch with a conventional message (e.g. `chore(autofix): style + type hygiene`).
 
 ## Result Labels & Status Comment
-- Same-repo branches that receive an autofix commit automatically gain the `autofix:applied` label; forked PRs receive `autofix:patch` when an artifact is uploaded.【F:.github/workflows/reusable-18-autofix.yml†L213-L291】
-- Runs that finish clean (no diff) toggle `autofix:clean`, while any unresolved diagnostics append `autofix:debt` alongside the primary outcome label.【F:.github/workflows/reusable-18-autofix.yml†L292-L360】
-- Every execution updates a single status comment with an **Autofix result** block that lists the applied labels so reviewers can confirm the outcome at a glance.【F:.github/workflows/reusable-18-autofix.yml†L187-L286】【F:scripts/build_autofix_pr_comment.py†L218-L253】
+- Same-repo branches that receive an autofix commit automatically gain the `autofix:applied` label; forked PRs receive `autofix:patch` when an artifact is uploaded.【F:.github/workflows/reusable-18-autofix.yml†L187-L281】
+- Runs that finish clean (no diff) toggle `autofix:clean`, while any unresolved diagnostics append `autofix:debt` alongside the primary outcome label.【F:.github/workflows/reusable-18-autofix.yml†L283-L371】
+- Every execution updates a single status comment with an **Autofix result** block that lists the applied labels so reviewers can confirm the outcome at a glance.【F:.github/workflows/reusable-18-autofix.yml†L187-L297】【F:scripts/build_autofix_pr_comment.py†L218-L253】
 
 ## What It Intentionally Does NOT Do
 - It does **not** attempt deep structural refactors or resolve complex type inference issues.
@@ -100,9 +100,9 @@ Run these quick checks whenever the PR-02 autofix lane changes to confirm Issue�
 3. Download and apply the patch with `git am` to confirm it replays cleanly, then push manually to complete the fix.
 
 ### Label outcomes
-1. Re-run the workflow on a clean branch (no staged lint issues) and verify the status comment reports “No changes required” with the `autofix:clean` label.【F:.github/workflows/reusable-18-autofix.yml†L248-L272】
-2. Introduce a trivial lint (e.g. reorder imports) and confirm the rerun pushes a commit, applies `autofix:applied`, and lists the label in the comment.【F:.github/workflows/reusable-18-autofix.yml†L213-L239】
-3. If the run leaves residual diagnostics, expect `autofix:debt` to accompany either result label.【F:.github/workflows/reusable-18-autofix.yml†L292-L360】
+1. Re-run the workflow on a clean branch (no staged lint issues) and verify the status comment reports “No changes required” with the `autofix:clean` label.【F:.github/workflows/reusable-18-autofix.yml†L283-L297】
+2. Introduce a trivial lint (e.g. reorder imports) and confirm the rerun pushes a commit, applies `autofix:applied`, and lists the label in the comment.【F:.github/workflows/reusable-18-autofix.yml†L187-L209】
+3. If the run leaves residual diagnostics, expect `autofix:debt` to accompany either result label.【F:.github/workflows/reusable-18-autofix.yml†L299-L371】
 
 ### Label gating sanity check
 1. Remove the `autofix` label (or open a fresh PR without it) and trigger the workflow via the **Re-run** button.


### PR DESCRIPTION
## Summary
- update the autofix hygiene guide so its citations match the latest workflow line numbers
- keep the verification checklist in sync with the updated commit / no-change label logic

## Testing
- pytest tests/test_build_autofix_pr_comment.py

------
https://chatgpt.com/codex/tasks/task_e_68f2b966699c8331ba70a71126aa9048