### PR TITLE
Ensure orchestrator can dispatch belt workflows

### DIFF
--- a/.github/workflows/agents-70-orchestrator.yml
+++ b/.github/workflows/agents-70-orchestrator.yml
@@ -20,6 +20,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  actions: write
 
 concurrency:
   group: orchestrator-${{ github.ref }}
@@ -438,6 +439,68 @@ jobs:
       max_parallel: ${{ fromJson(needs.resolve-params.outputs.worker_max_parallel || '1') }}
     secrets:
       actions_bot_pat: ${{ secrets.ACTIONS_BOT_PAT }}
+
+  belt-dispatch-summary:
+    name: Summarise Codex dispatch outcomes
+    needs:
+      - belt-dispatch
+      - belt-worker
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Append dispatch summary
+        uses: actions/github-script@v7
+        env:
+          DISPATCH_RESULT: ${{ needs.belt-dispatch.result || '' }}
+          DISPATCH_ISSUE: ${{ needs.belt-dispatch.outputs.issue || '' }}
+          WORKER_RESULT: ${{ needs.belt-worker.result || '' }}
+          WORKER_ALLOWED: ${{ needs.belt-worker.outputs.allowed || '' }}
+        with:
+          script: |
+            const dispatchResult = (process.env.DISPATCH_RESULT || '').trim().toLowerCase();
+            const workerResult = (process.env.WORKER_RESULT || '').trim().toLowerCase();
+            const workerAllowed = (process.env.WORKER_ALLOWED || '').trim().toLowerCase();
+            const dispatchedIssue = (process.env.DISPATCH_ISSUE || '').trim();
+
+            let success = 0;
+            let skipped = 0;
+            let failures = 0;
+
+            const normalise = (value) => {
+              if (!value) {
+                return 'unknown';
+              }
+              return value.toLowerCase();
+            };
+
+            const dispatchState = normalise(dispatchResult);
+            const workerState = normalise(workerResult);
+
+            if (dispatchState === 'success' && dispatchedIssue) {
+              if (workerState === 'success') {
+                success += 1;
+              } else if (['failure', 'cancelled'].includes(workerState)) {
+                failures += 1;
+              } else if (workerState === 'skipped' || workerAllowed === 'false') {
+                skipped += 1;
+              } else {
+                skipped += 1;
+              }
+            } else if (dispatchState === 'success') {
+              skipped += 1;
+            } else if (dispatchState === 'skipped' || dispatchState === 'cancelled') {
+              skipped += 1;
+            } else if (dispatchState === 'failure') {
+              failures += 1;
+            } else {
+              skipped += 1;
+            }
+
+            const summary = core.summary;
+            summary
+              .addRaw(`Dispatch succeeded for ${success} PRs; ${skipped} skipped; ${failures} failures.`)
+              .addEOL();
+            await summary.write();
 
   belt-scan-ready-prs:
     name: Scan Codex promotion queue


### PR DESCRIPTION
## Summary
- grant the orchestrator workflow `actions: write` permission so belt jobs can be dispatched
- append a follow-up job that records dispatch success/skip/failure counts in the run summary

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f85ac7fa008331934b97581d15479d