### PR TITLE
feat: enforce keepalive gate preconditions

### DIFF
--- a/.github/scripts/keepalive_gate.js
+++ b/.github/scripts/keepalive_gate.js
@@ -1,0 +1,548 @@
+'use strict';
+
+const KEEPALIVE_LABEL = 'agents:keepalive';
+const AGENT_LABEL_PREFIX = 'agent:';
+const KEEPALIVE_MARKER = '<!-- codex-keepalive-marker -->';
+const GATE_WORKFLOWS = ['pr-00-gate.yml', 'pr-00-gate.yaml'];
+const ORCHESTRATOR_WORKFLOWS = ['agents-70-orchestrator.yml', 'agents-70-orchestrator.yaml'];
+const DEFAULT_RUN_CAP = 2;
+
+function normaliseString(value) {
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function normaliseLabelName(value) {
+  return normaliseString(value).toLowerCase();
+}
+
+function extractLabels(pr) {
+  const rawLabels = pr?.labels;
+  const labels = [];
+  if (Array.isArray(rawLabels)) {
+    for (const entry of rawLabels) {
+      if (!entry) {
+        continue;
+      }
+      if (typeof entry === 'string') {
+        labels.push(entry);
+        continue;
+      }
+      if (entry.name) {
+        labels.push(String(entry.name));
+      }
+    }
+  }
+  return labels;
+}
+
+function toAliasEntry(label) {
+  const trimmed = normaliseString(label);
+  if (!trimmed.toLowerCase().startsWith(AGENT_LABEL_PREFIX)) {
+    return null;
+  }
+  const alias = normaliseString(trimmed.slice(AGENT_LABEL_PREFIX.length));
+  if (!alias) {
+    return null;
+  }
+  return {
+    label: trimmed,
+    alias,
+    normalised: alias.toLowerCase(),
+  };
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function isAutomationUser(login, type) {
+  const lowered = normaliseString(login).toLowerCase();
+  if (!lowered) {
+    return false;
+  }
+  if (lowered.endsWith('[bot]')) {
+    return true;
+  }
+  if (lowered.endsWith('-bot')) {
+    return true;
+  }
+  const loweredType = normaliseString(type).toLowerCase();
+  if (loweredType === 'bot' || loweredType === 'app') {
+    return true;
+  }
+  const automationLogins = new Set([
+    'chatgpt-codex-connector',
+    'stranske-automation-bot',
+    'github-actions',
+    'dependabot[bot]',
+    'dependabot',
+    'copilot',
+  ]);
+  return automationLogins.has(lowered);
+}
+
+function findMentionAlias(body, aliasEntries) {
+  if (!aliasEntries.length) {
+    return null;
+  }
+  const source = normaliseString(body).toLowerCase();
+  if (!source.includes('@')) {
+    return null;
+  }
+  for (const entry of aliasEntries) {
+    const alias = entry.normalised;
+    if (!alias) {
+      continue;
+    }
+    const needle = `@${alias}`;
+    let index = source.indexOf(needle);
+    while (index !== -1) {
+      const before = index === 0 ? '' : source[index - 1];
+      const afterIndex = index + needle.length;
+      const after = afterIndex < source.length ? source[afterIndex] : '';
+      const beforeAllowed = !before || /[^a-z0-9_/-]/.test(before);
+      const afterAllowed = !after || /[^a-z0-9_/-]/.test(after);
+      if (beforeAllowed && afterAllowed) {
+        return entry;
+      }
+      index = source.indexOf(needle, index + needle.length);
+    }
+  }
+  return null;
+}
+
+function extractKeepaliveAlias(body, aliasEntries) {
+  if (!body || !body.includes('@')) {
+    return '';
+  }
+  const aliasByNormalised = new Map();
+  for (const entry of aliasEntries) {
+    if (entry.normalised) {
+      aliasByNormalised.set(entry.normalised, entry.alias);
+    }
+  }
+  const lines = String(body)
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map((line) => line.trim());
+  for (const line of lines) {
+    if (!line || line.startsWith('<!--')) {
+      continue;
+    }
+    if (!line.startsWith('@')) {
+      continue;
+    }
+    const mention = line.slice(1).split(/[^A-Za-z0-9_-]/, 1)[0] || '';
+    if (!mention) {
+      continue;
+    }
+    const normalised = mention.toLowerCase();
+    if (aliasByNormalised.has(normalised)) {
+      return aliasByNormalised.get(normalised);
+    }
+    return mention;
+  }
+  return '';
+}
+
+function analyseComments(comments, aliasEntries) {
+  const result = {
+    hasHumanActivation: false,
+    humanAlias: '',
+    hasPriorKeepalive: false,
+    keepaliveAlias: '',
+    highestRound: 0,
+  };
+  if (!Array.isArray(comments) || comments.length === 0) {
+    return result;
+  }
+
+  let latestHumanTimestamp = 0;
+  let latestKeepaliveTimestamp = 0;
+
+  for (const comment of comments) {
+    if (!comment) {
+      continue;
+    }
+    const body = String(comment.body || '');
+    const createdAtRaw = comment.created_at || comment.updated_at || null;
+    const createdAt = createdAtRaw ? Date.parse(createdAtRaw) : NaN;
+    const timestamp = Number.isFinite(createdAt) ? createdAt : 0;
+
+    if (body.includes(KEEPALIVE_MARKER)) {
+      result.hasPriorKeepalive = true;
+      if (timestamp >= latestKeepaliveTimestamp) {
+        latestKeepaliveTimestamp = timestamp;
+        result.keepaliveAlias = extractKeepaliveAlias(body, aliasEntries) || result.keepaliveAlias;
+      }
+      const roundMatch = body.match(/<!--\s*keepalive-round\s*:?\s*(\d+)\s*-->/i);
+      if (roundMatch) {
+        const parsed = Number.parseInt(roundMatch[1], 10);
+        if (Number.isFinite(parsed) && parsed > result.highestRound) {
+          result.highestRound = parsed;
+        }
+      }
+    }
+
+    const user = comment.user || comment.author || {};
+    const login = user.login || user.name || '';
+    const type = user.type || '';
+    if (isAutomationUser(login, type)) {
+      continue;
+    }
+
+    const mention = findMentionAlias(body, aliasEntries);
+    if (!mention) {
+      continue;
+    }
+
+    if (!result.hasHumanActivation || timestamp >= latestHumanTimestamp) {
+      result.hasHumanActivation = true;
+      latestHumanTimestamp = timestamp;
+      result.humanAlias = mention.alias;
+    }
+  }
+
+  return result;
+}
+
+function parseRunCap(labels) {
+  const entries = Array.isArray(labels) ? labels : [];
+  for (const entry of entries) {
+    const name = normaliseString(entry);
+    if (!name.toLowerCase().startsWith('agents:max-runs:')) {
+      continue;
+    }
+    const value = name.slice('agents:max-runs:'.length).trim();
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_RUN_CAP;
+}
+
+async function fetchComments({ github, owner, repo, prNumber }) {
+  try {
+    const comments = await github.paginate(
+      github.rest.issues.listComments,
+      {
+        owner,
+        repo,
+        issue_number: prNumber,
+        per_page: 100,
+      },
+      (response) => Array.isArray(response.data) ? response.data : []
+    );
+    return comments;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to load PR comments: ${message}`);
+  }
+}
+
+async function fetchPullRequest({ github, owner, repo, prNumber }) {
+  try {
+    const response = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+    return response.data;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to load pull request #${prNumber}: ${message}`);
+  }
+}
+
+function collectCandidateNumbers(value, bucket) {
+  const raw = normaliseString(value);
+  if (!raw) {
+    return;
+  }
+  const patterns = [
+    /keepalive[_-]?pr\s*[:=#-]?\s*(\d+)/gi,
+    /pull\s*request\s*[:=#-]?\s*(\d+)/gi,
+    /pr\s*[:=#-]?\s*(\d+)/gi,
+    /issue\s*[:=#-]?\s*(\d+)/gi,
+    /pull\/(\d+)/gi,
+    /#(\d+)/g,
+  ];
+  for (const pattern of patterns) {
+    let match;
+    while ((match = pattern.exec(raw)) !== null) {
+      const candidate = normaliseString(match[1]);
+      if (candidate) {
+        bucket.add(candidate);
+      }
+    }
+  }
+}
+
+function runMatchesPr(run, target) {
+  const normalizedTarget = normaliseString(target);
+  if (!normalizedTarget) {
+    return false;
+  }
+  const candidates = new Set();
+
+  if (Array.isArray(run?.pull_requests)) {
+    for (const pr of run.pull_requests) {
+      const number = pr?.number;
+      if (Number.isFinite(number)) {
+        candidates.add(String(number));
+      }
+    }
+  }
+
+  collectCandidateNumbers(run?.display_title, candidates);
+  collectCandidateNumbers(run?.name, candidates);
+  collectCandidateNumbers(run?.head_branch, candidates);
+  collectCandidateNumbers(run?.path, candidates);
+  collectCandidateNumbers(run?.html_url, candidates);
+  collectCandidateNumbers(run?.head_commit && run.head_commit.message, candidates);
+
+  return candidates.has(normalizedTarget);
+}
+
+async function countActiveRuns({ github, owner, repo, prNumber, currentRunId }) {
+  const statuses = ['in_progress', 'queued'];
+  const matching = new Set();
+
+  for (const workflowId of ORCHESTRATOR_WORKFLOWS) {
+    for (const status of statuses) {
+      try {
+        const runs = await github.paginate(
+          github.rest.actions.listWorkflowRuns,
+          {
+            owner,
+            repo,
+            workflow_id: workflowId,
+            status,
+            per_page: 100,
+          },
+          (response) => {
+            const data = response.data?.workflow_runs;
+            if (Array.isArray(data)) {
+              return data;
+            }
+            return [];
+          }
+        );
+        for (const run of runs) {
+          const runId = run?.id ? String(run.id) : '';
+          if (runId && currentRunId && String(currentRunId) === runId) {
+            continue;
+          }
+          if (runMatchesPr(run, prNumber)) {
+            if (runId) {
+              matching.add(runId);
+            } else {
+              matching.add(JSON.stringify({ workflowId, status, head: run?.head_sha || '' }));
+            }
+          }
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Unable to query orchestrator runs (${workflowId}, ${status}): ${message}`);
+      }
+    }
+  }
+
+  return matching.size;
+}
+
+async function resolveGateRun({ github, owner, repo, headSha }) {
+  if (!headSha) {
+    return { concluded: false };
+  }
+  const normalizedHead = headSha.toLowerCase();
+  for (const workflowId of GATE_WORKFLOWS) {
+    try {
+      const runs = await github.paginate(
+        github.rest.actions.listWorkflowRuns,
+        {
+          owner,
+          repo,
+          workflow_id: workflowId,
+          head_sha: headSha,
+          per_page: 50,
+        },
+        (response) => {
+          const data = response.data?.workflow_runs;
+          if (Array.isArray(data)) {
+            return data;
+          }
+          return [];
+        }
+      );
+      if (!runs.length) {
+        continue;
+      }
+      const match = runs.find((run) => normaliseString(run.head_sha).toLowerCase() === normalizedHead) || runs[0];
+      if (!match) {
+        continue;
+      }
+      const status = normaliseString(match.status).toLowerCase();
+      return {
+        concluded: status === 'completed',
+        status,
+        conclusion: normaliseString(match.conclusion).toLowerCase(),
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Unable to evaluate Gate workflow (${workflowId}): ${message}`);
+    }
+  }
+  return { concluded: false };
+}
+
+function resolvePrNumberFromContext(context) {
+  const payload = context?.payload || {};
+  if (payload.issue?.number) {
+    return payload.issue.number;
+  }
+  if (payload.pull_request?.number) {
+    return payload.pull_request.number;
+  }
+  const workflowRun = payload.workflow_run;
+  if (workflowRun && Array.isArray(workflowRun.pull_requests) && workflowRun.pull_requests.length) {
+    const pr = workflowRun.pull_requests.find((entry) => Number.isFinite(entry?.number));
+    if (pr && Number.isFinite(pr.number)) {
+      return pr.number;
+    }
+  }
+  if (payload.client_payload?.pr) {
+    return payload.client_payload.pr;
+  }
+  if (payload.client_payload?.issue) {
+    return payload.client_payload.issue;
+  }
+  return null;
+}
+
+async function evaluateKeepaliveGate({
+  core,
+  github,
+  context,
+  env = process.env,
+  prNumber: explicitPrNumber,
+  headSha: explicitHeadSha,
+  prData,
+  labels: explicitLabels,
+  comments: explicitComments,
+  requireHumanActivation = true,
+  enforceHumanForSubsequentRounds = false,
+  currentRunId = env.CURRENT_RUN_ID || env.GITHUB_RUN_ID || '',
+} = {}) {
+  const owner = context?.repo?.owner;
+  const repo = context?.repo?.repo;
+  if (!owner || !repo) {
+    throw new Error('Repository context is required to evaluate keepalive gate.');
+  }
+
+  const resolvedPrNumber = explicitPrNumber ?? resolvePrNumberFromContext(context);
+  const parsedPrNumber = Number.parseInt(resolvedPrNumber, 10);
+  if (!Number.isFinite(parsedPrNumber) || parsedPrNumber <= 0) {
+    return {
+      ok: false,
+      reason: 'missing-pr-number',
+      hasKeepaliveLabel: false,
+      hasHumanActivation: false,
+      gateConcluded: false,
+      underRunCap: false,
+      runCap: DEFAULT_RUN_CAP,
+      activeRunCount: 0,
+      hasPriorKeepalive: false,
+      agentAlias: '',
+      agentAliases: [],
+      prNumber: null,
+    };
+  }
+
+  let pull = prData;
+  if (!pull) {
+    pull = await fetchPullRequest({ github, owner, repo, prNumber: parsedPrNumber });
+  }
+
+  const labels = explicitLabels || extractLabels(pull);
+  const normalisedLabels = new Set(labels.map(normaliseLabelName));
+  const hasKeepaliveLabel = normalisedLabels.has(KEEPALIVE_LABEL);
+
+  const aliasEntries = labels
+    .map(toAliasEntry)
+    .filter(Boolean);
+
+  const comments = explicitComments || (await fetchComments({ github, owner, repo, prNumber: parsedPrNumber }));
+  const commentAnalysis = analyseComments(comments, aliasEntries);
+
+  const runCap = parseRunCap(labels);
+
+  const headSha = normaliseString(explicitHeadSha || pull?.head?.sha);
+  const gateStatus = await resolveGateRun({ github, owner, repo, headSha });
+
+  let activeRunCount = 0;
+  try {
+    activeRunCount = await countActiveRuns({
+      github,
+      owner,
+      repo,
+      prNumber: parsedPrNumber,
+      currentRunId,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    core?.warning?.(`Unable to count orchestrator runs: ${message}`);
+    activeRunCount = Number.POSITIVE_INFINITY;
+  }
+
+  const hasPriorKeepalive = commentAnalysis.hasPriorKeepalive;
+  const humanRequired = requireHumanActivation && (enforceHumanForSubsequentRounds || !hasPriorKeepalive);
+  const hasHumanActivation = commentAnalysis.hasHumanActivation;
+  const gateConcluded = gateStatus.concluded === true;
+  const underRunCap = Number.isFinite(activeRunCount) ? activeRunCount < runCap : false;
+
+  let agentAlias = '';
+  if (commentAnalysis.keepaliveAlias) {
+    agentAlias = commentAnalysis.keepaliveAlias;
+  } else if (commentAnalysis.humanAlias) {
+    agentAlias = commentAnalysis.humanAlias;
+  } else if (aliasEntries.length) {
+    agentAlias = aliasEntries[0].alias;
+  }
+  agentAlias = normaliseString(agentAlias);
+
+  let reason = '';
+  if (!hasKeepaliveLabel) {
+    reason = 'keepalive-label-missing';
+  } else if (!aliasEntries.length) {
+    reason = 'no-human-activation';
+  } else if (humanRequired && !hasHumanActivation) {
+    reason = 'no-human-activation';
+  } else if (!gateConcluded) {
+    reason = 'gate-not-concluded';
+  } else if (!underRunCap) {
+    reason = 'run-cap-reached';
+  }
+
+  const ok = !reason;
+
+  return {
+    ok,
+    reason,
+    hasKeepaliveLabel,
+    hasHumanActivation,
+    gateConcluded,
+    underRunCap,
+    runCap,
+    activeRunCount: Number.isFinite(activeRunCount) ? activeRunCount : runCap,
+    hasPriorKeepalive,
+    agentAlias,
+    agentAliases: aliasEntries.map((entry) => entry.alias),
+    highestRecordedRound: commentAnalysis.highestRound,
+    prNumber: parsedPrNumber,
+  };
+}
+
+module.exports = {
+  evaluateKeepaliveGate,
+};

--- a/.github/workflows/agents-70-orchestrator.yml
+++ b/.github/workflows/agents-70-orchestrator.yml
@@ -426,6 +426,7 @@ jobs:
     outputs:
       proceed: ${{ steps.guard.outputs.proceed || 'true' }}
       reason: ${{ steps.guard.outputs.reason || '' }}
+      agent_alias: ${{ steps.guard.outputs.agent_alias || '' }}
     steps:
       - name: Checkout guard helpers
         uses: actions/checkout@v4
@@ -443,6 +444,7 @@ jobs:
           KEEPALIVE_ROUND: ${{ needs.resolve-params.outputs.keepalive_round }}
           KEEPALIVE_PR: ${{ needs.resolve-params.outputs.keepalive_pr }}
           KEEPALIVE_MAX_RETRIES: ${{ needs.resolve-params.outputs.keepalive_max_retries || '5' }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
         with:
           github-token: ${{ secrets.ACTIONS_BOT_PAT || secrets.SERVICE_BOT_PAT || github.token }}
           script: |
@@ -452,6 +454,7 @@ jobs:
               analyseSkipComments,
               isGateReason,
             } = require('./.github/scripts/keepalive_guard_utils.js');
+            const { evaluateKeepaliveGate } = require('./.github/scripts/keepalive_gate.js');
             const normalise = (value) => String(value || '').trim();
             const toBool = (value) => {
               const norm = normalise(value).toLowerCase();
@@ -494,6 +497,7 @@ jobs:
             const trace = normalise(process.env.KEEPALIVE_TRACE);
             const round = normalise(process.env.KEEPALIVE_ROUND);
             const prRaw = normalise(process.env.KEEPALIVE_PR);
+            const currentRunId = normalise(process.env.CURRENT_RUN_ID);
             const summary = core.summary;
             summary.addHeading('Keepalive gate evaluation');
 
@@ -578,6 +582,46 @@ jobs:
               const message = error instanceof Error ? error.message : String(error);
               core.warning(`Unable to load PR #${prNumber}: ${message}`);
               await finaliseSkip('pr-fetch-failed', message ? `Details: ${message}` : null);
+              return;
+            }
+
+            let gateCheck;
+            try {
+              gateCheck = await evaluateKeepaliveGate({
+                core,
+                github,
+                context,
+                env: process.env,
+                prNumber,
+                headSha: pr?.head?.sha || '',
+                prData: pr,
+                currentRunId,
+              });
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              summary
+                .addRaw(`Keepalive gate evaluation failed: ${message}`)
+                .addEOL()
+                .write();
+              core.setOutput('agent_alias', '');
+              setOutputs(false, 'gate-evaluation-error');
+              return;
+            }
+
+            core.setOutput('agent_alias', gateCheck.agentAlias || '');
+
+            if (!gateCheck.ok) {
+              const reason = gateCheck.reason || 'gate-blocked';
+              summary
+                .addRaw(`Keepalive ${round || '?'} trace \`${trace || 'unknown'}\`: blocked (${reason})`)
+                .addEOL();
+              summary
+                .addRaw(
+                  `Preconditions → label=${gateCheck.hasKeepaliveLabel}, human=${gateCheck.hasHumanActivation}, gate=${gateCheck.gateConcluded}, run_cap=${gateCheck.underRunCap} (active=${gateCheck.activeRunCount}/cap=${gateCheck.runCap})`
+                )
+                .addEOL()
+                .write();
+              setOutputs(false, reason);
               return;
             }
 
@@ -884,6 +928,7 @@ jobs:
           OPTIONS_JSON: ${{ needs.resolve-params.outputs.options_json }}
           ACTIONS_AVAILABLE: ${{ secrets.ACTIONS_BOT_PAT != '' }}
           SERVICE_AVAILABLE: ${{ secrets.SERVICE_BOT_PAT != '' }}
+          AGENT_ALIAS: ${{ needs.keepalive-guard.outputs.agent_alias }}
         with:
           script: |
             const { makeTrace, renderInstruction } = require('./.github/scripts/keepalive_contract.js');
@@ -943,7 +988,13 @@ jobs:
 
             round = Math.max(round, highestRound) + 1;
             const trace = makeTrace();
-            const body = renderInstruction({ round, trace, body: instruction });
+            const agentAlias = (process.env.AGENT_ALIAS || '').trim();
+            if (!agentAlias) {
+              core.setFailed('Keepalive agent alias missing.');
+              return;
+            }
+
+            const body = renderInstruction({ round, trace, body: instruction, agentAlias });
             const actionsAvailable = (process.env.ACTIONS_AVAILABLE || '').toLowerCase() === 'true';
             const serviceAvailable = (process.env.SERVICE_AVAILABLE || '').toLowerCase() === 'true';
             const dispatchMode = actionsAvailable

--- a/.github/workflows/agents-pr-meta.yml
+++ b/.github/workflows/agents-pr-meta.yml
@@ -37,8 +37,8 @@ jobs:
     name: Detect keepalive round comments
     runs-on: ubuntu-latest
     outputs:
-      dispatch: ${{ steps.detect.outputs.dispatch }}
-      reason: ${{ steps.detect.outputs.reason }}
+      dispatch: ${{ steps.detect.outputs.dispatch || 'false' }}
+      reason: ${{ steps.detect.outputs.reason || steps.gate.outputs.reason }}
       issue: ${{ steps.detect.outputs.issue }}
       round: ${{ steps.detect.outputs.round }}
       branch: ${{ steps.detect.outputs.branch }}
@@ -48,16 +48,61 @@ jobs:
       author: ${{ steps.detect.outputs.author }}
       comment_id: ${{ steps.detect.outputs.comment_id }}
       comment_url: ${{ steps.detect.outputs.comment_url }}
+      agent_alias: ${{ steps.gate.outputs.agent_alias }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Evaluate keepalive gate
+        id: gate
+        uses: actions/github-script@v7
+        env:
+          CURRENT_RUN_ID: ${{ github.run_id }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { evaluateKeepaliveGate } = require('./.github/scripts/keepalive_gate.js');
+
+            const result = await evaluateKeepaliveGate({
+              core,
+              github,
+              context,
+              env: process.env,
+              currentRunId: process.env.CURRENT_RUN_ID,
+            });
+
+            const setOutput = (key, value) => core.setOutput(key, value ?? '');
+            setOutput('proceed', result.ok ? 'true' : 'false');
+            setOutput('reason', result.reason || '');
+            setOutput('has_keepalive_label', result.hasKeepaliveLabel ? 'true' : 'false');
+            setOutput('has_human_activation', result.hasHumanActivation ? 'true' : 'false');
+            setOutput('gate_concluded', result.gateConcluded ? 'true' : 'false');
+            setOutput('under_run_cap', result.underRunCap ? 'true' : 'false');
+            setOutput('run_cap', Number.isFinite(result.runCap) ? String(result.runCap) : '');
+            setOutput('active_runs', Number.isFinite(result.activeRunCount) ? String(result.activeRunCount) : '');
+            setOutput('has_prior_keepalive', result.hasPriorKeepalive ? 'true' : 'false');
+            setOutput('agent_alias', result.agentAlias || '');
+            setOutput('agent_aliases', Array.isArray(result.agentAliases) ? result.agentAliases.join(',') : '');
+
+      - name: Summarise keepalive gate
+        if: steps.gate.outputs.proceed != 'true'
+        run: |
+          cat <<'EOF' >>"$GITHUB_STEP_SUMMARY"
+          ## Keepalive gate
+          | proceed | reason | keepalive label | human activation | gate concluded | under run cap | active | cap |
+          | --- | --- | --- | --- | --- | --- | --- | --- |
+          | ${{ steps.gate.outputs.proceed || 'false' }} | ${{ steps.gate.outputs.reason || '—' }} | ${{ steps.gate.outputs.has_keepalive_label || 'false' }} | ${{ steps.gate.outputs.has_human_activation || 'false' }} | ${{ steps.gate.outputs.gate_concluded || 'false' }} | ${{ steps.gate.outputs.under_run_cap || 'false' }} | ${{ steps.gate.outputs.active_runs || '0' }} | ${{ steps.gate.outputs.run_cap || '2' }} |
+          EOF
+
       - name: Evaluate keepalive comment
         id: detect
+        if: steps.gate.outputs.proceed == 'true'
         uses: actions/github-script@v7
         env:
           ALLOWED_LOGINS: chatgpt-codex-connector,stranske-automation-bot,stranske
           KEEPALIVE_MARKER: '<!-- codex-keepalive-marker -->'
+          KEEPALIVE_AGENT_ALIAS: ${{ steps.gate.outputs.agent_alias }}
+          KEEPALIVE_AGENT_ALIASES: ${{ steps.gate.outputs.agent_aliases }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -90,7 +135,7 @@ jobs:
           ## Keepalive detection
           | ok | reason | author | comment | pr | round | trace |
           | --- | --- | --- | --- | --- | --- | --- |
-          | ${{ steps.detect.outputs.dispatch == 'true' && 'true' || 'false' }} | ${{ steps.detect.outputs.reason || '(none)' }} | ${{ steps.detect.outputs.author || '—' }} | ${{ steps.summary_context.outputs.comment || '—' }} | ${{ steps.detect.outputs.pr || '—' }} | ${{ steps.detect.outputs.round || '—' }} | ${{ steps.detect.outputs.trace || '—' }} |
+          | ${{ steps.detect.outputs.dispatch == 'true' && 'true' || 'false' }} | ${{ steps.detect.outputs.reason || steps.gate.outputs.reason || '(none)' }} | ${{ steps.detect.outputs.author || '—' }} | ${{ steps.summary_context.outputs.comment || '—' }} | ${{ steps.detect.outputs.pr || '—' }} | ${{ steps.detect.outputs.round || '—' }} | ${{ steps.detect.outputs.trace || '—' }} |
           EOF
 
       - name: Register keepalive detection
@@ -101,7 +146,7 @@ jobs:
       - name: Report keepalive dispatch outcome
         if: steps.detect.outputs.dispatch != 'true'
         run: |
-          echo "Keepalive dispatch skipped: ${{ steps.detect.outputs.reason }}"
+          echo "Keepalive dispatch skipped: ${{ steps.detect.outputs.reason || steps.gate.outputs.reason || 'gate-blocked' }}"
 
   keepalive_orchestrator:
     needs: keepalive_dispatch

--- a/tests/fixtures/agents_pr_meta/harness.js
+++ b/tests/fixtures/agents_pr_meta/harness.js
@@ -147,6 +147,10 @@ async function main() {
     ALLOWED_LOGINS:
       scenario.env?.ALLOWED_LOGINS || 'chatgpt-codex-connector,stranske-automation-bot',
     KEEPALIVE_MARKER: scenario.env?.KEEPALIVE_MARKER || '<!-- codex-keepalive-marker -->',
+    KEEPALIVE_AGENT_ALIASES:
+      scenario.env?.KEEPALIVE_AGENT_ALIASES ||
+      scenario.env?.KEEPALIVE_AGENT_ALIAS ||
+      'codex',
   };
 
   const result = await detectKeepalive({ core, github, context, env });


### PR DESCRIPTION
## Summary
- add a reusable keepalive gate helper to validate labels, human activation, Gate completion, and run-cap limits while deriving the active agent alias
- update the keepalive detection and orchestrator workflows to call the helper, respect the no-noise requirement, and pass the resolved alias through to instruction creation
- require the instruction renderer and detector to use dynamic agent aliases and adjust the Node test harness accordingly

## Testing
- pytest tests/test_agents_pr_meta_keepalive.py
- pytest tests/test_keepalive_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_690ce38d0c048331805909aadc76f6c3