### PR TITLE
Update timezone dtype guard for sample windows

### DIFF
--- a/src/trend_analysis/pipeline.py
+++ b/src/trend_analysis/pipeline.py
@@ -396,8 +396,9 @@ def _build_sample_windows(
     out_sdate = _resolve_bound(out_start, bound="start")
     out_edate = _resolve_bound(out_end, bound="end")
 
-    if pd.api.types.is_datetime64tz_dtype(preprocess.df[preprocess.date_col]):
-        tz = preprocess.df[preprocess.date_col].dt.tz
+    date_series = preprocess.df[preprocess.date_col]
+    if pd.DatetimeTZDtype.is_dtype(date_series.dtype):
+        tz = date_series.dt.tz
         in_sdate = in_sdate.tz_localize(tz)
         in_edate = in_edate.tz_localize(tz)
         out_sdate = out_sdate.tz_localize(tz)

--- a/tests/test_pipeline_run_analysis_helpers.py
+++ b/tests/test_pipeline_run_analysis_helpers.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pandas as pd
 import pytest
 
@@ -89,6 +91,48 @@ def test_build_sample_windows_handles_empty_slice() -> None:
 
     assert isinstance(window.diagnostic.reason_code, str)
     assert window.diagnostic.reason_code == PipelineReasonCode.SAMPLE_WINDOW_EMPTY.value
+
+
+def test_build_sample_windows_retains_timezone_metadata() -> None:
+    df = _make_simple_frame()
+    stats_cfg = RiskStatsConfig(metrics_to_run=["Return"], risk_free=0.0)
+    preprocess = _prepare_preprocess_stage(
+        df,
+        floor_vol=None,
+        warmup_periods=0,
+        missing_policy=None,
+        missing_limit=None,
+        stats_cfg=stats_cfg,
+        periods_per_year_override=None,
+        allow_risk_free_fallback=None,
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("error", (FutureWarning, DeprecationWarning))
+        window = _build_sample_windows(
+            preprocess,
+            in_start="2020-01-31",
+            in_end="2020-03-31",
+            out_start="2020-04-30",
+            out_end="2020-06-30",
+        )
+
+    assert isinstance(window, _WindowStage)
+    assert not caught
+
+    expected = preprocess.df.set_index(preprocess.date_col)
+    expected_in = expected.loc["2020-01-31":"2020-03-31"]
+    expected_out = expected.loc["2020-04-30":"2020-06-30"]
+
+    assert df["Date"].dt.tz is not None
+    assert window.in_start == pd.Timestamp("2020-01-31")
+    assert window.in_end == pd.Timestamp("2020-03-31")
+    assert window.out_start == pd.Timestamp("2020-04-30")
+    assert window.out_end == pd.Timestamp("2020-06-30")
+    assert window.in_df.index.tz == expected.index.tz
+    assert window.out_df.index.tz == expected.index.tz
+    pd.testing.assert_frame_equal(window.in_df, expected_in)
+    pd.testing.assert_frame_equal(window.out_df, expected_out)
 
 
 def test_select_universe_reports_missing_funds() -> None:


### PR DESCRIPTION
## Summary
- replace deprecated timezone dtype detection in `_build_sample_windows`
- add regression coverage for timezone-aware sample windows to ensure metadata is preserved and no deprecation warnings surface

## Testing
- pytest tests/test_pipeline_run_analysis_helpers.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b1bfc26ac83318103f08c863296ab)