### PR TITLE
Add tests to expand time_utils coverage

### DIFF
--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -115,3 +115,61 @@ def test_align_calendar_defaults_to_simple_calendar_when_unknown():
     alignment = result.attrs["calendar_alignment"]
     assert alignment["calendar"] == "simple"
     assert alignment["holiday_rows_dropped"] == 1
+
+
+def test_align_calendar_missing_column_raises_key_error():
+    df = pd.DataFrame({"wrong": [pd.Timestamp("2023-01-01")]})
+
+    with pytest.raises(KeyError, match="DataFrame must contain a 'Date' column"):
+        align_calendar(df)
+
+
+def test_align_calendar_all_invalid_dates_raise_value_error():
+    df = pd.DataFrame({"Date": ["not-a-date", "also-bad"]})
+
+    with pytest.raises(ValueError, match="Column 'Date' contains no valid timestamps"):
+        align_calendar(df)
+
+
+def test_align_calendar_weekly_frequency_retains_weekend_rows():
+    df = pd.DataFrame(
+        {
+            "Date": [
+                dt.datetime(2023, 7, 8),  # Saturday
+                dt.datetime(2023, 7, 9),  # Sunday
+                dt.datetime(2023, 7, 10),
+            ],
+            "value": [1, 2, 3],
+        }
+    )
+
+    result = align_calendar(df, frequency="W")
+
+    assert result["Date"].dt.normalize().tolist() == [pd.Timestamp("2023-07-08")]
+    alignment = result.attrs["calendar_alignment"]
+    assert alignment["weekend_rows_dropped"] == 0
+    assert alignment["target_frequency"] == "W-FRI"
+
+
+def test_align_calendar_holiday_overrides_are_range_filtered():
+    df = pd.DataFrame(
+        {
+            "Date": [dt.datetime(2023, 7, 3), dt.datetime(2023, 7, 6)],
+            "value": [10, 20],
+        }
+    )
+
+    holidays = [
+        pd.Timestamp("2022-12-25"),
+        pd.Timestamp("2023-07-04"),
+        pd.Timestamp("2024-01-01"),
+    ]
+
+    result = align_calendar(df, frequency="B", holidays=holidays)
+
+    assert result["Date"].dt.normalize().tolist() == [
+        pd.Timestamp("2023-07-03"),
+        pd.Timestamp("2023-07-05"),
+        pd.Timestamp("2023-07-06"),
+    ]
+    assert result.attrs["calendar_alignment"]["holiday_rows_dropped"] == 0


### PR DESCRIPTION
## Summary
- add coverage for alignment edge cases including missing date columns and invalid timestamps
- verify weekly frequency handling and holiday override filtering in align_calendar

## Testing
- pytest tests/test_time_utils.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931c9449e848331bd9c4425a4a3a3f4)