### PR TITLE
Enhance repo health branch protection checks

### DIFF
--- a/.github/workflows/health-41-repo-health.yml
+++ b/.github/workflows/health-41-repo-health.yml
@@ -162,7 +162,10 @@ jobs:
               summary.addRaw('All open issues have at least one assignee ✅', true);
             }
 
-            const expectedContexts = ['Gate / gate'];
+            const expectedContextsByBranch = new Map();
+            expectedContextsByBranch.set(defaultBranch, ['Gate / gate']);
+
+            const expectedContexts = expectedContextsByBranch.get(defaultBranch) ?? [];
             const branchProtectionResult = {
               contexts: [],
               strict: null,
@@ -208,6 +211,7 @@ jobs:
               ],
               ['Branch', defaultBranch],
               ['Source', branchProtectionResult.source],
+              ['Expected contexts', expectedContexts.length > 0 ? expectedContexts.join(', ') : '–'],
               ['Required contexts', uniqueContexts.length > 0 ? uniqueContexts.join(', ') : '–'],
               ['Required “up to date”', branchProtectionResult.strict === null ? 'unknown' : String(branchProtectionResult.strict)],
             ]);
@@ -221,8 +225,14 @@ jobs:
               if (unexpected.length > 0) {
                 problems.push(`unexpected contexts: ${unexpected.join(', ')}`);
               }
-              summary.addRaw(`❌ Branch protection drift detected — ${problems.join('; ')}`, true);
-              branchProtectionFailure = `Branch protection drift detected (${problems.join('; ')}).`;
+              const failurePrefix = `Branch protection drift detected for ${defaultBranch}`;
+              summary.addRaw(`❌ ${failurePrefix} — ${problems.join('; ')}`, true);
+
+              if (missing.includes('Gate / gate')) {
+                branchProtectionFailure = `Default branch ("${defaultBranch}") no longer requires the "Gate / gate" status check. Update branch protection to restore Gate.`;
+              } else {
+                branchProtectionFailure = `${failurePrefix} (${problems.join('; ')}).`;
+              }
             } else {
               summary.addRaw('✅ Branch protection contexts match the expected configuration.', true);
             }

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -52,7 +52,7 @@ _Optional label-gated helper_
 - **`health-44-gate-branch-protection.yml`** — Enforces branch-protection policy via `tools/enforce_gate_branch_protection.py` when the PAT is configured.
 
 _Additional opt-in utilities_
-- **`health-41-repo-health.yml`** — Weekly repository health sweep that writes a single run-summary report, with optional `workflow_dispatch` reruns.
+- **`health-41-repo-health.yml`** — Weekly repository health sweep that writes a single run-summary report covering stale branches, unassigned issues, and default-branch protection drift, with optional `workflow_dispatch` reruns.
 - **`health-40-repo-selfcheck.yml`** — Read-only governance probe that surfaces label coverage and branch-protection visibility gaps in the run summary.
 - **`maint-45-cosmetic-repair.yml`** — Manual dispatch utility that runs `pytest -q`, applies guard-gated cosmetic fixes via `scripts/ci_cosmetic_repair.py`, and opens a labelled PR when changes exist.
 

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -70,7 +70,7 @@ flowchart TD
 | **Maint Coverage Guard** | `.github/workflows/maint-coverage-guard.yml` | `schedule` (`45 6 * * *`), `workflow_dispatch` | `contents: read`, `actions: read`, `issues: write` | No | Pulls the latest Gate coverage payload and trend artifact, compares them to `config/coverage-baseline.json`, and fails when coverage slips outside the configured guard rails. |
 | **Maint Keepalive Heartbeat** | `.github/workflows/maint-keepalive.yml` | Cron (`17 */12 * * *`), `workflow_dispatch` | `contents: read`, `actions: write`, `issues: write` | No | Keepalive job that posts a UTC timestamp comment (with run link) to the configured Ops heartbeat issue via `ACTIONS_BOT_PAT`; fails fast when the issue variable or PAT is missing. |
 | **Maint 45 Cosmetic Repair** | `.github/workflows/maint-45-cosmetic-repair.yml` | `workflow_dispatch` | `contents: write`, `pull-requests: write` | No | Manual pytest + guardrail fixer that opens a labelled PR when drift is detected. |
