### PR TITLE
chore(workflow): rerun bridge when codex label exists

### DIFF
--- a/.github/workflows/agents-63-codex-issue-bridge.yml
+++ b/.github/workflows/agents-63-codex-issue-bridge.yml
@@ -34,6 +34,8 @@ concurrency:
 
 jobs:
   bridge:
+    # Run on any label event once agent:codex is present so concurrency cancellations
+    # from follow-up labels (e.g. agents:keepalive) still execute the bridge.
     if: >
       github.event_name == 'workflow_dispatch' ||
       (
@@ -41,7 +43,12 @@ jobs:
         (
           (
             github.event.action == 'labeled' &&
-            (contains(github.event.label.name, 'agent:codex') || contains(github.event.label.name, 'agents:codex'))
+            (
+              contains(github.event.label.name, 'agent:codex') ||
+              contains(github.event.label.name, 'agents:codex') ||
+              contains(join(github.event.issue.labels.*.name, ' '), 'agent:codex') ||
+              contains(join(github.event.issue.labels.*.name, ' '), 'agents:codex')
+            )
           ) ||
           (
             github.event.action != 'labeled' &&


### PR DESCRIPTION
## Summary
- [ ] Provide a concise description of the change.
- [ ] Note any follow-up tasks or docs to update later.

## Testing
- [ ] Listed the commands or scripts used to validate the change.
- [ ] Attached or linked relevant logs when tests are not applicable.

## CI readiness
- [ ] Skimmed the [workflow spotlight](../docs/ci/WORKFLOW_SYSTEM.md#spotlight-the-six-guardrails-everyone-touches) for Gate, Maint 46, Repo Health, Actionlint, Agents Orchestrator, and Health 45 Agents Guard when touching automation.
- [ ] Reviewed the [Workflow System Overview](../docs/ci/WORKFLOW_SYSTEM.md#required-vs-informational-checks-on-phase-2-dev) to confirm Gate / `gate` is the required status and Maint 46 Post CI is informational after merge.
- [ ] Checked this pull request's **Checks** tab to confirm Gate / `gate` appears under **Required checks** (Health 45 Agents Guard auto-adds when `agents-*.yml` files change).
- [ ] Escalated via the [branch protection playbook](../docs/ci/WORKFLOW_SYSTEM.md#branch-protection-playbook) if Gate / `gate` is missing or Maint 46 Post CI shows up as required.
- [ ] Confirmed the latest Gate run is green (or linked the failing run with context).
