### PR TITLE
Add CLI helper tests and harden ruleset default resolution

### DIFF
--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from trend_analysis import cli
+
+
+def test_extract_cache_stats_returns_last_valid_snapshot():
+    payload = {
+        "early": {"entries": 1, "hits": 0, "misses": 1, "incremental_updates": 0},
+        "nested": [
+            {"entries": 2, "hits": 1, "misses": 1, "incremental_updates": 0.0},
+            "ignore",
+            {"entries": 3, "hits": 2, "misses": 0, "incremental_updates": 1},
+        ],
+        "frame": pd.DataFrame({"A": [1, 2]}),
+        "array": np.array([1, 2, 3]),
+    }
+
+    stats = cli._extract_cache_stats(payload)
+
+    assert stats == {"entries": 3, "hits": 2, "misses": 0, "incremental_updates": 1}
+
+
+def test_extract_cache_stats_returns_none_when_absent():
+    payload = {"no_stats": [{"entries": 1, "hits": 1}], "series": pd.Series([1.0])}
+
+    assert cli._extract_cache_stats(payload) is None
+
+
+def test_apply_universe_mask_filters_and_preserves_dates():
+    df = pd.DataFrame(
+        {
+            "Date": ["2020-01-01", "2020-01-02"],
+            "A": [1.0, 2.0],
+            "B": [3.0, 4.0],
+        }
+    )
+    mask = pd.DataFrame(
+        {"A": [True, False], "B": [False, True]},
+        index=pd.to_datetime(["2020-01-01", "2020-01-02"]),
+    )
+
+    result = cli._apply_universe_mask(df, mask, date_column="date")
+
+    assert list(result.columns) == ["Date", "A", "B"]
+    assert pd.to_datetime(result["Date"]).tolist() == list(mask.index)
+    assert np.isnan(result.loc[0, "B"]) and np.isnan(result.loc[1, "A"])
+    assert result.loc[0, "A"] == 1.0 and result.loc[1, "B"] == 4.0
+
+
+def test_apply_universe_mask_raises_for_missing_members():
+    df = pd.DataFrame({"date": ["2020-01-01"], "A": [1.0]})
+    mask = pd.DataFrame({"Missing": [True]}, index=pd.to_datetime(["2020-01-01"]))
+
+    with pytest.raises(KeyError):
+        cli._apply_universe_mask(df, mask, date_column="date")
+
+
+def test_apply_universe_mask_short_circuits_on_empty_mask():
+    df = pd.DataFrame({"date": ["2020-01-01"], "A": [1.0]})
+    mask = pd.DataFrame()
+
+    result = cli._apply_universe_mask(df, mask, date_column="date")
+
+    assert result is df

--- a/tools/enforce_gate_branch_protection.py
+++ b/tools/enforce_gate_branch_protection.py
@@ -209,6 +209,28 @@ def _state_from_branch_payload(payload: Mapping[str, Any]) -> StatusCheckState:
     return _state_from_status_payload(status_checks, default_strict=None)
 
 
+def _resolve_default_branch(
+    session: requests.Session, repo: str, *, api_root: str = DEFAULT_API_ROOT
+) -> str | None:
+    """Return the repository's default branch when available."""
+
+    response = _call_with_rate_limit_retry(
+        "fetching repository metadata for default branch",
+        lambda: session.get(f"{api_root}/repos/{repo}", timeout=30),
+    )
+    if response.status_code >= 400:
+        return None
+
+    payload = response.json()
+    if not isinstance(payload, Mapping):
+        return None
+
+    default_branch = payload.get("default_branch")
+    if isinstance(default_branch, str) and default_branch:
+        return default_branch
+    return None
+
+
 def _fetch_ruleset_status_checks(
     session: requests.Session,
     repo: str,
@@ -247,12 +269,18 @@ def _fetch_ruleset_status_checks(
         # Check if this ruleset applies to the branch
         conditions = ruleset.get("conditions", {})
         ref_name = conditions.get("ref_name", {})
-        includes = ref_name.get("include", [])
-        excludes = ref_name.get("exclude", [])
+        includes = ref_name.get("include") or ["refs/heads/*"]
+        excludes = ref_name.get("exclude") or []
 
         branch_ref = branch if branch.startswith("refs/") else f"refs/heads/{branch}"
 
-        default_branch = os.getenv("DEFAULT_BRANCH", "main")
+        default_branch = os.getenv("DEFAULT_BRANCH")
+        if default_branch is None and any(
+            pattern == "~DEFAULT_BRANCH" for pattern in includes + excludes
+        ):
+            default_branch = _resolve_default_branch(session, repo, api_root=api_root)
+        if default_branch is None:
+            default_branch = "main"
         default_ref = (
             default_branch
             if default_branch.startswith("refs/")


### PR DESCRIPTION
## Summary
- add tests covering CLI cache extraction and universe masking helpers
- resolve ruleset matching using repository default branch and sensible ref filters
- extend ruleset tests for default-branch resolution fallback paths

## Testing
- pytest tests/tools/test_enforce_gate_branch_protection.py::test_ruleset_fetch_resolves_repo_default_when_env_missing tests/tools/test_enforce_gate_branch_protection.py::test_ruleset_fetch_ignores_non_default_branch_after_repo_lookup tests/test_cli_helpers.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930a8e61f3c83318e10f34f2cb1ca1c)