### PR TITLE
ci: gate actionlint errors and externalize summary helpers

### DIFF
--- a/.github/actionlint-allowlist.txt
+++ b/.github/actionlint-allowlist.txt
@@ -1,0 +1,5 @@
+# Format: CODE:pattern
+# Lines are passed to actionlint via `-ignore` flags. Keep this list short and
+# document the reason for each entry.
+# Example (uncomment to use):
+# SC2086:Allow unquoted matrix expansion in scripts/ci_*.sh

--- a/.github/scripts/autofix_emit_report.py
+++ b/.github/scripts/autofix_emit_report.py
@@ -1,0 +1,81 @@
+"""Write the autofix JSON report consumed by downstream jobs."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass
+class AutofixContext:
+    output_path: Path
+    enriched_path: Path
+    pr_number: str | None
+    mode: str
+    changed: str
+    remaining: str
+    new: str
+    file_list_raw: str
+
+    @property
+    def file_list(self) -> list[str]:
+        return [line.strip() for line in self.file_list_raw.splitlines() if line.strip()]
+
+
+def load_enriched(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def build_report(ctx: AutofixContext) -> dict:
+    report = load_enriched(ctx.enriched_path)
+    if report is not None:
+        report.update(
+            {
+                "pull_request": ctx.pr_number,
+                "timestamp_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+        )
+        return report
+
+    return {
+        "mode": ctx.mode,
+        "changed": ctx.changed,
+        "remaining_issues": ctx.remaining,
+        "new_issues": ctx.new,
+        "file_list": ctx.file_list,
+    }
+
+
+def write_report(report: dict, destination: Path) -> None:
+    destination.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def build_context() -> AutofixContext:
+    return AutofixContext(
+        output_path=Path(os.environ.get("AUTOFIX_REPORT", "autofix_report.json")),
+        enriched_path=Path(os.environ.get("AUTOFIX_REPORT_ENRICHED", "autofix_report_enriched.json")),
+        pr_number=os.environ.get("PR_NUMBER"),
+        mode=os.environ.get("REPORT_MODE", ""),
+        changed=os.environ.get("REPORT_CHANGED", ""),
+        remaining=os.environ.get("REPORT_REMAINING", ""),
+        new=os.environ.get("REPORT_NEW", ""),
+        file_list_raw=os.environ.get("REPORT_FILE_LIST", ""),
+    )
+
+
+def main() -> None:
+    ctx = build_context()
+    write_report(build_report(ctx), ctx.output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/render_cosmetic_summary.py
+++ b/.github/scripts/render_cosmetic_summary.py
@@ -1,0 +1,66 @@
+"""Render the cosmetic repair summary for GitHub Actions.
+
+This script reads the JSON payload produced by the cosmetic repair job and
+prints a markdown summary suitable for appending to the GitHub step summary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def build_summary_lines(data: dict) -> list[str]:
+    """Convert the cosmetic repair metadata into human readable lines."""
+
+    lines: list[str] = []
+    status = data.get("status", "unknown")
+    lines.append(f"- Status: **{status}**")
+
+    changed = data.get("changed_files") or []
+    if changed:
+        lines.append(f"- Changed files ({len(changed)}):")
+        lines.extend(f"  - `{path}`" for path in changed)
+    else:
+        lines.append("- No file changes detected.")
+
+    pr_url = data.get("pr_url")
+    if pr_url:
+        lines.append(f"- PR: {pr_url}")
+
+    instructions = data.get("instructions") or []
+    if instructions:
+        lines.append("- Instructions processed:")
+        for entry in instructions:
+            kind = entry.get("kind", "unknown")
+            path = entry.get("path", "?")
+            guard = entry.get("guard", "")
+            extra = f" ({guard})" if guard else ""
+            lines.append(f"  - `{kind}` → `{path}`{extra}")
+
+    return lines
+
+
+def read_summary(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Failed to parse {path}: {exc}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render cosmetic repair summary")
+    parser.add_argument("summary_path", type=Path, help="Path to the summary JSON file")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    data = read_summary(args.summary_path)
+    for line in build_summary_lines(data):
+        print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/health-42-actionlint.yml
+++ b/.github/workflows/health-42-actionlint.yml
@@ -24,15 +24,44 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Compute actionlint allowlist
+        id: allowlist
+        shell: bash
+        run: |
+          python - <<'PY' '.github/actionlint-allowlist.txt' "$GITHUB_OUTPUT"
+          import shlex
+          import sys
+          from pathlib import Path
+
+
+          def load_entries(path: Path) -> list[str]:
+              if not path.is_file():
+                  return []
+              entries: list[str] = []
+              for raw in path.read_text(encoding='utf-8').splitlines():
+                  line = raw.strip()
+                  if not line or line.startswith('#'):
+                      continue
+                  entries.append(line)
+              return entries
+
+
+          entries = load_entries(Path(sys.argv[1]))
+          flag_str = ' '.join(shlex.join(['-ignore', entry]) for entry in entries)
+          with Path(sys.argv[2]).open('a', encoding='utf-8') as handle:
+              handle.write(f'flags={flag_str}\n')
+          PY
+
       - name: Run actionlint via reviewdog
         id: actionlint
         uses: reviewdog/action-actionlint@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          actionlint_flags: ${{ steps.allowlist.outputs.flags }}
           reporter: ${{ github.event_name == 'pull_request' && 'github-pr-review' || 'github-check' }}
           filter_mode: nofilter
           level: warning
-          fail_on_error: true
+          fail_level: error
 
       - name: Publish lint summary
         if: always()

--- a/.github/workflows/maint-45-cosmetic-repair.yml
+++ b/.github/workflows/maint-45-cosmetic-repair.yml
@@ -171,33 +171,7 @@ jobs:
             echo "### Cosmetic repair summary"
             echo
             if [ -f "$summary_file" ]; then
-              python - <<'PYCODE'
-              import json
-              from pathlib import Path
-
-              data = json.loads(Path(".cosmetic-repair-summary.json").read_text(encoding="utf-8"))
-              status = data.get("status", "unknown")
-              print(f"- Status: **{status}**")
-              changed = data.get("changed_files") or []
-              if changed:
-                  print(f"- Changed files ({len(changed)}):")
-                  for path in changed:
-                      print(f"  - `{path}`")
-              else:
-                  print("- No file changes detected.")
-              pr_url = data.get("pr_url")
-              if pr_url:
-                  print(f"- PR: {pr_url}")
-              instructions = data.get("instructions") or []
-              if instructions:
-                  print("- Instructions processed:")
-                  for entry in instructions:
-                      kind = entry.get("kind", "unknown")
-                      path = entry.get("path", "?")
-                      guard = entry.get("guard", "")
-                      extra = f" ({guard})" if guard else ""
-                      print(f"  - `{kind}` → `{path}`{extra}")
-              PYCODE
+              python .github/scripts/render_cosmetic_summary.py "$summary_file"
             else
               git status --short || true
             fi

--- a/.github/workflows/reusable-18-autofix.yml
+++ b/.github/workflows/reusable-18-autofix.yml
@@ -772,43 +772,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python <<'PY' || { echo '{"error":"merge_failed"}' > autofix_report.json; }
-            import json
-            import os
-            from datetime import datetime, timezone
-            from pathlib import Path
-
-            def load_enriched() -> dict | None:
-                path = Path('autofix_report_enriched.json')
-                if not path.exists():
-                    return None
-                try:
-                    data = json.loads(path.read_text(encoding='utf-8'))
-                except json.JSONDecodeError:
-                    return None
-                return data if isinstance(data, dict) else None
-
-            report = load_enriched()
-            if report is not None:
-                report.update({
-                    'pull_request': os.environ.get('PR_NUMBER'),
-                    'timestamp_utc': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
-                })
-            else:
-                files = [line.strip() for line in os.environ.get('REPORT_FILE_LIST', '').splitlines() if line.strip()]
-                report = {
-                    'mode': os.environ.get('REPORT_MODE', ''),
-                    'changed': os.environ.get('REPORT_CHANGED', ''),
-                    'remaining_issues': os.environ.get('REPORT_REMAINING', ''),
-                    'new_issues': os.environ.get('REPORT_NEW', ''),
-                    'file_list': files,
-                }
-
-            Path('autofix_report.json').write_text(
-                json.dumps(report, indent=2, sort_keys=True) + '\n',
-                encoding='utf-8',
-            )
-            PY
+          python .github/scripts/autofix_emit_report.py || { echo '{"error":"merge_failed"}' > autofix_report.json; }
           echo "Enriched report ready."
         env:
           PR_NUMBER: ${{ inputs.pr_number }}

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ ci/autofix/history.json
 ci/autofix/diagnostics.json
 *.txt
 !/.github/signature-fixtures/basic_hash.txt
+!.github/actionlint-allowlist.txt
 
 # Python package build artifacts
 *.egg-info/


### PR DESCRIPTION
## Summary
- gate actionlint by replacing the deprecated fail_on_error flag with fail_level and wiring an allowlist loader
- extract Python helpers for the cosmetic repair summary and the autofix JSON report to keep workflow steps shellcheck clean
- add an actionlint allowlist manifest and ensure it is tracked in git

## Testing
- `actionlint`


------
https://chatgpt.com/codex/tasks/task_e_68f49831d340833193ba8923a70c3864