### PR TITLE
Codex bootstrap for #2738

### DIFF
--- a/agents/codex-2738.md
+++ b/agents/codex-2738.md
@@ -27,10 +27,14 @@
 4. Record verification details (e.g., API responses, command snippets) either within the documentation appendix or linked artifacts so reviewers can reproduce the checks.
 5. Obtain review sign-off confirming that ruleset protections align with policy and that documentation is complete.
 
-## Initial Task Checklist
-- [ ] Enumerate current protected workflows and confirm file paths.
-- [ ] Create a throwaway branch and attempt to delete each protected workflow; capture the push rejection evidence.
-- [ ] Repeat with file rename attempts to validate rename protection.
-- [ ] If enforcement fails, adjust the repository ruleset (UI/API) to block deletions/renames and restrict edits to CODEOWNERS, then retest.
-- [ ] Summarize verification steps, ruleset metadata, and evidence references in `docs/ci/AGENTS_POLICY.md`.
+## Task Checklist & Status
+- [x] Enumerate current protected workflows and confirm file paths.
+- [x] Query repository rulesets to determine existing protections and enforcement status.
+- [ ] Attempt deletes on each protected workflow from a throwaway branch; capture rejection evidence. _(Blocked: repository ruleset currently disabled, so enforcement cannot be validated yet.)_
+- [ ] Attempt renames on each protected workflow from a throwaway branch; capture rejection evidence. _(Blocked pending rule reactivation.)_
+- [ ] Adjust the repository ruleset (UI/API) to block deletions/renames and restrict edits to CODEOWNERS, then retest. _(Requires maintainer/admin access to GitHub rulesets.)_
+- [x] Summarize verification steps, ruleset metadata, and evidence references in `docs/ci/AGENTS_POLICY.md`.
 - [ ] Share collected logs/screenshots in Issue #2738 for historical record.
+
+## Progress Log
+- **2025-09-05** – Used the public REST API to list repository rulesets. Confirmed `Tests Pass to Merge` (ID `7880490`) is disabled and lacks `restrict_file_updates` entries, so deletion/rename protection is inactive. Captured command output in `docs/ci/agents_ruleset_verification.md` for reproducibility.


### PR DESCRIPTION
### Source Issue #2738: Repository ruleset: verify block on deletion/renames of protected agent workflows

Source: https://github.com/stranske/Trend_Model_Project/issues/2738

> Topic GUID: 69cec0f2-a2f8-54c1-8fb2-17734921d811
> 
> ## Why
> - Summary
>     - Policy claims a repository ruleset blocks deletion or unsafe edits to the three protected agent workflows (Agents 63 pair + 70 Orchestrator). This is configured outside the repo and needs validation.
> 
> ## Tasks
> - [ ] Attempt to delete or rename each protected workflow from a test branch and push.
> 
> - [ ] Expected: push is rejected by the ruleset.
> 
> - [ ] If the push succeeds, configure a repository ruleset to block file deletions/renames and restrict edits to CODEOWNERS.
> 
> - [ ] Document the ruleset name and settings in docs/ci/AGENTS_POLICY.md and add a one‑line verification command/UI path.
> 
> ## Acceptance criteria
> - Proof of failed push for delete/rename attempts (screenshot or link to failed action).
> 
> - Policy doc updated with the ruleset name and a quick verification step.
> 
> ## Implementation notes
> _Not provided._
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18576005771).

—
PR created automatically to engage Codex.