### PR TITLE
fix: exclude keepalive from agent label validation

### DIFF
--- a/.github/workflows/agents-63-issue-intake.yml
+++ b/.github/workflows/agents-63-issue-intake.yml
@@ -175,7 +175,8 @@ jobs:
               [
                 .issue.labels[]?.name
                 | select(test("^agents?:[A-Za-z0-9-]+$"))
-                | sub("^agents?:(?<key>[A-Za-z0-9-]+)$"; "\\(.key)")
+                | sub("^agents?:(?<key>[A-Za-z0-9-]+)$"; "\(.key)")
+                | select(. != "keepalive")
               ][0] // empty
             ' "$GITHUB_EVENT_PATH" 2>/dev/null || echo '')
             if [ -n "$event_agent" ]; then
@@ -1115,9 +1116,15 @@ jobs:
               .map(label => typeof label === 'string' ? label : (label.name || ''))
               .filter(Boolean)
               .map(name => name.toLowerCase());
+            // Control labels that should not be counted as agent assignments
+            const controlLabelSuffixes = ['keepalive'];
             const codexGuardLabels = ['agent:codex', 'agents:codex'];
             const agentLabels = labels
-              .filter(name => /^agents?:[a-z0-9-]+$/.test(name));
+              .filter(name => /^agents?:[a-z0-9-]+$/.test(name))
+              .filter(name => {
+                const suffix = name.replace(/^agents?:/, '');
+                return !controlLabelSuffixes.includes(suffix);
+              });
             if (agentLabels.length !== 1) {
               core.setFailed(`Expected exactly one agent:* or agents:* label but found ${agentLabels.length}: ${agentLabels.join(', ')}`);
               return;


### PR DESCRIPTION
## Summary

The `agents:keepalive` and `agent:keepalive` labels are **control labels** used for keepalive functionality, not agent assignments. The issue intake workflow was incorrectly counting them as agent assignment labels.

## Problem

When an issue has both `agent:codex` **and** `agents:keepalive` labels (like #3860), the workflow fails with:
```
Expected exactly one agent:* or agents:* label but found 2: agent:codex, agents:keepalive
```

## Solution

This fix excludes `keepalive` control labels from the agent label count in two places:

1. **`normalize_inputs` job** - jq filter that extracts `bridge_agent` from issue labels
2. **`bridge_preflight` job** - JavaScript validation that ensures exactly one agent label exists

## Testing

After merge, re-run the workflow on issue #3860 which has both `agent:codex` and `agents:keepalive` labels.

## Related

- Fixes processing for issues like #3860 that have both agent assignment and keepalive control labels

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] The risk-free fallback chooses the lowest-volatility numeric column with any non-null value, so sparse series can be selected and later propagate NaNs when aligned to the analysis windows.

#### Tasks
- [ ] Enforce minimum coverage within the requested window before considering a column eligible for fallback selection (e.g., threshold on non-null share or span).
- [ ] Align fallback volatility checks to the same window slice used downstream rather than the full dataset.
- [ ] Add tests that include sparse columns and confirm only sufficiently covered, window-aligned series are selected (or a clear diagnostic is emitted).

#### Acceptance criteria
- [ ] - Fallback risk-free selection ignores sparse or short series and uses window-scoped data for volatility comparison.
- [ ] - Omitted risk-free column scenarios produce deterministic, well-documented outcomes with no unexpected NaNs from missing coverage.
- [ ] - Tests cover explicit risk-free columns, eligible fallback selections, and rejection of sparse series with corresponding diagnostics.

**Head SHA:** d263c98ab3730e878bb0d6ce31ba3c085df7c0e0
**Latest Runs:** ❔ in progress — Agents PR meta manager
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/19780296598) |
<!-- auto-status-summary:end -->