### PR TITLE
fix(ci): validate LLM dependency pins

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -51,6 +51,29 @@ jobs:
       enable-soft-gate: true
     secrets: inherit
 
+  llm-deps:
+    name: LLM Dependency Compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies (LLM + dev)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,llm]"
+
+      - name: Validate LLM dependency compatibility
+        run: |
+          python scripts/validate_llm_deps.py
+          pytest -q tests/test_llm_dependency_compatibility.py
+
   config-coverage:
     name: Config Coverage Check
     runs-on: ubuntu-latest
@@ -80,7 +103,7 @@ jobs:
 
   summary:
     name: gate-summary
-    needs: [python-ci, config-coverage]
+    needs: [python-ci, llm-deps, config-coverage]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions:
@@ -102,11 +125,13 @@ jobs:
         id: summarize
         env:
           PYTHON_RESULT: ${{ needs.python-ci.result || 'skipped' }}
+          LLM_DEPS_RESULT: ${{ needs.llm-deps.result || 'skipped' }}
           CONFIG_COV_RESULT: ${{ needs.config-coverage.result || 'skipped' }}
         run: |
           set -euo pipefail
 
           python_result="${PYTHON_RESULT:-skipped}"
+          llm_deps_result="${LLM_DEPS_RESULT:-skipped}"
           config_cov_result="${CONFIG_COV_RESULT:-skipped}"
           state="success"
           description="All checks passed"
@@ -130,6 +155,28 @@ jobs:
               description="Python CI status unknown"
               ;;
           esac
+
+          # Check LLM dependency validation
+          if [ "$state" = "success" ]; then
+            case "$llm_deps_result" in
+              success)
+                ;;
+              failure)
+                state="failure"
+                description="LLM dependency compatibility check failed"
+                ;;
+              cancelled)
+                state="error"
+                description="LLM dependency compatibility check was cancelled"
+                ;;
+              skipped)
+                ;;
+              *)
+                state="pending"
+                description="LLM dependency compatibility status unknown"
+                ;;
+            esac
+          fi
 
           # Check Config Coverage
           if [ "$state" = "success" ]; then


### PR DESCRIPTION
Fix validate_llm_deps.py to match pyproject llm pins and enforce via Gate CI job (installing .[dev,llm] and running validate_llm_deps.py + tests/test_llm_dependency_compatibility.py).