### PR TITLE
Update safe Ruff sweep to include import sorting and formatting

### DIFF
--- a/.github/workflows/reusable-18-autofix.yml
+++ b/.github/workflows/reusable-18-autofix.yml
@@ -195,7 +195,12 @@ jobs:
         run: |
           set -euo pipefail
           ruff --version
+          echo "[autofix] Normalising imports with Ruff"
+          ruff check --select I --fix --exit-zero .
+          echo "[autofix] Applying Ruff lint fixes"
           ruff check --fix --exit-zero .
+          echo "[autofix] Normalising whitespace with Ruff formatter"
+          ruff format .
 
       - name: Tests-only cosmetic sweep
         if: steps.guard.outputs.skip != 'true' && steps.clean_mode.outputs.enabled == 'true'


### PR DESCRIPTION
## Summary
- extend the reusable autofix workflow's initial Ruff sweep to normalise imports and whitespace before running the broader lint fixes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4a0bef6788331bb4fe75e21b1c026