### PR TITLE
Codex bootstrap for #2726 – refine keepalive summary

### DIFF
--- a/.github/workflows/reusable-16-agents.yml
+++ b/.github/workflows/reusable-16-agents.yml
@@ -759,7 +759,7 @@ jobs:
             }
 
             if (triggered.length) {
-              summary.addList(summariseList(triggered));
+              summary.addDetails('Triggered keepalive comments', summariseList(triggered));
             } else {
               summary.addRaw('No unattended Codex tasks detected.');
             }

--- a/tests/test_workflow_agents_consolidation.py
+++ b/tests/test_workflow_agents_consolidation.py
@@ -295,8 +295,21 @@ def test_keepalive_summary_reports_scope_and_activity():
         or "keepalive posted" in text
     ), "Keepalive summary must describe whether any PRs required intervention"
     assert (
+        "Triggered keepalive comments" in text
+    ), "Keepalive summary should wrap triggered comment list in a collapsible section"
+    assert (
         "Triggered keepalive count:" in text
     ), "Keepalive summary should record how many follow-up comments were sent"
+
+
+def test_keepalive_job_runs_after_failures():
+    data = _load_workflow_yaml("reusable-16-agents.yml")
+    jobs = data.get("jobs", {})
+    keepalive = jobs.get("keepalive")
+    assert keepalive, "Reusable workflow must define keepalive job"
+    assert (
+        keepalive.get("if") == "${{ always() && inputs.enable_keepalive == 'true' }}"
+    ), "Keepalive job must run even if earlier jobs fail while respecting enable_keepalive flag"
 
 
 def test_orchestrator_forwards_enable_watchdog_flag():


### PR DESCRIPTION
### Source Issue #2726: Agents 70 Orchestrator: dedupe keepalive step and lock bootstrap filters

Source: https://github.com/stranske/Trend_Model_Project/issues/2726

> Topic GUID: 6f6af46c-1518-52a8-9315-6d4b7e9fad1e
> 
> ## Why
> - Summary
>     - The orchestrator lists “Codex Keepalive Sweep” twice and has broad toggles. Remove duplication and ensure bootstrap only acts on a specific label (default agent:codex). Concurrency should remain per-branch ref. 
> 
>   - Scope
> 
>     - Remove duplicate keepalive entry.
> 
>     - Confirm defaults: bootstrap_issues_label: agent:codex.
> 
>     - Validate concurrency group and schedule remain as is.
> 
> ## Tasks
> - [ ] One keepalive job appears in job list
> 
> - [ ] Bootstrap filters strictly on the configured label
> 
> - [ ] Successful scheduled run without no-op spam
> 
> ## Acceptance criteria
> - Orchestrator run shows a single keepalive job, and bootstrap operates only on issues labeled agent:codex.
> 
> ## Implementation notes
> _Not provided._

### Follow-up updates
- Wrap triggered keepalive comment logs in a collapsible job-summary section to cut down on scheduled-run noise while retaining the triggered count.
- Lock in the `always()` guard on the keepalive job with a consolidation test so the sweep continues to fire after upstream failures when enabled.


------
https://chatgpt.com/codex/tasks/task_e_68f310b448bc8331af23bc8f6fc68820