### PR TITLE
Codex bootstrap for #2820

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -46,6 +46,7 @@ Flow:
 | `agent:codex` / `agent:copilot` | Marks automation-owned issues and PRs | Agent labeler |
 | `from:codex` / `from:copilot` | Origin marker for automation PRs | Agent labeler |
 | `autofix` / `autofix:applied` | Track PR autofix results | Autofix workflow |
+| `autofix:tests` / `autofix:tests-only` | Opt-in label that restricts cosmetic sweeps to `tests/**` and the status label applied when that mode runs | Autofix workflow |
 | `ci-failure` | Pins the rolling CI dashboard issue | Maint 46 Post CI |
 | Area labels | Scope classification for review routing | Path labeler |
 


### PR DESCRIPTION
### Source Issue #2820: Cosmetic tests fixer: narrow scope to tests/

Source: https://github.com/stranske/Trend_Model_Project/issues/2820

> Topic GUID: 01c503a0-0f10-5680-8c49-9d0c6ca87716
> 
> ## Why
> Keeping test noise low speeds PR review. A tests-only autofix mode avoids risky edits elsewhere.
> 
> ## Tasks
> Add a label-gated mode autofix:tests that only targets tests/**.
> 
>  Apply import reordering, whitespace fixes, and simple ruff fixes.
> 
>  Post a brief summary comment.
> 
> ## Acceptance criteria
> A demo PR with autofix:tests only modifies files under tests/**.
> 
> Gate remains green after fixes.
> 
> ## Implementation notes
> Reuse steps from the cosmetic autofix workflow, but restrict pathspecs.
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18627465345).

—
PR created automatically to engage Codex.

------
https://chatgpt.com/codex/tasks/task_e_68f4b3b5a03083319c3cb879955b9521