### PR TITLE
Improve parsing of issue sections for PR summaries

### DIFF
--- a/.github/scripts/__tests__/issue_scope_parser.test.js
+++ b/.github/scripts/__tests__/issue_scope_parser.test.js
@@ -3,7 +3,10 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { extractScopeTasksAcceptanceSections } = require('../issue_scope_parser');
+const {
+  extractScopeTasksAcceptanceSections,
+  parseScopeTasksAcceptanceSections,
+} = require('../issue_scope_parser');
 
 test('extracts sections inside auto-status markers', () => {
   const issue = [
@@ -45,6 +48,27 @@ test('parses plain headings without markdown hashes', () => {
     result,
     ['#### Scope', '- summary', '', '#### Task List', '- [ ] alpha', '', '#### Acceptance Criteria', '- ok'].join('\n')
   );
+});
+
+test('parseScopeTasksAcceptanceSections preserves structured sections', () => {
+  const issue = [
+    '## Issue Scope',
+    '- overview line',
+    '',
+    '**Task List**',
+    '- [ ] do one',
+    '- [x] done two',
+    '',
+    'Acceptance criteria:',
+    '- ✅ verified',
+  ].join('\n');
+
+  const parsed = parseScopeTasksAcceptanceSections(issue);
+  assert.deepEqual(parsed, {
+    scope: '- overview line',
+    tasks: ['- [ ] do one', '- [x] done two'].join('\n'),
+    acceptance: '- ✅ verified',
+  });
 });
 
 test('returns empty string when no headings present', () => {

--- a/.github/workflows/agents-pr-meta.yml
+++ b/.github/workflows/agents-pr-meta.yml
@@ -1902,6 +1902,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const { extractIssueNumberFromPull } = require('./.github/scripts/agents_pr_meta_keepalive.js');
+            const { parseScopeTasksAcceptanceSections } = require('./.github/scripts/issue_scope_parser.js');
 
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -2138,9 +2139,13 @@ jobs:
             const ci = normalizeWhitespace(extractWithAliases(issueBody, ['CI readiness', 'Implementation notes', 'Technical notes']));
 
             core.info(`Final sections - Summary: ${summary ? 'OK' : 'EMPTY'}, Testing: ${testing ? 'OK' : 'EMPTY'}, CI: ${ci ? 'OK' : 'EMPTY'}`);
-            const scope = extractSection(issueBody, 'Scope') || '';
-            const tasks = extractSection(issueBody, 'Tasks') || '';
-            const acceptance = extractWithAliases(issueBody, ['Acceptance criteria', 'Success criteria', 'Definition of done']) || '';
+            const parsedSections = parseScopeTasksAcceptanceSections(issueBody);
+            const scope = parsedSections.scope || extractSection(issueBody, 'Scope') || '';
+            const tasks = parsedSections.tasks || extractSection(issueBody, 'Tasks') || '';
+            const acceptance =
+              parsedSections.acceptance
+              || extractWithAliases(issueBody, ['Acceptance criteria', 'Success criteria', 'Definition of done'])
+              || '';
 
             core.info(`Status block sections - Scope: ${scope ? 'OK' : 'EMPTY'}, Tasks: ${tasks ? 'OK' : 'EMPTY'}, Acceptance: ${acceptance ? 'OK' : 'EMPTY'}`);
             const preamble = buildPreamble({summary, testing, ci});
@@ -2458,9 +2463,13 @@ jobs:
 
             core.info(`Final sections - Summary: ${summary ? 'OK' : 'EMPTY'}, Testing: ${testing ? 'OK' : 'EMPTY'}, CI: ${ci ? 'OK' : 'EMPTY'}`);
 
-            const scope = extractSection(issueBody, 'Scope') || '';
-            const tasks = extractSection(issueBody, 'Tasks') || '';
-            const acceptance = extractWithAliases(issueBody, ['Acceptance criteria', 'Success criteria', 'Definition of done']) || '';
+            const parsedSections = parseScopeTasksAcceptanceSections(issueBody);
+            const scope = parsedSections.scope || extractSection(issueBody, 'Scope') || '';
+            const tasks = parsedSections.tasks || extractSection(issueBody, 'Tasks') || '';
+            const acceptance =
+              parsedSections.acceptance
+              || extractWithAliases(issueBody, ['Acceptance criteria', 'Success criteria', 'Definition of done'])
+              || '';
 
             core.info(`Status block sections - Scope: ${scope ? 'OK' : 'EMPTY'}, Tasks: ${tasks ? 'OK' : 'EMPTY'}, Acceptance: ${acceptance ? 'OK' : 'EMPTY'}`);
 


### PR DESCRIPTION
## Summary
- add structured parser to reuse issue scope, tasks, and acceptance sections
- update PR body sync workflow to pull scope/task/acceptance from tolerant parser
- extend parser tests to cover structured output helpers

## Testing
- node --test .github/scripts/__tests__/issue_scope_parser.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692911eee5e48331b38a4d1642f2e6ff)