### PR TITLE
Improve run-cap detection and reporting

### DIFF
--- a/.github/scripts/__tests__/keepalive-gate.test.js
+++ b/.github/scripts/__tests__/keepalive-gate.test.js
@@ -151,6 +151,31 @@ test('countActive matches by branch metadata when pull requests array is empty',
   assert.equal(result.breakdown.get('orchestrator'), 1);
 });
 
+test('countActive matches runs tagged via concurrency group', async () => {
+  const registry = {
+    'agents-70-orchestrator.yml|queued': [
+      {
+        id: 615,
+        head_branch: 'phase-2-dev',
+        concurrency: 'agents-70-orchestrator-42-keepalive-trace1234',
+        pull_requests: [],
+      },
+    ],
+  };
+  const github = makeGithubStub(registry);
+  const result = await countActive({
+    github,
+    owner: 'stranske',
+    repo: 'Trend_Model_Project',
+    prNumber: 42,
+    headRef: 'codex/issue-42',
+    headSha: 'non-matching-sha',
+  });
+
+  assert.equal(result.active, 1);
+  assert.equal(result.breakdown.get('orchestrator'), 1);
+});
+
 test('evaluateRunCapForPr returns ok when active runs are below cap', async () => {
   const registry = {
     'agents-70-orchestrator.yml|queued': [

--- a/.github/workflows/agents-pr-meta.yml
+++ b/.github/workflows/agents-pr-meta.yml
@@ -180,8 +180,13 @@ jobs:
           else
             head='unknown'
           fi
-          printf 'GATE: ok=%s reason=%s pr=%s agent=%s cap=%s active=%s head=%s\n' \
-            "${ok}" "${reason}" "${pr_value}" "${agent}" "${cap}" "${active}" "${head}"
+          if [[ "${reason}" == 'run-cap-reached' ]]; then
+            printf 'CAP: ok=%s reason=%s pr=%s cap=%s active=%s\n' \
+              "${ok}" "${reason}" "${pr_value}" "${cap}" "${active}"
+          else
+            printf 'GATE: ok=%s reason=%s pr=%s agent=%s cap=%s active=%s head=%s\n' \
+              "${ok}" "${reason}" "${pr_value}" "${agent}" "${cap}" "${active}" "${head}"
+          fi
         env:
           OK: ${{ steps.pre_gate.outputs.ok || 'false' }}
           REASON: ${{ steps.pre_gate.outputs.reason || 'unspecified' }}
@@ -393,8 +398,13 @@ jobs:
           else
             head='unknown'
           fi
-          printf 'GATE: ok=%s reason=%s pr=%s agent=%s cap=%s active=%s head=%s\n' \
-            "${ok}" "${reason}" "${pr_value}" "${agent}" "${cap}" "${active}" "${head}"
+          if [[ "${reason}" == 'run-cap-reached' ]]; then
+            printf 'CAP: ok=%s reason=%s pr=%s cap=%s active=%s\n' \
+              "${ok}" "${reason}" "${pr_value}" "${cap}" "${active}"
+          else
+            printf 'GATE: ok=%s reason=%s pr=%s agent=%s cap=%s active=%s head=%s\n' \
+              "${ok}" "${reason}" "${pr_value}" "${agent}" "${cap}" "${active}" "${head}"
+          fi
         env:
           OK: ${{ steps.gate.outputs.ok || 'false' }}
           REASON: ${{ steps.gate.outputs.reason || 'unspecified' }}


### PR DESCRIPTION
<!-- pr-preamble:start -->
## Summary
On PR #3491, several PR‑meta runs launched close together and orchestrator accepted parallel starts (as designed). The cap didn’t prevent the burst because, at dispatch time, concurrent PR‑meta instances likely evaluated the cap before any orchestrator run had flipped to in_progress. With the current PR‑meta triggers (issue_comment, pull_request, and workflow_run: Gate.completed), it’s critical to count queued runs as active and to tie the count to this PR, independent of event type. Evidence:

multiple PR‑meta runs visible on #3491, including under on: pull_request; orchestrator triggers support parallel acceptance.


**Scope:** In PR‑meta (before any dispatch), compute active = # of orchestrator runs for this PR with status ∈ {queued, in_progress} and enforce active < cap.

Cap defaults to 2; override via label agents:max-runs:X (X ∈ 1..5).

Use workflow id/name to filter orchestrator runs; use a PR discriminator independent of event type.

Non‑Goals

Changing orchestrator concurrency or the worker pipeline

Changing label names or defaults

## CI readiness
Counting both queued and in_progress is essential because parallel PR‑meta instances evaluate the cap before the first run transitions to in_progress.

Filtering by PR must not rely on pull_requests[] for repository_dispatch/workflow_run events; use the orchestrator workflow name/id and your own PR discriminator (e.g., concurrency group containing -<PR>-).

---
Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/19286410592).

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
In PR‑meta (before any dispatch), compute active = # of orchestrator runs for this PR with status ∈ {queued, in_progress} and enforce active < cap.

Cap defaults to 2; override via label agents:max-runs:X (X ∈ 1..5).

Use workflow id/name to filter orchestrator runs; use a PR discriminator independent of event type.

Non‑Goals

Changing orchestrator concurrency or the worker pipeline

Changing label names or defaults

#### Tasks
- [ ] Active‑run counter (github‑script step) in agents-pr-meta.yml just before dispatch:

- [ ] List orchestrator workflow runs twice (status queued and in_progress).

- [ ] Filter by this PR using a discriminator you control (e.g., the orchestrator’s concurrency.group embeds the PR number, or inputs.options_json.pr is echoed into the run’s display_title/run_name).

- [ ] Return active and cap (from label or default 2); set ok = active < cap.

- [ ] Gate decision: if ok == false, skip dispatch and write one summary line:
CAP: ok=false reason=run-cap-reached pr=#<n> cap=<cap> active=<active>

- [ ] Mirror the same check in Orchestrator before posting the next instruction (prevents over‑posting when several orchestrators are in flight).

#### Acceptance criteria
- [ ] On a test PR with agents:max-runs:2, two dispatches in quick succession succeed; a third concurrent dispatch attempt is skipped with the cap summary line.

- [ ] The orchestrator still runs in parallel up to the cap; no unintended serialization occurs.

- [ ] The Checks tab shows no bursts beyond the set cap.

**Head SHA:** 574e198dc366139b3efee9a3cdf6a773a0055f82
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/agents-70-orchestrator.yml | ❌ failure | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19288995270) |
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19289115966) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19289004068) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19289004449) |
| Gate | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19289004074) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19289004094) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19289004052) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19289004042) |
<!-- auto-status-summary:end -->