-| **Health 41 Repo Health** | `.github/workflows/health-41-repo-health.yml` | Monday cron (`15 7 * * 1`), `workflow_dispatch` | `contents: read`, `issues: read` | No | Weekly stale-branch and unassigned-issue sweep. |
+| **Health 41 Repo Health** | `.github/workflows/health-41-repo-health.yml` | Monday cron (`15 7 * * 1`), `workflow_dispatch` | `contents: read`, `issues: read` | No | Weekly stale-branch, unassigned-issue, and branch-protection drift sweep. |
 | **Health 40 Repo Selfcheck** | `.github/workflows/health-40-repo-selfcheck.yml` | Weekly cron (`20 6 * * 1`), `workflow_dispatch` | `contents: read`, `issues: write`, `actions: write` | No | Summarises label coverage and branch-protection visibility, downgrading unauthorized or rate-limited branch checks to warnings while updating the `[health] repository self-check failed` tracker when problems persist. |
 | **Health 42 Actionlint** | `.github/workflows/health-42-actionlint.yml` | `pull_request`, `push` to `phase-2-dev` (workflow edits), weekly cron, `workflow_dispatch` | `contents: read`, `pull-requests: write`, `checks: write` | No | Workflow-lint gate using `actionlint` via reviewdog. |
 | **Health 43 CI Signature Guard** | `.github/workflows/health-43-ci-signature-guard.yml` | `push`/`pull_request` targeting `phase-2-dev` | Defaults (`contents: read`) | No | Validates the signed job manifest for Gate. |
@@ -156,7 +156,7 @@ lockstep and remain the single sources of truth for keep vs retire decisions.
 
 | Workflow | File | Trigger(s) | Permissions | Required? | Purpose |
 |----------|------|------------|-------------|-----------|---------|
-| `health-41-repo-health.yml` (`Health 41 Repo Health`) | `.github/workflows/health-41-repo-health.yml` | Weekly cron, manual | `contents: read`, `issues: read` | No | Reports stale branches & unassigned issues. |
+| `health-41-repo-health.yml` (`Health 41 Repo Health`) | `.github/workflows/health-41-repo-health.yml` | Weekly cron, manual | `contents: read`, `issues: read` | No | Reports stale branches, unassigned issues, and default-branch protection context drift. |
 | `maint-46-post-ci.yml` (`Maint 46 Post CI`) | `.github/workflows/maint-46-post-ci.yml` | `workflow_run` (Gate) | `contents: write`, `pull-requests: write`, `issues: write`, `checks: read`, `actions: read` | No | Consolidated follower that posts Gate summaries, applies low-risk autofix commits, and owns CI failure-tracker updates. |
 | `maint-coverage-guard.yml` (`Maint Coverage Guard`) | `.github/workflows/maint-coverage-guard.yml` | Cron, manual | `contents: read`, `actions: read`, `issues: write` | No | Downloads the most recent Gate coverage payloads and trend file, compares against the baseline, and raises failures when coverage drops below the guard thresholds. |
 | `health-40-repo-selfcheck.yml` (`Health 40 Repo Selfcheck`) | `.github/workflows/health-40-repo-selfcheck.yml` | Weekly cron, manual | `contents: read`, `issues: write`, `actions: write` | No | Repo health pulse that surfaces missing labels or branch-protection visibility gaps, warns on unauthorized branch visibility, and maintains the `[health] repository self-check failed` tracker issue. |
@@ -172,7 +172,7 @@ lockstep and remain the single sources of truth for keep vs retire decisions.
 - **Remedies:**
   1. Confirm the repository setting **Settings → Actions → General → Workflow permissions** grants the default token _Read access to contents and metadata_. The repo-health jobs use only read scopes.
    2. If the default token still cannot read branch protection, rerun **Health 44 Gate Branch Protection** with a `BRANCH_PROTECTION_TOKEN` that has `repo` scope. The verification step will surface the current policy and unblock Health 40 on the next scheduled run.
-  3. Escalate to a repository admin if neither step restores access—the repo-health jobs cannot self-grant elevated scopes.
+   3. Escalate to a repository admin if neither step restores access—the repo-health jobs cannot self-grant elevated scopes.
 
 ### CI failure rollup issue
 

--- a/docs/ci/WORKFLOW_SYSTEM.md
+++ b/docs/ci/WORKFLOW_SYSTEM.md
@@ -214,10 +214,12 @@ explain why a particular status appears in the Checks tab.
 #### Health 41 Repo Health (`health-41-repo-health.yml`)
 
 - **When it runs.** Monday 07:15 UTC on a schedule, or via manual dispatch.
-- **What it does.** Audits stale branches and unassigned issues, publishing the
-  weekly hygiene dashboard in the run summary.
+- **What it does.** Audits stale branches, unassigned issues, and default-branch
+  protection drift, publishing the weekly hygiene dashboard in the run summary.
+  When `Gate / gate` drops from branch protection the workflow fails with
+  branch-specific guidance that points responders back to the default branch.
 - **Merge impact.** Informational background signal; does not gate pull
-  requests.
+  requests, but a failure indicates branch protection needs repair.
 
 #### Health 42 Actionlint (`health-42-actionlint.yml`)
 

--- a/docs/ops/maintenance-playbook.md
+++ b/docs/ops/maintenance-playbook.md
@@ -8,9 +8,9 @@ maintenance workflows that remain after Issue 2190. The roster now consists of
 ## health-41-repo-health.yml
 
 1. **Open the run summary** — the weekly sweep writes a single report that
