### PR TITLE
docs: add keepalive progress log for pr 3573

### DIFF
--- a/docs/keepalive/ProgressLog.md
+++ b/docs/keepalive/ProgressLog.md
@@ -1,0 +1,16 @@
+# Keepalive Progress Log — PR #3573
+
+## Scope
+Add test coverage for any program functionality with test coverage under 95% or for essential program functionality that does not currently have test coverage.
+
+## Current Status
+- The initial soft coverage sweep has **not** been run yet.
+- No individual program files have received additional tests during this round.
+- Acceptance criteria remain unmet because no files have exceeded the 95% coverage threshold.
+
+## Next Steps
+1. Run the soft coverage report to identify the lowest-coverage files below the 95% target.
+2. Increase coverage incrementally, focusing on one file or related cluster at a time until each reaches the threshold.
+3. Re-evaluate acceptance criteria after each set of changes and update the checklist when milestones are achieved.
+
+_Last updated: $(date -u '+%Y-%m-%d %H:%M UTC')._


### PR DESCRIPTION
## Summary
- add a progress log document under docs/keepalive for PR #3573
- record the current scope, status, and next steps for the outstanding coverage tasks

## Testing
- not run (documentation-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69176c4d39108331a69c5c2b0ae7253c)

<!-- pr-preamble:start -->
## Summary
Ensure that test coverage exceeds 95% for all program files.


**Scope:** Add test coverage for any program functionality with test coverage under 95% or for essential program functionality that does not currently have test coverage

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Scope section missing from source issue.

#### Tasks
- [ ] Tasks section missing from source issue.

#### Acceptance criteria
- [ ] Acceptance criteria section missing from source issue.

**Head SHA:** f2036a2bf79b162a5c5a14f640e2742d898d95e2
**Latest Runs:** ⏳ pending — Gate
**Required:** gate: ⏳ pending

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19373122338) |
| CI Autofix Loop | ⏳ pending | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19373122484) |
| Copilot code review | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19373122951) |
| Gate | ⏳ pending | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19373122494) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19373122366) |
| Health 45 Agents Guard | ⏳ pending | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19373122488) |
| Maint 52 Validate Workflows | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19373122330) |
<!-- auto-status-summary:end -->