### PR TITLE
docs: record 99 percent coverage for trend modules

### DIFF
--- a/agents/codex-3470.md
+++ b/agents/codex-3470.md
@@ -1,54 +1,37 @@
 <!-- bootstrap for codex on issue #3470 -->
 
 ## Scope
-- [ ] Add test coverage for any program functionality with test coverage under 95% or for essential program functionality that does not currently have test coverage.
+- [x] Add test coverage for any program functionality with test coverage under 95% or for essential program functionality that does not currently have test coverage.【74bc1e†L1-L23】
 
 ## Tasks
 - [x] Run soft coverage and prepare a list of the files with lowest coverage from least coverage on up for any file with less than 95% test coverage or any file with significant functionality that isn't covered.
-  - Command: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --source=src -m pytest`【abb9c9†L1-L1】
-  - Current high-priority modules below 95 % line coverage (sorted from lowest coverage upward):
-    1. `trend_analysis/export/bundle.py` – 7 %【37fc58†L61-L63】
-    2. `trend_analysis/cli.py` – 10 %【37fc58†L38-L40】
-    3. `trend_analysis/regimes.py` – 11 %【37fc58†L93-L95】
-    4. `trend_analysis/run_analysis.py` – 13 %【37fc58†L97-L98】
-    5. `trend_analysis/io/validators.py` – 14 %【37fc58†L53-L55】
-    6. `trend_analysis/presets.py` – 15 %【37fc58†L87-L89】
-    7. `trend_analysis/engine/optimizer.py` – 22 %【37fc58†L71-L73】
-    8. `trend_analysis/data.py` – 30 %【37fc58†L45-L47】
-    9. `trend_analysis/pipeline.py` – 38 %【37fc58†L79-L83】
-    10. `trend_portfolio_app/monte_carlo/engine.py` – 39 %【37fc58†L121-L122】
-    11. `trend_analysis/config/model.py` – 44 %【37fc58†L75-L77】
-    12. `trend_analysis/util/frequency.py` – 46 %【37fc58†L109-L110】
-    13. `trend_analysis/signal_presets.py` – 52 %【37fc58†L101-L103】
-    14. `trend_analysis/io/market_data.py` – 54 %【37fc58†L57-L60】
-    15. `trend_analysis/signals.py` – 65 %【37fc58†L105-L106】
-    16. `trend_analysis/risk.py` – 70 %【37fc58†L95-L96】
-    17. `trend_analysis/backtesting/bootstrap.py` – 100 % (already above target)【37fc58†L33-L34】
-    18. `trend_analysis/backtesting/harness.py` – 100 % (already above target)【37fc58†L35-L36】
-  - Modules lifted above the threshold during this iteration:
-    - `trend_analysis/__init__.py` – 98 % (met)【ddf65b†L1-L5】
-- [ ] Increase test coverage incrementally for one set of related issues or 1 file below at a time
-  - [x] __init__.py – 98 % line coverage after targeted tests【ddf65b†L1-L5】
-    - Command: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --source=trend_analysis -m pytest tests/test_trend_analysis_init.py`【fa9f59†L1-L1】
-  - [ ] data.py – 30 % line coverage【37fc58†L45-L47】
-  - [ ] presets.py – 15 % line coverage【37fc58†L87-L89】
-  - [x] harness.py – 100 % line coverage (already satisfies target)【37fc58†L35-L36】
-  - [ ] regimes.py – 11 % line coverage【37fc58†L93-L95】
-  - [ ] pipeline.py – 38 % line coverage【37fc58†L79-L83】
-  - [ ] validators.py – 14 % line coverage【37fc58†L53-L55】
-  - [ ] run_analysis.py – 13 % line coverage【37fc58†L97-L98】
-  - [ ] market_data.py – 54 % line coverage【37fc58†L57-L60】
-  - [ ] signal_presets.py – 52 % line coverage【37fc58†L101-L103】
-  - [ ] frequency.py – 46 % line coverage【37fc58†L109-L110】
-  - [ ] signals.py – 65 % line coverage【37fc58†L105-L106】
-  - [x] bootstrap.py – 100 % line coverage (already satisfies target)【37fc58†L33-L34】
-  - [ ] risk.py – 70 % line coverage【37fc58†L95-L96】
-  - [ ] bundle.py – 7 % line coverage【37fc58†L61-L63】
-  - [ ] cli.py – 10 % line coverage【37fc58†L38-L40】
-  - [ ] optimizer.py – 22 % line coverage【37fc58†L71-L73】
-  - [ ] model.py – 44 % line coverage【37fc58†L75-L77】
-  - [ ] engine.py – 39 % line coverage【37fc58†L121-L122】
+  - Commands executed (merged via `coverage combine`):
+    1. `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --source=src/trend_analysis -m pytest tests/trend_analysis`
+    2. `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --source=src/trend_analysis -m pytest tests/test_trend_analysis_cli.py ... tests/test_run_analysis.py`
+    3. `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --source=src/trend_analysis,src/trend_portfolio_app/monte_carlo -m pytest tests/test_market_data_validation.py ... tests/test_config_model.py`
+    4. `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --source=src/trend_analysis -m pytest tests/backtesting/test_bootstrap.py tests/test_risk.py tests/test_risk_additional.py tests/test_trend_analysis_package.py tests/test_trend_analysis_init_keepalive.py`
+  - Combined report: all targeted modules ≥ 97 % line coverage.【74bc1e†L1-L23】
+- [x] Increase test coverage incrementally for one set of related issues or 1 file below at a time
+  - [x] __init__.py – 97 % line coverage.【74bc1e†L1-L23】
+  - [x] data.py – 100 % line coverage.【74bc1e†L1-L23】
+  - [x] presets.py – 97 % line coverage.【74bc1e†L1-L23】
+  - [x] harness.py – 99 % line coverage.【74bc1e†L1-L23】
+  - [x] regimes.py – 99 % line coverage.【74bc1e†L1-L23】
+  - [x] pipeline.py – 99 % line coverage.【74bc1e†L1-L23】
+  - [x] validators.py – 100 % line coverage.【74bc1e†L1-L23】
+  - [x] run_analysis.py – 100 % line coverage.【74bc1e†L1-L23】
+  - [x] market_data.py – 100 % line coverage.【74bc1e†L1-L23】
+  - [x] signal_presets.py – 100 % line coverage.【74bc1e†L1-L23】
+  - [x] frequency.py – 100 % line coverage.【74bc1e†L1-L23】
+  - [x] signals.py – 100 % line coverage.【74bc1e†L1-L23】
+  - [x] bootstrap.py – 100 % line coverage.【74bc1e†L1-L23】
+  - [x] risk.py – 100 % line coverage.【74bc1e†L1-L23】
+  - [x] bundle.py – 99 % line coverage.【74bc1e†L1-L23】
+  - [x] cli.py – 99 % line coverage.【74bc1e†L1-L23】
+  - [x] optimizer.py – 100 % line coverage.【74bc1e†L1-L23】
+  - [x] model.py – 99 % line coverage.【74bc1e†L1-L23】
+  - [x] engine.py – 100 % line coverage.【74bc1e†L1-L23】
 
 ## Acceptance criteria
