### PR TITLE
test: cover trend_analysis init edge cases

### DIFF
--- a/docs/coverage/low_coverage_priority.md
+++ b/docs/coverage/low_coverage_priority.md
@@ -1,0 +1,26 @@
+# Coverage priorities for trend_analysis modules
+
+The table below captures the current "soft" coverage snapshot gathered from running `pytest tests/test_trend_analysis_package_init.py --cov=trend_analysis --cov-report=term-missing`.
+
+| File | Coverage | Notes |
+| --- | --- | --- |
+| `src/trend_analysis/cli.py` | 0% | Command-line entry point remains untested. |
+| `src/trend_analysis/presets.py` | 0% | Preset registry logic entirely uncovered. |
+| `src/trend_analysis/run_analysis.py` | 0% | Pipeline wrapper lacks coverage. |
+| `src/trend_analysis/signal_presets.py` | 0% | Signal preset definitions not exercised. |
+| `src/trend_analysis/multi_period/engine.py` | 0% | Multi-period engine core lacks tests. |
+| `src/trend_analysis/export/bundle.py` | 7% | Bundle exporter has minimal coverage. |
+| `src/trend_analysis/pipeline.py` | 7% | Main pipeline orchestration largely untested in this run. |
+| `src/trend_analysis/engine/optimizer.py` | 7% | Optimizer logic requires coverage. |
+| `src/trend_analysis/data.py` | 8% | Data loaders and helpers mostly uncovered. |
+| `src/trend_analysis/regimes.py` | 9% | Regime detection logic needs tests. |
+| `src/trend_analysis/io/validators.py` | 10% | Input validators have sparse coverage. |
+| `src/trend_analysis/backtesting/bootstrap.py` | 11% | Bootstrap routines minimally covered. |
+| `src/trend_analysis/io/market_data.py` | 13% | Market data ingestion paths under-covered. |
+| `src/trend_analysis/backtesting/harness.py` | 14% | Harness utilities need more coverage. |
+| `src/trend_analysis/util/frequency.py` | 20% | Frequency utilities partially covered. |
+| `src/trend_analysis/risk.py` | 21% | Risk helpers missing tests. |
+| `src/trend_analysis/config/model.py` | 23% | Config model definitions under-covered. |
+| `src/trend_analysis/signals.py` | 27% | Signal generation functions require tests. |
+| `src/trend_analysis/__init__.py` | 100% | Achieved full coverage via targeted tests. |
+

--- a/tests/test_trend_analysis_package_init.py
+++ b/tests/test_trend_analysis_package_init.py
@@ -1,5 +1,6 @@
 import importlib
 import importlib.metadata
+import sys
 from types import ModuleType
 from typing import Optional
 
@@ -65,3 +66,56 @@ def test_top_level_reexports_expose_data_and_export_helpers() -> None:
     # Export helpers are re-exported when the export submodule imports succeed.
     assert hasattr(module, "export_to_csv")
     assert module.export_to_csv is module.export.export_to_csv
+
+
+def test_eager_import_skips_missing_optional_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = importlib.reload(importlib.import_module("trend_analysis"))
+    sys.modules.pop("trend_analysis.signals", None)
+
+    original_import = importlib.import_module
+
+    def fake_import(name: str, package: Optional[str] = None) -> ModuleType:
+        if name == "trend_analysis.signals":
+            raise ImportError("optional dependency not available")
+        return original_import(name, package=package)
+
+    with monkeypatch.context() as context:
+        context.delattr(module, "signals", raising=False)
+        context.setattr(importlib, "import_module", fake_import)
+        reloaded = importlib.reload(module)
+
+        assert not hasattr(reloaded, "signals")
+
+    importlib.reload(module)
+
+
+def test_conditional_reexports_skip_when_dependencies_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.reload(importlib.import_module("trend_analysis"))
+    for name in ("trend_analysis.data", "trend_analysis.export"):
+        sys.modules.pop(name, None)
+
+    original_import = importlib.import_module
+
+    def fake_import(name: str, package: Optional[str] = None) -> ModuleType:
+        if name in {"trend_analysis.data", "trend_analysis.export"}:
+            raise ImportError("optional dependency not available")
+        return original_import(name, package=package)
+
+    with monkeypatch.context() as context:
+        context.delattr(module, "data", raising=False)
+        context.delattr(module, "export", raising=False)
+        context.delattr(module, "load_csv", raising=False)
+        context.delattr(module, "identify_risk_free_fund", raising=False)
+        context.delattr(module, "export_to_csv", raising=False)
+        context.delattr(module, "export_data", raising=False)
+        context.setattr(importlib, "import_module", fake_import)
+        reloaded = importlib.reload(module)
+
+        assert not hasattr(reloaded, "load_csv")
+        assert not hasattr(reloaded, "identify_risk_free_fund")
+        assert not hasattr(reloaded, "export_to_csv")
+        assert not hasattr(reloaded, "export_data")
+
+    importlib.reload(module)


### PR DESCRIPTION
## Summary
- add regression tests that exercise trend_analysis optional import fallbacks
- capture a soft coverage snapshot highlighting priority modules below 95% coverage

## Testing
- pytest tests/test_trend_analysis_package_init.py -q
- pytest tests/test_trend_analysis_package_init.py --cov=trend_analysis --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_690b10550e248331aeb10d8c42aeea18