### PR TITLE
Fix cadence inf normalization path and tests

### DIFF
--- a/agents/codex-3879.md
+++ b/agents/codex-3879.md
@@ -1,2 +1,3 @@
 <!-- bootstrap for codex on issue #3879 -->
 
+

--- a/src/trend_analysis/io/market_data.py
+++ b/src/trend_analysis/io/market_data.py
@@ -47,11 +47,7 @@ _HUMAN_FREQUENCY_LABELS = {
 
 
 def _normalise_delta_days(delta_days: pd.Series) -> pd.Series:
-    if delta_days.empty:
-        return delta_days
-
-    cleaned = delta_days.replace([np.inf, -np.inf], np.nan)
-    return cleaned.dropna()
+    return _normalize_delta_days(delta_days)
 
 
 _DEFAULT_MISSING_POLICY = "drop"

--- a/tests/test_market_data_validation_additional.py
+++ b/tests/test_market_data_validation_additional.py
@@ -174,7 +174,7 @@ def test_classify_frequency_ignores_infinite_offsets(
 ) -> None:
     index = pd.date_range("2024-01-31", periods=5, freq="ME")
 
-    original = market_data._normalize_delta_days
+    original = market_data._normalise_delta_days
 
     def inject_and_clean(delta_days: pd.Series) -> pd.Series:
         polluted = delta_days.astype(float)
@@ -182,7 +182,7 @@ def test_classify_frequency_ignores_infinite_offsets(
         polluted.iloc[-1] = -float("inf")
         return original(polluted)
 
-    monkeypatch.setattr(market_data, "_normalize_delta_days", inject_and_clean)
+    monkeypatch.setattr(market_data, "_normalise_delta_days", inject_and_clean)
 
     info = market_data.classify_frequency(index)
 


### PR DESCRIPTION
## Summary
- align `_normalise_delta_days` with the shared normalization helper used by cadence validation
- fix cadence validation tests to inject infinite offsets through the correct helper
- add the missing trailing newline to the codex-3879 bootstrap file

## Testing
- pytest tests/test_market_data_validation_additional.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b7cea971c8331bc12be92630a5ab0)