### PR TITLE
chore(codex): bootstrap PR for issue #3040

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,9 +69,7 @@ def pytest_collection_modifyitems(config, items):
         it.user_properties.append(("test_markers", ",".join(markers)))
 
 
-def pytest_sessionfinish(
-    session: pytest.Session, exitstatus: int
-) -> None:  # noqa: ARG001
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:  # noqa: ARG001
     recorder = get_recorder()
     if not recorder.has_entries():
         return

--- a/tests/golden/test_demo.py
+++ b/tests/golden/test_demo.py
@@ -360,8 +360,8 @@ class TestDemoGoldenMaster:
         assert len(hashes_run2) > 0, "No output files generated in run 2"
 
         # Check that same files were generated
-        assert set(hashes_run1.keys()) == set(
-            hashes_run2.keys()
+        assert (
+            set(hashes_run1.keys()) == set(hashes_run2.keys())
         ), f"Different files generated: {set(hashes_run1.keys())} vs {set(hashes_run2.keys())}"
 
         # Check that content hashes match

--- a/tests/test_ci_cosmetic_repair.py
+++ b/tests/test_ci_cosmetic_repair.py
@@ -31,9 +31,7 @@ def _write_junit(tmp_path: Path, message: str) -> Path:
             </failure>
           </testcase>
         </testsuite>
-    """.strip().format(
-        message=escape(message, {'"': "&quot;"})
-    )
+    """.strip().format(message=escape(message, {'"': "&quot;"}))
     path = tmp_path / "report.xml"
     path.write_text(junit, encoding="utf-8")
     return path

--- a/tests/test_disable_legacy_workflows.py
+++ b/tests/test_disable_legacy_workflows.py
@@ -26,8 +26,8 @@ def test_canonical_workflow_names_match_expected_mapping() -> None:
     assert (
         set(EXPECTED_NAMES) == CANONICAL_WORKFLOW_FILES
     ), "Workflow naming expectations drifted; keep EXPECTED_NAMES in sync with the allowlist."
-    assert CANONICAL_WORKFLOW_NAMES == set(
-        EXPECTED_NAMES.values()
+    assert (
+        CANONICAL_WORKFLOW_NAMES == set(EXPECTED_NAMES.values())
     ), "Workflow display-name allowlist drifted; synchronize EXPECTED_NAMES in tests/test_workflow_naming.py."
 
 

--- a/tests/test_export_openpyxl_adapter.py
+++ b/tests/test_export_openpyxl_adapter.py
@@ -113,9 +113,7 @@ def test_export_to_excel_uses_adapter_when_xlsxwriter_missing(monkeypatch, tmp_p
 
     monkeypatch.setattr(pd, "ExcelWriter", fake_excel_writer)
 
-    def fake_to_excel(
-        self, writer, sheet_name, index=False, **_: object
-    ) -> None:  # noqa: ARG002
+    def fake_to_excel(self, writer, sheet_name, index=False, **_: object) -> None:  # noqa: ARG002
         writer.sheets[sheet_name] = object()
         writer.book.worksheets.append(DummyWorksheet("Sheet"))
 
@@ -412,9 +410,7 @@ def test_export_to_excel_strips_temp_sheet_key(monkeypatch, tmp_path):
 
     monkeypatch.setattr(pd, "ExcelWriter", fake_excel_writer)
 
-    def fake_to_excel(
-        self, writer, sheet_name, index=False, **_: object
-    ) -> None:  # noqa: ARG002
+    def fake_to_excel(self, writer, sheet_name, index=False, **_: object) -> None:  # noqa: ARG002
         ws = DummyWorksheet("Temp")
         writer.book.worksheets.append(ws)
         writer.sheets[sheet_name] = ws

--- a/tests/test_gui_app_extended.py
+++ b/tests/test_gui_app_extended.py
@@ -36,9 +36,7 @@ class DummyGrid:
 
 
 class DummyUpload:
-    def __init__(
-        self, accept: str = "", multiple: bool = False
-    ) -> None:  # noqa: ARG002
+    def __init__(self, accept: str = "", multiple: bool = False) -> None:  # noqa: ARG002
         self.accept = accept
         self.multiple = multiple
         self.value: dict[str, dict[str, bytes]] = {}
@@ -57,9 +55,7 @@ class DummyUpload:
 
 
 class DummyDropdown:
-    def __init__(
-        self, options, value=None, description: str = ""
-    ) -> None:  # noqa: ANN001, ARG002
+    def __init__(self, options, value=None, description: str = "") -> None:  # noqa: ANN001, ARG002
         self.options = list(options)
         self.description = description
         default_value = self.options[0] if self.options else None
@@ -93,9 +89,7 @@ class DummyCheckbox:
 
 
 class DummyToggleButtons(DummyCheckbox):
-    def __init__(
-        self, options, value=None, description: str = ""
-    ) -> None:  # noqa: ANN001, ARG002
+    def __init__(self, options, value=None, description: str = "") -> None:  # noqa: ANN001, ARG002
         super().__init__(
             value=value if value is not None else (options[0] if options else None),
             description=description,

--- a/tests/test_rank_selection_miscellaneous.py
+++ b/tests/test_rank_selection_miscellaneous.py
@@ -127,9 +127,7 @@ def test_blended_score_merges_aliases_and_inverts(sample_bundle):
         bundle._metrics["Sharpe"]
     ) + (  # type: ignore[index]
         canonical_total["MaxDrawdown"] / total
-    ) * (
-        -rank_selection._zscore(bundle._metrics["MaxDrawdown"])
-    )  # type: ignore[index]
+    ) * (-rank_selection._zscore(bundle._metrics["MaxDrawdown"]))  # type: ignore[index]
 
     pd.testing.assert_series_equal(result, expected)
 

--- a/tests/test_workflow_naming.py
+++ b/tests/test_workflow_naming.py
@@ -26,9 +26,7 @@ def test_workflow_slugs_follow_wfv1_prefixes():
         for path in _workflow_paths()
         if not path.name.startswith(ALLOWED_PREFIXES)
     ]
-    assert (
-        not non_compliant
-    ), f"Non-compliant workflow slug(s) detected outside {ALLOWED_PREFIXES}: {non_compliant}"
+    assert not non_compliant, f"Non-compliant workflow slug(s) detected outside {ALLOWED_PREFIXES}: {non_compliant}"
 
 
 def test_archive_directories_removed():


### PR DESCRIPTION
## Summary
- [ ] Provide a concise description of the change.
- [ ] Note any follow-up tasks or docs to update later.

## Testing
- [ ] Listed the commands or scripts used to validate the change.
- [ ] Attached or linked relevant logs when tests are not applicable.

## CI readiness
- [ ] Skimmed the [workflow spotlight](../docs/ci/WORKFLOW_SYSTEM.md#spotlight-the-six-guardrails-everyone-touches) for Gate, the Gate summary, Repo Health, Actionlint, Agents Orchestrator, and Health 45 Agents Guard when touching automation.
- [ ] Reviewed the [Workflow System Overview](../docs/ci/WORKFLOW_SYSTEM.md#required-vs-informational-checks-on-phase-2-dev) to confirm Gate / `gate` is the required status.
- [ ] Checked this pull request's **Checks** tab to confirm Gate / `gate` appears under **Required checks** (Health 45 Agents Guard auto-adds when `agents-*.yml` files change).
- [ ] Escalated via the [branch protection playbook](../docs/ci/WORKFLOW_SYSTEM.md#branch-protection-playbook) if Gate / `gate` is missing.
- [ ] Confirmed the latest Gate run is green (or linked the failing run with context).

<!-- pr-preamble:start -->
## Summary
Multiple nudgers cause duplicate comments and double dispatch; lack of branch scoping nudges the wrong PRs.

Scope
Keepalive listener logic and its comment behavior.

Non-Goals
No changes to belt step sizing or CI content.

## Testing
_No testing instructions provided by the source issue._

## CI readiness
Files: `.github/workflows/agents-70-orchestrator.yml` and/or `.github/workflows/agents-75-keepalive-on-gate.yml` (whichever is active), `scripts/keepalive-runner.js`

Branch: codex/issue--keepalive-scope-single
PR title prefix: [Agents] Keepalive: scoped single path + marker upsert
Touch only: active keepalive workflow(s) and scripts/keepalive-runner.js

Copy/paste to PR comment (kickoff)
@{agent} use the scope, acceptance criteria, and task list so the keepalive workflow continues nudging until everything is complete. Work through the tasks, checking them off only after each acceptance criterion is satisfied, but check during each comment implementation and check off tasks and acceptance criteria that have been satisfied and repost the current version of the initial scope, task list and acceptance criteria each time that any have been newly completed.

---
Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/18812359986).
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Scope section missing from source issue.

#### Tasks
- [ ] [ ] Disable the unused keepalive path (Gate-driven or Orchestrator sweep).
- [ ] [ ] Restrict nudge to branches matching `codex/issue-*`.
- [ ] [ ] Upsert keepalive comment using `<!-- codex-keepalive-marker -->`.

- [ ] [ ] Pick one keepalive path; disable the other.
- [ ] [ ] Add branch filter and marker-based comment upsert.

#### Acceptance criteria
- [ ] Exactly one keepalive mechanism is live.
- [ ] No keepalive activity on non-agent branches.
- [ ] No duplicate keepalive comments.

Topic GUID: 1a7a47c3-7a39-42c6-9b69-9c0b5a25f5f4

- [ ] Single source of truth for nudges; clean comments.

**Head SHA:** f7a949a085244581c25a4d814e51288ba742fcbb
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents 74 PR body writer | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/18813446232) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/18813446251) |
| Health 42 Actionlint | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/18813446236) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/18813446261) |
| Health 45 Agents Guard | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/18813446229) |
<!-- auto-status-summary:end -->