### PR TITLE
Codex bootstrap for #4501

### DIFF
--- a/agents/codex-4501.md
+++ b/agents/codex-4501.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #4501 -->

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -1247,8 +1247,9 @@ def _build_explain_artifact_payload(
     metric_count: int,
     trace_url: str | None,
     claim_issues: Iterable[ResultClaimIssue],
+    questions: str | None = None,
 ) -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "run_id": run_id,
         "created_at": created_at.isoformat(),
         "text": text,
@@ -1256,6 +1257,9 @@ def _build_explain_artifact_payload(
         "trace_url": trace_url,
         "claim_issues": [serialize_claim_issue(issue) for issue in claim_issues],
     }
+    if questions is not None:
+        payload["questions"] = questions
+    return payload
 
 
 def _finalize_explanation_text(
@@ -1687,6 +1691,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                         metric_count=0,
                         trace_url=None,
                         claim_issues=[],
+                        questions=questions,
                     )
                     _write_explain_artifacts(
                         output=Path(args.output),
@@ -1728,6 +1733,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     metric_count=len(compacted_entries),
                     trace_url=trace_url,
                     claim_issues=claim_issues,
+                    questions=questions,
                 )
                 _write_explain_artifacts(
                     output=Path(args.output),

--- a/src/trend_analysis/llm/result_metrics.py
+++ b/src/trend_analysis/llm/result_metrics.py
@@ -388,14 +388,20 @@ def _diagnostics_to_mapping(diagnostics: Any) -> dict[str, Any]:
 
 def _extract_turnover_series_entries(result: Mapping[str, Any]) -> list[MetricEntry]:
     turnover_obj = result.get("turnover")
+    details = result.get("details")
+    if turnover_obj is None and isinstance(details, Mapping):
+        turnover_obj = details.get("turnover")
+    turnover_source = "direct" if turnover_obj is not None else "diagnostics"
     if turnover_obj is None:
-        details = result.get("details")
-        if isinstance(details, Mapping):
-            turnover_obj = details.get("turnover")
+        turnover_obj = _turnover_from_diagnostics(result.get(_RISK_DIAGNOSTICS_SECTION))
+        if turnover_obj is None and isinstance(details, Mapping):
+            turnover_obj = _turnover_from_diagnostics(details.get(_RISK_DIAGNOSTICS_SECTION))
     series = _coerce_series(turnover_obj)
     if series is None or series.empty:
-        entry = _make_entry("turnover.value", turnover_obj, _TURNOVER_SCALAR_SOURCE)
-        return [entry] if entry is not None else []
+        if turnover_source == "direct":
+            entry = _make_entry("turnover.value", turnover_obj, _TURNOVER_SCALAR_SOURCE)
+            return [entry] if entry is not None else []
+        return []
     series = series.dropna()
     if series.empty:
         return []
@@ -405,6 +411,13 @@ def _extract_turnover_series_entries(result: Mapping[str, Any]) -> list[MetricEn
         MetricEntry(path="turnover.latest", value=latest, source=_TURNOVER_SUMMARY_SOURCE),
         MetricEntry(path="turnover.mean", value=mean, source=_TURNOVER_SUMMARY_SOURCE),
     ]
+
+
+def _turnover_from_diagnostics(diagnostics: Any) -> Any:
+    if diagnostics is None:
+        return None
+    diag_map = _diagnostics_to_mapping(diagnostics)
+    return diag_map.get("turnover")
 
 
 def _coerce_series(value: Any) -> pd.Series | None:

--- a/src/trend_analysis/llm/result_metrics.py
+++ b/src/trend_analysis/llm/result_metrics.py
@@ -398,10 +398,8 @@ def _extract_turnover_series_entries(result: Mapping[str, Any]) -> list[MetricEn
             turnover_obj = _turnover_from_diagnostics(details.get(_RISK_DIAGNOSTICS_SECTION))
     series = _coerce_series(turnover_obj)
     if series is None or series.empty:
-        if turnover_source == "direct":
-            entry = _make_entry("turnover.value", turnover_obj, _TURNOVER_SCALAR_SOURCE)
-            return [entry] if entry is not None else []
-        return []
+        entry = _make_entry("turnover.value", turnover_obj, _TURNOVER_SCALAR_SOURCE)
+        return [entry] if entry is not None else []
     series = series.dropna()
     if series.empty:
         return []
@@ -417,7 +415,10 @@ def _turnover_from_diagnostics(diagnostics: Any) -> Any:
     if diagnostics is None:
         return None
     diag_map = _diagnostics_to_mapping(diagnostics)
-    return diag_map.get("turnover")
+    turnover = diag_map.get("turnover")
+    if turnover is not None:
+        return turnover
+    return diag_map.get("turnover_value")
 
 
 def _coerce_series(value: Any) -> pd.Series | None:

--- a/src/trend_analysis/llm/result_metrics.py
+++ b/src/trend_analysis/llm/result_metrics.py
@@ -391,7 +391,6 @@ def _extract_turnover_series_entries(result: Mapping[str, Any]) -> list[MetricEn
     details = result.get("details")
     if turnover_obj is None and isinstance(details, Mapping):
         turnover_obj = details.get("turnover")
-    turnover_source = "direct" if turnover_obj is not None else "diagnostics"
     if turnover_obj is None:
         turnover_obj = _turnover_from_diagnostics(result.get(_RISK_DIAGNOSTICS_SECTION))
         if turnover_obj is None and isinstance(details, Mapping):

--- a/streamlit_app/components/explain_results.py
+++ b/streamlit_app/components/explain_results.py
@@ -198,6 +198,9 @@ def render_explain_results(
         key=question_key,
         help="Leave blank to use the default summary prompt.",
     )
+    questions_text = st.session_state.get(question_key)
+    if not questions_text:
+        questions_text = DEFAULT_QUESTION
 
     button_key = hashlib.sha256(run_key.encode("utf-8")).hexdigest()[:12]
     clicked = st.button("Explain Results", key=f"btn_explain_results_{button_key}")
@@ -240,6 +243,7 @@ def render_explain_results(
         "text": cached.text,
         "metric_count": cached.metric_count,
         "trace_url": cached.trace_url,
+        "questions": questions_text,
         "claim_issues": [serialize_claim_issue(issue) for issue in cached.claim_issues],
     }
     columns = st.columns(2)

--- a/tests/app/test_explain_results_component.py
+++ b/tests/app/test_explain_results_component.py
@@ -207,6 +207,7 @@ def test_render_explain_results_downloads_include_json_payload(explain_module) -
     assert payload["trace_url"] == "trace://example"
     assert payload["metric_count"] == 2
     assert payload["claim_issues"][0]["kind"] == "missing_citation"
+    assert payload["questions"] == explain_module.DEFAULT_QUESTION
 
 
 def test_render_explain_results_downloads_include_text(explain_module) -> None:

--- a/tests/test_explain_artifacts.py
+++ b/tests/test_explain_artifacts.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from trend.cli import (
     _build_explain_artifact_payload,
     _finalize_explanation_text,
+    _infer_explain_run_id,
     _resolve_explain_output_paths,
     _write_explain_artifacts,
 )
@@ -52,6 +53,23 @@ def test_resolve_explain_output_paths_missing_directory(tmp_path) -> None:
 
     assert txt_path == out_dir / "explanation_run-42.txt"
     assert json_path == out_dir / "explanation_run-42.json"
+
+
+def test_infer_explain_run_id_prefers_details(tmp_path) -> None:
+    details_path = tmp_path / "details_unknown.json"
+    details = {"metadata": {"reporting": {"run_id": "run-007"}}}
+
+    run_id = _infer_explain_run_id(details_path, None, details)
+
+    assert run_id == "run-007"
+
+
+def test_infer_explain_run_id_falls_back_to_filename(tmp_path) -> None:
+    details_path = tmp_path / "details_run-42.json"
+
+    run_id = _infer_explain_run_id(details_path, None, None)
+
+    assert run_id == "run-42"
 
 
 def test_build_explain_artifact_payload_serializes_claims() -> None:

--- a/tests/test_explain_artifacts.py
+++ b/tests/test_explain_artifacts.py
@@ -86,12 +86,14 @@ def test_build_explain_artifact_payload_serializes_claims() -> None:
         metric_count=5,
         trace_url="trace://example",
         claim_issues=[issue],
+        questions="- Summarize results.",
     )
 
     assert payload["run_id"] == "run-123"
     assert payload["metric_count"] == 5
     assert payload["trace_url"] == "trace://example"
     assert payload["claim_issues"] == [serialize_claim_issue(issue)]
+    assert payload["questions"] == "- Summarize results."
 
 
 def test_write_explain_artifacts_creates_files(tmp_path) -> None:
@@ -103,6 +105,7 @@ def test_write_explain_artifacts_creates_files(tmp_path) -> None:
         metric_count=3,
         trace_url="trace://unit-test",
         claim_issues=[],
+        questions="- Summarize results.",
     )
 
     txt_path, json_path = _write_explain_artifacts(
@@ -120,6 +123,7 @@ def test_write_explain_artifacts_creates_files(tmp_path) -> None:
     assert json_payload["metric_count"] == 3
     assert json_payload["trace_url"] == "trace://unit-test"
     assert json_payload["claim_issues"] == []
+    assert json_payload["questions"] == "- Summarize results."
 
 
 def test_finalize_explanation_text_adds_discrepancy_log_and_disclaimer() -> None:

--- a/tests/test_result_feedback.py
+++ b/tests/test_result_feedback.py
@@ -72,3 +72,25 @@ def test_build_deterministic_feedback_respects_env_thresholds(
     assert "high turnover" in lower
     assert "high concentration" in lower
     assert "large drawdown" in lower
+
+
+def test_missing_sections_respect_multi_period_expectation() -> None:
+    details_with_periods = {
+        "period_count": 2,
+        "out_user_stats": {"max_drawdown": -0.05},
+        "out_sample_scaled": {"foo": 1},
+    }
+    entries_with_periods = extract_metric_catalog(details_with_periods)
+    feedback_with_periods = build_deterministic_feedback(details_with_periods, entries_with_periods)
+
+    assert "missing result sections" in feedback_with_periods.lower()
+    assert "period_results" in feedback_with_periods
+
+    details_no_periods = {
+        "out_user_stats": {"max_drawdown": -0.05},
+        "out_sample_scaled": {"foo": 1},
+    }
+    entries_no_periods = extract_metric_catalog(details_no_periods)
+    feedback_no_periods = build_deterministic_feedback(details_no_periods, entries_no_periods)
+
+    assert feedback_no_periods == ""

--- a/tests/test_result_metric_extraction.py
+++ b/tests/test_result_metric_extraction.py
@@ -172,6 +172,18 @@ def test_extract_metric_catalog_adds_turnover_series_from_details() -> None:
     assert "[from turnover_series]" in catalog
 
 
+def test_extract_metric_catalog_adds_turnover_series_from_risk_diagnostics() -> None:
+    result = {"risk_diagnostics": {"turnover": pd.Series([0.03, 0.07, 0.12])}}
+
+    entries = extract_metric_catalog(result)
+    paths = {entry.path for entry in entries}
+    catalog = format_metric_catalog(entries)
+
+    assert "turnover.latest" in paths
+    assert "turnover.mean" in paths
+    assert "[from turnover_series]" in catalog
+
+
 def test_extract_metric_catalog_adds_turnover_scalar_from_details() -> None:
     result = {"details": {"turnover": 0.12}}
 

--- a/tests/test_result_metric_extraction.py
+++ b/tests/test_result_metric_extraction.py
@@ -195,6 +195,18 @@ def test_extract_metric_catalog_adds_turnover_scalar_from_details() -> None:
     assert "[from turnover_scalar]" in catalog
 
 
+def test_extract_metric_catalog_adds_turnover_scalar_from_risk_diagnostics() -> None:
+    result = {"risk_diagnostics": {"turnover_value": 0.18}}
+
+    entries = extract_metric_catalog(result)
+    paths = {entry.path for entry in entries}
+    catalog = format_metric_catalog(entries)
+
+    assert "risk_diagnostics.turnover_value" in paths
+    assert "turnover.value" in paths
+    assert "[from turnover_scalar]" in catalog
+
+
 def test_format_metric_catalog_defaults_missing_source() -> None:
     entries = [
         MetricEntry(path="risk_diagnostics.turnover", value=0.2, source=""),

--- a/tests/test_trend_cli_entrypoints.py
+++ b/tests/test_trend_cli_entrypoints.py
@@ -733,6 +733,7 @@ def test_main_explain_command_writes_json_artifact(
 ) -> None:
     details_path = _write_explain_details_with_run_id(tmp_path, "run-009")
     output_dir = tmp_path / "artifacts"
+    question = "Summarize the results."
 
     class DummyChain:
         def run(self, **kwargs: object) -> SimpleNamespace:
@@ -744,7 +745,15 @@ def test_main_explain_command_writes_json_artifact(
     monkeypatch.setattr(trend_cli, "_build_result_chain", lambda *_args, **_kwargs: DummyChain())
 
     exit_code = trend_cli.main(
-        ["explain", "--details", str(details_path), "--output", str(output_dir)]
+        [
+            "explain",
+            "--details",
+            str(details_path),
+            "--output",
+            str(output_dir),
+            "--question",
+            question,
+        ]
     )
 
     assert exit_code == 0
@@ -757,6 +766,7 @@ def test_main_explain_command_writes_json_artifact(
     assert payload["trace_url"] == "trace://cli"
     assert payload["metric_count"] > 0
     assert payload["claim_issues"] == []
+    assert payload["questions"] == f"- {question}"
     assert "CAGR was 8%" in payload["text"]
     assert "This is analytical output, not financial advice." in payload["text"]
     assert txt_path.read_text(encoding="utf-8") == payload["text"]


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
```markdown
## Why
PR #4499 addressed issue #4498 but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps with improved task structure.

## Source

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#4499](https://github.com/stranske/Trend_Model_Project/issues/4499)
- [#4498](https://github.com/stranske/Trend_Model_Project/issues/4498)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] - Original PR: #4499
- [ ] - Parent issue: #4498

#### Acceptance criteria
- [ ] Update the diagnostics block header to use Markdown formatting (e.g., '## Deterministic diagnostics:') instead of plain text.
- [ ] Revise the bullet generation function to ensure it outputs a minimum of 3 bullet points (and no more than 8), adding a default baseline bullet when necessary.
- [ ] Modify the citation generation to validate the source field for each metric. Replace empty or 'unknown' sources with a valid default or log a warning.
- [ ] Wrap the environment override parsing in a try/catch block to log a warning and revert to a default value if a float conversion fails.
- [ ] Add automated tests covering turnover, concentration, and drawdown triggers, simulating conditions with both valid and invalid environment variable inputs.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



```markdown
## Why
PR #4499 addressed issue #4498 but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps with improved task structure.

## Source
- Original PR: #4499
- Parent issue: #4498

## Tasks
- [ ] Update the diagnostics block header to use Markdown formatting (e.g., '## Deterministic diagnostics:') instead of plain text.
- [ ] Revise the bullet generation function to ensure it outputs a minimum of 3 bullet points (and no more than 8), adding a default baseline bullet when necessary.
- [ ] Modify the citation generation to validate the source field for each metric. Replace empty or 'unknown' sources with a valid default or log a warning.
- [ ] Wrap the environment override parsing in a try/catch block to log a warning and revert to a default value if a float conversion fails.
- [ ] Add automated tests covering turnover, concentration, and drawdown triggers, simulating conditions with both valid and invalid environment variable inputs.

## Acceptance Criteria
- [x] The diagnostics block in both the Streamlit Explain Results prompt and the CLI `trend explain` prompt starts with a Markdown header '## Deterministic diagnostics:' followed by a Markdown bullet list.
- [x] The bullet generation function outputs between 3 and 8 bullet points, adding a default baseline bullet when necessary.
- [x] Each bullet in the diagnostics list includes at least one numeric metric and a citation in the format '[from <source>]', where '<source>' is a non-empty, known value.
- [x] The environment override parsing is wrapped in a try/catch block that logs a warning and reverts to a default value if a float conversion fails.
- [x] Automated tests simulate scenarios for turnover, concentration, and drawdown triggers, verifying that the diagnostics block is generated correctly and processing does not crash with invalid environment variables.
- [x] The diagnostics generation handles cases where the metric extraction function changes its schema, ensuring both `entries` and `details` are accounted for, and adds a baseline bullet if expected sections are missing.

## Implementation Notes
- Update files: `src/trend_analysis/llm/result_feedback.py`, `streamlit_app/components/explain_results.py`, `src/trend/cli.py` for the diagnostics block header.
- Focus on `src/trend_analysis/llm/result_feedback.py` for bullet generation and citation validation.
- Ensure robust exception handling in `src/trend_analysis/llm/result_feedback.py` for environment variable parsing.
- Add and verify tests in the `tests/` directory.

<details>
<summary>Background (previous attempt context)</summary>

- Reliance solely on the 'entries' field for diagnostics with minimal use of 'details', leading to potential missed triggers if the metric export schema changes. Implement handling and testing for both 'entries' and 'details' fields, and consider a fallback or default diagnostic if expected sections are missing.
- Directly raising ValueError on invalid float parsing for environment overrides, which crashes the flow. Catch the ValueError and use default values with a warning to ensure stability.

</details>
```



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #4501

<!-- pr-preamble:end -->