### PR TITLE
Enhance keepalive comments with hidden markers

### DIFF
--- a/Issues.txt
+++ b/Issues.txt
@@ -90,9 +90,8 @@ Treat a comment as a valid activation only if:
 
   - the body contains both hidden markers:
 
+    <!-- keepalive-round: {roundNumber} -->
     <!-- codex-keepalive-marker -->
-
-    <!-- keepalive-round: N -->
 
 When valid, emit:
 


### PR DESCRIPTION
Update keepalive comments to include hidden markers for reliable dispatch. Re-enable command listeners for bot-authored keepalive instructions.