### PR TITLE
Handle duplicate Codex bootstrap labels

### DIFF
--- a/.github/workflows/reusable-16-agents.yml
+++ b/.github/workflows/reusable-16-agents.yml
@@ -380,14 +380,32 @@ jobs:
             const fallbackLabel = 'agent:codex';
             const fallbackMessage = 'bootstrap_issues_label not provided; defaulting to agent:codex.';
             const raw = process.env.LABEL || '';
-            let labels = raw
+            const trimmed = raw
               .split(',')
               .map((value) => value.trim())
               .filter(Boolean);
 
+            const dedupeLabels = (values) => {
+              const seen = new Set();
+              const unique = [];
+              for (const value of values) {
+                const lower = value.toLowerCase();
+                if (seen.has(lower)) {
+                  continue;
+                }
+                seen.add(lower);
+                unique.push({ raw: value, lower });
+              }
+              return unique;
+            };
+
+            const unique = dedupeLabels(trimmed);
+            const dedupeReduced = unique.length === 1 && trimmed.length > 1;
+
+            let labels = unique;
             let fallbackUsed = false;
             if (!labels.length) {
-              labels = [fallbackLabel];
+              labels = [{ raw: fallbackLabel, lower: fallbackLabel.toLowerCase() }];
               fallbackUsed = true;
             }
 
@@ -401,12 +419,18 @@ jobs:
               return;
             }
 
-            const label = labels[0];
-            const labelLower = label.toLowerCase();
+            const label = labels[0].raw;
+            const labelLower = labels[0].lower;
 
             if (fallbackUsed) {
               summary.addRaw(fallbackMessage).addEOL();
               core.notice(fallbackMessage);
+            }
+
+            if (!fallbackUsed && dedupeReduced) {
+              const dedupeNotice = `Duplicate bootstrap labels removed; proceeding with: ${label}`;
+              summary.addRaw(dedupeNotice).addEOL();
+              core.notice(dedupeNotice);
             }
 
             summary.addRaw(`Bootstrap label: **${label}**`).addEOL();

--- a/tests/test_workflow_agents_consolidation.py
+++ b/tests/test_workflow_agents_consolidation.py
@@ -189,10 +189,20 @@ def test_bootstrap_summary_mentions_truncation_notice():
     ), "Bootstrap summary must document when the issue scan hits the truncation guard"
 
 
+def test_bootstrap_dedupes_duplicate_labels():
+    text = (WORKFLOWS_DIR / "reusable-16-agents.yml").read_text(encoding="utf-8")
+    assert (
+        "const dedupeLabels = (values) =>" in text
+    ), "Bootstrap script should define a helper to dedupe requested labels"
+    assert (
+        "Duplicate bootstrap labels removed; proceeding with:" in text
+    ), "Bootstrap summary must surface when duplicate labels are trimmed"
+
+
 def test_bootstrap_label_filter_is_case_insensitive():
     text = (WORKFLOWS_DIR / "reusable-16-agents.yml").read_text(encoding="utf-8")
     assert (
-        "const labelLower = label.toLowerCase();" in text
+        "const labelLower = labels[0].lower;" in text
     ), "Bootstrap step must normalise the requested label for comparisons"
     assert (
         "labelNames.includes(labelLower)" in text


### PR DESCRIPTION
## Summary
- dedupe the Codex bootstrap label input before filtering so duplicates collapse to a single scope and log the trimmed result in the run summary
- update the consolidation tests to cover the new dedupe helper and adjusted label normalisation logic

## Testing
- pytest tests/test_workflow_agents_consolidation.py

------
https://chatgpt.com/codex/tasks/task_e_68f31cf148288331982c25dfb80af407