### PR TITLE
docs: log latest soft coverage findings

### DIFF
--- a/docs/coverage_progress.md
+++ b/docs/coverage_progress.md
@@ -15,11 +15,11 @@ Add test coverage for any program functionality with test coverage under 95% or 
   - [x] validators.py
   - [x] run_analysis.py
   - [x] market_data.py
-  - [ ] signal_presets.py
+  - [x] signal_presets.py
   - [x] frequency.py
-  - [ ] signals.py
-  - [ ] bootstrap.py
-  - [ ] risk.py
+  - [x] signals.py
+  - [x] bootstrap.py
+  - [x] risk.py
   - [x] bundle.py
   - [x] cli.py
   - [x] optimizer.py
@@ -38,13 +38,42 @@ Add test coverage for any program functionality with test coverage under 95% or 
 - Expanded the preset defaults regression suite with an explicit-enabled flag scenario (`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --data-file=.coverage_presets --source=trend_analysis.presets -m pytest tests/test_trend_analysis_presets.py`), clearing the remaining partial branch and pushing `trend_analysis/presets.py` to 100% coverage.
 - Built a CLI regression harness in `tests/test_run_analysis_cli_branches.py`, covering error handling and argument translation in `trend_analysis/run_analysis.py` and lifting it to 100% statement/branch coverage (`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 coverage run --source=trend_analysis.run_analysis -m pytest tests/test_default_export.py tests/test_run_analysis_cli_export.py tests/test_run_analysis_cli_branches.py`).
 - Verified that `trend_analysis.io.validators` now sits at 100% statement/branch coverage by running `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 coverage run --source=trend_analysis.io.validators -m pytest tests/test_validators.py tests/test_io_validators_additional.py tests/test_io_validators_extra.py tests/test_io_validators_negative_paths.py tests/test_io_utils.py test_upload_app.py` followed by `coverage report -m`.
-- Executed a consolidated "soft coverage" sweep across the higher-priority suites (`coverage run --source=trend_analysis -m pytest tests/test_validators.py tests/test_io_validators_additional.py tests/test_io_validators_extra.py tests/test_io_validators_negative_paths.py tests/test_io_utils.py test_upload_app.py tests/test_export_bundle.py tests/test_run_analysis_cli_branches.py tests/test_run_analysis_cli_export.py tests/test_default_export.py tests/test_trend_analysis_presets.py tests/test_trend_analysis_presets_additional.py tests/test_trend_analysis_data.py tests/test_trend_analysis_data_additional.py tests/test_trend_analysis_init.py tests/test_trend_analysis_init_extra.py tests/unit/util/test_frequency_comprehensive.py tests/test_frequency_missing.py tests/test_util_frequency_additional.py tests/test_util_frequency_missing.py`) and captured the resulting `coverage report -m` output.
+- Re-ran the consolidated soft-coverage command to include the backtesting, signal preset, signal engine, market-data, and CLI suites alongside the I/O regression packs (`coverage run --source=trend_analysis -m pytest tests/backtesting/test_bootstrap.py tests/test_validators.py tests/test_io_validators_additional.py tests/test_io_validators_extra.py tests/test_io_validators_negative_paths.py tests/test_io_utils.py tests/test_export_bundle.py tests/test_run_analysis_cli_branches.py tests/test_run_analysis_cli_export.py tests/test_default_export.py tests/test_trend_analysis_presets.py tests/test_trend_analysis_presets_additional.py tests/test_trend_analysis_data.py tests/test_trend_analysis_data_additional.py tests/test_trend_analysis_init.py tests/test_trend_analysis_init_extra.py tests/unit/util/test_frequency_comprehensive.py tests/test_frequency_missing.py tests/test_util_frequency_additional.py tests/test_util_frequency_missing.py tests/test_signals_engine.py tests/test_signals_additional.py tests/test_signals_validation.py tests/test_trend_signals.py tests/test_trend_signals_validation.py tests/test_signal_presets.py tests/test_signal_presets_additional.py tests/test_signal_presets_module.py tests/test_signal_presets_regressions.py tests/test_risk.py tests/test_risk_additional.py tests/test_market_data_validation.py tests/test_market_data_validation_additional.py tests/test_trend_cli.py tests/test_trend_cli_additional.py tests/test_trend_analysis_cli_main.py tests/test_cli_check.py tests/test_cli_smoke.py tests/test_cli_no_structured_log.py tests/test_cli_trend_presets.py test_upload_app.py`).【f4fd5e†L1-L10】【181736†L1-L9】【6a3ca6†L1-L64】
 - Drove the backtesting harness suite to full coverage by running `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --source=trend_analysis.backtesting.harness -m pytest tests/backtesting/test_harness.py`, confirming 100% statement and branch coverage for `trend_analysis/backtesting/harness.py`.
 - Extended the market-data validator regression suite with focused preview/ellipsis assertions and monotonic-index edge cases (`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --source=trend_analysis.io.market_data -m pytest tests/test_market_data_validation.py tests/test_market_data_validation_additional.py`), lifting `trend_analysis/io/market_data.py` to 99% statement coverage with only defensive loop-exit arcs remaining.
 - Crafted a comprehensive CLI regression harness (`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --source=trend_analysis.cli -m pytest tests/test_trend_cli_soft_coverage.py`) covering environment checks, run-mode fallbacks, export paths, bundling shims, and compatibility wrappers, raising `trend_analysis/cli.py` to 97% statement coverage.
 - Targeted the remaining uncovered arcs in `trend_analysis/regimes.py` with cache-tag regression tests, confirming 100% statement and branch coverage via `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --data-file=.coverage_regimes --source=trend_analysis.regimes -m pytest tests/test_regimes.py tests/test_regimes_additional.py tests/trend_analysis/test_regimes.py` followed by `python -m coverage report -m --data-file=.coverage_regimes`.
 - Exercised the constraint revalidation guards in `trend_analysis.engine.optimizer` with a dedicated safety-suite run (`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --source=trend_analysis.engine.optimizer -m pytest tests/test_optimizer.py tests/test_optimizer_constraints.py tests/test_optimizer_constraints_guardrails.py tests/test_optimizer_constraints_additional.py` followed by `python -m coverage report -m`), raising the module to 100% statement and branch coverage and documenting the legacy duplicate cash-handling branch with `# pragma: no cover` annotations.
