### PR TITLE
Fix: Revert issue intake trigger to known-good pattern

### DIFF
--- a/.github/workflows/agents-63-issue-intake.yml
+++ b/.github/workflows/agents-63-issue-intake.yml
@@ -105,8 +105,6 @@ jobs:
   normalize_inputs:
     if: >
       github.event_name != 'issues' ||
-      (github.event.action == 'labeled' && (startsWith(github.event.label.name, 'agent:') || startsWith(github.event.label.name, 'agents:'))) ||
-      (github.event.action == 'unlabeled' && (startsWith(github.event.label.name, 'agent:') || startsWith(github.event.label.name, 'agents:'))) ||
       contains(toJson(github.event.issue.labels.*.name), 'agent:') ||
       contains(toJson(github.event.issue.labels.*.name), 'agents:') ||
       (github.event.action == 'unlabeled' && (startsWith(github.event.label.name, 'agent:') || startsWith(github.event.label.name, 'agents:')))


### PR DESCRIPTION
Reverts the trigger logic to the version from commit 02bc289c which is known to work, while retaining support for the 'agents:' plural prefix. This fixes the regression introduced in PR #3865.

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Scope section missing from source issue.

#### Tasks
- [ ] Tasks section missing from source issue.

#### Acceptance criteria
- [ ] Acceptance criteria section missing from source issue.

**Head SHA:** adbb34c4a466077ee85067c5a61bd485db93bce7
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19778987063) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19778879482) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19778879610) |
| Gate | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19778879503) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19778879483) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19778879486) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19778879494) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19778879492) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19778879509) |
<!-- auto-status-summary:end -->