### PR TITLE
[CI] Auto-label cosmetic failures and tighten autofix guard

### DIFF
--- a/.github/scripts/gate_summary.py
+++ b/.github/scripts/gate_summary.py
@@ -26,6 +26,8 @@ class SummaryResult:
     lines: list[str]
     state: str
     description: str
+    cosmetic_failure: bool = False
+    failure_checks: tuple[str, ...] = ()
 
 
 PRIORITY: dict[str, int] = {
@@ -78,6 +80,14 @@ def _aggregate(entries: Iterable[tuple[str, str]]) -> tuple[str, str]:
     return best, detail or "no runs"
 
 
+def _normalize_check_outcome(section: Mapping[str, object] | None) -> str:
+    if isinstance(section, Mapping):
+        outcome = section.get("outcome")
+        if isinstance(outcome, str):
+            return _normalize(outcome)
+    return "unknown"
+
+
 def _load_summary_records(artifacts_root: Path) -> list[dict]:
     records: list[dict] = []
     base = artifacts_root / "downloads"
@@ -100,6 +110,35 @@ def _load_summary_records(artifacts_root: Path) -> list[dict]:
             records.append(data)
 
     return records
+
+
+def _detect_cosmetic_failure(records: Iterable[Mapping[str, object]]) -> tuple[bool, tuple[str, ...]]:
+    allowed_failures = {"format", "lint"}
+    benign_outcomes = {"success", "skipped", "pending"}
+    cosmetic_hits: set[str] = set()
+    has_records = False
+
+    for record in records:
+        if not isinstance(record, Mapping):
+            continue
+        has_records = True
+        checks = record.get("checks")
+        if not isinstance(checks, Mapping):
+            return False, ()
+
+        for name, section in checks.items():
+            outcome = _normalize_check_outcome(section if isinstance(section, Mapping) else None)
+            if outcome in benign_outcomes:
+                continue
+            if name in allowed_failures and outcome == "failure":
+                cosmetic_hits.add(str(name))
+                continue
+            return False, ()
+
+    if not has_records or not cosmetic_hits:
+        return False, ()
+
+    return True, tuple(sorted(cosmetic_hits))
 
 
 def _collect_table(records: Iterable[Mapping[str, object]]) -> tuple[
@@ -130,12 +169,9 @@ def _collect_table(records: Iterable[Mapping[str, object]]) -> tuple[
         )
 
         def _check(name: str) -> str:
-            section = checks.get(name)
-            if isinstance(section, Mapping):
-                outcome = section.get("outcome")
-                if isinstance(outcome, str):
-                    return _normalize(outcome)
-            return "unknown"
+            return _normalize_check_outcome(
+                checks.get(name) if isinstance(checks, Mapping) else None
+            )
 
         lint = _check("lint")
         typing = _check("type_check")
@@ -267,6 +303,8 @@ def summarize(context: SummaryContext) -> SummaryResult:
         )
         return SummaryResult(lines=lines, state="success", description=description)
 
+    records = _load_summary_records(context.artifacts_root)
+
     (
         table,
         lint_entries,
@@ -275,7 +313,7 @@ def summarize(context: SummaryContext) -> SummaryResult:
         coverage_entries,
         coverage_percents,
         job_results,
-    ) = _collect_table(_load_summary_records(context.artifacts_root))
+    ) = _collect_table(records)
 
     lines = _active_lines(
         table,
@@ -293,10 +331,13 @@ def summarize(context: SummaryContext) -> SummaryResult:
 
     python_result = _normalize(context.python_result or "success")
     docker_result_norm = _normalize(context.docker_result or "skipped")
+    cosmetic_failure = False
+    failure_checks: tuple[str, ...] = ()
 
     if python_result != "success":
         state = "failure"
         description = f"Python CI result: {python_result}."
+        cosmetic_failure, failure_checks = _detect_cosmetic_failure(records)
     elif context.docker_changed and docker_result_norm != "success":
         state = "failure"
         description = f"Docker smoke result: {docker_result_norm}."
@@ -310,7 +351,13 @@ def summarize(context: SummaryContext) -> SummaryResult:
         else:
             adjusted_lines.append(line)
 
-    return SummaryResult(lines=adjusted_lines, state=state, description=description)
+    return SummaryResult(
+        lines=adjusted_lines,
+        state=state,
+        description=description,
+        cosmetic_failure=cosmetic_failure,
+        failure_checks=failure_checks,
+    )
 
 
 def _resolve_path(env_var: str) -> Path | None:
@@ -359,6 +406,15 @@ def _write_outputs(result: SummaryResult, output_path: Path | None) -> None:
     with output_path.open("a", encoding="utf-8") as handle:
         handle.write(f"state={result.state}\n")
         handle.write(f"description={result.description}\n")
+        handle.write(
+            f"cosmetic_failure={'true' if result.cosmetic_failure else 'false'}\n"
+        )
+        if result.failure_checks:
+            handle.write(
+                "failure_checks=" + ",".join(result.failure_checks) + "\n"
+            )
+        else:
+            handle.write("failure_checks=\n")
 
 
 def main() -> int:

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -142,26 +142,16 @@ jobs:
               })
               .filter(Boolean);
 
