### PR TITLE
Add missing-data diagnostics to multi-period runs

### DIFF
--- a/src/trend_analysis/typing.py
+++ b/src/trend_analysis/typing.py
@@ -31,3 +31,6 @@ class MultiPeriodPeriodResult(TypedDict, total=False):
     transaction_cost: float
     cov_diag: CovarianceDiagonal
     cache_stats: StatsMapping
+    missing_policy_applied: bool
+    missing_policy: str | Mapping[str, str] | None
+    missing_policy_reason: str | None


### PR DESCRIPTION
## Summary
- flag each multi-period result with missing-data policy usage and reason
- log when user-supplied data runs without an explicit missing-data policy
- extend multi-period tests and typing contract for applied and skipped paths

## Testing
- python -m pytest tests/test_multi_period_engine_extended.py::test_run_marks_missing_policy_applied tests/test_multi_period_engine_extended.py::test_run_flags_missing_policy_skipped_for_user_data tests/test_trend_analysis_typing_contract.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d168c86b88331bec56a6e204938eb)