### PR TITLE
fix(ci): use unique heredoc delimiters in autofix workflow

### DIFF
--- a/.github/workflows/reusable-18-autofix.yml
+++ b/.github/workflows/reusable-18-autofix.yml
@@ -323,9 +323,9 @@ jobs:
           if [ ${#tests_only[@]} -gt 0 ]; then
             sorted_tests=$(printf '%s\n' "${tests_only[@]}" | sort -u)
             {
-              echo "file_list<<'EOF'"
+              echo "file_list<<AUTOFIX_DELIMITER_$$"
               printf '%s\n' "$sorted_tests"
-              echo 'EOF'
+              echo "AUTOFIX_DELIMITER_$$"
             } >> "$GITHUB_OUTPUT"
           fi
 
@@ -431,9 +431,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           if [ -n "$file_list_payload" ]; then
             {
-              echo "file_list<<'EOF'"
+              echo "file_list<<AUTOFIX_DELIMITER_$$"
               printf '%s\n' "$file_list_payload"
-              echo 'EOF'
+              echo "AUTOFIX_DELIMITER_$$"
             } >> "$GITHUB_OUTPUT"
           fi
 
@@ -475,9 +475,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           if [ -n "$file_list" ]; then
             {
-              echo "file_list<<'EOF'"
+              echo "file_list<<AUTOFIX_DELIMITER_$$"
               printf '%s\n' "$file_list"
-              echo 'EOF'
+              echo "AUTOFIX_DELIMITER_$$"
             } >> "$GITHUB_OUTPUT"
           fi
 
@@ -541,14 +541,14 @@ jobs:
               labels="$labels, \`autofix:debt\`"
             fi
             {
-              echo "AUTOFIX_RESULT_BLOCK<<'EOF'"
+              echo "AUTOFIX_RESULT_BLOCK<<AUTOFIX_BLOCK_DELIMITER_$$"
               if [ "$MODE" = "clean" ]; then
                 echo "Clean-mode cosmetic autofix commit: [${short_sha}]($url)"
               else
                 echo "Autofix commit: [${short_sha}]($url)"
               fi
               echo "Labels: $labels"
-              echo "EOF"
+              echo "AUTOFIX_BLOCK_DELIMITER_$$"
             } >> "$GITHUB_ENV"
           fi
 
@@ -626,7 +626,7 @@ jobs:
             labels="$labels, \`autofix:debt\`"
           fi
           {
-            echo "AUTOFIX_RESULT_BLOCK<<'EOF'"
+            echo "AUTOFIX_RESULT_BLOCK<<AUTOFIX_BLOCK_DELIMITER_$$"
             if [ "$MODE" = "clean" ]; then
               echo "Clean-mode cosmetic patch: [${name}](${url})"
             else
@@ -640,7 +640,7 @@ jobs:
             echo "   git am < autofix.patch"
             echo "3. Push to your PR branch:"
             echo "   git push origin HEAD:${HEAD_REF}"
-            echo "EOF"
+            echo "AUTOFIX_BLOCK_DELIMITER_$$"
           } >> "$GITHUB_ENV"
 
       - name: Prepare no-change summary
@@ -662,14 +662,14 @@ jobs:
             labels="$labels, \`autofix:debt\`"
           fi
           {
-            echo "AUTOFIX_RESULT_BLOCK<<'EOF'"
+            echo "AUTOFIX_RESULT_BLOCK<<AUTOFIX_BLOCK_DELIMITER_$$"
             if [ "$MODE" = "clean" ]; then
               echo "Clean-mode cosmetic sweep found no changes."
             else
               echo "No changes required."
             fi
             echo "Labels: $labels"
-            echo "EOF"
+            echo "AUTOFIX_BLOCK_DELIMITER_$$"
           } >> "$GITHUB_ENV"
 
       - name: Manage autofix outcome labels
@@ -1116,8 +1116,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           if [ -n "$file_list" ]; then
             {
-              echo "file_list<<'EOF'"
+              echo "file_list<<AUTOFIX_DELIMITER_$$"
               printf '%s\n' "$file_list"
-              echo 'EOF'
+              echo "AUTOFIX_DELIMITER_$$"
             } >> "$GITHUB_OUTPUT"
           fi
+


### PR DESCRIPTION
## Problem

The autofix workflow was failing with:
```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid value. Matching delimiter not found ''EOF''
```

This occurred when the workflow tried to set multiline `file_list` outputs using heredoc with a generic `'EOF'` delimiter. If file paths or content contained that exact string, it would break the delimiter matching.

## Solution

Replace all generic `'EOF'` heredoc delimiters with process-specific delimiters:
- `file_list` outputs: `'EOF'` → `AUTOFIX_DELIMITER_$$`
- `AUTOFIX_RESULT_BLOCK`: `'EOF'` → `AUTOFIX_BLOCK_DELIMITER_$$`

The `$$` suffix includes the process ID, making collisions virtually impossible.

## Testing

This fix addresses the autofix failures seen in PR #3043 where:
- ✅ Autofix successfully reformatted 10 files and fixed 5 errors
- ❌ But failed when trying to record the output due to delimiter collision

With this fix, the workflow should be able to record outputs reliably regardless of file path content.

## Changes

- 5 heredoc blocks updated with unique delimiters
- No functional changes to autofix behavior
- Only affects output recording mechanism

Closes #3043 (autofix failure issue)

<!-- pr-preamble:start -->
## Summary
- [ ] Provide a concise description of the change.
- [ ] Note any follow-up tasks or docs to update later.

## Testing
- [ ] Listed the commands or scripts used to validate the change.
- [ ] Attached or linked relevant logs when tests are not applicable.

## CI readiness
- [ ] Skimmed the [workflow spotlight](../docs/ci/WORKFLOW_SYSTEM.md#spotlight-the-six-guardrails-everyone-touches) for Gate, the Gate summary, Repo Health, Actionlint, Agents Orchestrator, and Health 45 Agents Guard when touching automation.
- [ ] Reviewed the [Workflow System Overview](../docs/ci/WORKFLOW_SYSTEM.md#required-vs-informational-checks-on-phase-2-dev) to confirm Gate / `gate` is the required status.
- [ ] Checked this pull request's **Checks** tab to confirm Gate / `gate` appears under **Required checks** (Health 45 Agents Guard auto-adds when `agents-*.yml` files change).
- [ ] Escalated via the [branch protection playbook](../docs/ci/WORKFLOW_SYSTEM.md#branch-protection-playbook) if Gate / `gate` is missing.
- [ ] Confirmed the latest Gate run is green (or linked the failing run with context).

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Scope section missing from source issue.

#### Tasks
- [ ] Tasks section missing from source issue.

#### Acceptance criteria
- [ ] Acceptance criteria section missing from source issue.

**Head SHA:** d8eb0f2b7549740be028064b895f8fe507e89494
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents 74 PR body writer | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/18812750063) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/18812750079) |
| Health 42 Actionlint | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/18812750060) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/18812750064) |
| Health 45 Agents Guard | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/18812750074) |
<!-- auto-status-summary:end -->