-- The latest report now highlights the remaining sub-95% hotspots: `trend_analysis/engine/walkforward.py` (14%), `trend_analysis/export/__init__.py` (44%), support modules such as `trend_analysis/api.py` (79%), and the `_autofix_*` probes (0%).
+- The refreshed coverage report confirms that `trend_analysis/signal_presets.py`, `trend_analysis/signals.py`, `trend_analysis/backtesting/bootstrap.py`, and `trend_analysis/risk.py` each now sit at 100% statement and branch coverage.【4ddd7e†L1-L1】【489003†L1-L1】【67b5e8†L1-L1】【80a71e†L1-L1】
 
+
+- Remaining files under 95% coverage (sorted by ascending coverage):
+
+| File | Coverage |
+| --- | ---: |
+| `src/trend_analysis/core/metric_cache.py` | 0% |
+| `src/trend_analysis/metrics/rolling.py` | 13% |
+| `src/trend_analysis/backtesting/harness.py` | 14% |
+| `src_trend_analysis/engine/walkforward.py` | 14% |
+| `src_trend_analysis/core/rank_selection.py` | 16% |
+| `src_trend_analysis/regimes.py` | 19% |
+| `src_trend_analysis/metrics/attribution.py` | 26% |
+| `src_trend_analysis/timefreq.py` | 30% |
+| `src_trend_analysis/metrics/summary.py` | 33% |
+| `src_trend_analysis/logging.py` | 38% |
+| `src_trend_analysis/engine/optimizer.py` | 38% |
+| `src_trend_analysis/pipeline.py` | 41% |
+| `src_trend_analysis/metrics/turnover.py` | 41% |
+| `src_trend_analysis/reporting/__init__.py` | 43% |
+| `src_trend_analysis/export/__init__.py` | 44% |
+| `src_trend_analysis/config/model.py` | 45% |
+| `src_trend_analysis/config/models.py` | 53% |
+| `src_trend_analysis/metrics/__init__.py` | 56% |
+| `src_trend_analysis/perf/rolling_cache.py` | 67% |
+| `src_trend_analysis/util/joblib_shim.py` | 69% |
+| `src_trend_analysis/api.py` | 79% |
+| `src_trend_analysis/util/hash.py` | 86% |
+| `src_trend_analysis/util/missing.py` | 92% |
+- Auxiliary `_autofix_*`, GUI, proxy, and rebalancing helpers remain intentionally uncovered (0%) and will be triaged separately once the core pipeline files clear the 95% threshold.【4124cd†L1-L58】【4124cd†L256-L320】
 ## Next steps
 - Develop targeted suites for the remaining low-coverage workhorses surfaced in the latest report (`trend_analysis/export/__init__.py`, `trend_analysis/engine/walkforward.py`, and high-traffic orchestration modules such as `pipeline.py`, `signals.py`, and `risk.py`) so each clears the 95% goal while keeping essential functionality covered end-to-end.


### PR DESCRIPTION
## Summary
- record the latest soft-coverage command covering backtesting, signal, market-data, and CLI suites
- document the refreshed coverage results, highlighting modules now at 100% and the remaining <95% list

## Testing
- coverage run --source=trend_analysis -m pytest tests/backtesting/test_bootstrap.py tests/test_validators.py tests/test_io_validators_additional.py tests/test_io_validators_extra.py tests/test_io_validators_negative_paths.py tests/test_io_utils.py tests/test_export_bundle.py tests/test_run_analysis_cli_branches.py tests/test_run_analysis_cli_export.py tests/test_default_export.py tests/test_trend_analysis_presets.py tests/test_trend_analysis_presets_additional.py tests/test_trend_analysis_data.py tests/test_trend_analysis_data_additional.py tests/test_trend_analysis_init.py tests/test_trend_analysis_init_extra.py tests/unit/util/test_frequency_comprehensive.py tests/test_frequency_missing.py tests/test_util_frequency_additional.py tests/test_util_frequency_missing.py tests/test_signals_engine.py tests/test_signals_additional.py tests/test_signals_validation.py tests/test_trend_signals.py tests/test_trend_signals_validation.py tests/test_signal_presets.py tests/test_signal_presets_additional.py tests/test_signal_presets_module.py tests/test_signal_presets_regressions.py tests/test_risk.py tests/test_risk_additional.py tests/test_market_data_validation.py tests/test_market_data_validation_additional.py tests/test_trend_cli.py tests/test_trend_cli_additional.py tests/test_trend_analysis_cli_main.py tests/test_cli_check.py tests/test_cli_smoke.py tests/test_cli_no_structured_log.py tests/test_cli_trend_presets.py test_upload_app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69118c317d388331bdd0177df4569982)