### PR TITLE
Add tests covering run_analysis CLI error handling

### DIFF
--- a/tests/test_run_analysis_additional.py
+++ b/tests/test_run_analysis_additional.py
@@ -227,7 +227,7 @@ def test_main_requires_csv_path(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(run_analysis, "load_csv", _unexpected_load_csv)
 
-    with pytest.raises(KeyError, match="csv_path"):
+    with pytest.raises(KeyError, match=r"csv_path.*must be provided"):
         run_analysis.main(["-c", "config.yml"])
 
 


### PR DESCRIPTION
## Summary
- add regression tests for run_analysis.main when CSV path is missing, loader returns None, or detailed mode is requested
- ensure optional loader kwargs are skipped when not supported so the CLI handles minimal configurations
- raises run_analysis.py line coverage above 95%

## Testing
- coverage run -m pytest tests/test_run_analysis_additional.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124306c7ec8331a4c58ed54c5eec76)