### PR TITLE
Add tests covering Codex orchestrator bootstrap label sanitisation

### DIFF
--- a/tests/test_workflow_agents_consolidation.py
+++ b/tests/test_workflow_agents_consolidation.py
@@ -36,6 +36,12 @@ def test_agents_orchestrator_inputs_and_uses():
         "bootstrap_issues_label:" in text
     ), "Orchestrator must forward bootstrap label configuration"
     assert (
+        "bootstrap_issues_label not provided; defaulting to agent:codex." in text
+    ), "Orchestrator must log when it falls back to the default Codex label"
+    assert (
+        "const bootstrapLabelCandidate = toString" in text
+    ), "Orchestrator must sanitise the bootstrap label input before dispatch"
+    assert (
         "./.github/workflows/reusable-16-agents.yml" in text
     ), "Orchestrator must call the reusable agents workflow"
 


### PR DESCRIPTION
## Summary
- extend the agents workflow consolidation tests to assert the orchestrator records the bootstrap label fallback notice
- verify the resolve step sanitises bootstrap label inputs before dispatching the reusable workflow

## Testing
- pytest tests/test_workflow_agents_consolidation.py

------
https://chatgpt.com/codex/tasks/task_e_68f31420d648833187278f796c1ce1fd