### PR TITLE
Add missing-data policy observability to multi-period engine

### DIFF
--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -706,8 +706,12 @@ def run(
         and missing_policy_cfg is None
         and missing_limit_cfg is None
     )
+    missing_policy_applied = not skip_missing_policy
 
     if skip_missing_policy:
+        logger.info(
+            "Skipping missing-data policy: user-supplied data without missing_policy/missing_limit"
+        )
         policy_spec: str | Mapping[str, str] | None = None
         cleaned = original_returns
         _missing_summary = None
@@ -831,6 +835,7 @@ def run(
                 pt.out_start,
                 pt.out_end,
             )
+            res_dict["missing_policy_applied"] = missing_policy_applied
 
             # (Experimental) attach covariance diag using cache/incremental path for diagnostics.
             # Keeps existing outputs stable; adds optional "cov_diag" key.
@@ -1183,6 +1188,7 @@ def run(
                         "score_frame": pd.DataFrame(),
                         "weight_engine_fallback": None,
                         "manager_changes": [],
+                        "missing_policy_applied": missing_policy_applied,
                     },
                 )
             )
@@ -1490,6 +1496,7 @@ def run(
         res_dict["manager_changes"] = events
         res_dict["turnover"] = period_turnover
         res_dict["transaction_cost"] = float(period_cost)
+        res_dict["missing_policy_applied"] = missing_policy_applied
         # Append this period's result (was incorrectly outside loop causing only last period kept)
         results.append(res_dict)
     # Update complete for this period; next loop will use prev_weights

--- a/src/trend_analysis/typing.py
+++ b/src/trend_analysis/typing.py
@@ -31,3 +31,4 @@ class MultiPeriodPeriodResult(TypedDict, total=False):
     transaction_cost: float
     cov_diag: CovarianceDiagonal
     cache_stats: StatsMapping
+    missing_policy_applied: bool

--- a/tests/test_multi_period_engine_missing_policy.py
+++ b/tests/test_multi_period_engine_missing_policy.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+import pandas as pd
+import pytest
+
+import trend_analysis.multi_period.engine as mp_engine
+
+
+@dataclass
+class DummyCfg:
+    multi_period: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "frequency": "M",
+            "in_sample_len": 1,
+            "out_sample_len": 1,
+            "start": "2020-01",
+            "end": "2020-02",
+        }
+    )
+    data: Dict[str, Any] = field(default_factory=lambda: {"csv_path": "unused.csv"})
+    portfolio: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "policy": "standard",
+            "selection_mode": "all",
+            "random_n": 2,
+            "custom_weights": None,
+            "rank": {},
+            "manual_list": None,
+            "indices_list": None,
+        }
+    )
+    vol_adjust: Dict[str, Any] = field(default_factory=lambda: {"target_vol": 1.0})
+    benchmarks: Dict[str, Any] = field(default_factory=dict)
+    run: Dict[str, Any] = field(default_factory=lambda: {"monthly_cost": 0.0})
+    performance: Dict[str, Any] = field(default_factory=lambda: {"enable_cache": False})
+    seed: int = 7
+
+    def model_dump(self) -> Dict[str, Any]:
+        return {
+            "multi_period": self.multi_period,
+            "portfolio": self.portfolio,
+            "vol_adjust": self.vol_adjust,
+        }
+
+
+def test_run_sets_flag_when_missing_policy_applied(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = DummyCfg()
+
+    raw_df = pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2020-01-31", "2020-02-29", "2020-03-31"]),
+            "FundA": [0.1, None, 0.3],
+        }
+    )
+
+    applied: dict[str, Any] = {}
+
+    def fake_loader(path: str, **kwargs: object) -> pd.DataFrame:
+        applied["loader_kwargs"] = kwargs
+        return raw_df
+
+    def fake_apply_policy(frame: pd.DataFrame, *, policy: object, limit: object):
+        applied["policy"] = policy
+        applied["limit"] = limit
+        return frame.fillna(0.0), {"policy": policy}
+
+    def fake_call_pipeline(*args: Any, **kwargs: Any):
+        return mp_engine.DiagnosticResult(value={"result": "ok"}, diagnostic=None)
+
+    monkeypatch.setattr(mp_engine, "load_csv", fake_loader)
+    monkeypatch.setattr(mp_engine, "apply_missing_policy", fake_apply_policy)
+    monkeypatch.setattr(mp_engine, "_call_pipeline_with_diag", fake_call_pipeline)
+
+    results = mp_engine.run(cfg, df=None)
+
+    assert applied["policy"] == "ffill"
+    assert applied["limit"] is None
+    assert all(result["missing_policy_applied"] is True for result in results)
+
+
+def test_run_logs_and_flags_when_missing_policy_skipped(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    cfg = DummyCfg()
+
+    user_df = pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2020-01-31", "2020-02-29"]),
+            "FundA": [0.1, 0.2],
+        }
+    )
+
+    def forbid_apply(*args: object, **kwargs: object):  # pragma: no cover - sanity guard
+        raise AssertionError("apply_missing_policy should not be invoked when skipping")
+
+    def fake_call_pipeline(*args: Any, **kwargs: Any):
+        return mp_engine.DiagnosticResult(value={"result": "ok"}, diagnostic=None)
+
+    monkeypatch.setattr(mp_engine, "apply_missing_policy", forbid_apply)
+    monkeypatch.setattr(mp_engine, "_call_pipeline_with_diag", fake_call_pipeline)
+
+    with caplog.at_level("INFO"):
+        results = mp_engine.run(cfg, df=user_df)
+
+    assert any("Skipping missing-data policy" in rec.message for rec in caplog.records)
+    assert all(result["missing_policy_applied"] is False for result in results)

--- a/tests/test_trend_analysis_typing_contract.py
+++ b/tests/test_trend_analysis_typing_contract.py
@@ -31,6 +31,7 @@ def test_multi_period_period_result_schema_matches_expected_contract() -> None:
     assert MultiPeriodPeriodResult.__total__ is False
 
     assert hints["period"] == tuple[str, str, str, str]
+    assert hints["missing_policy_applied"] is bool
 
     def assert_mapping_union(value: object) -> None:
         typed_value = cast(Any, value)


### PR DESCRIPTION
## Summary
- record whether missing-data policy ran on each multi-period result and log when user-provided data skips policy enforcement
- update the multi-period result typing contract to include the new missing-data policy flag
- cover applied and skipped missing-data policy branches with targeted multi-period engine tests

## Testing
- pytest tests/test_multi_period_engine_missing_policy.py tests/test_trend_analysis_typing_contract.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d171066a48331a772b4e6bf4d8b23)