### PR TITLE
fix(workflow): re-trigger GitHub workflow registration for agents-pr-meta

### DIFF
--- a/.github/workflows/agents-pr-meta.yml
+++ b/.github/workflows/agents-pr-meta.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow
+# Workflow: Manages PR body sections including status summary and keepalive dispatch
 name: Agents PR meta manager
 
 on:


### PR DESCRIPTION
## Problem

After the merge of PR #3888, the `agents-pr-meta.yml` workflow stopped working:

**Symptoms:**
1. Workflow name shows as `.github/workflows/agents-pr-meta.yml` instead of `Agents PR meta manager`
2. `pull_request` events do not trigger the workflow
3. `workflow_run` events do not trigger the workflow  
4. Spurious `push` events appear (despite no `push:` trigger in the file)
5. All runs after the merge fail with 'workflow file issue' error

**Evidence:**
```bash
# Before merge (working):
gh api '/repos/.../actions/runs/19790935766' | jq .name
# Output: "Agents PR meta manager"

# After merge (broken):
gh api '/repos/.../actions/runs/19791002472' | jq .name  
# Output: ".github/workflows/agents-pr-meta.yml"
```

## Investigation

- The workflow file passes `actionlint` validation
- The YAML is syntactically valid (verified with yq and Python yaml)
- The `Maint 52 Validate Workflows` check passes
- Other workflows with identical trigger configurations work fine
- This is the only workflow in the repo with corrupted registration

## Root Cause

GitHub's workflow parser appears to have encountered an internal error during the merge that corrupted the workflow's registration metadata. The exact trigger is unclear, but the corruption is reproducible and persistent.

## Fix

Adding a yaml-language-server schema directive comment to force GitHub to re-parse the workflow file from scratch when this PR is merged.

## Impact

- PR #3892 was created without automatic body population (manually fixed)
- Keepalive system is non-functional for new PRs
- Once merged, all new PRs should receive automatic body population again

## Validation

After merge, verify:
1. `gh api '/repos/{owner}/{repo}/actions/workflows' | jq '.workflows[] | select(.path | contains("pr-meta")) | .name'` shows `Agents PR meta manager`
2. New PRs trigger the workflow on `pull_request: opened` event
3. Gate completion triggers the workflow via `workflow_run`
