### PR TITLE
feat: add in-app LLM settings for summaries

### DIFF
--- a/streamlit_app/components/explain_results.py
+++ b/streamlit_app/components/explain_results.py
@@ -99,9 +99,7 @@ def _resolve_llm_provider_config(
     base_url: str | None = None,
     organization: str | None = None,
 ) -> LLMProviderConfig:
-    provider_name = (
-        provider or os.environ.get("TREND_LLM_PROVIDER") or "openai"
-    ).lower()
+    provider_name = (provider or os.environ.get("TREND_LLM_PROVIDER") or "openai").lower()
     supported = {"openai", "anthropic", "ollama"}
     if provider_name not in supported:
         raise ValueError(
@@ -115,12 +113,9 @@ def _resolve_llm_provider_config(
         elif provider_name == "anthropic":
             resolved_api_key = os.environ.get("ANTHROPIC_API_KEY")
     if provider_name in {"openai", "anthropic"} and not resolved_api_key:
-        env_hint = (
-            "OPENAI_API_KEY" if provider_name == "openai" else "ANTHROPIC_API_KEY"
-        )
+        env_hint = "OPENAI_API_KEY" if provider_name == "openai" else "ANTHROPIC_API_KEY"
         raise ValueError(
-            f"Missing API key for {provider_name}. "
-            f"Set TREND_LLM_API_KEY or {env_hint}."
+            f"Missing API key for {provider_name}. " f"Set TREND_LLM_API_KEY or {env_hint}."
         )
     resolved_model = model or os.environ.get("TREND_LLM_MODEL")
     resolved_base_url = base_url or os.environ.get("TREND_LLM_BASE_URL")
@@ -175,9 +170,7 @@ def generate_result_explanation(
     compacted_entries = compact_metric_catalog(all_entries, questions=questions)
     metric_catalog = format_metric_catalog(compacted_entries)
     if not all_entries:
-        text = ensure_result_disclaimer(
-            "No metrics were detected in the analysis output."
-        )
+        text = ensure_result_disclaimer("No metrics were detected in the analysis output.")
         return ExplanationResult(
             text=text,
             trace_url=None,

--- a/streamlit_app/components/explain_results.py
+++ b/streamlit_app/components/explain_results.py
@@ -91,42 +91,67 @@ def _format_questions(raw: str | None) -> str:
     return "\n".join(f"- {line}" for line in lines)
 
 
-def _resolve_llm_provider_config(provider: str | None = None) -> LLMProviderConfig:
-    provider_name = (provider or os.environ.get("TREND_LLM_PROVIDER") or "openai").lower()
+def _resolve_llm_provider_config(
+    provider: str | None = None,
+    *,
+    api_key: str | None = None,
+    model: str | None = None,
+    base_url: str | None = None,
+    organization: str | None = None,
+) -> LLMProviderConfig:
+    provider_name = (
+        provider or os.environ.get("TREND_LLM_PROVIDER") or "openai"
+    ).lower()
     supported = {"openai", "anthropic", "ollama"}
     if provider_name not in supported:
         raise ValueError(
             f"Unknown LLM provider '{provider_name}'. "
             f"Expected one of: {', '.join(sorted(supported))}."
         )
-    api_key = os.environ.get("TREND_LLM_API_KEY")
-    if not api_key:
+    resolved_api_key = api_key or os.environ.get("TREND_LLM_API_KEY")
+    if not resolved_api_key:
         if provider_name == "openai":
-            api_key = os.environ.get("OPENAI_API_KEY")
+            resolved_api_key = os.environ.get("OPENAI_API_KEY")
         elif provider_name == "anthropic":
-            api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if provider_name in {"openai", "anthropic"} and not api_key:
-        env_hint = "OPENAI_API_KEY" if provider_name == "openai" else "ANTHROPIC_API_KEY"
-        raise ValueError(
-            f"Missing API key for {provider_name}. " f"Set TREND_LLM_API_KEY or {env_hint}."
+            resolved_api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if provider_name in {"openai", "anthropic"} and not resolved_api_key:
+        env_hint = (
+            "OPENAI_API_KEY" if provider_name == "openai" else "ANTHROPIC_API_KEY"
         )
-    model = os.environ.get("TREND_LLM_MODEL")
-    base_url = os.environ.get("TREND_LLM_BASE_URL")
-    organization = os.environ.get("TREND_LLM_ORG")
+        raise ValueError(
+            f"Missing API key for {provider_name}. "
+            f"Set TREND_LLM_API_KEY or {env_hint}."
+        )
+    resolved_model = model or os.environ.get("TREND_LLM_MODEL")
+    resolved_base_url = base_url or os.environ.get("TREND_LLM_BASE_URL")
+    resolved_org = organization or os.environ.get("TREND_LLM_ORG")
     kwargs: dict[str, Any] = {"provider": provider_name}
-    if model:
-        kwargs["model"] = model
-    if api_key:
-        kwargs["api_key"] = api_key
-    if base_url:
-        kwargs["base_url"] = base_url
-    if organization:
-        kwargs["organization"] = organization
+    if resolved_model:
+        kwargs["model"] = resolved_model
+    if resolved_api_key:
+        kwargs["api_key"] = resolved_api_key
+    if resolved_base_url:
+        kwargs["base_url"] = resolved_base_url
+    if resolved_org:
+        kwargs["organization"] = resolved_org
     return LLMProviderConfig(**kwargs)
 
 
-def _build_result_chain(provider: str | None = None) -> ResultSummaryChain:
-    config = _resolve_llm_provider_config(provider)
+def _build_result_chain(
+    provider: str | None = None,
+    *,
+    api_key: str | None = None,
+    model: str | None = None,
+    base_url: str | None = None,
+    organization: str | None = None,
+) -> ResultSummaryChain:
+    config = _resolve_llm_provider_config(
+        provider,
+        api_key=api_key,
+        model=model,
+        base_url=base_url,
+        organization=organization,
+    )
     llm = create_llm(config)
     return ResultSummaryChain.from_env(
         llm=llm,
@@ -140,13 +165,19 @@ def generate_result_explanation(
     *,
     questions: str | None,
     provider: str | None = None,
+    api_key: str | None = None,
+    model: str | None = None,
+    base_url: str | None = None,
+    organization: str | None = None,
 ) -> ExplanationResult:
     created_at = datetime.now(timezone.utc).isoformat()
     all_entries = extract_metric_catalog(details)
     compacted_entries = compact_metric_catalog(all_entries, questions=questions)
     metric_catalog = format_metric_catalog(compacted_entries)
     if not all_entries:
-        text = ensure_result_disclaimer("No metrics were detected in the analysis output.")
+        text = ensure_result_disclaimer(
+            "No metrics were detected in the analysis output."
+        )
         return ExplanationResult(
             text=text,
             trace_url=None,
@@ -155,7 +186,13 @@ def generate_result_explanation(
             created_at=created_at,
         )
 
-    chain = _build_result_chain(provider)
+    chain = _build_result_chain(
+        provider,
+        api_key=api_key,
+        model=model,
+        base_url=base_url,
+        organization=organization,
+    )
     analysis_output = _render_analysis_output(details)
     diagnostics = build_deterministic_feedback(details, all_entries)
     if diagnostics:
@@ -198,6 +235,45 @@ def render_explain_results(
         key=question_key,
         help="Leave blank to use the default summary prompt.",
     )
+    st.markdown("#### LLM Settings")
+    with st.expander("Configure provider and API key", expanded=False):
+        provider_key = "explain_results_provider"
+        api_key_key = "explain_results_api_key"
+        model_key = "explain_results_model"
+        base_url_key = "explain_results_base_url"
+        org_key = "explain_results_org"
+
+        st.selectbox(
+            "Provider",
+            ["openai", "anthropic", "ollama"],
+            index=["openai", "anthropic", "ollama"].index(
+                st.session_state.get(provider_key, provider or "openai")
+            ),
+            key=provider_key,
+            help="Defaults to TREND_LLM_PROVIDER if set; otherwise OpenAI.",
+        )
+        st.text_input(
+            "API Key",
+            value=st.session_state.get(api_key_key, ""),
+            key=api_key_key,
+            type="password",
+            help="Stored only in this browser session.",
+        )
+        st.text_input(
+            "Model (optional)",
+            value=st.session_state.get(model_key, ""),
+            key=model_key,
+        )
+        st.text_input(
+            "Base URL (optional)",
+            value=st.session_state.get(base_url_key, ""),
+            key=base_url_key,
+        )
+        st.text_input(
+            "Organization (optional)",
+            value=st.session_state.get(org_key, ""),
+            key=org_key,
+        )
     questions_text = st.session_state.get(question_key)
     if not questions_text:
         questions_text = DEFAULT_QUESTION
@@ -213,7 +289,11 @@ def render_explain_results(
                 cached = generate_result_explanation(
                     details,
                     questions=st.session_state.get(question_key),
-                    provider=provider,
+                    provider=st.session_state.get("explain_results_provider", provider),
+                    api_key=st.session_state.get("explain_results_api_key") or None,
+                    model=st.session_state.get("explain_results_model") or None,
+                    base_url=st.session_state.get("explain_results_base_url") or None,
+                    organization=st.session_state.get("explain_results_org") or None,
                 )
                 cache[run_key] = cached
             except Exception as exc:

--- a/tests/app/test_explain_results_component.py
+++ b/tests/app/test_explain_results_component.py
@@ -30,7 +30,9 @@ def explain_module(monkeypatch: pytest.MonkeyPatch):
     st_stub = MagicMock()
     st_stub.session_state = {}
     monkeypatch.setitem(sys.modules, "streamlit", st_stub)
-    module = importlib.reload(importlib.import_module("streamlit_app.components.explain_results"))
+    module = importlib.reload(
+        importlib.import_module("streamlit_app.components.explain_results")
+    )
     return module
 
 
@@ -56,9 +58,15 @@ def test_generate_result_explanation_uses_chain_and_disclaimer(
     )
     stub = _StubChain(response)
 
-    monkeypatch.setattr(explain_module, "_build_result_chain", lambda provider=None: stub)
+    monkeypatch.setattr(
+        explain_module,
+        "_build_result_chain",
+        lambda *args, **kwargs: stub,
+    )
 
-    explanation = explain_module.generate_result_explanation(details, questions="Summarize")
+    explanation = explain_module.generate_result_explanation(
+        details, questions="Summarize"
+    )
 
     assert explanation.trace_url == "trace://example"
     assert explanation.metric_count == 6
@@ -95,7 +103,11 @@ def test_generate_result_explanation_appends_diagnostics(
     )
     stub = _StubChain(response)
 
-    monkeypatch.setattr(explain_module, "_build_result_chain", lambda provider=None: stub)
+    monkeypatch.setattr(
+        explain_module,
+        "_build_result_chain",
+        lambda *args, **kwargs: stub,
+    )
     monkeypatch.setattr(
         explain_module,
         "build_deterministic_feedback",
@@ -200,7 +212,9 @@ def test_render_explain_results_downloads_include_json_payload(explain_module) -
     calls = st_stub.download_button.call_args_list
     assert len(calls) == 2
     json_call = next(
-        call for call in calls if call.kwargs.get("file_name") == "explanation_run-001.json"
+        call
+        for call in calls
+        if call.kwargs.get("file_name") == "explanation_run-001.json"
     )
     payload = json.loads(json_call.kwargs["data"])
     assert payload["run_id"] == "run-001"
@@ -240,7 +254,9 @@ def test_render_explain_results_downloads_include_text(explain_module) -> None:
     calls = st_stub.download_button.call_args_list
     assert len(calls) == 2
     txt_call = next(
-        call for call in calls if call.kwargs.get("file_name") == "explanation_run-001.txt"
+        call
+        for call in calls
+        if call.kwargs.get("file_name") == "explanation_run-001.txt"
     )
     assert txt_call.kwargs["data"] == "Cached output"
 
@@ -252,7 +268,9 @@ def test_render_explain_results_handles_missing_details(explain_module) -> None:
 
     explain_module.render_explain_results(result, run_key="run:missing")
 
-    st_stub.info.assert_any_call("Explanation is unavailable because detailed results are missing.")
+    st_stub.info.assert_any_call(
+        "Explanation is unavailable because detailed results are missing."
+    )
 
 
 def test_render_explain_results_reports_llm_error(explain_module, monkeypatch) -> None:

--- a/tests/app/test_explain_results_component.py
+++ b/tests/app/test_explain_results_component.py
@@ -30,9 +30,7 @@ def explain_module(monkeypatch: pytest.MonkeyPatch):
     st_stub = MagicMock()
     st_stub.session_state = {}
     monkeypatch.setitem(sys.modules, "streamlit", st_stub)
-    module = importlib.reload(
-        importlib.import_module("streamlit_app.components.explain_results")
-    )
+    module = importlib.reload(importlib.import_module("streamlit_app.components.explain_results"))
     return module
 
 
@@ -64,9 +62,7 @@ def test_generate_result_explanation_uses_chain_and_disclaimer(
         lambda *args, **kwargs: stub,
     )
 
-    explanation = explain_module.generate_result_explanation(
-        details, questions="Summarize"
-    )
+    explanation = explain_module.generate_result_explanation(details, questions="Summarize")
 
     assert explanation.trace_url == "trace://example"
     assert explanation.metric_count == 6
@@ -212,9 +208,7 @@ def test_render_explain_results_downloads_include_json_payload(explain_module) -
     calls = st_stub.download_button.call_args_list
     assert len(calls) == 2
     json_call = next(
-        call
-        for call in calls
-        if call.kwargs.get("file_name") == "explanation_run-001.json"
+        call for call in calls if call.kwargs.get("file_name") == "explanation_run-001.json"
     )
     payload = json.loads(json_call.kwargs["data"])
     assert payload["run_id"] == "run-001"
@@ -254,9 +248,7 @@ def test_render_explain_results_downloads_include_text(explain_module) -> None:
     calls = st_stub.download_button.call_args_list
     assert len(calls) == 2
     txt_call = next(
-        call
-        for call in calls
-        if call.kwargs.get("file_name") == "explanation_run-001.txt"
+        call for call in calls if call.kwargs.get("file_name") == "explanation_run-001.txt"
     )
     assert txt_call.kwargs["data"] == "Cached output"
 
@@ -268,9 +260,7 @@ def test_render_explain_results_handles_missing_details(explain_module) -> None:
 
     explain_module.render_explain_results(result, run_key="run:missing")
 
-    st_stub.info.assert_any_call(
-        "Explanation is unavailable because detailed results are missing."
-    )
+    st_stub.info.assert_any_call("Explanation is unavailable because detailed results are missing.")
 
 
 def test_render_explain_results_reports_llm_error(explain_module, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add an LLM settings expander to the Streamlit Explain Results panel
- allow provider/API key/model/base URL/org overrides from the UI
- pass overrides into the result summary chain

## Testing
- pre-commit (black, ruff)