### PR TITLE
chore(codex): bootstrap PR for issue #4130

### DIFF
--- a/agents/codex-4130.md
+++ b/agents/codex-4130.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #4130 -->


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #4130

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The `max_weight` constraint in `compute_constrained_weights()` is applied AFTER volatility scaling, but the constraint logic assumes weights sum to 1.0. When vol targeting scales up low-volatility assets, individual weights can exceed 1.0 (e.g., 2.0 per asset), causing the constraint to fail with `ConstraintViolation: max_weight too small for number of assets`. The pipeline then falls back to base weights, completely ignoring the max_weight constraint.

#### Tasks
- [ ] Identify correct ordering of constraint application vs vol scaling in `src/trend_analysis/risk.py`
- [ ] Apply max_weight constraint to normalized weights (sum=1.0) before vol scaling
- [ ] Ensure constraint still enforces intended behavior after scaling
- [ ] Add test case that verifies max_weight works with vol_adjust enabled
- [ ] Update settings wiring test for max_weight to use vol_adjust (currently disabled as workaround)

#### Acceptance criteria
- [ ] `max_weight=0.35` with `vol_adjust_enabled=True` produces weights capped at 35%
- [ ] No `ConstraintViolation` exceptions when both settings are enabled
- [ ] Settings effectiveness test for max_weight passes without disabling vol_adjust
- [ ] Unit tests verify constraint + scaling interaction

<!-- auto-status-summary:end -->