### PR TITLE
Fix keepalive runner indentation for default instruction

### DIFF
--- a/scripts/keepalive-runner.js
+++ b/scripts/keepalive-runner.js
@@ -338,9 +338,9 @@ async function runKeepalive({ core, github, context, env = process.env }) {
       const totalTasks = latestChecklist.total;
       const outstanding = latestChecklist.unchecked;
       const completed = Math.max(0, totalTasks - outstanding);
-  const itemWord = outstanding === 1 ? 'item' : 'items';
-  const verb = outstanding === 1 ? 'remains' : 'remain';
-  const defaultInstruction = `Codex, ${outstanding}/${totalTasks} checklist ${itemWord} ${verb} unchecked (completed ${completed}). Continue executing the plan, update the checklist, and confirm once everything is complete.`;
+      const itemWord = outstanding === 1 ? 'item' : 'items';
+      const verb = outstanding === 1 ? 'remains' : 'remain';
+      const defaultInstruction = `Codex, ${outstanding}/${totalTasks} checklist ${itemWord} ${verb} unchecked (completed ${completed}). Continue executing the plan, update the checklist, and confirm once everything is complete.`;
 
       let instruction = instructionTemplate || defaultInstruction;
       const replacements = {


### PR DESCRIPTION
## Summary
- correct the indentation of the default keepalive instruction so it stays within the checklist block

## Testing
- node -e "require('./scripts/keepalive-runner.js')"

------
https://chatgpt.com/codex/tasks/task_e_68fb75acd77c8331a8d3b270ce3c188f