### PR TITLE
Archive latest keepalive snapshots and add audit

### DIFF
--- a/archives/ROOT_FILE_INDEX.md
+++ b/archives/ROOT_FILE_INDEX.md
@@ -1,12 +1,15 @@
-# Root-level historical file index (2025-11-22)
+# Root-level historical file index (2025-11-25)
 
 Date-stamped moves consolidated under `archives/`:
 
 - `archives/reports/2025-11-22_Portfolio_Test_Results_Summary.md` – archived portfolio demo results summary (historical report).
 - `archives/reports/2025-11-22_TESTING_SUMMARY.md` – archived upload/portfolio testing ledger retained for reference.
 - `archives/docs/2025-11-22_Issues.txt` – historical parser input ledger for automation/backlog exploration.
-- `archives/generated/2025/2025-11-22_coverage-summary.md` – CI coverage snapshot (root `coverage-summary.md` symlinks here).
-- `archives/generated/2025/2025-11-22_gate-summary.md` – CI gate status snapshot (root `gate-summary.md` symlinks here).
-- `archives/generated/2025/2025-11-22_keepalive_status.md` – Keepalive monitoring snapshot (root `keepalive_status.md` symlinks here).
+- `archives/generated/2025/2025-11-22_coverage-summary.md` – CI coverage snapshot (replaced by the newer 2025-11-25 copy below).
+- `archives/generated/2025/2025-11-22_gate-summary.md` – CI gate status snapshot (superseded by the 2025-11-25 copy below).
+- `archives/generated/2025/2025-11-22_keepalive_status.md` – Keepalive monitoring snapshot (superseded by the 2025-11-25 copy below).
+- `archives/generated/2025/2025-11-25_coverage-summary.md` – Latest CI coverage snapshot captured from root `coverage-summary.md` (2025-11-25 sweep).
+- `archives/generated/2025/2025-11-25_gate-summary.md` – Latest CI gate status snapshot captured from root `gate-summary.md` (2025-11-25 sweep).
+- `archives/generated/2025/2025-11-25_keepalive_status.md` – Latest keepalive status index captured from root `keepalive_status.md` (2025-11-25 sweep).
 
 Use this index to trace legacy artefacts relocated from the repository root without losing backward references.

--- a/archives/generated/2025/2025-11-25_coverage-summary.md
+++ b/archives/generated/2025/2025-11-25_coverage-summary.md
@@ -1,0 +1,8 @@
+### Coverage Trend
+- Trend: 85.00% → 0.00% (-85.00 pts)
+- Current: 0.00%
+- Baseline: 85.00%
+- Change: -85.00 pts
+- Warning: drop exceeds 1.00-pt soft limit
+- Soft drop limit: 1.00 pts
+- Required minimum: 70.00%

--- a/archives/generated/2025/2025-11-25_gate-summary.md
+++ b/archives/generated/2025/2025-11-25_gate-summary.md
@@ -1,0 +1,17 @@
+---
+**Keepalive checklist snapshot (issue #3689)**
+
+#### Scope
+- [x] `analysis/tearsheet.py::render(results, out="reports/tearsheet.md")` with headline stats and run metadata.
+- [x] Plots for equity curve, rolling Sharpe/vol, drawdown, and turnover.
+- [x] CLI wiring: `python -m src.cli report --last-run`.
+- [x] Reference the new report from `archives/reports/2025-11-22_Portfolio_Test_Results_Summary.md`.
+
+#### Tasks
+- [x] Implement renderer and basic plots.
+- [x] Minimal CLI and example run command in README.
+- [x] Test that the file is written and includes expected sections.
+
+#### Acceptance criteria
+- [x] Running the CLI produces a tearsheet file with stats and plots using the latest `Results`.
+- [x] CI artifact (optional) or repo file present after a demo run.

--- a/archives/generated/2025/2025-11-25_keepalive_status.md
+++ b/archives/generated/2025/2025-11-25_keepalive_status.md
@@ -1,0 +1,11 @@
+# Keepalive status index
+
+To avoid PR conflicts between concurrent keepalive runs, place each run's checklist in its own file under `docs/keepalive/status/`.
+
+Active/most recent entries:
+- PR #3791 (CI caching and install consolidation): [docs/keepalive/status/PR3791_Status.md](docs/keepalive/status/PR3791_Status.md)
+- Diagnostics scope: [docs/keepalive/status/diagnostics.md](docs/keepalive/status/diagnostics.md)
+- PR #3787 (fork-safe autofix fallback): [docs/keepalive/status/PR3787_Status.md](docs/keepalive/status/PR3787_Status.md)
+- PR #3790 (fork-safe head checkout hardening): [docs/keepalive/status/PR3790_Status.md](docs/keepalive/status/PR3790_Status.md)
+
+Add new bullet points here only to register additional keepalive runs; do not reuse or overwrite existing status files.

--- a/docs/repository_housekeeping_audit_2025-11-25.md
+++ b/docs/repository_housekeeping_audit_2025-11-25.md
@@ -1,0 +1,18 @@
+# Repository organization audit – 2025-11-25
+
+## Scope
+- Re-ran the organizational prompt to validate whether existing checklists and archival rules remain satisfied without changing the repo structure.
+- Reviewed the root log/status files, keepalive status index, and notebook directory expectations to confirm housekeeping guidance is being followed.
+
+## Findings
+1. **Root snapshots needed archival copies.** The most recent `coverage-summary.md`, `gate-summary.md`, and `keepalive_status.md` files were sitting at the root without dated copies in `archives/generated/`. The housekeeper index (`archives/ROOT_FILE_INDEX.md`) still referenced only the 2025-11-22 sweep, so historical traceability lagged behind the latest keepalive round.
+2. **Keepalive status layout remains compliant.** Active checklists live under `docs/keepalive/status/` with no overlapping edits. The root `keepalive_status.md` still lists the current runs and directs writers to create per-run files to avoid PR conflicts.
+3. **Notebook maintenance checklist still holds.** `notebooks/README.md` lists a single maintained notebook and an archive path for explorations. The tree matches that contract (one live notebook, archives kept under `archives/notebooks/2025`). No stray experiment notebooks were found outside the archive.
+
+## Remediation performed
+- Captured dated archival copies of the current root snapshots under `archives/generated/2025/` and updated `archives/ROOT_FILE_INDEX.md` to record the new sweep for traceability.
+
+## Recommended follow-ups
+1. **Continue quarterly sweeps.** Run the `docs/repository_housekeeping.md` checklist during the first week of each quarter to decide whether the new 2025-11-25 snapshots should remain at the root or be converted into stubs that point directly to the archives.
+2. **Log future keepalive rounds promptly.** When new keepalive runs start, add a new file under `docs/keepalive/status/` and append it to `keepalive_status.md` so the status index stays current before the next archival sweep.
+3. **Track emerging diagnostic catalogues.** If the diagnostics keepalive spawns additional catalogues (like `docs/keepalive/status/diagnostics_catalogue.md`), decide whether they belong in the status index or an appendix to prevent the root index from drifting from the active files.


### PR DESCRIPTION
## Summary
- Add dated archival copies of the latest root coverage, gate, and keepalive status snapshots.
- Update the root historical index to record the new 2025-11-25 sweep.
- Document the 2025-11-25 repository organization audit and follow-up recommendations.

## Testing
- Not run (documentation-only changes).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692555176bcc8331a64b7d54ee352444)