### PR TITLE
fix: Make Codex PR auto-merge opt-in with 'automerge' label

### DIFF
--- a/.github/scripts/agents_belt_scan.js
+++ b/.github/scripts/agents_belt_scan.js
@@ -7,10 +7,12 @@ function isCodexBranch(branch) {
 async function identifyReadyCodexPRs({ github, context, core, env = process.env }) {
   const maxPromotionsRaw = env.MAX_PROMOTIONS || '0';
   const maxPromotions = Math.max(0, Math.floor(Number(maxPromotionsRaw || '0')));
+  const automergeLabel = (env.AUTOMERGE_LABEL || 'automerge').trim().toLowerCase();
   const { owner, repo } = context.repo;
 
   const { data: pulls } = await github.rest.pulls.list({ owner, repo, state: 'open', per_page: 50 });
   const candidates = [];
+  const skipped = [];
 
   for (const pr of pulls) {
     if (!pr || typeof pr !== 'object') {
@@ -21,14 +23,33 @@ async function identifyReadyCodexPRs({ github, context, core, env = process.env 
       continue;
     }
     if (pr.draft) {
+      skipped.push({ pr: pr.number, reason: 'draft' });
       continue;
     }
+    
+    // Check for automerge label
+    const labels = (pr.labels || [])
+      .map((label) => {
+        if (!label) return '';
+        if (typeof label === 'string') return label.toLowerCase();
+        if (typeof label.name === 'string') return label.name.toLowerCase();
+        return '';
+      })
+      .filter(Boolean);
+    
+    if (!labels.includes(automergeLabel)) {
+      skipped.push({ pr: pr.number, reason: `missing '${automergeLabel}' label` });
+      continue;
+    }
+    
     const headSha = pr.head && pr.head.sha ? pr.head.sha : '';
     if (!headSha) {
+      skipped.push({ pr: pr.number, reason: 'no head SHA' });
       continue;
     }
     const { data: status } = await github.rest.repos.getCombinedStatusForRef({ owner, repo, ref: headSha });
     if (!status || status.state !== 'success') {
+      skipped.push({ pr: pr.number, reason: `status: ${status?.state || 'unknown'}` });
       continue;
     }
     const issueMatch = branch.match(/^codex\/issue-(\d+)$/);
@@ -47,6 +68,8 @@ async function identifyReadyCodexPRs({ github, context, core, env = process.env 
   const summary = core.summary;
   summary
     .addHeading('Codex belt conveyor scan')
+    .addRaw(`Automerge label: \`${automergeLabel}\``)
+    .addEOL()
     .addRaw(`Ready pull requests: ${candidates.length}`)
     .addEOL();
   if (candidates.length) {
@@ -58,6 +81,14 @@ async function identifyReadyCodexPRs({ github, context, core, env = process.env 
         entry.branch
       ])
     ]);
+  }
+  if (skipped.length) {
+    summary
+      .addHeading('Skipped PRs', 3)
+      .addTable([
+        [{ data: 'PR', header: true }, { data: 'Reason', header: true }],
+        ...skipped.map((entry) => [`#${entry.pr}`, entry.reason])
+      ]);
   }
   await summary.write();
 


### PR DESCRIPTION
The belt conveyor was automatically merging all Codex PRs that passed CI, even when work wasn't complete. This caused PR #3145 to merge prematurely.

Changes:
- Require 'automerge' label for Codex PRs to be eligible for auto-merge
- Add skipped PRs table to scan summary showing why PRs weren't promoted
- Show configured automerge label in scan output
- Track skip reasons (draft, missing label, CI not passed, no SHA)

Behavior:
- Before: All Codex PRs with passing CI auto-merged
- After: Only Codex PRs with 'automerge' label AND passing CI auto-merge

This makes auto-merge opt-in, preventing premature merges while still supporting automated promotion when explicitly requested.

Resolves issue where PR #3145 merged automatically when work incomplete.

<!-- pr-preamble:start -->
## Summary
Ensure that test coverage exceeds 95% for all program files.


**Scope:** Add test coverage for any program functionality with test coverage under 95% or for essential program functionality that does not currently have test coverage

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Scope section missing from source issue.

#### Tasks
- [ ] Tasks section missing from source issue.

#### Acceptance criteria
- [ ] Acceptance criteria section missing from source issue.

**Head SHA:** 884d7ae3aa85197184e666e1ab6305481c260631
**Latest Runs:** ❌ failure — Gate
**Required:** gate: ❌ failure

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/18924081049) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/18924081057) |
| Gate | ❌ failure | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/18924081054) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/18924081048) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/18924081047) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/18924081060) |
<!-- auto-status-summary:end -->