### PR TITLE
fix: resolve actionlint complaint about reusable autofix ref

### DIFF
--- a/.github/workflows/pr-02-autofix.yml
+++ b/.github/workflows/pr-02-autofix.yml
@@ -69,7 +69,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: 'stranske/Trend_Model_Project/.github/workflows/reusable-18-autofix.yml@${{ github.sha }}'
+    uses: ./.github/workflows/reusable-18-autofix.yml
     with:
       opt_in_label: ${{ needs.label_gate.outputs.label }}
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- update the PR autofix workflow to call the reusable workflow via a local path so actionlint no longer rejects the github context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f33502c5148331b5f851acf39c766e