### PR TITLE
[Agents] Keepalive → connector dispatch: guard comment author allow list

### DIFF
--- a/tests/fixtures/keepalive/harness.js
+++ b/tests/fixtures/keepalive/harness.js
@@ -166,16 +166,23 @@ async function runScenario(scenario) {
     return { data: slice };
   };
 
+  const commentAuthor = () => {
+    const identity = scenario.identity || {};
+    return identity.keepalive_author || identity.service_bot || 'stranske-automation-bot';
+  };
+
   const createComment = async ({ issue_number, body }) => {
     const entry = { issue_number, body };
     entry.id = allocateCommentId();
     entry.html_url = `https://example.test/${issue_number}#comment-${entry.id}`;
+    entry.user = { login: commentAuthor() };
     createdComments.push(entry);
     return { data: entry };
   };
 
   const updateComment = async ({ comment_id, body }) => {
     const entry = { comment_id, body };
+    entry.user = { login: commentAuthor() };
     updatedComments.push(entry);
     return { data: entry };
   };

--- a/tests/fixtures/keepalive/unauthorised_author.json
+++ b/tests/fixtures/keepalive/unauthorised_author.json
@@ -1,0 +1,29 @@
+{
+  "repo": {"owner": "stranske", "repo": "Trend_Model_Project"},
+  "now": "2024-05-18T12:00:00Z",
+  "env": {
+    "OPTIONS_JSON": "{}",
+    "DRY_RUN": "false"
+  },
+  "identity": {
+    "keepalive_author": "helper-bot"
+  },
+  "pulls": [
+    {
+      "number": 313,
+      "labels": ["agent:codex"],
+      "comments": [
+        {
+          "user": {"login": "triage-bot"},
+          "body": "@codex plan-and-execute",
+          "created_at": "2024-05-18T08:00:00Z"
+        },
+        {
+          "user": {"login": "chatgpt-codex-connector"},
+          "body": "Daily update\n- [ ] Review signal output\n- [x] Stage summary",
+          "created_at": "2024-05-18T09:00:00Z"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_keepalive_workflow.py
+++ b/tests/test_keepalive_workflow.py
@@ -198,6 +198,20 @@ def test_keepalive_respects_paused_label() -> None:
     assert payload["comment_id"] == created[0]["id"]
 
 
+def test_keepalive_skips_unapproved_comment_author() -> None:
+    data = _run_scenario("unauthorised_author")
+
+    created = data["created_comments"]
+    assert len(created) == 1
+    assert created[0]["issue_number"] == 313
+    assert "@codex" in created[0]["body"]
+
+    _assert_no_dispatch(data)
+
+    warnings = data["logs"]["warnings"]
+    assert any("not in dispatch allow list" in warning for warning in warnings)
+
+
 def test_keepalive_handles_paged_comments() -> None:
     data = _run_scenario("paged_comments")
     created = data["created_comments"]


### PR DESCRIPTION
## Summary
* Required `ACTIONS_BOT_PAT` in the keepalive sweep, surfaced an explicit check for the secret, and forwarded it to the JavaScript runner so connector dispatches use the correct identity.
* Emitted a `codex-pr-comment-command` `repository_dispatch` immediately after each keepalive comment and guarded the dispatch behind the hidden markers and service-bot identity checks.
* Extended the keepalive harness and workflow tests to capture dispatch payloads and assert the new hand-off behaviour across all scenarios.
* Guarded keepalive dispatches behind a configurable author allow list so only approved identities can trigger the connector and recorded the allow list in workflow summaries.
* Added a negative keepalive scenario to the harness that ensures unauthorised comment authors do not emit connector dispatch events.

## Testing
* pytest tests/test_keepalive_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_69083cebd7008331953224c5b62285b2