### PR TITLE
Add coverage for multi-period loaders and tidy walk forward tests

### DIFF
--- a/tests/test_walk_forward_helpers_additional.py
+++ b/tests/test_walk_forward_helpers_additional.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -81,7 +80,7 @@ def test_compute_turnover_handles_union_of_indices() -> None:
     assert turnover == pytest.approx(1.0)
 
 
-def test_evaluate_parameter_grid_builds_records_and_summary(tmp_path: Path) -> None:
+def test_evaluate_parameter_grid_builds_records_and_summary() -> None:
     returns = pd.DataFrame(
         {
             "a": [0.01, -0.02, 0.03, 0.04],


### PR DESCRIPTION
## Summary
- expand multi-period loader tests to cover nan fallback behaviour, missing files, relative paths, membership defaults, and benchmark validation
- remove unused fixture from walk-forward helper test to address review feedback

## Testing
- pytest tests/test_multi_period_loaders.py tests/test_walk_forward_helpers_additional.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931061ece6c833187e1e68875ca9663)