### PR TITLE
Add Issues.txt entries for ranking robustness fixes

### DIFF
--- a/Issues.txt
+++ b/Issues.txt
@@ -1,0 +1,74 @@
+1) Guard widget imports and isolate notebook UI helpers
+Labels: agent:codex, enhancement, ui
+Why
+Notebook-specific widget imports in core modules break non-notebook environments and entangle UI scaffolding with ranking utilities.
+Tasks
+- Make ipywidgets imports lazy or optional so pure pipeline consumers can import ranking modules without notebook dependencies.
+- Split the notebook UI helpers into a dedicated module guarded by availability checks, keeping core computation import-safe.
+- Update any callers or docs to point at the optional UI module and verify the pipeline still runs headless.
+Acceptance criteria
+- Importing the ranking core modules succeeds when ipywidgets is absent, and UI helpers only load when explicitly requested.
+- Automated or manual smoke tests confirm the analytical pipeline works in a non-notebook environment.
+- Any remaining widget usage is isolated to clearly optional entrypoints.
+Implementation notes
+- Focus on src/trend_analysis/core/rank_selection.py and gui/app.py; keep computation paths free of hard widget dependencies.
+
+2) Add lifecycle controls for window metric cache
+Labels: agent:codex, enhancement, performance
+Why
+The rank selection module uses global dictionaries for window metric caching with no size limits, eviction, or reset hooks, risking stale data and memory growth in long-lived or concurrent runs.
+Tasks
+- Encapsulate the window metric cache behind a small helper with explicit reset/eviction and optional size bounds.
+- Ensure cache state can be scoped per run or cleared between analyses to avoid cross-request pollution.
+- Add lightweight tests covering cache hits, evictions, and reset behavior.
+Acceptance criteria
+- Ranking functions can reset or scope cache state, preventing stale metrics from influencing subsequent runs.
+- Cache size does not grow unbounded during repeated executions in tests.
+- New tests cover cache lifecycle behaviors.
+Implementation notes
+- Target the cache dictionaries and counters in src/trend_analysis/core/rank_selection.py; keep changes minimal to public APIs.
+
+3) Harden risk-free series detection and defaults
+Labels: agent:codex, bug, selection
+Why
+Risk-free column detection raises when a column is unspecified and fallback is disabled, and the fallback selects the lowest-volatility series without aligning to the analysis window, producing brittle or incorrect defaults.
+Tasks
+- Document and enable a safe default behavior when no risk-free column is supplied, with an explicit configuration flag.
+- Align fallback detection with the requested analysis window so volatility comparisons use the same slice as downstream metrics.
+- Add tests that cover missing columns, fallback paths, and window alignment to ensure deterministic selection.
+Acceptance criteria
+- rank_select_funds no longer hard-fails by default when the risk-free column is omitted but follows a documented fallback when enabled.
+- Fallback selection uses window-aligned data and produces deterministic results in tests.
+- Unit tests cover both explicit column selection and fallback scenarios.
+Implementation notes
+- Focus on _resolve_risk_free_column logic in src/trend_analysis/core/rank_selection.py; avoid altering metric definitions.
+
+4) Handle empty or all-NaN windows in single_period_run
+Labels: agent:codex, bug, testing
+Why
+single_period_run computes metrics on sliced windows without checking for empty or all-NaN data and swallows correlation errors, leading to silent NaNs and masking data-quality problems.
+Tasks
+- Add guards that detect empty or all-NaN window slices and emit a clear error or warning instead of propagating NaN metrics.
+- Tighten error handling around optional metrics (e.g., correlations) to log or raise informative exceptions instead of silent pass-through.
+- Expand tests to cover empty-window and all-NaN scenarios, asserting clear failure modes.
+Acceptance criteria
+- Running single_period_run on empty or all-NaN windows produces explicit diagnostics and avoids silent NaNs in outputs.
+- Correlation metric failures are surfaced with actionable messages.
+- New tests validate the guarded behaviors.
+Implementation notes
+- Changes live in src/trend_analysis/pipeline/single_period.py (or equivalent) and any correlation helpers it invokes; keep metric defaults intact.
+
+5) Surface empty selection outcomes in rank_select_funds
+Labels: agent:codex, bug, selection
+Why
+When all candidates are filtered out or scores are empty, rank_select_funds returns an empty selection silently, obscuring upstream data issues.
+Tasks
+- Detect empty score sets after filtering and emit a clear warning or error indicating why selection failed.
+- Optionally allow a configurable fallback behavior (e.g., return metadata explaining the failure) without altering normal successful flows.
+- Add tests that simulate fully filtered inputs and assert the new diagnostics.
+Acceptance criteria
+- Empty selections are accompanied by explicit diagnostics describing the filter condition that led to zero candidates.
+- Default successful paths remain unchanged, and tests cover both empty and non-empty cases.
+- Diagnostics are accessible to callers (e.g., via return metadata or logged warnings).
+Implementation notes
+- Implement checks near the sorting/selection branch in src/trend_analysis/core/rank_selection.py; avoid breaking existing selection outputs.


### PR DESCRIPTION
## Summary
- add backlog issues to address widget import isolation, cache lifecycle, and ranking fallbacks
- cover risk-free detection defaults, empty-window handling, and empty selection diagnostics

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692555fffeec83319f4005f6e70f6336)