### PR TITLE
Refactor _run_analysis with diagnostics and helper tests

### DIFF
--- a/archives/generated/2025/2025-11-22_keepalive_status.md
+++ b/archives/generated/2025/2025-11-22_keepalive_status.md
@@ -1,18 +1,19 @@
-# Keepalive Status for Tearsheets PR
+# Keepalive Status for Issue #3770
 
 ## Scope
-- [x] `analysis/tearsheet.py::render(results, out="reports/tearsheet.md")` with headline stats and run metadata.
-- [x] Plots for equity curve, rolling Sharpe/vol, drawdown, and turnover.
-- [x] CLI wiring: `python -m src.cli report --last-run`.
-- [x] Reference the new report from `archives/reports/2025-11-22_Portfolio_Test_Results_Summary.md`.
+- [x] Introduce focused helpers for each stage (preprocessing, sampling/window resolution, selection, weighting/risk scaling, benchmarking/report assembly) and have `_run_analysis` orchestrate them.
+- [x] Return structured result/diagnostic objects instead of bare `None` so callers can trace why a run produced no output.
+- [x] Preserve existing behaviour by keeping the public API intact while internally delegating to the new helpers.
 
 ## Tasks
-- [x] Implement renderer and basic plots.
-- [x] Minimal CLI and example run command in README.
-- [x] Test that the file is written and includes expected sections.
+- [x] Identify logical sub-steps in `_run_analysis` and extract them into testable functions with clear inputs/outputs.
+- [x] Add unit tests per helper covering success and failure paths.
+- [x] Update `_run_analysis` to orchestrate helpers and propagate structured diagnostics.
+- [x] Verify existing entry points (CLI/API) handle the richer return values without behaviour changes.
 
 ## Acceptance criteria
-- [x] Running the CLI produces a tearsheet file with stats and plots using the latest `Results`.
-- [x] CI artifact (optional) or repo file present after a demo run.
+- [x] `_run_analysis` reads as a short orchestrator calling extracted helpers.
+- [x] Unit tests cover the new helpers and confirm early exits report explicit reasons instead of returning `None`.
+- [x] Existing external behaviour (inputs/outputs) remains unchanged aside from added diagnostics.
 
 Status auto-updates as tasks complete on this branch.

--- a/src/trend_analysis/api.py
+++ b/src/trend_analysis/api.py
@@ -185,12 +185,11 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
         risk_free_column=risk_free_column,
         allow_risk_free_fallback=allow_risk_free_fallback,
     )
-    if res is None:
-        logger.warning("run_simulation produced no result")
-        return RunResult(pd.DataFrame(), {}, seed, env)
-
-    if isinstance(res, dict):
-        res_dict: dict[str, Any] = res
+    if isinstance(res, AnalysisResult):
+        if not res.success:
+            logger.warning("run_simulation produced no result")
+            return RunResult(pd.DataFrame(), {}, seed, env, details=res.diagnostics)
+        res_dict: dict[str, Any] = res.payload or {}
     elif isinstance(res, Mapping):
         res_dict = dict(res)
     else:

--- a/tests/test_pipeline_analysis_helpers.py
+++ b/tests/test_pipeline_analysis_helpers.py
@@ -1,0 +1,105 @@
+import pandas as pd
+
+from trend_analysis.pipeline import (
+    AnalysisResult,
+    RiskStatsConfig,
+    _preprocess_stage,
+    _resolve_windows_stage,
+    _run_analysis,
+    _select_assets_stage,
+)
+
+
+def _sample_df() -> pd.DataFrame:
+    dates = pd.date_range("2020-01-31", periods=6, freq="M")
+    return pd.DataFrame(
+        {
+            "Date": dates,
+            "fund_a": [0.01, 0.0, 0.02, -0.01, 0.03, 0.0],
+            "fund_b": [0.0, 0.01, -0.02, 0.01, 0.0, 0.02],
+            "cash": [0.0] * 6,
+        }
+    )
+
+
+def test_preprocess_stage_returns_diagnostics_on_failure():
+    df = pd.DataFrame({"Date": [pd.NaT]})
+    result, diag = _preprocess_stage(df)
+    assert result is None
+    assert diag.stage == "preprocessing"
+    assert diag.status == "failed"
+
+
+def test_resolve_windows_stage_handles_empty_slices():
+    prep, _ = _preprocess_stage(_sample_df())
+    windows, diag = _resolve_windows_stage(
+        prep,
+        in_start="2010-01",
+        in_end="2010-02",
+        out_start="2010-03",
+        out_end="2010-04",
+    )
+    assert windows is None
+    assert diag.status == "failed"
+    assert diag.stage == "window_resolution"
+
+
+def test_select_assets_stage_success_path():
+    prep, _ = _preprocess_stage(_sample_df())
+    windows, _ = _resolve_windows_stage(
+        prep,
+        in_start="2020-01",
+        in_end="2020-03",
+        out_start="2020-04",
+        out_end="2020-06",
+    )
+    stats_cfg = RiskStatsConfig(metrics_to_run=["Sharpe"], risk_free=0.0)
+    selection, diag = _select_assets_stage(
+        prep,
+        windows,
+        selection_mode="all",
+        random_n=2,
+        custom_weights=None,
+        rank_kwargs=None,
+        manual_funds=None,
+        indices_list=None,
+        stats_cfg=stats_cfg,
+        seed=1,
+        risk_free_column=None,
+        allow_risk_free_fallback=True,
+    )
+    assert selection is not None
+    assert selection.fund_cols
+    assert diag.status == "success"
+
+
+def test_run_analysis_returns_result_object():
+    df = _sample_df()
+    result = _run_analysis(
+        df,
+        "2020-01",
+        "2020-03",
+        "2020-04",
+        "2020-06",
+        1.0,
+        0.0,
+    )
+    assert isinstance(result, AnalysisResult)
+    assert result.success
+    assert "out_sample_stats" in (result.payload or {})
+
+
+def test_run_analysis_reports_failure_reason():
+    df = pd.DataFrame({"Date": [pd.NaT]})
+    result = _run_analysis(
+        df,
+        "2020-01",
+        "2020-01",
+        "2020-02",
+        "2020-02",
+        1.0,
+        0.0,
+    )
+    assert isinstance(result, AnalysisResult)
+    assert not result.success
+    assert any(d.status == "failed" for d in result.diagnostics)


### PR DESCRIPTION
## Summary
- refactor `_run_analysis` into staged helpers that return structured `AnalysisResult` diagnostics
- update API and multi-period callers to consume the new result container
- add helper-focused pytest coverage and refresh the keepalive checklist

## Testing
- pytest tests/test_pipeline_analysis_helpers.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922da74407483319be61f55a9dadd3b)