### PR TITLE
fix: add merge=ours strategy for pr_body.md to prevent conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,6 @@ ci/autofix/history.json merge=ours linguist-generated
 # (Git's built-in 'ours' strategy works when invoked via -s ours for a whole merge, but for a path-specific
 #  merge driver we map to a no-op driver. If not configured, this entry will be ignored; alternatively,
 #  we can simply rely on the file being removed so future merges skip it.)
+# Prevent merge conflicts on PR-specific files
+pr_body.md merge=ours
+


### PR DESCRIPTION
## Problem

`pr_body.md` causes merge conflicts on virtually every PR because:

1. Each PR modifies `pr_body.md` with issue-specific content (tasks, acceptance criteria)
2. When PR A merges to main, main gets PR A's content
3. All other open PRs (with different issue-specific content) immediately conflict

## Solution

Add `.gitattributes` rule: `pr_body.md merge=ours`

This tells Git to always keep the current branch's version during merges, avoiding conflicts entirely.

**Note:** Same fix applied to Portable-Alpha-Extension-Model in PR #955.

<!-- pr-preamble:start -->
> **Source:** Issue #955

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

#### Tasks
- [ ] Tasks section missing from source issue.

#### Acceptance criteria
- [ ] Acceptance criteria section missing from source issue.

**Head SHA:** 00cac3d2c8d4ab457b111e4c126d154ad6a0c3df
**Latest Runs:** ⏳ queued — Gate
**Required:** gate: ⏳ queued

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/20677210113) |
| Autofix | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/20677210124) |
| Copilot code review | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/20677210263) |
| Gate | ⏳ queued | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/20677210123) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/20677210085) |
| PR 11 - Minimal invariant CI | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/20677210090) |
| PR 12 - Fund selector Playwright smoke | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/20677210084) |
<!-- auto-status-summary:end -->