### PR TITLE
docs: log coverage blockers and soft snapshot

### DIFF
--- a/docs/coverage_keepalive_status.md
+++ b/docs/coverage_keepalive_status.md
@@ -1,0 +1,29 @@
+# Coverage Status — Keepalive Round
+
+## Soft coverage snapshot
+
+- Generated a soft coverage report using `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --source=src -m pytest` followed by `python -m coverage report -m`.
+- Captured the ranked module list from `coverage_report.txt`; the lowest coverage files (<50%) currently are:
+  1. `src/trend_analysis/export/__init__.py` — 7 %
+  2. `src/trend_analysis/export/bundle.py` — 7 %
+  3. `src/trend_analysis/engine/walkforward.py` — 14 %
+  4. `src/trend_analysis/core/rank_selection.py` — 17 %
+  5. `src/trend_analysis/config/model.py` — 44 %
+  6. `src/trend_analysis/config/models.py` — 46 %
+  7. `src/trend_analysis/data.py` — 29 %
+  8. `src/trend_analysis/cli.py` — 10 %
+  9. `src/trend_analysis/regimes.py` — 19 %
+  10. `src/trend_analysis/core/metric_cache.py` — 36 %
+
+(See `coverage_report.txt` for the full listing.)
+
+## Test execution blockers
+
+- Re-running the focused CLI regression suite against Python 3.12 / NumPy 2.1 failed with `_NoValueType` conversion errors raised by NumPy’s ufuncs when pandas resampling relies on deprecated behaviour. The failure log is stored at `tmp_logs/run_analysis_fail.log` for reference.
+- Similar `_NoValueType` failures surface when running the backtesting harness and frequency utilities test packs, so targeted coverage improvements for those modules are blocked until we patch the NumPy compatibility issues in the fixtures.
+
+## Next steps
+
+1. Patch the pandas/Numpy interaction in the CLI, frequency, and backtesting fixtures so the suites run cleanly on Python 3.12/NumPy 2.1.
+2. Once the regression suites pass, re-run the soft coverage command and lift the remaining modules above the 95 % target starting with `export/__init__.py`, `engine/walkforward.py`, and `config/model.py`.
+3. Document the updated coverage deltas in `docs/coverage_progress.md` after confirming the fixes.

--- a/tmp_logs/run_analysis_fail.log
+++ b/tmp_logs/run_analysis_fail.log
@@ -1,0 +1,40 @@
+initial = <no value>, where = True
+
+    def _sum(a, axis=None, dtype=None, out=None, keepdims=False,
+             initial=_NoValue, where=True):
+>       return umr_sum(a, axis, dtype, out, keepdims, initial, where)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+E       TypeError: int() argument must be a string, a bytes-like object or a real number, not '_NoValueType'
+
+/root/.pyenv/versions/3.12.12/lib/python3.12/site-packages/numpy/_core/_methods.py:51: TypeError
+======================================================= warnings summary =======================================================
+../../root/.pyenv/versions/3.12.12/lib/python3.12/site-packages/pandas/__init__.py:14
+  /root/.pyenv/versions/3.12.12/lib/python3.12/site-packages/pandas/__init__.py:14: UserWarning: The NumPy module was reloaded (imported a second time). This can in some cases result in small but subtle issues and is discouraged.
+    __import__(_dependency)
+
+tests/test_run_analysis_additional.py::test_main_passes_missing_policy
+  /workspace/Trend_Model_Project/tests/test_run_analysis_additional.py:70: FutureWarning: 'M' is deprecated and will be removed in a future version, please use 'ME' instead.
+    "Date": pd.date_range("2024-01-31", periods=2, freq="M"),
+
+tests/test_run_analysis_additional.py::test_main_passes_missing_policy
+tests/test_run_analysis_additional.py::test_main_maps_nan_policy_when_signature_uses_nan
+  /workspace/Trend_Model_Project/tests/test_run_analysis_additional.py:15: FutureWarning: 'M' is deprecated and will be removed in a future version, please use 'ME' instead.
+    dates = pd.date_range("2024-01-31", periods=2, freq="M")
+
+tests/test_run_analysis_additional.py::test_main_maps_nan_policy_when_signature_uses_nan
+  /workspace/Trend_Model_Project/tests/test_run_analysis_additional.py:116: FutureWarning: 'M' is deprecated and will be removed in a future version, please use 'ME' instead.
+    "Date": pd.date_range("2024-01-31", periods=2, freq="M"),
+
+tests/test_run_analysis_additional.py::test_main_uses_nan_fallback_and_default_exports
+  /workspace/Trend_Model_Project/tests/test_run_analysis_additional.py:166: FutureWarning: 'M' is deprecated and will be removed in a future version, please use 'ME' instead.
+    "Date": pd.date_range("2024-01-31", periods=3, freq="M"),
+
+tests/test_run_analysis_additional.py::test_main_uses_nan_fallback_and_default_exports
+  /workspace/Trend_Model_Project/tests/test_run_analysis_additional.py:22: FutureWarning: 'M' is deprecated and will be removed in a future version, please use 'ME' instead.
+    index = pd.date_range("2024-01-31", periods=3, freq="M")
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=================================================== short test summary info ====================================================
+FAILED tests/test_run_analysis_cli_default.py::test_cli_default_output - TypeError: int() argument must be a string, a bytes-...
+FAILED tests/test_run_analysis_cli_export.py::test_cli_exports_files - TypeError: int() argument must be a string, a bytes-li...
+========================================== 2 failed, 28 passed, 7 warnings in 10.28s ===========================================


### PR DESCRIPTION
## Summary
- document the soft-coverage snapshot and the lowest-coverage modules discovered in the latest report
- record the numpy 2.x TypeError blocking the CLI regression suite so future coverage work can resolve it

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --source=src -m pytest *(fails due to NumPy `_NoValueType` conversion errors; see tmp_logs/run_analysis_fail.log for context)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ee38d4488331bc7e678af673f8f9)