### PR TITLE
Handle sanitized keepalive markers

### DIFF
--- a/tests/fixtures/agents_pr_meta/after_markers.json
+++ b/tests/fixtures/agents_pr_meta/after_markers.json
@@ -1,0 +1,20 @@
+{
+  "comment": {
+    "id": 9988776655,
+    "html_url": "https://github.com/stranske/Trend_Model_Project/pull/4000#issuecomment-9988776655",
+    "body": "<- After: keepalive-round: 5 -->\n<- After: codex-keepalive-marker -->\n<- After: keepalive-trace: manual-test-2025-11-05-01-35 -->\n\n@codex please continue",
+    "user": { "login": "stranske" }
+  },
+  "issue": { "number": 4000 },
+  "pull": {
+    "number": 4000,
+    "title": "feat: ensure keepalive detection",
+    "body": "Related to #3260",
+    "head": { "ref": "codex/issue-3260-keepalive" },
+    "base": { "ref": "phase-2-dev" }
+  },
+  "reactions": [],
+  "env": {
+    "ALLOWED_LOGINS": "chatgpt-codex-connector,stranske-automation-bot,stranske"
+  }
+}

--- a/tests/test_agents_pr_meta_keepalive.py
+++ b/tests/test_agents_pr_meta_keepalive.py
@@ -59,6 +59,14 @@ def test_keepalive_detection_dispatches_orchestrator() -> None:
     assert created == [{"comment_id": 987654321, "content": "rocket"}]
 
 
+def test_keepalive_detection_handles_after_markers() -> None:
+    data = _run_scenario("after_markers")
+    outputs = data["outputs"]
+    assert outputs["dispatch"] == "true"
+    assert outputs["reason"] == "keepalive-detected"
+    assert outputs["round"] == "5"
+    assert outputs["trace"] == "manual-test-2025-11-05-01-35"
+
 def test_keepalive_detection_requires_marker() -> None:
     data = _run_scenario("missing_marker")
     outputs = data["outputs"]


### PR DESCRIPTION
## Summary
- broaden keepalive detection so sanitized comments with `After:` wrappers still match the required markers and clean up trace values
- add a regression fixture and test to ensure the detection pipeline dispatches on sanitized keepalive markers

## Testing
- node --test .github/scripts/__tests__/keepalive-contract.test.js
- pytest tests/test_agents_pr_meta_keepalive.py

------
https://chatgpt.com/codex/tasks/task_e_690aaa4ffee88331af757b2782932c3e