### PR TITLE
Add tests-only guard for clean autofix mode

### DIFF
--- a/.github/workflows/reusable-18-autofix.yml
+++ b/.github/workflows/reusable-18-autofix.yml
@@ -188,9 +188,11 @@ jobs:
           ruff check tests --fix --exit-zero
           if [ ! -d tests ]; then
             echo "[autofix-clean] No tests/ directory present; skipping."
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "remaining_issues=0" >> "$GITHUB_OUTPUT"
-            echo "new_issues=0" >> "$GITHUB_OUTPUT"
+            {
+              echo "changed=false"
+              echo "remaining_issues=0"
+              echo "new_issues=0"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
           ruff check tests --select I --fix --exit-zero || true

--- a/.github/workflows/reusable-18-autofix.yml
+++ b/.github/workflows/reusable-18-autofix.yml
@@ -177,6 +177,13 @@ jobs:
           set -euo pipefail
           echo "[autofix-clean] Running tests-only cosmetic sweep"
           ruff --version
+          if [ ! -d tests ]; then
+            echo "[autofix-clean] No tests/ directory present; skipping."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "remaining_issues=0" >> "$GITHUB_OUTPUT"
+            echo "new_issues=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           ruff check tests --select I --fix --exit-zero || true
           ruff check tests --fix --exit-zero || true
           ruff format tests || true

--- a/.github/workflows/reusable-18-autofix.yml
+++ b/.github/workflows/reusable-18-autofix.yml
@@ -184,8 +184,8 @@ jobs:
               echo "new_issues=0"
             } >> "$GITHUB_OUTPUT"
             exit 0
-          fi
-          ruff --version
+          ruff check tests --select I --fix --exit-zero
+          ruff check tests --fix --exit-zero
           if [ ! -d tests ]; then
             echo "[autofix-clean] No tests/ directory present; skipping."
             echo "changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- ensure the tests-only clean mode exits gracefully when a repository lacks a tests/ tree
- preserve the clean-mode bookkeeping by emitting unchanged metrics before returning early

## Testing
- ./scripts/workflow_lint.sh .github/workflows/reusable-18-autofix.yml
- python -m compileall scripts/build_autofix_pr_comment.py

------
https://chatgpt.com/codex/tasks/task_e_68f339ff96f083318ac20634340d3fa7