### PR TITLE
Address review feedback for tests PR

### DIFF
--- a/tests/test_io_validators_extra.py
+++ b/tests/test_io_validators_extra.py
@@ -199,6 +199,8 @@ def test_read_uploaded_file_path_failures(
         (RuntimeError("boom"), "Failed to read"),
     ],
 )
+
+
 def test_read_uploaded_file_lower_name_errors(
     monkeypatch: pytest.MonkeyPatch, exc: Exception, msg: str
 ) -> None:
@@ -244,9 +246,7 @@ def test_load_and_validate_upload_returns_metadata(
     assert loaded_frame.index.name == "Date"
 
 
-def test_create_sample_template_has_expected_shape(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_create_sample_template_has_expected_shape() -> None:
     template = create_sample_template()
     assert template.shape == (12, 7)
     assert template.columns[0] == "Date"

--- a/tests/test_pipeline_helpers.py
+++ b/tests/test_pipeline_helpers.py
@@ -18,6 +18,7 @@ from trend_analysis.pipeline import (
     _section_get,
     _unwrap_cfg,
 )
+from trend_analysis.util.frequency import FrequencySummary
 
 
 def test_cfg_helpers_handle_mappings_and_objects() -> None:
@@ -100,7 +101,7 @@ def test_prepare_input_data_applies_missing_policy() -> None:
         missing_policy={"default": "ffill"},
         missing_limit={"default": 1},
     )
-    assert isinstance(summary, type(summary))  # ensure FrequencySummary returned
+    assert isinstance(summary, FrequencySummary)
     assert normalised is False
     assert "FundA" in processed.columns
     assert missing.policy["FundA"] == "ffill"


### PR DESCRIPTION
## Summary
- add missing spacing between upload validator tests and drop unused fixture parameter
- assert against the concrete FrequencySummary type in pipeline helper tests
- import FrequencySummary explicitly for the pipeline helper coverage

## Testing
- pytest tests/test_pipeline_helpers.py::test_prepare_input_data_applies_missing_policy -q

------
https://chatgpt.com/codex/tasks/task_e_6906eb93451c8331865ead3389aabea9