### PR TITLE
[Agents] Keepalive → connector dispatch (route B)

### DIFF
--- a/.github/workflows/reusable-16-agents.yml
+++ b/.github/workflows/reusable-16-agents.yml
@@ -592,6 +592,7 @@ jobs:
     timeout-minutes: 25
     env:
       SERVICE_BOT_PAT: ${{ secrets.service_bot_pat || '' }}
+      ACTIONS_BOT_PAT: ${{ secrets.actions_bot_pat || '' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -614,11 +615,17 @@ jobs:
               return;
             }
             core.info('Verified keepalive identity: stranske-automation-bot.');
+      - name: Ensure dispatch PAT present
+        if: ${{ env.ACTIONS_BOT_PAT == '' }}
+        run: |
+          echo "::error::ACTIONS_BOT_PAT is required so keepalive dispatches can trigger the connector." >&2
+          exit 1
       - name: Resume Codex on unattended checklists
         uses: actions/github-script@v7
         env:
           OPTIONS_JSON: ${{ inputs.options_json }}
           DRY_RUN: ${{ inputs.dry_run }}
+          ACTIONS_BOT_PAT: ${{ env.ACTIONS_BOT_PAT }}
         with:
           github-token: ${{ secrets.service_bot_pat }}
           script: |

--- a/tests/fixtures/keepalive/harness.js
+++ b/tests/fixtures/keepalive/harness.js
@@ -119,6 +119,7 @@ async function runScenario(scenario) {
   const warnings = [];
   const notices = [];
   let failedMessage = null;
+  const dispatchEvents = [];
 
   const core = {
     summary,
@@ -134,6 +135,9 @@ async function runScenario(scenario) {
     number: pull.number,
     head: {
       ref: pull.head?.ref || `codex/issue-${pull.number}`,
+    },
+    base: {
+      ref: pull.base?.ref || 'main',
     },
     labels: Array.from(pull.labels || []).map((label) =>
       typeof label === 'string' ? { name: label } : label
@@ -165,6 +169,7 @@ async function runScenario(scenario) {
   const createComment = async ({ issue_number, body }) => {
     const entry = { issue_number, body };
     entry.id = allocateCommentId();
+    entry.html_url = `https://example.test/${issue_number}#comment-${entry.id}`;
     createdComments.push(entry);
     return { data: entry };
   };
@@ -192,9 +197,14 @@ async function runScenario(scenario) {
     return { data: {} };
   };
 
+  const dispatchEvent = async ({ owner, repo, event_type, client_payload }) => {
+    dispatchEvents.push({ owner, repo, event_type, client_payload });
+    return { data: {} };
+  };
+
   const github = {
     rest: {
-      pulls: { 
+      pulls: {
         list: listPulls,
         listCommits,
       },
@@ -204,6 +214,9 @@ async function runScenario(scenario) {
         updateComment,
         listAssignees,
         addAssignees,
+      },
+      repos: {
+        createDispatchEvent: dispatchEvent,
       },
     },
     paginate: {
@@ -232,6 +245,18 @@ async function runScenario(scenario) {
         };
       },
     },
+    getOctokit: (token) => {
+      if (!token) {
+        throw new Error('Token is required');
+      }
+      return {
+        rest: {
+          repos: {
+            createDispatchEvent: dispatchEvent,
+          },
+        },
+      };
+    },
   };
 
   const context = {
@@ -242,7 +267,7 @@ async function runScenario(scenario) {
   };
 
   const originalEnv = {};
-  const envOverrides = scenario.env || {};
+  const envOverrides = { ACTIONS_BOT_PAT: 'dummy-token', ...(scenario.env || {}) };
   for (const [key, value] of Object.entries(envOverrides)) {
     originalEnv[key] = process.env[key];
     process.env[key] = String(value);
@@ -273,6 +298,7 @@ async function runScenario(scenario) {
     logs: { info, warnings, notices, failedMessage },
     created_comments: createdComments,
     updated_comments: updatedComments,
+    dispatch_events: dispatchEvents,
   };
 }
 


### PR DESCRIPTION
## Summary
- ensure the keepalive sweep enforces ACTIONS_BOT_PAT and forwards it to the runner
- emit codex-pr-comment-command repository_dispatch events after posting bot keepalive comments
- extend the keepalive harness and workflow tests to validate the dispatch payloads

## Testing
- pytest tests/test_keepalive_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_69083aac400c83319c978e920402ec0f