### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/tests/test_import_sanity.py
+++ b/tests/test_import_sanity.py
@@ -49,11 +49,9 @@ def test_src_only_import_rejects_legacy_modules(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     src_dir = repo_root / "src"
 
+    # Use isolated environment to avoid site-packages pollution from editable installs
     env = os.environ.copy()
-    pythonpath = env.get("PYTHONPATH")
-    env["PYTHONPATH"] = (
-        str(src_dir) if not pythonpath else os.pathsep.join((str(src_dir), pythonpath))
-    )
+    env["PYTHONPATH"] = str(src_dir)
 
     script = textwrap.dedent(
         f"""
@@ -75,8 +73,9 @@ def test_src_only_import_rejects_legacy_modules(tmp_path: Path) -> None:
         """
     )
 
+    # Use -S (no site-packages) to prevent editable installs from leaking repo root
     subprocess.run(
-        [sys.executable, "-c", script],
+        [sys.executable, "-S", "-c", script],
         cwd=tmp_path,
         env=env,
         check=True,


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 2 version updates:
  - ruff: ==0.14.9 -> >=0.14.10
  - coverage: ==7.13.0 -> >=7.13.1

Run with --apply to update pyproject.toml
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** [`.github/workflows/autofix-versions.env`](https://github.com/stranske/Workflows/blob/main/.github/workflows/autofix-versions.env)