### PR TITLE
Ensure Codex bootstrap label falls back to default

### DIFF
--- a/.github/workflows/agents-70-orchestrator.yml
+++ b/.github/workflows/agents-70-orchestrator.yml
@@ -152,6 +152,17 @@ jobs:
             const bootstrap = nested(merged.bootstrap);
             const keepalive = nested(merged.keepalive);
 
+            const bootstrapLabelSource =
+              merged.bootstrap_issues_label ??
+              bootstrap.label ??
+              bootstrap.labels ??
+              '';
+            let bootstrapLabel = toString(bootstrapLabelSource, '').trim();
+            if (!bootstrapLabel) {
+              bootstrapLabel = DEFAULTS.bootstrap_issues_label;
+              core.notice(`Using default bootstrap label: ${DEFAULTS.bootstrap_issues_label}`);
+            }
+
             const diagnosticModeRaw = toString(merged.diagnostic_mode, DEFAULTS.diagnostic_mode).trim().toLowerCase();
             const diagnosticMode = ['full', 'dry-run'].includes(diagnosticModeRaw) ? diagnosticModeRaw : 'off';
 
@@ -206,11 +217,11 @@ jobs:
               verify_issue_valid_assignees: verifyIssueAssignees,
               enable_watchdog: toBoolString(merged.enable_watchdog, DEFAULTS.enable_watchdog),
               enable_keepalive: toBoolString(merged.enable_keepalive ?? keepalive.enabled, DEFAULTS.enable_keepalive),
-              enable_bootstrap: toBoolString(merged.enable_bootstrap ?? bootstrap.enable, DEFAULTS.enable_bootstrap),
-              bootstrap_issues_label: toString(
-                merged.bootstrap_issues_label ?? bootstrap.label,
-                DEFAULTS.bootstrap_issues_label
+              enable_bootstrap: toBoolString(
+                merged.enable_bootstrap ?? bootstrap.enabled ?? bootstrap.enable,
+                DEFAULTS.enable_bootstrap
               ),
+              bootstrap_issues_label: bootstrapLabel,
               draft_pr: toBoolString(merged.draft_pr, DEFAULTS.draft_pr),
               options_json: sanitiseOptions(optionsSource)
             };


### PR DESCRIPTION
## Summary
- trim and sanitise the Codex bootstrap label input when resolving orchestrator parameters
- fall back to the default `agent:codex` label and emit a notice when no usable label is provided

## Testing
- pytest tests/test_workflow_agents_consolidation.py

------
https://chatgpt.com/codex/tasks/task_e_68f2dc320e748331a215d04c97c588a9