### PR TITLE
fix(agents): strip agent labels in chatgpt_sync, rename codex_bridge …

### DIFF
--- a/.github/workflows/agents-63-issue-intake.yml
+++ b/.github/workflows/agents-63-issue-intake.yml
@@ -518,7 +518,7 @@ jobs:
               if (entriesWithBase.length > 0) {
                 topicsWithAgentLabels += 1;
               }
-              // Strip all agent:* labels - they will be applied manually from Issues tab
+              // Strip all agent:* labels in chatgpt_sync mode - they will be applied manually from Issues tab
               if (!Array.isArray(topic.labels)) {
                 topic.labels = [];
               }


### PR DESCRIPTION
…to agent_bridge

Changes:
- Renamed codex_bridge to agent_bridge (removes codex-specific naming)
- chatgpt_sync mode now strips ALL agent:* labels from topics
- Issues are created without agent labels
- Users manually apply agent labels from Issues tab to trigger agent workflows
- Removed validation that required agent:* labels on topics
- Added notice when agent labels are stripped

This allows Issues.txt to contain any labels without requiring agent:* assignments. Agent assignment happens manually in GitHub Issues UI.

## Summary
- [ ] Provide a concise description of the change.
- [ ] Note any follow-up tasks or docs to update later.

## Testing
- [ ] Listed the commands or scripts used to validate the change.
- [ ] Attached or linked relevant logs when tests are not applicable.

## CI readiness
- [ ] Skimmed the [workflow spotlight](../docs/ci/WORKFLOW_SYSTEM.md#spotlight-the-six-guardrails-everyone-touches) for Gate, the Gate summary, Repo Health, Actionlint, Agents Orchestrator, and Health 45 Agents Guard when touching automation.
- [ ] Reviewed the [Workflow System Overview](../docs/ci/WORKFLOW_SYSTEM.md#required-vs-informational-checks-on-phase-2-dev) to confirm Gate / `gate` is the required status.
- [ ] Checked this pull request's **Checks** tab to confirm Gate / `gate` appears under **Required checks** (Health 45 Agents Guard auto-adds when `agents-*.yml` files change).
- [ ] Escalated via the [branch protection playbook](../docs/ci/WORKFLOW_SYSTEM.md#branch-protection-playbook) if Gate / `gate` is missing.
- [ ] Confirmed the latest Gate run is green (or linked the failing run with context).
