### PR TITLE
Codex bootstrap for #2960

### DIFF
--- a/.github/workflows/reusable-agents-issue-bridge.yml
+++ b/.github/workflows/reusable-agents-issue-bridge.yml
@@ -74,15 +74,18 @@ jobs:
             const agent = process.env.AGENT || 'unknown';
             const issueNo = context.payload.issue && context.payload.issue.number;
             const manualIssue = '${{ inputs.issue_number }}';
-            core.summary.addHeading(`${agent.charAt(0).toUpperCase() + agent.slice(1)} Bridge Event Summary`).addTable([
-              [
-                {data:'Agent',header:true},
-                {data:'Issue (event)',header:true},
-                {data:'Issue (input)',header:true},
-                {data:'Mode',header:true}
-              ],
-              [agent, String(issueNo || ''), String(manualIssue || ''), '${{ inputs.mode }}']
-            ]).write();
+            await core.summary
+              .addHeading(`${agent.charAt(0).toUpperCase() + agent.slice(1)} Bridge Event Summary`)
+              .addTable([
+                [
+                  { data: 'Agent', header: true },
+                  { data: 'Issue (event)', header: true },
+                  { data: 'Issue (input)', header: true },
+                  { data: 'Mode', header: true }
+                ],
+                [agent, String(issueNo || ''), String(manualIssue || ''), '${{ inputs.mode }}']
+              ])
+              .write();
 
       - name: Resolve issue number
         id: ctx


### PR DESCRIPTION
### Keepalive: ON

### Source Issue #2960: Create reusable agents-issue-bridge and refactor Codex bridge to use it

Source: https://github.com/stranske/Trend_Model_Project/issues/2960

> Topic GUID: 48bb782f-5cd4-523c-9635-54cf7939f0f2
> 
> ## Why
> Introduce a reusable workflow agents-issue-bridge.yml with that allow for multiple agent inputs with any agent that will work on GitHub (so agent:codex when @codex engages Codex to work on an issue or agent:claude when @claude engages Claude to work on an issue, etc.). Refactor the existing “Agents 63 Codex Issue Bridge” to call it with agent=codex. This reduces drift and allows adding variants later without duplicating logic.
> 
> Scope
> 
> New reusable workflow with shared steps: parse issue, branch naming, PR open/update, label management.
> 
> Thin wrapper “Agents 63” calls the reusable with agent=codex.
> 
> Non-Goals
> 
> Changing current Codex behavior or branch naming.
> 
> ## Tasks
> - [ ] Add .github/workflows/reusable-agents-issue-bridge.yml with inputs: agent, issue_number, mode (create|invite), etc.
> 
> - [ ] Update “Agents 63 Codex Issue Bridge” to workflow_call the reusable.
> 
> - [ ] Document inputs and expected labels at file top.
> 
> ## Acceptance criteria
> - Existing Codex path works identically.
> 
> - Reusable shows in Actions list and can be invoked in future wrappers.
> 
> - Zero behavior change in labels/PR naming.
> 
> ## Implementation notes
> - Branch: codex/issue-<n>-agents-bridge-reusable
> 
> - PR title prefix: [Agents] Reusable issue bridge
> 
> - Touch only: .github/workflows/agents-63-*.yml and new reusable file.
> 
> ---
> Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18779408488).

—
PR created automatically to engage Codex.