### PR TITLE
fix(workflow): force GitHub to re-register agents-pr-meta workflow

### DIFF
--- a/.github/workflows/agents-pr-meta.yml
+++ b/.github/workflows/agents-pr-meta.yml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow
 # Workflow: Manages PR body sections including status summary and keepalive dispatch
+# Force re-registration: 2025-11-30T02:15:00Z
 name: Agents PR meta manager
 
 on:


### PR DESCRIPTION
## Summary
Adding timestamp comment to force GitHub's workflow parser to re-read and properly register the workflow with its correct name ('Agents PR meta manager') instead of showing the file path.

## Problem
The workflow shows as `.github/workflows/agents-pr-meta.yml` in the API instead of `Agents PR meta manager`, causing:
- No triggers on `pull_request` events
- No automatic PR body updates
- Workflow runs failing with 'workflow file issue'

## Solution
Add a timestamp comment to force GitHub to re-parse the workflow file on merge.

## Testing
- Verify workflow name shows correctly in GitHub Actions API after merge
- Confirm PR events trigger the workflow