### PR TITLE
test(run_analysis): add CLI branch coverage

### DIFF
--- a/docs/coverage_progress.md
+++ b/docs/coverage_progress.md
@@ -13,7 +13,7 @@ Add test coverage for any program functionality with test coverage under 95% or 
   - [ ] regimes.py
   - [ ] pipeline.py
   - [ ] validators.py
-  - [ ] run_analysis.py
+  - [x] run_analysis.py
   - [ ] market_data.py
   - [ ] signal_presets.py
   - [x] frequency.py
@@ -36,6 +36,7 @@ Add test coverage for any program functionality with test coverage under 95% or 
 - Captured a fresh coverage snapshot for the broader package to identify the lowest-coverage modules (`python -m coverage report -m`), noting that `trend_analysis/data.py` was previously at 49% coverage.
 - Added extensive regression and error-handling tests in `tests/test_data.py`, lifting `trend_analysis/data.py` to 97% statement coverage (PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --data-file=.coverage_data --source=trend_analysis.data -m pytest tests/test_data.py).
 - Expanded the preset defaults regression suite with an explicit-enabled flag scenario (`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --data-file=.coverage_presets --source=trend_analysis.presets -m pytest tests/test_trend_analysis_presets.py`), clearing the remaining partial branch and pushing `trend_analysis/presets.py` to 100% coverage.
+- Built a CLI regression harness in `tests/test_run_analysis_cli_branches.py`, covering error handling and argument translation in `trend_analysis/run_analysis.py` and lifting it to 100% statement/branch coverage (`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 coverage run --source=trend_analysis.run_analysis -m pytest tests/test_default_export.py tests/test_run_analysis_cli_export.py tests/test_run_analysis_cli_branches.py`).
 
 ## Next steps
 - Prioritise the remaining submodules from the coverage report (e.g. `validators.py`, `market_data.py`) and continue expanding targeted tests until each clears the 95% threshold.

