### PR TITLE
docs: update issue 2846 tracker with latest actionlint run

### DIFF
--- a/agents/codex-2846.md
+++ b/agents/codex-2846.md
@@ -12,7 +12,7 @@ Owner: @codex-maintainer
 - [x] Harden selftest-reusable-ci.yml defaults and validate execution logic
   - Confirmed `${{ jobs.scenarios.uses }}` continues to point at the reusable workflow and retains the `fail-fast: false` matrix strategy.
   - Ensured the publish job still uploads the `selftest-report` artifact and appends scenario details to `$GITHUB_STEP_SUMMARY`.
-  - Re-installed `actionlint` (v1.7.8) locally and re-ran `/root/.local/share/mise/installs/go/1.23.8/bin/actionlint .github/workflows/selftest-reusable-ci.yml` to confirm the workflow parses successfully (2025-02-14 and 2025-10-20).
+- Re-installed `actionlint` (v1.7.x) locally and re-ran `/root/.local/share/mise/installs/go/1.23.8/bin/actionlint .github/workflows/selftest-reusable-ci.yml` to confirm the workflow parses successfully (2025-02-14 – v1.7.8, 2025-10-20 – v1.7.8, 2025-10-21 – v1.7.1).
 - [ ] Verify workflow_dispatch run uploads expected artifacts *(pending manual GitHub Actions run)*
   - [ ] Coordinate maintainer-triggered dispatch once branch is ready for validation.
   - [x] Drafted maintainer request snippet for the manual dispatch (see **Maintainer Outreach**).
@@ -38,6 +38,7 @@ Owner: @codex-maintainer
 ## Local Validation Evidence
 - 2025-02-14: Installed `actionlint` (v1.7.8) via `go install` and executed `/root/.local/share/mise/installs/go/1.23.8/bin/actionlint .github/workflows/selftest-reusable-ci.yml` (no findings).
 - 2025-10-20: Re-synced `actionlint` (v1.7.8) using `go install` and reran `/root/.local/share/mise/installs/go/1.23.8/bin/actionlint .github/workflows/selftest-reusable-ci.yml` after the latest quoting review (no findings).
+- 2025-10-21: Reconfirmed quoting changes remain valid by reinstalling `actionlint` (v1.7.1) via `go install` and executing `/root/.local/share/mise/installs/go/1.23.8/bin/actionlint .github/workflows/selftest-reusable-ci.yml` (no findings).
 
 ## Run Tracking
 | Path | Status | Run link / ID | Notes |


### PR DESCRIPTION
## Summary
- document the most recent actionlint verification for issue #2846 in the Codex tracker
- note the specific actionlint version and command used to validate the workflow

## Testing
- /root/.local/share/mise/installs/go/1.23.8/bin/actionlint .github/workflows/selftest-reusable-ci.yml

------
https://chatgpt.com/codex/tasks/task_e_68f57c824a508331ae6a42940eb16fae