### PR TITLE
chore: refresh PR3827 keepalive checklist

### DIFF
--- a/docs/keepalive/status/PR3827_Status.md
+++ b/docs/keepalive/status/PR3827_Status.md
@@ -4,11 +4,12 @@
 
 ## Progress updates
 - Round 1: Captured the PR scope, tasks, and acceptance criteria for keepalive tracking.
+- Round 2: Confirmed keepalive tracking remains active; awaiting implementation to satisfy tasks and acceptance criteria.
 
 ## Scope
-- [ ] Signal computation uses only window-scoped data, eliminating look-ahead bias in both in-sample and out-of-sample runs.
-- [ ] Tests cover both windows and assert failures when future data is present.
-- [ ] Rebalance outputs align strictly to window boundaries without forward-looking inputs.
+- [ ] Signal computation must use only window-scoped data, eliminating look-ahead bias in both in-sample and out-of-sample runs.
+- [ ] Tests must cover both windows and assert failures when future data is present.
+- [ ] Rebalance outputs must align strictly to window boundaries without forward-looking inputs.
 
 ## Tasks
 - [ ] Scope every signal calculation to the active analysis window before any reindexing so no future observations influence the period being scored.


### PR DESCRIPTION
## Summary
- update the PR #3827 keepalive status log with the latest round and clarified scope language
- retain open checklists for scope, tasks, and acceptance criteria so progress can be tracked

## Testing
- not run (documentation-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692913cca1508331962defc1daf7ad9d)