### PR TITLE
Ensure issue invite flow posts issue comment

### DIFF
--- a/.github/workflows/reusable-agents-issue-bridge.yml
+++ b/.github/workflows/reusable-agents-issue-bridge.yml
@@ -247,7 +247,7 @@ jobs:
               if (hasInvite) {
                 mode = 'invite';
                 reason = 'issue-label-override';
-              } else if (hasBase && mode !== 'invite') {
+              } else if (hasBase) {
                 // Issue-triggered runs should stay in invite mode so the human post lands on the issue
                 mode = 'invite';
                 reason = 'issue-default-invite';


### PR DESCRIPTION
## Summary
- force issue-triggered bridge runs with agent labels to stay in invite mode even when inputs request create
- keep the invite comment posting on the issue so humans get the branch and instructions before opening the PR

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69281506eb0883318791ad795d971238)