### PR TITLE
Document docker helper usage for manual smoke tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/) and this p
 
 ### Changed
 - `compute_signal` now returns a strictly causal rolling mean shifted by one period (previously included the current row). Prevents subtle look‑ahead bias in downstream position construction (Issue #1438).
+- Documented the continued manual use of `docker-compose.yml` and `test_docker.sh` for local smoke tests and GHCR release verification, avoiding archival after confirming no CI dependencies.
 
 ### Deprecated
 - Legacy root scripts (`portfolio_analysis_report.py`, `manager_attribution_analysis.py`, `demo_turnover_cap.py`) now emit `DeprecationWarning` and delegate to unified `trend` CLI (Issue #1437).

--- a/TESTING_SUMMARY.md
+++ b/TESTING_SUMMARY.md
@@ -56,6 +56,11 @@ pip install --no-deps -e .[dev]
 COVERAGE_PROFILE=full ./scripts/run_tests.sh
 ```
 
+## Docker Helpers and Release Smoke Tests
+
+- **Local services with Compose:** Use `docker compose up --build app` for the Streamlit UI or `docker compose up --build api` to include the FastAPI service on port 8000. Both services share the local image built from `Dockerfile` and mount `./data` into the containers for quick manual validation.
+- **Published image verification:** After the GitHub release workflow publishes `ghcr.io/stranske/trend-model:latest`, run `./test_docker.sh` to pull the image, wait for the API health endpoint, and confirm CLI/import readiness. The script is manual-only; CI does not invoke it.
+
 ## Screenshots Available
 - Upload interface: ![Upload Interface](assets/screenshots/upload-interface.png)
 - Template section: ![Template Section](assets/screenshots/template-section.png)


### PR DESCRIPTION
## Summary
- add concise instructions for using docker-compose and the GHCR smoke-test script in TESTING_SUMMARY.md
- note in the changelog that docker-compose.yml and test_docker.sh remain manual helpers after confirming no CI dependencies

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692174804ca483319e3c3850f4a6d44a)