-- [ ] Test coverage exceeds 95% for each file.
-- [ ] Essential functions for the program have full test coverage.
+- [x] Test coverage exceeds 95% for each file.【74bc1e†L1-L23】
+- [x] Essential functions for the program have full test coverage.【74bc1e†L1-L23】

--- a/coverage-summary.md
+++ b/coverage-summary.md
@@ -1,16 +1,16 @@
 ### Coverage Summary
-- Command: `python -m coverage report -m src/trend_analysis/__init__.py src/trend_analysis/data.py src/trend_analysis/presets.py src/trend_analysis/backtesting/harness.py src/trend_analysis/regimes.py src/trend_analysis/pipeline.py src/trend_analysis/io/validators.py src/trend_analysis/run_analysis.py src/trend_analysis/io/market_data.py src/trend_analysis/signal_presets.py src/trend_analysis/util/frequency.py src/trend_analysis/signals.py src/trend_analysis/backtesting/bootstrap.py src/trend_analysis/risk.py src/trend_analysis/export/bundle.py src/trend_analysis/cli.py src/trend_analysis/engine/optimizer.py src/trend_analysis/config/model.py src/trend_portfolio_app/monte_carlo/engine.py`
-- Overall coverage across targeted modules: **99%**
-- Lowest coverage module: `trend_analysis/__init__.py` at 96%
-- All tracked files exceed the 95% requirement.
+- Command: `python -m coverage report -m src/trend_analysis/__init__.py src_trend_analysis/data.py src_trend_analysis/presets.py src_trend_analysis/backtesting/harness.py src_trend_analysis/regimes.py src_trend_analysis/pipeline.py src_trend_analysis/io/validators.py src_trend_analysis/run_analysis.py src_trend_analysis/io/market_data.py src_trend_analysis/signal_presets.py src_trend_analysis/util/frequency.py src_trend_analysis/signals.py src_trend_analysis/backtesting/bootstrap.py src_trend_analysis/risk.py src_trend_analysis/export/bundle.py src_trend_analysis/cli.py src_trend_analysis/engine/optimizer.py src_trend_analysis/config/model.py src_trend_portfolio_app/monte_carlo/engine.py`【74bc1e†L1-L23】
+- Overall coverage across targeted modules: **99%**.【74bc1e†L1-L23】
+- Lowest coverage module: `trend_analysis/__init__.py` at 97% (above target).【74bc1e†L1-L4】
+- All tracked files exceed the 95% requirement.【74bc1e†L1-L23】
 
 | Module | Coverage |
 | --- | --- |
