### PR TITLE
Fix YAML syntax error in Codex keepalive summary

### DIFF
--- a/.github/workflows/reusable-16-agents.yml
+++ b/.github/workflows/reusable-16-agents.yml
@@ -818,12 +818,11 @@ jobs:
               }
             }
 
-            core.summary.addHeading('Codex Keepalive');
-# summary trimmed to concise heading to avoid duplication during revert
- 4bcf3a1e (Revert accidental change to reusable-16-agents.yml to satisfy Health 45 guard)
-            if (triggered.length) {
-              core.summary.addList(triggered);
-            } else {
-              core.summary.addRaw('No unattended Codex tasks detected.');
-            }
-            core.summary.write();
+              core.summary.addHeading('Codex Keepalive');
+              // Summary trimmed to a concise heading to avoid duplication during revert handling.
+              if (triggered.length) {
+                core.summary.addList(triggered);
+              } else {
+                core.summary.addRaw('No unattended Codex tasks detected.');
+              }
+              core.summary.write();


### PR DESCRIPTION
## Summary
- remove stray revert annotation from the reusable agents workflow
- replace it with a JavaScript comment inside the keepalive summary step so the YAML parses again

## Testing
- actionlint .github/workflows/reusable-16-agents.yml *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f2d8a38ec4833185d9b67e3a53509a