### PR TITLE
Ensure keepalive fallback dispatch uses ACTIONS_BOT_PAT

### DIFF
--- a/.github/workflows/agents-70-orchestrator.yml
+++ b/.github/workflows/agents-70-orchestrator.yml
@@ -847,7 +847,7 @@ jobs:
             core.setOutput('acknowledged', acknowledged ? 'true' : 'false');
 
       - name: Emit fallback dispatch
-        if: steps.ack.outputs.acknowledged != 'true' && steps.prepare.outputs.dispatch_mode != 'none'
+        if: steps.ack.outputs.acknowledged != 'true' && steps.prepare.outputs.actions_available == 'true'
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.prepare.outputs.pr_number }}
@@ -858,7 +858,7 @@ jobs:
           ISSUE_NUMBER: ${{ needs.resolve-params.outputs.dispatcher_force_issue }}
           DISPATCH_MODE: ${{ steps.prepare.outputs.dispatch_mode }}
         with:
-          github-token: ${{ secrets.ACTIONS_BOT_PAT || secrets.SERVICE_BOT_PAT }}
+          github-token: ${{ secrets.ACTIONS_BOT_PAT }}
           script: |
             const prNumber = Number(process.env.PR_NUMBER || 0);
             const commentId = Number(process.env.COMMENT_ID || 0);


### PR DESCRIPTION
## Summary
- require the keepalive fallback dispatch step to run only when ACTIONS_BOT_PAT is available and authenticate with that token

## Testing
- node --test .github/scripts/__tests__/keepalive-contract.test.js

------
https://chatgpt.com/codex/tasks/task_e_690a970c18d48331ba1c0fe5f2734b3b