### PR TITLE
Codex bootstrap for #2728

### DIFF
--- a/docs/ci/selftest-workflow-manualization-plan.md
+++ b/docs/ci/selftest-workflow-manualization-plan.md
@@ -1,17 +1,25 @@
 # Self-Test Workflow Manualization Plan (Issue #2496)
 
+> **2026-11-15 update (Issue #2728):** the manual-only policy implemented here was
+> a temporary safeguard while the consolidated runner stabilized. With the
+> retirement of `selftest-reusable-ci.yml`, the nightly cron on
+> `selftest-runner.yml` returned. This plan is retained for historical context; the
+> current workflow inventory and triggers live in
+> [`docs/ci/WORKFLOWS.md`](WORKFLOWS.md) and the workflow system overview
+> ([`WORKFLOW_SYSTEM.md`](WORKFLOW_SYSTEM.md)).
+
 ## Scope and Key Constraints
 - **Workflow coverage**: All `.github/workflows/selftest-*.yml` (and related maintenance self-test variants) must be inventoried so the manual-only policy applies consistently, including any archived or auxiliary copies referenced by the docs.
-- **Trigger restriction**: Every self-test workflow may only declare a `workflow_dispatch:` trigger; scheduled (`schedule:`), push, pull-request, or other repo-event triggers must be removed to prevent automatic execution.
+- **Trigger restriction**: Every self-test workflow may only declare a `workflow_dispatch:` trigger; scheduled (`schedule:`), push, pull-request, or other repo-event triggers must be removed to prevent automatic execution. *(Historical constraint satisfied during the manual-only window; superseded once the nightly cron resumed in Issue #2728.)*
 - **Redundancy cleanup**: Duplicate or superseded self-test workflows should be deleted rather than merely disabled, ensuring the remaining catalog reflects the canonical set.
 - **Documentation alignment**: `docs/ci/WORKFLOWS.md` (and any other workflow guides) must explain that self-test pipelines are reference examples that run solely on demand.
 - **Historical traceability**: File renames or deletions should use `git mv` and Git history-friendly methods so reviewers can trace previous automation runs if needed.
 
 ## Acceptance Criteria / Definition of Done
-1. All self-test workflow files trigger exclusively via `workflow_dispatch` and contain no other event triggers or schedules.
+1. All self-test workflow files trigger exclusively via `workflow_dispatch` and contain no other event triggers or schedules. *(Achieved for the manualization initiative, later relaxed when the nightly schedule was restored.)*
 2. Duplicate or obsolete self-test workflows are removed, with the authoritative set now reduced to the consolidated `selftest-runner.yml` entry point (superseding the earlier `selftest-8X-*` wrappers from Issue #2496).
-3. Documentation describing CI workflows (at minimum `docs/ci/WORKFLOWS.md`) includes a note clarifying self-tests are manual examples and not part of automated CI.
-4. Repository search confirms no lingering references to deleted self-test workflows or to automated triggers for self-tests.
+3. Documentation describing CI workflows (at minimum `docs/ci/WORKFLOWS.md`) includes a note clarifying self-tests are manual examples and not part of automated CI. *(Historical requirement superseded by the current nightly-runner description.)*
+4. Repository search confirms no lingering references to deleted self-test workflows or to automated triggers for self-tests. *(Historical verification step from the manual-only rollout.)*
 5. Required checks (notably `pr-00-gate`) succeed after the workflow adjustments, demonstrating no unintended CI regressions.
 
 ## Initial Task Checklist

--- a/docs/selftest_manual_plan.md
+++ b/docs/selftest_manual_plan.md
@@ -1,5 +1,13 @@
 # Self-Test Workflow Restriction Plan (Issue #2526)
 
+> **2026-11-15 update (Issue #2728):** the consolidated self-test refresh restored
+> the nightly cron on `selftest-runner.yml` once the reusable wrapper was retired.
+> This document now serves as historical background for the manual-only window
+> introduced by Issue #2526. The acceptance criteria below capture that temporary
+> posture and remain satisfied for that effort, while the current configuration is
+> described in [`docs/ci/WORKFLOWS.md`](ci/WORKFLOWS.md) and
+> [`docs/ci/WORKFLOW_SYSTEM.md`](ci/WORKFLOW_SYSTEM.md).
+
 ## Scope and Key Constraints
 - Limit automation to the GitHub Actions workflow `selftest-runner.yml` (the successor to the `selftest-8X-*` wrappers).
 - Adjust only workflow trigger definitions and supporting documentation; do not change test logic or artefacts.
@@ -8,8 +16,8 @@
 - Document updates must fit the existing CONTRIBUTING.md tone and structure while keeping instructions concise (two paragraphs).
 
 ## Acceptance Criteria / Definition of Done
-1. The remaining self-test workflow (`selftest-runner.yml`) defines **only** a `workflow_dispatch` trigger, optionally with a `reason` input, and has no other automatic triggers (`push`, `pull_request`, `schedule`, etc.). ✅ Verified for the runner.
-2. No other workflows trigger self-tests implicitly; repository automation reflects the manual-only expectation. ✅ Guarded by `tests/test_workflow_selftest_consolidation.py`.
+1. The remaining self-test workflow (`selftest-runner.yml`) defines **only** a `workflow_dispatch` trigger, optionally with a `reason` input, and has no other automatic triggers (`push`, `pull_request`, `schedule`, etc.). ✅ Verified for the runner during the manual-only phase (superseded when the nightly cron returned in Issue #2728).
+2. No other workflows trigger self-tests implicitly; repository automation reflects the manual-only expectation. ✅ Guarded by `tests/test_workflow_selftest_consolidation.py` during the restriction window (restored schedule now validated by the same guardrails).
 3. `CONTRIBUTING.md` contains a new two-paragraph section that explains the purpose of self-tests, when to run them, and how to interpret their output at a high level. ✅ Added in this iteration.
 4. A self-test workflow has been manually triggered after the changes land, and the run link is recorded in PR communications. ⏳ Requires GitHub Actions UI access post-merge.
 


### PR DESCRIPTION
### Source Issue #2728: Reduce workflow sprawl: archive or remove duplicate “selftest‑reusable‑ci” variants

Source: https://github.com/stranske/Trend_Model_Project/issues/2728

> Topic GUID: 5605ef81-e184-596b-91ab-5fd0c5fd6eef
> 
> ## Why
> - Summary
>     - There are at least two selftest-reusable-ci tracks (maint-44, maint-48, plus the root one). Keep a single source of truth and update ARCHIVE_WORKFLOWS.md. 
> 
>   - Scope
> 
>     - Choose one canonical file for self-test (see Issue #1).
> 
>     - Remove or archive others; document rationale.
> 
> ## Tasks
> - [ ] One self-test workflow remains
> 
> - [ ] Archive note added
> 
> ## Acceptance criteria
> - Actions page no longer lists multiple selftest variants.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18575667639).

### Follow-up adjustments
- Documented that the manual-only self-test plans now serve as historical context after the nightly cron on `selftest-runner.yml` was restored.


------
https://chatgpt.com/codex/tasks/task_e_68f32663f86c8331b6fd90cbd3770a18