--- a/tests/test_run_analysis_cli_branches.py
+++ b/tests/test_run_analysis_cli_branches.py
@@ -1,0 +1,226 @@
+"""Focused regression tests for the run_analysis CLI helper."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from trend_analysis import run_analysis
+
+
+def _make_config(data: dict[str, object]) -> SimpleNamespace:
+    """Construct a lightweight config stub matching the real object."""
+
+    return SimpleNamespace(
+        data=data,
+        export={"directory": None, "formats": ["json"], "filename": "analysis"},
+        sample_split={
+            "in_start": "2020-01",
+            "in_end": "2020-02",
+            "out_start": "2020-03",
+            "out_end": "2020-04",
+        },
+    )
+
+
+def test_main_requires_csv_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configs without a csv_path should raise a KeyError early."""
+
+    monkeypatch.setattr(run_analysis, "load", lambda _: _make_config({}))
+
+    with pytest.raises(KeyError, match="csv_path"):
+        run_analysis.main(["-c", "config.yml"])
+
+
+def test_main_populates_missing_policy_kwargs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit missing-policy configuration should be forwarded verbatim."""
+
+    captured: dict[str, object] = {}
+
+    def fake_load(_: str) -> SimpleNamespace:
+        return _make_config(
+            {
+                "csv_path": "data.csv",
+                "missing_policy": "zero",
+                "missing_limit": 12,
+            }
+        )
+
+    def fake_load_csv(
+        path: str,
+        *,
+        errors: str = "raise",
+        missing_policy: str | None = None,
+        missing_limit: int | None = None,
+    ) -> pd.DataFrame:
+        captured["args"] = {
+            "path": path,
+            "errors": errors,
+            "missing_policy": missing_policy,
+            "missing_limit": missing_limit,
+        }
+        return pd.DataFrame(
+            {
+                "Date": pd.date_range("2024-01-31", periods=3, freq="ME"),
+                "FundA": [0.01, 0.02, 0.03],
+            }
+        )
+
+    def fake_run_simulation(cfg: SimpleNamespace, df: pd.DataFrame) -> SimpleNamespace:
+        assert not df.empty
+        return SimpleNamespace(
+            metrics=pd.DataFrame({"metric": [1.0]}),
+            details={"summary": "ok", "performance_by_regime": pd.DataFrame()},
+        )
+
+    monkeypatch.setattr(run_analysis, "load", fake_load)
+    monkeypatch.setattr(run_analysis, "load_csv", fake_load_csv)
+    monkeypatch.setattr(run_analysis.api, "run_simulation", fake_run_simulation)
+    monkeypatch.setattr(run_analysis.export, "format_summary_text", lambda *_, **__: "summary")
+
+    exit_code = run_analysis.main(["-c", "config.yml"])
+
+    assert exit_code == 0
+    assert captured["args"] == {
+        "path": "data.csv",
+        "errors": "raise",
+        "missing_policy": "zero",
+        "missing_limit": 12,
+    }
+
+
+def test_main_translates_nan_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Legacy nan_* keys should still be accepted when load_csv lacks the modern names."""
+
+    captured: dict[str, object] = {}
+
+    def fake_load(_: str) -> SimpleNamespace:
+        return _make_config(
+            {
+                "csv_path": "data.csv",
+                "nan_policy": "ffill",
+                "nan_limit": 7,
+            }
+        )
+
+    def fake_load_csv(
+        path: str,
+        *,
+        errors: str = "raise",
+        nan_policy: str | None = None,
+        nan_limit: int | None = None,
+    ) -> pd.DataFrame:
+        captured["kwargs"] = {
+            "path": path,
+            "errors": errors,
+            "nan_policy": nan_policy,
+            "nan_limit": nan_limit,
+        }
+        return pd.DataFrame(
+            {
+                "Date": pd.date_range("2024-02-29", periods=2, freq="ME"),
+                "FundA": [0.05, 0.01],
+            }
+        )
+
+    monkeypatch.setattr(run_analysis, "load", fake_load)
+    monkeypatch.setattr(run_analysis, "load_csv", fake_load_csv)
+    monkeypatch.setattr(
+        run_analysis.api,
+        "run_simulation",
+        lambda *_: SimpleNamespace(metrics=pd.DataFrame({"metric": [2.0]}), details={"summary": "ok"}),
+    )
+    monkeypatch.setattr(run_analysis.export, "format_summary_text", lambda *_, **__: "summary")
+
+    exit_code = run_analysis.main(["-c", "config.yml"])
+
+    assert exit_code == 0
+    assert captured["kwargs"] == {
+        "path": "data.csv",
+        "errors": "raise",
+        "nan_policy": "ffill",
+        "nan_limit": 7,
+    }
+
+
+def test_main_skips_unsupported_missing_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No kwargs should be forwarded when load_csv lacks both legacy and new names."""
+
+    def fake_load(_: str) -> SimpleNamespace:
+        return _make_config(
+            {
+                "csv_path": "data.csv",
+                "missing_policy": "drop",
+                "missing_limit": 5,
+            }
+        )
+
+    def fake_load_csv(path: str, *, errors: str = "raise") -> pd.DataFrame:
+        assert path == "data.csv"
+        assert errors == "raise"
+        return pd.DataFrame(
+            {
+                "Date": pd.date_range("2024-03-31", periods=2, freq="ME"),
+                "FundA": [0.01, 0.015],
+            }
+        )
+
+    monkeypatch.setattr(run_analysis, "load", fake_load)
+    monkeypatch.setattr(run_analysis, "load_csv", fake_load_csv)
+    monkeypatch.setattr(
+        run_analysis.api,
+        "run_simulation",
+        lambda *_: SimpleNamespace(metrics=pd.DataFrame({"metric": [3.0]}), details={"summary": "ok"}),
+    )
+    monkeypatch.setattr(run_analysis.export, "format_summary_text", lambda *_, **__: "summary")
+
+    exit_code = run_analysis.main(["-c", "config.yml"])
+
+    assert exit_code == 0
+
+
+def test_main_raises_when_load_csv_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing CSV should bubble up as FileNotFoundError."""
+
+    monkeypatch.setattr(
+        run_analysis,
+        "load",
+        lambda _: _make_config({"csv_path": "missing.csv"}),
+    )
+    monkeypatch.setattr(run_analysis, "load_csv", lambda *_, **__: None)
+
+    with pytest.raises(FileNotFoundError):
+        run_analysis.main(["-c", "config.yml"])
+
+
+def test_main_handles_detailed_flag(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """When --detailed is provided the metrics-only branch should trigger."""
+
+    monkeypatch.setattr(
+        run_analysis,
+        "load",
+        lambda _: _make_config({"csv_path": "data.csv"}),
+    )
+
+    def fake_load_csv(
+        path: str,
+        *,
+        errors: str = "raise",
+    ) -> pd.DataFrame:
+        assert path == "data.csv"
+        return pd.DataFrame({"Date": pd.date_range("2024-01-31", periods=1, freq="ME")})
+
+    monkeypatch.setattr(run_analysis, "load_csv", fake_load_csv)
+    monkeypatch.setattr(
+        run_analysis.api,
+        "run_simulation",
+        lambda *_: SimpleNamespace(metrics=pd.DataFrame(), details={}),
+    )
+
+    exit_code = run_analysis.main(["-c", "config.yml", "--detailed"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "No results" in captured.out


### PR DESCRIPTION
## Summary
- add CLI-focused regression tests that exercise run_analysis CLI error handling and option forwarding
- document the run_analysis coverage milestone in docs/coverage_progress.md

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_run_analysis_cli_branches.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 coverage run --source=trend_analysis.run_analysis -m pytest tests/test_default_export.py tests/test_run_analysis_cli_export.py tests/test_run_analysis_cli_branches.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d575d88c48331b700a24b0cbe3d7f)