-            const hasAutofix = labelNames.includes('autofix');
-            const hasAgent = labelNames.some((name) => name.startsWith('agent:'));
+            const hasAutofix = labelNames.some(
+              (name) => name === 'autofix' || name === 'autofix:clean'
+            );
 
             summary.addRaw(`Labels: ${labelNames.join(', ') || '(none)'}`).addEOL();
-            summary.addRaw(`Has autofix label: ${hasAutofix}`).addEOL();
-            summary.addRaw(`Has agent:* label: ${hasAgent}`).addEOL();
+            summary.addRaw(`Has autofix/autofix:clean label: ${hasAutofix}`).addEOL();
 
             if (!hasAutofix) {
               result.skip_reason = 'missing-autofix-label';
               summary.addRaw('Autofix label not present; skipping.').addEOL();
-              for (const [key, value] of Object.entries(result)) {
-                core.setOutput(key, value);
-              }
-              await summary.write();
-              return;
-            }
-
-            if (!hasAgent) {
-              result.skip_reason = 'missing-agent-label';
-              summary.addRaw('Agent label not present; skipping.').addEOL();
               for (const [key, value] of Object.entries(result)) {
                 core.setOutput(key, value);
               }
@@ -185,6 +175,42 @@ jobs:
             if (!sameRepo) {
               result.skip_reason = 'fork-pr';
               summary.addRaw('Autofix loop only runs for same-repo branches.').addEOL();
+              for (const [key, value] of Object.entries(result)) {
+                core.setOutput(key, value);
+              }
+              await summary.write();
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const allowedExtensions = ['.py', '.pyi'];
+            const disallowedFiles = files
+              .map((file) => {
+                if (!file) return '';
+                if (typeof file === 'string') return file;
+                if (typeof file.filename === 'string') return file.filename;
+                return '';
+              })
+              .filter(Boolean)
+              .filter((filename) => {
+                const lower = filename.toLowerCase();
+                return !allowedExtensions.some((ext) => lower.endsWith(ext));
+              });
+
+            summary.addRaw(`Non-Python files detected: ${disallowedFiles.length}`).addEOL();
+
+            if (disallowedFiles.length > 0) {
+              result.skip_reason = 'non-python-changes';
+              summary
+                .addRaw(
+                  `Detected non-Python changes; skipping autofix loop (${disallowedFiles.join(', ')})`
+                )
+                .addEOL();
               for (const [key, value] of Object.entries(result)) {
                 core.setOutput(key, value);
               }

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -413,6 +413,91 @@ jobs:
           COVERAGE_ENABLED: ${{ needs.detect.outputs.coverage || 'true' }}
         run: python .github/scripts/gate_summary.py
 
+      - name: Auto-apply autofix label for cosmetic failures
+        id: autofix_label
+        if: |
+          github.event_name == 'pull_request' &&
+          needs.detect.outputs.doc_only != 'true' &&
+          steps.summarize.outputs.state == 'failure' &&
+          steps.summarize.outputs.cosmetic_failure == 'true' &&
+          !contains(github.event.pull_request.labels.*.name, 'autofix:clean')
+        uses: actions/github-script@v7
+        env:
+          ALLOWED_EXTENSIONS: 'py,pyi'
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            core.setOutput('applied', 'false');
+            core.setOutput('skipped_reason', '');
+
+            if (!pr) {
+              core.info('No pull request context available; skipping auto-label.');
+              core.setOutput('skipped_reason', 'missing-pr');
+              return;
+            }
+
+            if (!pr.number) {
+              core.info('Pull request number missing; skipping auto-label.');
+              core.setOutput('skipped_reason', 'invalid-pr');
+              return;
+            }
+
+            const sameRepo =
+              pr.head?.repo?.full_name === `${owner}/${repo}` &&
+              pr.base?.repo?.full_name === `${owner}/${repo}`;
+            if (!sameRepo) {
+              core.info('Skipping auto-label for forked PR.');
+              core.setOutput('skipped_reason', 'fork-pr');
+              return;
+            }
+
+            const iterator = github.paginate.iterator(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const allowedExtensions = String(process.env.ALLOWED_EXTENSIONS || '')
+              .split(',')
+              .map(ext => ext.trim().toLowerCase())
+              .filter(Boolean)
+              .map(ext => (ext.startsWith('.') ? ext : `.${ext}`));
+
+            const disallowed = [];
+            for await (const page of iterator) {
+              if (!Array.isArray(page.data)) {
+                continue;
+              }
+              for (const file of page.data) {
+                const filename = file?.filename;
+                if (typeof filename !== 'string' || filename.length === 0) {
+                  continue;
+                }
+                const lower = filename.toLowerCase();
+                const allowed = allowedExtensions.some(ext => lower.endsWith(ext));
+                if (!allowed) {
+                  disallowed.push(filename);
+                }
+              }
+            }
+
+            if (disallowed.length > 0) {
+              core.info(`Skipping auto-label; non-Python changes detected: ${disallowed.join(', ')}`);
+              core.setOutput('skipped_reason', 'non-python');
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: pr.number,
+              labels: ['autofix:clean'],
+            });
+            core.info('Applied autofix:clean label for cosmetic failure.');
+            core.setOutput('applied', 'true');
+
       - name: Prepare summary body
         id: summary_body
         run: |
@@ -460,26 +545,36 @@ jobs:
           HEAD_SHA: ${{ steps.gather.outputs.head_sha || github.event.pull_request.head.sha || github.sha }}
 
       - name: Append keepalive checklists
+        env:
+          LABEL_APPLIED: ${{ steps.autofix_label.outputs.applied || 'false' }}
         run: |
-          cat <<'EOF' >> gate-summary.md
+          autofix_task=' '
+          if [ "${LABEL_APPLIED}" = "true" ]; then
+            autofix_task='x'
+          fi
+
+          autofix_accept=' '
+          if [ "${LABEL_APPLIED}" = "true" ]; then
+            autofix_accept='x'
+          fi
+
+          cat <<EOF >> gate-summary.md
 
           ---
           ### Keepalive checklist
 
           #### Scope
-          - [x] Inputs: lint, format_check, typecheck, pytest_markers, coverage, cache toggles are exposed.
-          - [x] Outputs: coverage JSON, JUnit XML, and CI summary paths are published for callers.
-          - [x] Artifacts use the gate-* prefix for reuse across runs and branches.
+          - [x] Small change in Gate’s summary job plus label logic in Autofix.
 
           #### Tasks
-          - [x] Add inputs/outputs to reusable-10-ci-python.yml.
-          - [x] Update Gate to pass toggles per path filters.
-          - [x] Ensure all artifacts and job outputs use consistent names.
+          - [${autofix_task}] In Gate summary, detect format/import-only failures and add autofix:clean.
+          - [ ] In autofix.yml, drop the agent:* co-label requirement; trigger solely on autofix/autofix:clean.
+          - [ ] Keep ALLOWED_GLOBS as *.py, *.pyi; add explicit guard against non-Python changes.
 
           #### Acceptance criteria
-          - [x] Gate can enable/disable each stage via inputs.
-          - [x] Artifact names remain stable across runs and branches.
-          - [x] Coverage output is consumed by the Gate summary job.
+          - [${autofix_accept}] For cosmetic failures, PR gains autofix:clean automatically.
+          - [ ] Autofix Loop runs and pushes minimal import/format fixes.
+          - [ ] No edits outside allowed globs.
           EOF
 
       - name: Upload Gate summary artifact
@@ -587,7 +682,8 @@ jobs:
       always() &&
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      contains(github.event.pull_request.labels.*.name, 'autofix') &&
+      (contains(github.event.pull_request.labels.*.name, 'autofix') ||
+       contains(github.event.pull_request.labels.*.name, 'autofix:clean')) &&
       needs.summary.result == 'failure'
     uses: ./.github/workflows/reusable-18-autofix.yml
     with:
@@ -601,4 +697,7 @@ jobs:
       trigger_conclusion: ${{ needs.summary.result }}
       trigger_class: ${{ needs.summary.outputs.state == 'failure' && 'ci-failure' || 'ci-success' }}
       trigger_reason: 'Triggered by Gate workflow after CI completion'
+      allowed_file_globs: |-
+        **/*.py
+        **/*.pyi
     secrets: inherit

--- a/tests/github_scripts/test_gate_summary.py
+++ b/tests/github_scripts/test_gate_summary.py
@@ -15,16 +15,23 @@ import gate_summary  # noqa: E402
 
 
 def write_summary(
-    root: Path, runtime: str, *, lint: str = "success", tests: str = "success"
+    root: Path,
+    runtime: str,
+    *,
+    format_outcome: str = "success",
+    lint: str = "success",
+    tests: str = "success",
+    type_check: str = "success",
 ) -> None:
     summary_dir = root / "downloads" / runtime
     summary_dir.mkdir(parents=True, exist_ok=True)
     payload = {
         "python_version": runtime,
         "checks": {
+            "format": {"outcome": format_outcome},
             "lint": {"outcome": lint},
             "tests": {"outcome": tests},
-            "type_check": {"outcome": "success"},
+            "type_check": {"outcome": type_check},
             "coverage_minimum": {"outcome": "success"},
         },
         "coverage": {"percent": 91.23},
@@ -73,6 +80,7 @@ def test_active_summary_reads_artifacts(tmp_path: Path) -> None:
     assert "Reported coverage" in joined
     assert "Docker smoke skipped" in joined
     assert "| docker-smoke | success |" in joined
+    assert result.cosmetic_failure is False
 
 
 @pytest.mark.parametrize(
@@ -97,3 +105,43 @@ def test_summary_state_reflects_python_outcome(
 
     result = gate_summary.summarize(context)
     assert result.state == expected_state
+    assert result.cosmetic_failure is False
+
+
+def test_cosmetic_failure_detected(tmp_path: Path) -> None:
+    write_summary(tmp_path, "3.11", format_outcome="failure")
+    context = gate_summary.SummaryContext(
+        doc_only=False,
+        run_core=True,
+        reason="",
+        python_result="failure",
+        docker_result="success",
+        docker_changed=False,
+        artifacts_root=tmp_path,
+        summary_path=None,
+        output_path=None,
+    )
+
+    result = gate_summary.summarize(context)
+    assert result.state == "failure"
+    assert result.cosmetic_failure is True
+    assert result.failure_checks == ("format",)
+
+
+def test_cosmetic_failure_rejects_other_failures(tmp_path: Path) -> None:
+    write_summary(tmp_path, "3.11", tests="failure")
+    context = gate_summary.SummaryContext(
+        doc_only=False,
+        run_core=True,
+        reason="",
+        python_result="failure",
+        docker_result="success",
+        docker_changed=False,
+        artifacts_root=tmp_path,
+        summary_path=None,
+        output_path=None,
+    )
+
+    result = gate_summary.summarize(context)
+    assert result.state == "failure"
+    assert result.cosmetic_failure is False


### PR DESCRIPTION
## Summary
- detect format/import-only failures in the Gate summary job and automatically apply the `autofix:clean` label when it is safe to do so
- refresh the keepalive checklist and pass python-only globs to the reusable autofix workflow
- drop the `agent:*` co-label requirement in the autofix loop and guard against non-Python edits before running

## Testing
- pytest tests/github_scripts/test_gate_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68fe98e8c0b0833192c7bc53578056db