### PR TITLE
Fix infinite cadence test coverage and format bootstrap file

### DIFF
--- a/agents/codex-3879.md
+++ b/agents/codex-3879.md
@@ -1,2 +1,3 @@
 <!-- bootstrap for codex on issue #3879 -->
 
+

--- a/tests/test_market_data_validation_additional.py
+++ b/tests/test_market_data_validation_additional.py
@@ -174,7 +174,7 @@ def test_classify_frequency_ignores_infinite_offsets(
 ) -> None:
     index = pd.date_range("2024-01-31", periods=5, freq="ME")
 
-    original = market_data._normalize_delta_days
+    original = market_data._normalise_delta_days
 
     def inject_and_clean(delta_days: pd.Series) -> pd.Series:
         polluted = delta_days.astype(float)
@@ -182,7 +182,7 @@ def test_classify_frequency_ignores_infinite_offsets(
         polluted.iloc[-1] = -float("inf")
         return original(polluted)
 
-    monkeypatch.setattr(market_data, "_normalize_delta_days", inject_and_clean)
+    monkeypatch.setattr(market_data, "_normalise_delta_days", inject_and_clean)
 
     info = market_data.classify_frequency(index)
 


### PR DESCRIPTION
## Summary
- add trailing blank line to codex-3879 bootstrap entry for consistency
- patch cadence classification test to monkeypatch the correct normalisation helper when injecting infinite offsets

## Testing
- pytest tests/test_market_data_validation_additional.py -k "infinite"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b7020697c8331901302edd2290837)