### PR TITLE
Fix autofix JSON report fallback for clean mode

### DIFF
--- a/.github/workflows/reusable-18-autofix.yml
+++ b/.github/workflows/reusable-18-autofix.yml
@@ -769,25 +769,43 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ -f autofix_report_enriched.json ]; then
-            python -c "import json, os; from datetime import datetime, timezone; from pathlib import Path; meta={'pull_request': os.environ.get('PR_NUMBER'), 'timestamp_utc': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}; path = Path('autofix_report_enriched.json'); data = json.loads(path.read_text(encoding='utf-8')) if path.exists() else {}; data.update(meta); Path('autofix_report.json').write_text(json.dumps(data, indent=2, sort_keys=True) + '\n', encoding='utf-8')" || echo '{"error":"merge_failed"}' > autofix_report.json
-          else
-            python <<'PY' || echo '{"error":"merge_failed"}' > autofix_report.json
+          python <<'PY' || { echo '{"error":"merge_failed"}' > autofix_report.json; }
             import json
             import os
+            from datetime import datetime, timezone
             from pathlib import Path
 
-            files = [line.strip() for line in os.environ.get('REPORT_FILE_LIST', '').splitlines() if line.strip()]
-            payload = {
-                'mode': os.environ.get('REPORT_MODE', ''),
-                'changed': os.environ.get('REPORT_CHANGED', ''),
-                'remaining_issues': os.environ.get('REPORT_REMAINING', ''),
-                'new_issues': os.environ.get('REPORT_NEW', ''),
-                'file_list': files,
-            }
-            Path('autofix_report.json').write_text(json.dumps(payload, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+            def load_enriched() -> dict | None:
+                path = Path('autofix_report_enriched.json')
+                if not path.exists():
+                    return None
+                try:
+                    data = json.loads(path.read_text(encoding='utf-8'))
+                except json.JSONDecodeError:
+                    return None
+                return data if isinstance(data, dict) else None
+
+            report = load_enriched()
+            if report is not None:
+                report.update({
+                    'pull_request': os.environ.get('PR_NUMBER'),
+                    'timestamp_utc': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                })
+            else:
+                files = [line.strip() for line in os.environ.get('REPORT_FILE_LIST', '').splitlines() if line.strip()]
+                report = {
+                    'mode': os.environ.get('REPORT_MODE', ''),
+                    'changed': os.environ.get('REPORT_CHANGED', ''),
+                    'remaining_issues': os.environ.get('REPORT_REMAINING', ''),
+                    'new_issues': os.environ.get('REPORT_NEW', ''),
+                    'file_list': files,
+                }
+
+            Path('autofix_report.json').write_text(
+                json.dumps(report, indent=2, sort_keys=True) + '\n',
+                encoding='utf-8',
+            )
             PY
-          fi
           echo "Enriched report ready."
         env:
           PR_NUMBER: ${{ inputs.pr_number }}


### PR DESCRIPTION
## Summary
- consolidate the reusable autofix JSON report generation into a single Python helper so fallback runs emit one JSON object
- retain the enriched-report metadata update for clean mode while avoiding duplicate output records

## Testing
- ./scripts/workflow_lint.sh .github/workflows/reusable-18-autofix.yml

------
https://chatgpt.com/codex/tasks/task_e_68f40aa0d37c83319a6846a0448d0788