### PR TITLE
fix: normalize keepalive dispatch outputs

### DIFF
--- a/.github/scripts/agents_pr_meta_keepalive.js
+++ b/.github/scripts/agents_pr_meta_keepalive.js
@@ -180,7 +180,7 @@ async function detectKeepalive({ core, github, context, env = process.env }) {
   }
 
   outputs.dispatch = 'true';
-  outputs.reason = 'keepalive-detected';
+  outputs.reason = 'ok';
   outputs.issue = String(issueNumber);
   outputs.round = String(round);
   outputs.branch = pull?.head?.ref || '';

--- a/.github/workflows/agents-70-orchestrator.yml
+++ b/.github/workflows/agents-70-orchestrator.yml
@@ -47,18 +47,7 @@ permissions:
   actions: write
 
 concurrency:
-  group: >-
-    agents-70-orchestrator-${{
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.options_json)
-      || (github.event_name == 'repository_dispatch'
-        && github.event.client_payload
-        && (
-          github.event.client_payload.options_json
-          || (github.event.client_payload.options && toJson(github.event.client_payload.options))
-        )
-      )
-      || github.run_id
-    }}
+  group: agents-70-orchestrator-${{ inputs.options_json || github.run_id }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/agents-pr-meta.yml
+++ b/.github/workflows/agents-pr-meta.yml
@@ -105,15 +105,14 @@ jobs:
               dispatcher_force_issue: issue ? String(issue) : '',
             };
 
+            const roundValue = Number.isFinite(round) && round > 0 ? String(round) : '';
+            const fallbackPr = Number(context.payload?.issue?.number || 0);
+            const prValue = Number.isFinite(prNumber) && prNumber > 0 ? prNumber : fallbackPr;
+
             const options = {
               keepalive_trace: trace,
-              round: round || 0,
-              pr: prNumber || Number(context.payload?.issue?.number || 0),
-              keepalive_enabled: true,
-              keepalive_source: 'agents-pr-meta',
-              keepalive_round: round || 0,
-              keepalive_branch: branch,
-              keepalive_base: base,
+              round: roundValue,
+              pr: prValue,
             };
 
             await github.rest.actions.createWorkflowDispatch({


### PR DESCRIPTION
## Summary
- mark successful keepalive detection runs with an `ok` reason for downstream summaries
- dispatch the orchestrator with a minimal keepalive payload and round/pr normalization
- key orchestrator concurrency on the serialized options payload to avoid canceling keepalive traces

## Testing
- Not run (workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_69093cfd0e308331baed549a4e3410a4