### PR TITLE
chore(codex): bootstrap PR for issue #3737

### DIFF
--- a/docs/keepalive/status/PR3787_Status.md
+++ b/docs/keepalive/status/PR3787_Status.md
@@ -1,0 +1,19 @@
+# Keepalive Status — PR #3787
+
+> **Status:** In progress — fallback automation path for forked PRs still pending implementation.
+
+## Scope
+- [ ] Introduce a fallback path that uses GITHUB_TOKEN-only permissions for forked PRs and produces patch artifacts instead of pushing branches when a PAT is missing.
+- [ ] Preserve the current PAT-powered branch push/comment flow for trusted contexts where secrets are available.
+- [ ] Ensure autofix status reporting clearly indicates when a fallback mode was used and where maintainers can fetch patches.
+
+## Tasks
+- [ ] Detect forked contexts or missing ACTIONS_BOT_PAT and switch to a patch-only mode using GITHUB_TOKEN, skipping branch pushes.
+- [ ] Continue using the PAT path (checkout + push) when secrets are present while keeping step conditions mutual and explicit.
+- [ ] Emit clear summary/comment text that states whether autofix ran in PAT or fallback mode and links to the produced patch artifact when no push occurs.
+- [ ] Add coverage in the workflow tests (or mock runs) to confirm both paths succeed without secret access errors on forks.
+
+## Acceptance criteria
+- [ ] Autofix no longer fails on forked PRs due to missing ACTIONS_BOT_PAT and instead provides a downloadable patch artifact.
+- [ ] PAT-backed runs still push branches and comments as before, with logs showing which path executed.
+- [ ] Workflow documentation/comments note the fork-safe fallback behaviour for future maintenance.

--- a/keepalive_status.md
+++ b/keepalive_status.md
@@ -4,5 +4,6 @@ To avoid PR conflicts between concurrent keepalive runs, place each run's checkl
 
 Active/most recent entries:
 - Diagnostics scope: [docs/keepalive/status/diagnostics.md](docs/keepalive/status/diagnostics.md)
+- PR #3787 (fork-safe autofix fallback): [docs/keepalive/status/PR3787_Status.md](docs/keepalive/status/PR3787_Status.md)
 
 Add new bullet points here only to register additional keepalive runs; do not reuse or overwrite existing status files.


### PR DESCRIPTION
Why
The autofix loop exits early on forked pull requests because it hard-requires the ACTIONS_BOT_PAT secret before running, so contributors cannot receive patch artifacts or cosmetic fixes when repository secrets are unavailable.

Scope
Introduce a fallback path that uses GITHUB_TOKEN-only permissions for forked PRs and produces patch artifacts instead of pushing branches when a PAT is missing.
Preserve the current PAT-powered branch push/comment flow for trusted contexts where secrets are available.
Ensure autofix status reporting clearly indicates when a fallback mode was used and where maintainers can fetch patches.
Non-Goals
Changing formatter/tool versions or adding new linters.
Altering the max-attempts/keepalive logic that decides whether autofix should run.

Tasks

[ ] Detect forked contexts or missing ACTIONS_BOT_PAT and switch to a patch-only mode using GITHUB_TOKEN, skipping branch pushes.

[ ] Continue using the PAT path (checkout + push) when secrets are present while keeping step conditions mutual and explicit.

[ ] Emit clear summary/comment text that states whether autofix ran in PAT or fallback mode and links to the produced patch artifact when no push occurs.

[ ] Add coverage in the workflow tests (or mock runs) to confirm both paths succeed without secret access errors on forks.

Acceptance criteria
Autofix no longer fails on forked PRs due to missing ACTIONS_BOT_PAT and instead provides a downloadable patch artifact.
PAT-backed runs still push branches and comments as before, with logs showing which path executed.
Workflow documentation/comments note the fork-safe fallback behaviour for future maintenance.

Follow-up tracking
- Added a keepalive checklist entry at docs/keepalive/status/PR3787_Status.md to mirror the scope, tasks, and acceptance criteria for this PR.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692531c278bc8331884293794c0f2f8c)