### PR TITLE
Align selftest runner aggregate error messages

### DIFF
--- a/.github/workflows/selftest-runner.yml
+++ b/.github/workflows/selftest-runner.yml
@@ -369,12 +369,12 @@ jobs:
         if: ${{ env.MODE != 'comment' }}
         run: |
           if [ -z "${VERIFICATION_TABLE}" ]; then
-            echo "::error::Verification table output missing from selftest-81 aggregate job." >&2
+            echo "::error::Verification table output missing from selftest-runner aggregate job." >&2
             exit 1
           fi
 
           if [ -z "${FAILURE_COUNT}" ]; then
-            echo "::error::Failure count output missing from selftest-81 aggregate job." >&2
+            echo "::error::Failure count output missing from selftest-runner aggregate job." >&2
             exit 1
           fi
 
@@ -466,12 +466,12 @@ jobs:
         if: ${{ env.MODE == 'comment' }}
         run: |
           if [ -z "${VERIFICATION_TABLE}" ]; then
-            echo "::error::Verification table output missing from selftest-81 aggregate job." >&2
+            echo "::error::Verification table output missing from selftest-runner aggregate job." >&2
             exit 1
           fi
 
           if [ -z "${FAILURE_COUNT}" ]; then
-            echo "::error::Failure count output missing from selftest-81 aggregate job." >&2
+            echo "::error::Failure count output missing from selftest-runner aggregate job." >&2
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- update self-test runner log failures to reference the consolidated aggregate job name

## Testing
- pytest tests/test_workflow_selftest_consolidation.py tests/test_workflow_naming.py

------
https://chatgpt.com/codex/tasks/task_e_68f325e1c9f483319673a3879d43b1d2