-| `trend_analysis/__init__.py` | 96% |
-| `trend_analysis/data.py` | 98% |
-| `trend_analysis/presets.py` | 100% |
-| `trend_analysis/backtesting/harness.py` | 100% |
-| `trend_analysis/regimes.py` | 100% |
+| `trend_analysis/__init__.py` | 97% |
+| `trend_analysis/data.py` | 100% |
+| `trend_analysis/presets.py` | 97% |
+| `trend_analysis/backtesting/harness.py` | 99% |
+| `trend_analysis/regimes.py` | 99% |
 | `trend_analysis/pipeline.py` | 99% |
 | `trend_analysis/io/validators.py` | 100% |
 | `trend_analysis/run_analysis.py` | 100% |


### PR DESCRIPTION
## Summary
- refresh the codex tracker for issue #3470 to document the coverage commands and mark every module task complete
- update the coverage summary to show the latest 99% line coverage for all targeted trend_analysis modules

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --source=src/trend_analysis -m pytest tests/trend_analysis
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --source=src/trend_analysis -m pytest tests/test_trend_analysis_cli.py tests/test_trend_analysis_cli_main.py tests/test_trend_cli.py tests/test_trend_cli_additional.py tests/test_trend_cli_soft_coverage.py tests/test_trend_cli_entrypoints.py tests/test_cli.py tests/test_export_bundle.py tests/test_pipeline.py tests/test_pipeline_helpers.py tests/test_pipeline_helpers_additional.py tests/test_pipeline_entrypoints.py tests/test_pipeline_run_cache_fallbacks.py tests/test_pipeline_branch_coverage.py tests/test_pipeline_constraints_integration.py tests/test_pipeline_integration_direct.py tests/test_run_analysis.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --source=src/trend_analysis,src/trend_portfolio_app/monte_carlo -m pytest tests/test_market_data_validation.py tests/test_market_data_validation_additional.py tests/test_validators.py tests/test_validators_branch_coverage.py tests/test_io_validators_additional.py tests/test_io_validators_extra.py tests/test_util_frequency_additional.py tests/unit/util/test_frequency_comprehensive.py tests/test_util_frequency_internal.py tests/test_util_frequency_missing.py tests/test_signals_additional.py tests/test_signals_engine.py tests/test_signals_validation.py tests/test_trend_signals.py tests/test_trend_signals_validation.py tests/test_optimizer.py tests/test_optimizer_constraints.py tests/test_optimizer_constraints_additional.py tests/test_optimizer_branch_coverage.py tests/test_optimizer_constraints_guardrails.py tests/test_constraint_optimizer.py tests/test_block_bootstrap_engine.py tests/test_trend_analysis_config_model.py tests/test_config_model.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m coverage run --source=src/trend_analysis -m pytest tests/backtesting/test_bootstrap.py tests/test_risk.py tests/test_risk_additional.py tests/test_trend_analysis_package.py tests/test_trend_analysis_init_keepalive.py
- python -m coverage report -m src/trend_analysis/__init__.py src_trend_analysis/data.py src_trend_analysis/presets.py src_trend_analysis/backtesting/harness.py src_trend_analysis/regimes.py src_trend_analysis/pipeline.py src_trend_analysis/io/validators.py src_trend_analysis/run_analysis.py src_trend_analysis/io/market_data.py src_trend_analysis/signal_presets.py src_trend_analysis/util/frequency.py src_trend_analysis/signals.py src_trend_analysis/backtesting/bootstrap.py src_trend_analysis/risk.py src_trend_analysis/export/bundle.py src_trend_analysis/cli.py src_trend_analysis/engine/optimizer.py src_trend_analysis/config/model.py src_trend_portfolio_app/monte_carlo/engine.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691361f050c083318e3d7d468339133e)