-   lists stale branches (older than the configured threshold) and open issues
-   without assignees. The heading `Repository health weekly sweep` marks the
-   latest results.
+   lists stale branches (older than the configured threshold), open issues
+   without assignees, and the default-branch protection state. The heading
+   `Repository health weekly sweep` marks the latest results.
 2. **Handle stale branches** — follow the table entries to prune abandoned
    branches or push a fresh commit if the branch is still active. The table is
    capped at 20 rows; the summary includes an overflow note when additional
@@ -18,7 +18,13 @@ maintenance workflows that remain after Issue 2190. The roster now consists of
 3. **Triage unassigned issues** — assign an owner or update labels for the
    surfaced issues so they no longer show up in the next run. Issues are sorted
    by oldest activity first.
-4. **Adjust the threshold if needed** — update the repository variable
+4. **Restore branch protection when drift appears** — failures call out the
+   default branch explicitly when `Gate / gate` is no longer required. Navigate
+   to **Settings → Branches → Branch protection rules**, edit the default-branch
+   rule, and re-add the Gate status check (plus any other missing contexts).
+   Re-run the workflow once protection is restored to confirm the summary turns
+   green.
+5. **Adjust the threshold if needed** — update the repository variable
    `REPO_HEALTH_STALE_BRANCH_DAYS` when the stale-branch window should change.
    Re-run the workflow via `workflow_dispatch` to validate the new threshold.
 

--- a/docs/repo_health_self_check.md
+++ b/docs/repo_health_self_check.md
@@ -2,11 +2,11 @@
 
 The `health-41-repo-health.yml` workflow runs a light-touch sweep of repository
 hygiene each Monday at 07:15 UTC. It records a single Markdown report in the job
-summary highlighting stale branches and open issues without an assignee so the
-on-call maintainer can triage them quickly. The report is generated directly
-with `actions/github-script`, so the former `.github/scripts/repo_health_probe.py`
-wrapper has been removed and there is no Python probe helper to maintain
-alongside the workflow.
+summary highlighting stale branches, open issues without an assignee, and the
+default-branch protection state so the on-call maintainer can triage them
+quickly. The report is generated directly with `actions/github-script`, so the
+former `.github/scripts/repo_health_probe.py` wrapper has been removed and there
+is no Python probe helper to maintain alongside the workflow.
 
 ## What it reports
 
@@ -14,6 +14,7 @@ alongside the workflow.
 | ------ | ---------------- | ----- |
 | Stale branches | Branches (excluding the default) whose latest commit is older than `REPO_HEALTH_STALE_BRANCH_DAYS`. | Sorted by oldest commit first and capped at 20 rows. |
 | Unassigned issues | Open issues without assignees ordered by last update. | Includes links so triage is one click away. |
+| Branch protection | Expected vs. enforced required status contexts on the default branch. | Fails when `Gate / gate` drops from branch protection and surfaces the current context list for audit. |
 
 The summary also surfaces aggregate counts for each signal at the top of the
 report.
@@ -38,11 +39,15 @@ Generated on Mon, 03 Feb 2025 07:15:32 GMT
 
 Each section expands into a table with the specific branches or issues. When
 more than 20 entries exist, the summary notes how many were omitted so you know
-whether further cleanup is required.
+whether further cleanup is required. The branch-protection section lists the
+expected context(s) alongside what GitHub currently enforces; drift triggers a
+failure with language calling out the default branch so the responder knows
+exactly where to restore the `Gate / gate` requirement.
 
 ## Outputs
 
-- **Workflow summary** — The run log records the Markdown summary shown above.
+- **Workflow summary** — The run log records the Markdown summary shown above,
+  including the branch-protection comparison.
 - **JSON artifact** — `repo-health-summary.json` captures the raw check payload
   (timestamps, branch status, label findings) for scripting or audit trails.
 - **Optional PR checklist** — When the workflow is dispatched with
@@ -57,5 +62,6 @@ to decide how old a branch must be before it is reported. Increase the value for
 long-lived release branches or decrease it to surface drift sooner. The `MAX_TABLE_ROWS`
 setting is hard-coded to 20 inside the workflow for concise reports.
 
-After updating the threshold, dispatch the workflow manually to confirm the new
-window behaves as expected.
+After updating the threshold or restoring branch protection, dispatch the
+workflow manually to confirm the new window behaves as expected and that the
+`Gate / gate` requirement is back in place.


### PR DESCRIPTION
## Summary
- extend the Health 41 repo-health workflow to record expected contexts, show them in the summary, and surface branch-specific failures when Gate / gate drifts
- document the new branch-protection audit path across the repo health, workflow, and maintenance guides

## Testing
- ⚠️ Not run (workflow and documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68f7178702448331bb2672a930aa944b