### PR TITLE
Document Gate required check and Maint 46 guidance

### DIFF
--- a/docs/ci/WORKFLOW_SYSTEM.md
+++ b/docs/ci/WORKFLOW_SYSTEM.md
@@ -503,7 +503,8 @@ Keep this table handy when you are triaging automation: it confirms which workfl
 > required status is expected—Maint 46 Post CI never appears in that list
 > because it runs only after merge. Maintainers reviewing follow-up CI should
 > scroll to the Maint 46 Post CI timeline comment after merge—it links back to
-> the successful Gate run and aggregates the reusable CI matrix. The pull-
+> the successful Gate run, aggregates the reusable CI matrix, and is titled
+> **“Maint 46 Post CI summary”** for quick scanning. The pull-
 > request template links here so authors confirm the required check before
 > requesting review.
 


### PR DESCRIPTION
## Summary
- document the required versus informational CI contexts for `phase-2-dev`, including a quick-reference table and Maint 46 recovery steps
- expand the branch protection playbook so maintainers can enforce Gate while keeping Maint 46 Post CI informational
- link the updated workflow guidance from the pull request template and call out the “Maint 46 Post CI summary” timeline comment for reviewers

## Testing
- not run (docs-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f330d6149c8331a93e98b8726cd02f