### PR TITLE
fix: ensure hired funds appear in portfolio weights

### DIFF
--- a/src/trend_analysis/llm/prompts.py
+++ b/src/trend_analysis/llm/prompts.py
@@ -32,14 +32,48 @@ If asked to target unknown keys or unsafe content, return empty operations and
 explain the refusal in the summary without echoing the unsafe request.
 """
 
-DEFAULT_RESULT_SYSTEM_PROMPT = """You are a results explanation assistant for Trend Model.
-Your task is to summarize the analysis output and answer result questions in
-plain language using only the provided metrics and output snippets.
+DEFAULT_RESULT_SYSTEM_PROMPT = """You are a quantitative investment analyst reviewing a trend-following manager selection backtest.
+The purpose of this tool is to simulate typical allocator decision-making when using systematic selection heuristics.
 
-Every claim must cite specific metric values with explicit source references
-like "[from out_sample_stats]" that match the provided metric catalog.
-If a metric is missing or unavailable, say so explicitly and do not guess.
-Include this disclaimer verbatim at the end of every response:
+ANALYSIS FRAMEWORK - Focus on manager selection dynamics:
+
+1. **Selection Rationale**
+   - Why were certain managers selected over others?
+   - What metrics drove their inclusion (Sharpe, drawdown, combination)?
+   - Were selections driven by genuine outperformance or favorable timing?
+
+2. **Portfolio Persistence Analysis**
+   - Which managers stayed in the portfolio across multiple periods? Why?
+   - Identify any "lukewarm" performers that survived simply by not underperforming badly
+   - Flag managers that entered during benign periods and may not have been stress-tested
+
+3. **Turnover and Replacement Decisions**
+   - What triggered manager exits - underperformance or mechanical rules?
+   - Were replacements upgrades or lateral moves?
+   - Could different selection parameters have avoided unnecessary churn?
+
+4. **Out-of-Sample Reality Check**
+   - Do IS selection metrics predict OS performance?
+   - Which managers showed consistent behavior vs. regime-dependent results?
+   - Flag any concerning divergence that suggests overfitting to history
+
+5. **Portfolio Construction Insights**
+   - Is the weighting scheme producing expected concentration/diversification?
+   - How does the selected portfolio compare to equal-weight baseline?
+   - Are position sizes aligned with conviction from the metrics?
+
+6. **Actionable Observations**
+   - What parameter adjustments might improve selection quality?
+   - Should lookback periods, selection counts, or thresholds change?
+   - Note any managers that warrant manual review outside systematic rules
+
+STYLE GUIDELINES:
+- Lead with decision-making insights, not metric recitation
+- Use comparative language: "Manager X was selected over Y because..."
+- Be direct about weak selections that may have slipped through
+- Focus on what an allocator would want to know for the next decision
+
+Include this disclaimer verbatim at the end:
 "This is analytical output, not financial advice. Always verify metrics independently."
 """
 
@@ -56,11 +90,12 @@ DEFAULT_SAFETY_RULES = (
 )
 
 DEFAULT_RESULT_RULES = (
-    "Use only metrics present in the analysis output and metric catalog.",
-    "Cite every claim with the metric name and source reference in brackets.",
-    "If a question requests unavailable data, respond with unavailability.",
-    "Do not infer or estimate values beyond what is provided.",
-    "Keep summaries concise and grounded in quantitative evidence.",
+    "Ground all claims in metrics from the analysis output - cite sparingly for key points.",
+    "Focus on analytical insights and comparisons, not restating individual numbers.",
+    "Flag potential overfitting when in-sample metrics significantly exceed out-of-sample.",
+    "Compare against equal-weight baseline when available to assess selection value.",
+    "If critical data is missing, note what additional analysis would be needed.",
+    "Prioritize actionable observations over comprehensive metric listing.",
 )
 
 

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -81,7 +81,9 @@ def _run_analysis(*args: Any, **kwargs: Any) -> PipelineResult:
     return _invoke_analysis_with_diag(*args, **kwargs)
 
 
-def _call_pipeline_with_diag(*args: Any, **kwargs: Any) -> DiagnosticResult[dict[str, Any] | None]:
+def _call_pipeline_with_diag(
+    *args: Any, **kwargs: Any
+) -> DiagnosticResult[dict[str, Any] | None]:
     """Execute ``_run_analysis`` and normalise into a ``DiagnosticResult``.
 
     Tests and legacy callers monkeypatch ``_run_analysis`` to return raw dict
@@ -151,7 +153,9 @@ def _membership_table_from_frame(frame: pd.DataFrame) -> MembershipTable:
     eff_col = lookup.get("effective_date")
     end_col = lookup.get("end_date")
     if not fund_col or not eff_col or not end_col:
-        raise ValueError("membership data must include fund, effective_date, and end_date columns")
+        raise ValueError(
+            "membership data must include fund, effective_date, and end_date columns"
+        )
 
     normalised = frame.rename(
         columns={fund_col: "fund", eff_col: "effective_date", end_col: "end_date"}
@@ -210,9 +214,9 @@ def _compute_turnover_state(
     new_aligned: FloatArray = new_series.reindex(union_index, fill_value=0.0).to_numpy(
         dtype=float, copy=False
     )
-    prev_aligned: FloatArray = prev_series.reindex(union_index, fill_value=0.0).to_numpy(
-        dtype=float, copy=False
-    )
+    prev_aligned: FloatArray = prev_series.reindex(
+        union_index, fill_value=0.0
+    ).to_numpy(dtype=float, copy=False)
 
     turnover = float(np.abs(new_aligned - prev_aligned).sum())
     return turnover, nidx, nvals
@@ -296,9 +300,9 @@ def _apply_weight_bounds(
                 room = (max_w_bound - receivers).clip(lower=0.0)
                 rm = room.sum()
                 if rm > 0:
-                    floored.loc[receivers.index] = (receivers + (room / rm) * deficit).clip(
-                        upper=max_w_bound
-                    )
+                    floored.loc[receivers.index] = (
+                        receivers + (room / rm) * deficit
+                    ).clip(upper=max_w_bound)
 
     return floored
 
@@ -338,7 +342,12 @@ def _enforce_max_active_positions(
                 .index
             )
     else:
-        keep = active.abs().sort_values(ascending=False, kind="mergesort").head(max_active).index
+        keep = (
+            active.abs()
+            .sort_values(ascending=False, kind="mergesort")
+            .head(max_active)
+            .index
+        )
     trimmed = weights.copy()
     trimmed.loc[~trimmed.index.isin(keep)] = 0.0
 
@@ -523,7 +532,11 @@ def run_schedule(
         turnover = float(np.abs(new_aligned - prev_aligned).sum())
         return turnover, nidx, nvals
 
-    col = rank_column or getattr(selector, "rank_column", None) or getattr(selector, "column", None)
+    col = (
+        rank_column
+        or getattr(selector, "rank_column", None)
+        or getattr(selector, "column", None)
+    )
 
     for date in sorted(score_frames):
         sf = score_frames[date]
@@ -557,7 +570,9 @@ def run_schedule(
 
         # Apply rebalancing strategies if configured
         if rebalance_strategies and rebalance_params:
-            current_weights = prev_weights if prev_weights is not None else pd.Series(dtype=float)
+            current_weights = (
+                prev_weights if prev_weights is not None else pd.Series(dtype=float)
+            )
             target_weight_series = target_weights["weight"].astype(float)
 
             # Get scores for priority-based strategies
@@ -582,7 +597,9 @@ def run_schedule(
             cost = 0.0
             weights = target_weights
             tw = target_weights["weight"].astype(float)
-            turnover, prev_tidx, prev_tvals = _compute_turnover_state(prev_tidx, prev_tvals, tw)
+            turnover, prev_tidx, prev_tvals = _compute_turnover_state(
+                prev_tidx, prev_tvals, tw
+            )
             prev_weights = tw
 
         pf.rebalance(date, weights, turnover, cost)
@@ -617,7 +634,9 @@ def run_schedule(
                     pv = prev.reindex(u, fill_value=0.0).to_numpy()
                     expected = float(np.abs(dv - pv).sum())
                 got = pf.turnover[d]
-                if not np.isclose(expected, got, rtol=0, atol=1e-12):  # pragma: no cover
+                if not np.isclose(
+                    expected, got, rtol=0, atol=1e-12
+                ):  # pragma: no cover
                     raise AssertionError(
                         f"Turnover mismatch for {d}: expected {expected} got {got}"
                     )
@@ -667,9 +686,13 @@ def run(
             raise TypeError("price_frames must be a dict[str, pd.DataFrame] or None")
         for date_key, frame in price_frames.items():
             if not isinstance(frame, pd.DataFrame):
-                raise TypeError(f"price_frames['{date_key}'] must be a pandas DataFrame")
+                raise TypeError(
+                    f"price_frames['{date_key}'] must be a pandas DataFrame"
+                )
             required_columns = ["Date"]
-            missing_columns = [col for col in required_columns if col not in frame.columns]
+            missing_columns = [
+                col for col in required_columns if col not in frame.columns
+            ]
             if missing_columns:
                 raise ValueError(
                     (
@@ -686,7 +709,9 @@ def run(
         # columns are included, handling missing data gracefully.
         combined_frames = [frame.copy() for frame in price_frames.values()]
         if combined_frames:
-            df = pd.concat(combined_frames, axis=0, join="outer", ignore_index=True, sort=True)
+            df = pd.concat(
+                combined_frames, axis=0, join="outer", ignore_index=True, sort=True
+            )
             # Sort by Date to ensure proper ordering
             df = df.sort_values("Date").reset_index(drop=True)
             # Remove any duplicates created during concatenation
@@ -873,7 +898,8 @@ def run(
         # Persist for debugging/export consumers.
         cleaned.attrs = dict(cleaned.attrs)
         cleaned.attrs["inception_dates"] = {
-            k: (v.strftime("%Y-%m-%d") if v is not None else None) for k, v in inception_raw.items()
+            k: (v.strftime("%Y-%m-%d") if v is not None else None)
+            for k, v in inception_raw.items()
         }
     except Exception:  # pragma: no cover - defensive
         pass
@@ -938,7 +964,9 @@ def run(
 
         periods = generate_periods(cfg_dump)
         if not periods:
-            logger.warning("generate_periods produced no periods; skipping multi-period run")
+            logger.warning(
+                "generate_periods produced no periods; skipping multi-period run"
+            )
             return []
         out_results: List[MultiPeriodPeriodResult] = []
         # Performance flags
@@ -955,7 +983,9 @@ def run(
             except Exception:  # pragma: no cover - defensive
                 cov_cache_obj = None
         prev_in_df = None
-        prev_weights_for_pipeline = _coerce_previous_weights(cfg.portfolio.get("previous_weights"))
+        prev_weights_for_pipeline = _coerce_previous_weights(
+            cfg.portfolio.get("previous_weights")
+        )
 
         for pt in periods:
             analysis_res = _call_pipeline_with_diag(
@@ -1028,7 +1058,9 @@ def run(
                 # Recreate in-sample frame identical to _run_analysis slice
                 date_col = "Date"
                 sub = df.copy()
-                sub[date_col] = pd.to_datetime(sub[date_col], utc=True).dt.tz_localize(None)
+                sub[date_col] = pd.to_datetime(sub[date_col], utc=True).dt.tz_localize(
+                    None
+                )
                 sub.sort_values(date_col, inplace=True)
                 sdate = pd.to_datetime(f"{in_start}-01", utc=True).tz_localize(
                     None
@@ -1036,19 +1068,27 @@ def run(
                 edate = pd.to_datetime(f"{in_end}-01", utc=True).tz_localize(
                     None
                 ) + pd.offsets.MonthEnd(0)
-                in_df_full = sub[(sub[date_col] >= sdate) & (sub[date_col] <= edate)].set_index(
-                    date_col
-                )
+                in_df_full = sub[
+                    (sub[date_col] >= sdate) & (sub[date_col] <= edate)
+                ].set_index(date_col)
                 # Remove benchmark columns if present in result universe
                 fund_cols = [
-                    c for c in in_df_full.columns if c not in (cfg.benchmarks or {}).values()
+                    c
+                    for c in in_df_full.columns
+                    if c not in (cfg.benchmarks or {}).values()
                 ]
                 in_df_full = in_df_full[fund_cols]
                 in_df_prepared = _prepare_returns_frame(in_df_full)
 
-                if incremental_cov and prev_cov_payload is not None and prev_in_df is not None:
+                if (
+                    incremental_cov
+                    and prev_cov_payload is not None
+                    and prev_in_df is not None
+                ):
                     same_len = prev_in_df.shape[0] == in_df_prepared.shape[0]
-                    same_cols = prev_in_df.columns.tolist() == in_df_prepared.columns.tolist()
+                    same_cols = (
+                        prev_in_df.columns.tolist() == in_df_prepared.columns.tolist()
+                    )
                     n_rows = in_df_prepared.shape[0]
                     if same_cols and n_rows >= 3:
                         # Determine shift distance k (number of rows replaced at head and appended at tail)
@@ -1086,10 +1126,12 @@ def run(
                             # Apply k incremental updates sequentially
                             try:
                                 for step in range(k):
-                                    old_row = prev_in_df.iloc[step].to_numpy(dtype=float)
-                                    new_row = in_df_prepared.iloc[n_rows - k + step].to_numpy(
+                                    old_row = prev_in_df.iloc[step].to_numpy(
                                         dtype=float
                                     )
+                                    new_row = in_df_prepared.iloc[
+                                        n_rows - k + step
+                                    ].to_numpy(dtype=float)
                                     prev_cov_payload = incremental_cov_update(
                                         prev_cov_payload, old_row, new_row
                                     )
@@ -1107,7 +1149,9 @@ def run(
                 else:
                     from ..perf.cache import compute_cov_payload as _ccp
 
-                    prev_cov_payload = _ccp(in_df_prepared, materialise_aggregates=incremental_cov)
+                    prev_cov_payload = _ccp(
+                        in_df_prepared, materialise_aggregates=incremental_cov
+                    )
                 prev_in_df = in_df_prepared
                 res_dict["cov_diag"] = prev_cov_payload.cov.diagonal().tolist()
                 if cov_cache_obj is not None:
@@ -1177,12 +1221,14 @@ def run(
                 continue
             seen.add(resolved)
             benchmark_cols.append(resolved)
-    resolved_rf_col, _resolver_fund_cols, resolved_rf_source = _resolve_risk_free_column(
-        df,
-        date_col="Date",
-        indices_list=indices_list,
-        risk_free_column=risk_free_column_cfg,
-        allow_risk_free_fallback=allow_risk_free_fallback_cfg,
+    resolved_rf_col, _resolver_fund_cols, resolved_rf_source = (
+        _resolve_risk_free_column(
+            df,
+            date_col="Date",
+            indices_list=indices_list,
+            risk_free_column=risk_free_column_cfg,
+            allow_risk_free_fallback=allow_risk_free_fallback_cfg,
+        )
     )
 
     # Build a stable investable universe list.
@@ -1195,7 +1241,9 @@ def run(
     idx_set |= {str(c) for c in benchmark_cols}
     resolved_fund_candidates = [c for c in numeric_cols_all if c not in idx_set]
     if resolved_rf_source == "configured" and resolved_rf_col:
-        resolved_fund_candidates = [c for c in resolved_fund_candidates if c != resolved_rf_col]
+        resolved_fund_candidates = [
+            c for c in resolved_fund_candidates if c != resolved_rf_col
+        ]
     elif resolved_rf_source == "fallback" and resolved_rf_col:
         # Fallback RF selection can legitimately pick a true cash proxy (flat
         # zero-return series). Treat such near-constant columns as non-investable
@@ -1212,7 +1260,9 @@ def run(
 
     # --- helpers --------------------------------------------------------
     def _parse_month(s: str) -> pd.Timestamp:
-        return pd.to_datetime(f"{s}-01", utc=True).tz_localize(None) + pd.offsets.MonthEnd(0)
+        return pd.to_datetime(f"{s}-01", utc=True).tz_localize(
+            None
+        ) + pd.offsets.MonthEnd(0)
 
     def _valid_universe(
         full: pd.DataFrame,
@@ -1227,16 +1277,22 @@ def run(
         sub.sort_values(date_col, inplace=True)
         in_sdate, in_edate = _parse_month(in_start), _parse_month(in_end)
         out_sdate, out_edate = _parse_month(out_start), _parse_month(out_end)
-        in_df = sub[(sub[date_col] >= in_sdate) & (sub[date_col] <= in_edate)].set_index(date_col)
-        out_df = sub[(sub[date_col] >= out_sdate) & (sub[date_col] <= out_edate)].set_index(
-            date_col
-        )
+        in_df = sub[
+            (sub[date_col] >= in_sdate) & (sub[date_col] <= in_edate)
+        ].set_index(date_col)
+        out_df = sub[
+            (sub[date_col] >= out_sdate) & (sub[date_col] <= out_edate)
+        ].set_index(date_col)
         if in_df.empty or out_df.empty:
             return in_df, out_df, [], ""
         numeric_cols = [c for c in sub.select_dtypes("number").columns if c != date_col]
         idx_set = {str(c) for c in indices_list}
         idx_set |= {str(c) for c in benchmark_cols}
-        fund_cols = [c for c in resolved_fund_candidates if c in numeric_cols and c not in idx_set]
+        fund_cols = [
+            c
+            for c in resolved_fund_candidates
+            if c in numeric_cols and c not in idx_set
+        ]
 
         if not fund_cols:
             return in_df, out_df, [], resolved_rf_col
@@ -1254,7 +1310,9 @@ def run(
         in_ok = ~in_tail.isna().any()
         out_ok = ~out_df[fund_cols].isna().any()
         fund_cols = [
-            c for c in fund_cols if bool(in_ok.get(c, False)) and bool(out_ok.get(c, False))
+            c
+            for c in fund_cols
+            if bool(in_ok.get(c, False)) and bool(out_ok.get(c, False))
         ]
 
         # Guardrail: exclude funds that are effectively inactive/flatlined at
@@ -1380,11 +1438,15 @@ def run(
     z_exit_hard = _parse_optional_float(th_cfg.get("z_exit_hard"))
 
     target_n = int(
-        th_cfg.get("target_n", portfolio_cfg.get("target_n", cfg.portfolio.get("random_n", 8)))
+        th_cfg.get(
+            "target_n", portfolio_cfg.get("target_n", cfg.portfolio.get("random_n", 8))
+        )
     )
     seed_metric = cast(
         str,
-        (cfg.portfolio.get("selector", {}) or {}).get("params", {}).get("rank_column", "Sharpe"),
+        (cfg.portfolio.get("selector", {}) or {})
+        .get("params", {})
+        .get("rank_column", "Sharpe"),
     )
     selector = create_selector_by_name("rank", top_n=target_n, rank_column=seed_metric)
 
@@ -1429,7 +1491,9 @@ def run(
     if cooldown_periods_raw is None:
         cooldown_periods_raw = mp_cfg.get("cooldown_months")
     try:
-        cooldown_periods = int(cooldown_periods_raw) if cooldown_periods_raw is not None else 0
+        cooldown_periods = (
+            int(cooldown_periods_raw) if cooldown_periods_raw is not None else 0
+        )
     except (TypeError, ValueError):
         cooldown_periods = 0
     cooldown_periods = max(0, cooldown_periods)
@@ -1457,7 +1521,9 @@ def run(
     if raw_max_active is None:
         raw_max_active = constraints.get("max_active")
     try:
-        max_active_positions = int(raw_max_active) if raw_max_active is not None else None
+        max_active_positions = (
+            int(raw_max_active) if raw_max_active is not None else None
+        )
     except (TypeError, ValueError):
         max_active_positions = None
     if max_active_positions is not None and max_active_positions <= 0:
@@ -1502,7 +1568,9 @@ def run(
 
     # Risk-based weighting scheme (risk_parity, hrp) from weighting_scheme config.
     # This overrides the legacy `portfolio.weighting` dict config for primary weights.
-    weighting_scheme = str(cfg.portfolio.get("weighting_scheme", "equal") or "equal").lower()
+    weighting_scheme = str(
+        cfg.portfolio.get("weighting_scheme", "equal") or "equal"
+    ).lower()
     if weighting_scheme == "robust":
         weighting_scheme = "robust_mv"
     use_risk_weighting = weighting_scheme in {
@@ -1525,7 +1593,9 @@ def run(
                 weighting_scheme,
                 robustness_cfg if isinstance(robustness_cfg, Mapping) else None,
             )
-            risk_weight_engine = create_weight_engine(weighting_scheme, **weight_engine_params)
+            risk_weight_engine = create_weight_engine(
+                weighting_scheme, **weight_engine_params
+            )
         except Exception:  # pragma: no cover - best-effort only
             use_risk_weighting = False
             risk_weight_engine = None
@@ -1551,7 +1621,9 @@ def run(
     # --- main loop ------------------------------------------------------
     # Pre-index returns once for intra-period rebalance snapshots.
     df_indexed = df.copy()
-    df_indexed["Date"] = pd.to_datetime(df_indexed["Date"], utc=True).dt.tz_localize(None)
+    df_indexed["Date"] = pd.to_datetime(df_indexed["Date"], utc=True).dt.tz_localize(
+        None
+    )
     df_indexed.sort_values("Date", inplace=True)
     df_indexed = df_indexed.set_index("Date")
 
@@ -1590,7 +1662,9 @@ def run(
             return True
         return int(add_streaks.get(manager, 0)) >= sticky_add_periods
 
-    def _min_tenure_protected(holdings: Iterable[str], score_frame: pd.DataFrame) -> set[str]:
+    def _min_tenure_protected(
+        holdings: Iterable[str], score_frame: pd.DataFrame
+    ) -> set[str]:
         if min_tenure_n <= 0:
             return set()
         protected: set[str] = set()
@@ -1659,7 +1733,9 @@ def run(
                 int(cooldown_periods) + 1,
             )
 
-    def _dedupe_one_per_firm(sf: pd.DataFrame, holdings: list[str], metric: str) -> list[str]:
+    def _dedupe_one_per_firm(
+        sf: pd.DataFrame, holdings: list[str], metric: str
+    ) -> list[str]:
         if not holdings:
             return holdings
         col = metric if metric in sf.columns else "Sharpe"
@@ -1795,7 +1871,9 @@ def run(
         keep = ordered[:-bottom_k]
         return filtered.loc[keep]
 
-    def _filter_entry_candidates(candidates: list[str], score_frame: pd.DataFrame) -> list[str]:
+    def _filter_entry_candidates(
+        candidates: list[str], score_frame: pd.DataFrame
+    ) -> list[str]:
         if not candidates:
             return candidates
         eligible_frame = _filter_entry_frame(score_frame)
@@ -1804,7 +1882,9 @@ def run(
         eligible = {str(ix) for ix in eligible_frame.index}
         return [str(ix) for ix in candidates if str(ix) in eligible]
 
-    def _hard_exit_forced(holdings: Iterable[str], score_frame: pd.DataFrame) -> set[str]:
+    def _hard_exit_forced(
+        holdings: Iterable[str], score_frame: pd.DataFrame
+    ) -> set[str]:
         if z_exit_hard is None or "zscore" not in score_frame.columns:
             return set()
         z = pd.to_numeric(score_frame["zscore"], errors="coerce")
@@ -1925,7 +2005,14 @@ def run(
             # Risk-based weighting requires returns data
             try:
                 if returns_window is not None and not returns_window.empty:
-                    subset = returns_window.reindex(columns=holdings).dropna(axis=1, how="all")
+                    # Only include holdings that have data in returns_window
+                    # to avoid NaN columns that would get 0 weight
+                    holdings_in_window = [
+                        h for h in holdings if h in returns_window.columns
+                    ]
+                    subset = returns_window[holdings_in_window].dropna(
+                        axis=1, how="all"
+                    )
                 else:
                     # Fall back to score frame data if no returns window provided
                     subset = sf.loc[holdings]
@@ -1937,6 +2024,7 @@ def run(
                     return weighting.weight(sf.loc[holdings], date)
                 w_series = risk_weight_engine.weight(cov)
                 # Ensure all holdings have weights (fill missing with zero)
+                # Note: holdings not in returns_window will get 0 weight here
                 w_series = w_series.reindex(holdings).fillna(0.0)
                 total = w_series.sum()
                 if total > 1e-9:
@@ -2015,7 +2103,9 @@ def run(
         rf_rate_annual = float(metrics_cfg.get("rf_rate_annual", 0.0) or 0.0)
         # Convert annualised RF to a per-period return.
         # Use geometric conversion so 2% annual becomes ~0.165% monthly.
-        rf_rate_periodic = (1.0 + rf_rate_annual) ** (1.0 / float(periods_per_year)) - 1.0
+        rf_rate_periodic = (1.0 + rf_rate_annual) ** (
+            1.0 / float(periods_per_year)
+        ) - 1.0
 
         # UI semantics:
         # - override disabled: use the selected risk-free column series (if available)
@@ -2084,12 +2174,16 @@ def run(
                     holdings = []
                 else:
                     # Seed varies per period to get different selections
-                    period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(hash(str(pt)) % 10000)
+                    period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(
+                        hash(str(pt)) % 10000
+                    )
                     rng = np.random.default_rng(period_seed)
                     n_select = max(1, min(target_n, len(available)))
                     holdings = list(rng.choice(available, size=n_select, replace=False))
                     # Enforce one-per-firm constraint
-                    holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
+                    holdings = _dedupe_one_per_firm_with_events(
+                        sf, holdings, metric, events
+                    )
                     # If dedupe reduced us, refill with random selection
                     if len(holdings) < n_select:
                         candidates = [c for c in available if c not in holdings]
@@ -2114,11 +2208,15 @@ def run(
                     holdings = []
                 elif buy_hold_initial == "random":
                     # Random initial selection
-                    period_seed = abs((getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000)
+                    period_seed = abs(
+                        (getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000
+                    )
                     rng = np.random.default_rng(period_seed)
                     n_select = max(1, min(buy_hold_n, len(available)))
                     holdings = list(rng.choice(available, size=n_select, replace=False))
-                    holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
+                    holdings = _dedupe_one_per_firm_with_events(
+                        sf, holdings, metric, events
+                    )
                     # Refill if dedupe reduced holdings
                     if len(holdings) < n_select:
                         candidates = [c for c in available if c not in holdings]
@@ -2141,7 +2239,9 @@ def run(
                     if rank_score_by == "blended" and rank_blended_weights:
                         total_w = sum(rank_blended_weights.values())
                         if total_w > 0:
-                            norm_w = {k: v / total_w for k, v in rank_blended_weights.items()}
+                            norm_w = {
+                                k: v / total_w for k, v in rank_blended_weights.items()
+                            }
                         else:
                             norm_w = {"Sharpe": 1.0}
                         combo = pd.Series(0.0, index=eligible_sf.index, dtype=float)
@@ -2161,7 +2261,9 @@ def run(
                         scores = combo
                     else:
                         score_col = (
-                            rank_score_by if rank_score_by in eligible_sf.columns else "Sharpe"
+                            rank_score_by
+                            if rank_score_by in eligible_sf.columns
+                            else "Sharpe"
                         )
                         scores = eligible_sf[score_col].astype(float)
 
@@ -2174,7 +2276,10 @@ def run(
                             scores = pd.Series(0.0, index=scores.index)
 
                     ascending = False
-                    if rank_score_by in ASCENDING_METRICS and buy_hold_initial != "threshold":
+                    if (
+                        rank_score_by in ASCENDING_METRICS
+                        and buy_hold_initial != "threshold"
+                    ):
                         ascending = True
 
                     sorted_scores = scores.sort_values(ascending=ascending)
@@ -2199,7 +2304,9 @@ def run(
                         holdings = all_candidates[:buy_hold_n]
 
                     # Enforce one-per-firm constraint
-                    holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
+                    holdings = _dedupe_one_per_firm_with_events(
+                        sf, holdings, metric, events
+                    )
                     # Historical weighting call
                     if holdings:
                         try:
@@ -2230,7 +2337,9 @@ def run(
                         and rank_col in selected.columns
                     ):
                         ascending = rank_col in ASCENDING_METRICS
-                        ordered = selected.sort_values(rank_col, ascending=ascending).index
+                        ordered = selected.sort_values(
+                            rank_col, ascending=ascending
+                        ).index
                         holdings = [str(x) for x in ordered.tolist()]
                     else:
                         holdings = [str(x) for x in selected.index.tolist()]
@@ -2251,7 +2360,10 @@ def run(
                             # Normalize weights
                             total_w = sum(rank_blended_weights.values())
                             if total_w > 0:
-                                norm_w = {k: v / total_w for k, v in rank_blended_weights.items()}
+                                norm_w = {
+                                    k: v / total_w
+                                    for k, v in rank_blended_weights.items()
+                                }
                             else:
                                 norm_w = {"Sharpe": 1.0}
                             # Compute blended score from the score frame
@@ -2275,7 +2387,9 @@ def run(
                         else:
                             # Single metric
                             score_col = (
-                                rank_score_by if rank_score_by in score_frame.columns else "Sharpe"
+                                rank_score_by
+                                if rank_score_by in score_frame.columns
+                                else "Sharpe"
                             )
                             scores = score_frame[score_col].astype(float)
 
@@ -2289,7 +2403,10 @@ def run(
 
                         # Determine sort order
                         ascending = False  # Higher score is better for blended/zscore
-                        if rank_score_by in ASCENDING_METRICS and rank_transform != "zscore":
+                        if (
+                            rank_score_by in ASCENDING_METRICS
+                            and rank_transform != "zscore"
+                        ):
                             ascending = True
 
                         # Sort scores
@@ -2345,11 +2462,15 @@ def run(
                 if len(holdings) > target_n:
                     holdings = holdings[:target_n]
                 # Enforce one-per-firm on seed
-                holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
+                holdings = _dedupe_one_per_firm_with_events(
+                    sf, holdings, metric, events
+                )
                 desired_seed = min(max_funds, target_n)
                 # If we're still above the desired size, trim by zscore (best-first).
                 if len(holdings) > desired_seed:
-                    zsorted = sf.loc[holdings].sort_values("zscore", ascending=False).index
+                    zsorted = (
+                        sf.loc[holdings].sort_values("zscore", ascending=False).index
+                    )
                     holdings = list(zsorted[:desired_seed])
 
                 # If dedupe reduced us below the target size, fill from the remaining
@@ -2359,8 +2480,12 @@ def run(
                 # that percentage of the universe.
                 if len(holdings) < desired_seed and inclusion_approach != "top_pct":
                     candidates = [c for c in sf.index if c not in holdings]
-                    candidates = _filter_entry_candidates([str(c) for c in candidates], sf)
-                    add_from = sf.loc[candidates].sort_values("zscore", ascending=False).index
+                    candidates = _filter_entry_candidates(
+                        [str(c) for c in candidates], sf
+                    )
+                    add_from = (
+                        sf.loc[candidates].sort_values("zscore", ascending=False).index
+                    )
                     seen_firms = {_firm(h) for h in holdings}
                     for f in add_from:
                         if len(holdings) >= desired_seed:
@@ -2380,7 +2505,9 @@ def run(
                     and resolved_rf_col in holdings
                 ):
                     candidates = [c for c in sf.index if c not in holdings]
-                    candidates = _filter_entry_candidates([str(c) for c in candidates], sf)
+                    candidates = _filter_entry_candidates(
+                        [str(c) for c in candidates], sf
+                    )
                     add_from = (
                         sf.loc[candidates].sort_values("zscore", ascending=False).index
                         if candidates
@@ -2399,7 +2526,11 @@ def run(
                         holdings.append(replacement)
 
             # Compute weights using risk engine or fallback to legacy weighting
-            weights_df = _compute_weights(sf, holdings, period_ts, in_df.reindex(columns=fund_cols))
+            # Use holdings (not fund_cols) so newly added funds get proper weight data
+            holdings_with_data = [h for h in holdings if h in in_df.columns]
+            weights_df = _compute_weights(
+                sf, holdings, period_ts, in_df.reindex(columns=holdings_with_data)
+            )
             raw_weight_series = _as_weight_series(weights_df)
             signal_slice = sf.loc[holdings, metric] if metric in sf.columns else None
             weight_series = _apply_policy_to_weights(weights_df, signal_slice)
@@ -2458,7 +2589,9 @@ def run(
                 # Replace exited funds using the same initial selection method
                 n_needed = buy_hold_n - len(current_holdings)
                 if n_needed > 0:
-                    available = [str(c) for c in sf.index if str(c) not in current_holdings]
+                    available = [
+                        str(c) for c in sf.index if str(c) not in current_holdings
+                    ]
                     if cooldown_periods > 0 and cooldown_book:
                         available = [c for c in available if c not in cooldown_book]
                     available = _filter_entry_candidates(available, sf)
@@ -2485,7 +2618,10 @@ def run(
                         if rank_score_by == "blended" and rank_blended_weights:
                             total_w = sum(rank_blended_weights.values())
                             if total_w > 0:
-                                norm_w = {k: v / total_w for k, v in rank_blended_weights.items()}
+                                norm_w = {
+                                    k: v / total_w
+                                    for k, v in rank_blended_weights.items()
+                                }
                             else:
                                 norm_w = {"Sharpe": 1.0}
                             combo = pd.Series(0.0, index=sf.index, dtype=float)
@@ -2504,7 +2640,11 @@ def run(
                                     combo += w * z
                             scores = combo
                         else:
-                            score_col = rank_score_by if rank_score_by in sf.columns else "Sharpe"
+                            score_col = (
+                                rank_score_by
+                                if rank_score_by in sf.columns
+                                else "Sharpe"
+                            )
                             scores = sf[score_col].astype(float)
 
                         # Apply zscore transform if threshold mode
@@ -2516,11 +2656,16 @@ def run(
                                 scores = pd.Series(0.0, index=scores.index)
 
                         ascending = False
-                        if rank_score_by in ASCENDING_METRICS and buy_hold_initial != "threshold":
+                        if (
+                            rank_score_by in ASCENDING_METRICS
+                            and buy_hold_initial != "threshold"
+                        ):
                             ascending = True
 
                         # Sort scores and filter to available candidates
-                        sorted_scores = scores.loc[available].sort_values(ascending=ascending)
+                        sorted_scores = scores.loc[available].sort_values(
+                            ascending=ascending
+                        )
 
                         # Select replacements respecting threshold if applicable
                         if buy_hold_initial == "threshold":
@@ -2563,7 +2708,9 @@ def run(
                 # each period. This is essential to avoid survivorship bias - we select
                 # from the available universe at each point in time, not funds we know
                 # will survive.
-                period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(hash(str(pt)) % 10000)
+                period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(
+                    hash(str(pt)) % 10000
+                )
                 rebased = rebalancer.apply_triggers(
                     prev_weights.astype(float),
                     sf,
@@ -2572,10 +2719,14 @@ def run(
                 )
 
                 # Restrict to funds available in this period's score-frame.
-                proposed_holdings = [str(h) for h in list(rebased.index) if h in sf.index]
+                proposed_holdings = [
+                    str(h) for h in list(rebased.index) if h in sf.index
+                ]
 
             if hard_exit_forced:
-                proposed_holdings = [m for m in proposed_holdings if m not in hard_exit_forced]
+                proposed_holdings = [
+                    m for m in proposed_holdings if m not in hard_exit_forced
+                ]
 
             raw_proposed_holdings = [str(h) for h in proposed_holdings]
 
@@ -2648,7 +2799,8 @@ def run(
                                 "firm": _firm(mgr),
                                 "reason": "sticky_add",
                                 "detail": (
-                                    f"streak={add_streaks.get(mgr, 0)}/" f"{sticky_add_periods}"
+                                    f"streak={add_streaks.get(mgr, 0)}/"
+                                    f"{sticky_add_periods}"
                                 ),
                             }
                         )
@@ -2669,7 +2821,8 @@ def run(
                                 "firm": _firm(mgr),
                                 "reason": "sticky_drop",
                                 "detail": (
-                                    f"streak={drop_streaks.get(mgr, 0)}/" f"{sticky_drop_periods}"
+                                    f"streak={drop_streaks.get(mgr, 0)}/"
+                                    f"{sticky_drop_periods}"
                                 ),
                             }
                         )
@@ -2703,7 +2856,8 @@ def run(
                             "firm": _firm(mgr),
                             "reason": "min_tenure",
                             "detail": (
-                                f"tenure={int(holdings_tenure.get(mgr, 0))}/" f"{min_tenure_n}"
+                                f"tenure={int(holdings_tenure.get(mgr, 0))}/"
+                                f"{min_tenure_n}"
                             ),
                         }
                     )
@@ -2767,12 +2921,18 @@ def run(
                 candidates = _filter_entry_candidates(candidates, sf)
                 if candidates:
                     if is_random_mode:
-                        period_seed = abs((getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000)
+                        period_seed = abs(
+                            (getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000
+                        )
                         rng = np.random.default_rng(period_seed)
                         rng.shuffle(candidates)
                         ranked = candidates
                     else:
-                        ranked = sf.loc[candidates].sort_values("zscore", ascending=False).index
+                        ranked = (
+                            sf.loc[candidates]
+                            .sort_values("zscore", ascending=False)
+                            .index
+                        )
                     for c in ranked:
                         if len(proposed_holdings) >= desired_size:
                             break
@@ -2791,8 +2951,12 @@ def run(
             pruned_existing: set[str] = set()
             if desired_size > 0:
                 current_set = {str(x) for x in before_reb}
-                kept_existing = [str(h) for h in proposed_holdings if str(h) in current_set]
-                new_candidates = [str(h) for h in proposed_holdings if str(h) not in current_set]
+                kept_existing = [
+                    str(h) for h in proposed_holdings if str(h) in current_set
+                ]
+                new_candidates = [
+                    str(h) for h in proposed_holdings if str(h) not in current_set
+                ]
 
                 def _zscore(mgr: str) -> float:
                     try:
@@ -2815,14 +2979,20 @@ def run(
                 # not happen), prune incumbents by weakest zscore.
                 # In random mode, prune randomly instead.
                 if len(kept_existing) > desired_size:
-                    protected_existing = [mgr for mgr in kept_existing if mgr in protected_holdings]
+                    protected_existing = [
+                        mgr for mgr in kept_existing if mgr in protected_holdings
+                    ]
                     unprotected_existing = [
                         mgr for mgr in kept_existing if mgr not in protected_holdings
                     ]
                     if is_random_mode:
-                        unprotected_sorted = sorted(unprotected_existing, key=_random_key)
+                        unprotected_sorted = sorted(
+                            unprotected_existing, key=_random_key
+                        )
                     else:
-                        unprotected_sorted = sorted(unprotected_existing, key=_zscore, reverse=True)
+                        unprotected_sorted = sorted(
+                            unprotected_existing, key=_zscore, reverse=True
+                        )
                     if protected_existing:
                         slots = max(0, desired_size - len(protected_existing))
                         if slots > 0:
@@ -2878,7 +3048,9 @@ def run(
                 selected, _ = selector.select(_filter_entry_frame(sf))
                 proposed_holdings = [str(x) for x in selected.index.tolist()]
                 if cooldown_periods > 0 and cooldown_book:
-                    filtered = [mgr for mgr in proposed_holdings if mgr not in cooldown_book]
+                    filtered = [
+                        mgr for mgr in proposed_holdings if mgr not in cooldown_book
+                    ]
                     if filtered:
                         for mgr in proposed_holdings:
                             if mgr in cooldown_book:
@@ -3075,7 +3247,11 @@ def run(
                 )
 
             # Compute weights using risk engine or fallback to legacy weighting
-            weights_df = _compute_weights(sf, holdings, period_ts, in_df.reindex(columns=fund_cols))
+            # Use holdings (not fund_cols) so newly added funds get proper weight data
+            holdings_with_data = [h for h in holdings if h in in_df.columns]
+            weights_df = _compute_weights(
+                sf, holdings, period_ts, in_df.reindex(columns=holdings_with_data)
+            )
             raw_weight_series = _as_weight_series(weights_df)
             signal_slice = sf.loc[holdings, metric] if metric in sf.columns else None
             weight_series = _apply_policy_to_weights(weights_df, signal_slice)
@@ -3120,7 +3296,8 @@ def run(
                         "firm": _firm(f),
                         "reason": "low_weight_strikes",
                         "detail": (
-                            f"below min {min_w_bound:.2%} for " f"{low_min_strikes_req} periods"
+                            f"below min {min_w_bound:.2%} for "
+                            f"{low_min_strikes_req} periods"
                         ),
                     }
                 )
@@ -3133,11 +3310,17 @@ def run(
             need = max(0, desired_after_low_weight - len(holdings))
             if need > 0:
                 candidates = [
-                    c for c in sf.index if c not in holdings and _eligible_sticky_add(str(c))
+                    c
+                    for c in sf.index
+                    if c not in holdings and _eligible_sticky_add(str(c))
                 ]
                 if cooldown_periods > 0 and cooldown_book:
                     candidates = [c for c in candidates if str(c) not in cooldown_book]
-                add_from = sf.loc[candidates].sort_values("zscore", ascending=False).index.tolist()
+                add_from = (
+                    sf.loc[candidates]
+                    .sort_values("zscore", ascending=False)
+                    .index.tolist()
+                )
                 for f in add_from:
                     if len(holdings) >= desired_after_low_weight:
                         break
@@ -3155,11 +3338,15 @@ def run(
                     )
             if holdings:
                 # Compute weights using risk engine or fallback to legacy weighting
+                # Use holdings (not fund_cols) so newly added funds get proper weight data
+                holdings_with_data = [h for h in holdings if h in in_df.columns]
                 weights_df = _compute_weights(
-                    sf, holdings, period_ts, in_df.reindex(columns=fund_cols)
+                    sf, holdings, period_ts, in_df.reindex(columns=holdings_with_data)
                 )
                 raw_weight_series = _as_weight_series(weights_df)
-                signal_slice = sf.loc[holdings, metric] if metric in sf.columns else None
+                signal_slice = (
+                    sf.loc[holdings, metric] if metric in sf.columns else None
+                )
                 weight_series = _apply_policy_to_weights(weights_df, signal_slice)
                 weights_df = weight_series.to_frame("weight")
                 prev_weights = weight_series.astype(float)
@@ -3170,18 +3357,24 @@ def run(
             holdings = _enforce_min_funds(
                 sf,
                 holdings,
-                before_reb=(set(prev_weights.index) if prev_weights is not None else None),
+                before_reb=(
+                    set(prev_weights.index) if prev_weights is not None else None
+                ),
                 cooldowns=cooldown_book,
                 desired_min=min_funds,
                 events=events,
             )
             if holdings and prev_weights is not None:
                 # Compute weights using risk engine or fallback to legacy weighting
+                # Use holdings (not fund_cols) so newly added funds get proper weight data
+                holdings_with_data = [h for h in holdings if h in in_df.columns]
                 weights_df = _compute_weights(
-                    sf, holdings, period_ts, in_df.reindex(columns=fund_cols)
+                    sf, holdings, period_ts, in_df.reindex(columns=holdings_with_data)
                 )
                 raw_weight_series = _as_weight_series(weights_df)
-                signal_slice = sf.loc[holdings, metric] if metric in sf.columns else None
+                signal_slice = (
+                    sf.loc[holdings, metric] if metric in sf.columns else None
+                )
                 weight_series = _apply_policy_to_weights(weights_df, signal_slice)
                 weights_df = weight_series.to_frame("weight")
                 prev_weights = weight_series.astype(float)
@@ -3237,7 +3430,9 @@ def run(
             mandatory = desired_trades.copy()
             if forced_ix:
                 # Keep only forced exit trades in mandatory bucket
-                mandatory.loc[[ix for ix in mandatory.index if ix not in forced_ix]] = 0.0
+                mandatory.loc[[ix for ix in mandatory.index if ix not in forced_ix]] = (
+                    0.0
+                )
             else:
                 mandatory[:] = 0.0
 
@@ -3251,7 +3446,11 @@ def run(
                 final_w = last_aligned + mandatory
             else:
                 remaining_turnover = max_turnover_cap - mandatory_turnover
-                scale = remaining_turnover / optional_turnover if optional_turnover > 0 else 0.0
+                scale = (
+                    remaining_turnover / optional_turnover
+                    if optional_turnover > 0
+                    else 0.0
+                )
                 scale = max(0.0, min(1.0, scale))
                 final_w = last_aligned + mandatory + optional * scale
         # Ensure bounds and normalisation remain satisfied
@@ -3274,8 +3473,12 @@ def run(
             if total > eps and abs(total - 1.0) <= 1e-8:
                 final_w = final_w / total
         # Only pass the selected holdings (if still present after filtering).
-        manual_funds: list[str] = [str(h) for h in manual_holdings if h in final_w.index]
-        custom: dict[str, float] = {str(k): float(v) * 100.0 for k, v in final_w.items()}
+        manual_funds: list[str] = [
+            str(h) for h in manual_holdings if h in final_w.index
+        ]
+        custom: dict[str, float] = {
+            str(k): float(v) * 100.0 for k, v in final_w.items()
+        }
 
         # Construct previous weights dict for pipeline (turnover tracking)
         prev_weights_for_pipeline = _coerce_previous_weights(prev_final_weights)
@@ -3330,7 +3533,10 @@ def run(
         # consumers can audit soft-entry/soft-exit decisions without
         # recomputation.
         score_frame_payload = res_dict.get("score_frame")
-        if isinstance(score_frame_payload, pd.DataFrame) and not score_frame_payload.empty:
+        if (
+            isinstance(score_frame_payload, pd.DataFrame)
+            and not score_frame_payload.empty
+        ):
             score_frame_out = score_frame_payload.copy()
             if "zscore" in sf.columns and "zscore" not in score_frame_out.columns:
                 score_frame_out = score_frame_out.join(sf[["zscore"]], how="left")
@@ -3349,21 +3555,16 @@ def run(
         res_dict["selection_score_frame"] = sf.copy()
         res_dict["selection_metric"] = metric
 
-        # Determine the realised weights/holdings as used by the pipeline.
-        # This is the contract for downstream reporting/export.  In particular,
-        # missing-data filters or other pipeline constraints may alter the final
-        # investable set.  Manager changes must match these realised holdings.
-        pipeline_weights_raw = res_dict.get("fund_weights")
-        effective_w: pd.Series
-        used_pipeline_weights = False
-        if isinstance(pipeline_weights_raw, dict) and pipeline_weights_raw:
-            try:
-                effective_w = pd.Series(pipeline_weights_raw, dtype=float)
-                used_pipeline_weights = True
-            except Exception:
-                effective_w = final_w.copy()
-        else:
-            effective_w = final_w.copy()
+        # Determine the realised weights/holdings.
+        # IMPORTANT: Use final_w (our selection-engine computed weights) rather
+        # than pipeline_weights_raw, because the pipeline may filter out newly
+        # added funds that don't meet its data requirements for the in-sample
+        # window. The multi-period engine has already validated these funds can
+        # be selected; their weights should be respected.
+        #
+        # Note: If pipeline_weights_raw has funds NOT in final_w (e.g., indices,
+        # benchmarks), we filter those out later via drop_cols.
+        effective_w: pd.Series = final_w.copy()
 
         effective_w = effective_w[effective_w.abs() > eps]
 
@@ -3379,29 +3580,13 @@ def run(
         # Turnover alignment can introduce additional indices (e.g., prior
         # holdings carried at zero then floored by bounds). These should not
         # become realised holdings unless they are part of the manual fund list
-        # passed to the pipeline. However, if the pipeline emits a non-empty
-        # fund_weights mapping, treat it as authoritative for realised holdings
-        # (subject to index/risk-free filtering).
-        if manual_holdings and not used_pipeline_weights:
+        # passed to the pipeline.
+        if manual_holdings:
             manual_set = {str(x) for x in manual_holdings}
             effective_w = effective_w.drop(
                 labels=[c for c in effective_w.index if str(c) not in manual_set],
                 errors="ignore",
             )
-
-        # Some pipeline fallbacks can yield a populated-but-zero weight mapping.
-        # Treat that as unusable and fall back to the intended weights.
-        if used_pipeline_weights and effective_w.abs().sum() <= eps:
-            effective_w = final_w.copy()
-            effective_w = effective_w[effective_w.abs() > eps]
-            if drop_cols:
-                effective_w = effective_w.drop(labels=list(drop_cols), errors="ignore")
-            if manual_holdings:
-                manual_set = {str(x) for x in manual_holdings}
-                effective_w = effective_w.drop(
-                    labels=[c for c in effective_w.index if str(c) not in manual_set],
-                    errors="ignore",
-                )
 
         # Enforce max_funds contract on realised holdings.
         # This guards against any upstream components returning extra positions.
@@ -3499,7 +3684,9 @@ def run(
         realised_holdings = [str(x) for x in effective_nonzero.index]
         # Do not emit zero-weight positions: they are not real holdings and
         # confuse downstream audits (e.g., a dropped fund showing up with 0.0).
-        res_dict["fund_weights"] = {str(k): float(v) for k, v in effective_nonzero.items()}
+        res_dict["fund_weights"] = {
+            str(k): float(v) for k, v in effective_nonzero.items()
+        }
 
         # Record cooldowns for any managers that exited based on realised holdings.
         if cooldown_periods > 0 and prev_final_weights is not None:
@@ -3560,7 +3747,8 @@ def run(
                         ) + pd.offsets.MonthEnd(0)
 
                         window = df_indexed.reindex(columns=realised_holdings).loc[
-                            (df_indexed.index >= start_dt) & (df_indexed.index <= end_dt)
+                            (df_indexed.index >= start_dt)
+                            & (df_indexed.index <= end_dt)
                         ]
                         if window.empty:
                             w_row = prev_reb_w
@@ -3608,7 +3796,9 @@ def run(
                             except Exception:  # pragma: no cover - best-effort only
                                 w_row = prev_reb_w
 
-                        rebalance_rows.append({str(k): float(v) for k, v in w_row.items()})
+                        rebalance_rows.append(
+                            {str(k): float(v) for k, v in w_row.items()}
+                        )
 
                     rebalance_frame = pd.DataFrame(
                         rebalance_rows,
@@ -3622,7 +3812,9 @@ def run(
         if rebalance_frame is not None and not rebalance_frame.empty:
             out_scaled = res_dict.get("out_sample_scaled")
             if isinstance(out_scaled, pd.DataFrame) and not out_scaled.empty:
-                weights_by_date = rebalance_frame.reindex(out_scaled.index).ffill().fillna(0.0)
+                weights_by_date = (
+                    rebalance_frame.reindex(out_scaled.index).ffill().fillna(0.0)
+                )
                 weights_by_date = weights_by_date.reindex(
                     columns=out_scaled.columns, fill_value=0.0
                 )
@@ -3643,8 +3835,12 @@ def run(
 
                 out_raw = out_df.reindex(columns=out_scaled.columns)
                 if isinstance(out_raw, pd.DataFrame) and not out_raw.empty:
-                    weights_raw = rebalance_frame.reindex(out_raw.index).ffill().fillna(0.0)
-                    weights_raw = weights_raw.reindex(columns=out_raw.columns, fill_value=0.0)
+                    weights_raw = (
+                        rebalance_frame.reindex(out_raw.index).ffill().fillna(0.0)
+                    )
+                    weights_raw = weights_raw.reindex(
+                        columns=out_raw.columns, fill_value=0.0
+                    )
                     rebalance_raw = (out_raw * weights_raw).sum(axis=1)
                     res_dict["portfolio_user_weight_raw"] = rebalance_raw
                     res_dict["out_user_stats_raw"] = _compute_stats(

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -2466,16 +2466,12 @@ def run(
                 # Replace exited funds using the same initial selection method
                 n_needed = buy_hold_n - len(current_holdings)
                 if n_needed > 0:
-                    available = [
-                        str(c) for c in sf.index if str(c) not in current_holdings
-                    ]
+                    available = [str(c) for c in sf.index if str(c) not in current_holdings]
                     # Only consider funds that still have out-of-sample data;
                     # prevents re-adding funds whose data has disappeared.
                     if isinstance(out_df, pd.DataFrame) and not out_df.empty:
                         available = [
-                            c
-                            for c in available
-                            if c in out_df.columns and out_df[c].notna().any()
+                            c for c in available if c in out_df.columns and out_df[c].notna().any()
                         ]
                     if cooldown_periods > 0 and cooldown_book:
                         available = [c for c in available if c not in cooldown_book]

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -81,9 +81,7 @@ def _run_analysis(*args: Any, **kwargs: Any) -> PipelineResult:
     return _invoke_analysis_with_diag(*args, **kwargs)
 
 
-def _call_pipeline_with_diag(
-    *args: Any, **kwargs: Any
-) -> DiagnosticResult[dict[str, Any] | None]:
+def _call_pipeline_with_diag(*args: Any, **kwargs: Any) -> DiagnosticResult[dict[str, Any] | None]:
     """Execute ``_run_analysis`` and normalise into a ``DiagnosticResult``.
 
     Tests and legacy callers monkeypatch ``_run_analysis`` to return raw dict
@@ -153,9 +151,7 @@ def _membership_table_from_frame(frame: pd.DataFrame) -> MembershipTable:
     eff_col = lookup.get("effective_date")
     end_col = lookup.get("end_date")
     if not fund_col or not eff_col or not end_col:
-        raise ValueError(
-            "membership data must include fund, effective_date, and end_date columns"
-        )
+        raise ValueError("membership data must include fund, effective_date, and end_date columns")
 
     normalised = frame.rename(
         columns={fund_col: "fund", eff_col: "effective_date", end_col: "end_date"}
@@ -214,9 +210,9 @@ def _compute_turnover_state(
     new_aligned: FloatArray = new_series.reindex(union_index, fill_value=0.0).to_numpy(
         dtype=float, copy=False
     )
-    prev_aligned: FloatArray = prev_series.reindex(
-        union_index, fill_value=0.0
-    ).to_numpy(dtype=float, copy=False)
+    prev_aligned: FloatArray = prev_series.reindex(union_index, fill_value=0.0).to_numpy(
+        dtype=float, copy=False
+    )
 
     turnover = float(np.abs(new_aligned - prev_aligned).sum())
     return turnover, nidx, nvals
@@ -300,9 +296,9 @@ def _apply_weight_bounds(
                 room = (max_w_bound - receivers).clip(lower=0.0)
                 rm = room.sum()
                 if rm > 0:
-                    floored.loc[receivers.index] = (
-                        receivers + (room / rm) * deficit
-                    ).clip(upper=max_w_bound)
+                    floored.loc[receivers.index] = (receivers + (room / rm) * deficit).clip(
+                        upper=max_w_bound
+                    )
 
     return floored
 
@@ -342,12 +338,7 @@ def _enforce_max_active_positions(
                 .index
             )
     else:
-        keep = (
-            active.abs()
-            .sort_values(ascending=False, kind="mergesort")
-            .head(max_active)
-            .index
-        )
+        keep = active.abs().sort_values(ascending=False, kind="mergesort").head(max_active).index
     trimmed = weights.copy()
     trimmed.loc[~trimmed.index.isin(keep)] = 0.0
 
@@ -532,11 +523,7 @@ def run_schedule(
         turnover = float(np.abs(new_aligned - prev_aligned).sum())
         return turnover, nidx, nvals
 
-    col = (
-        rank_column
-        or getattr(selector, "rank_column", None)
-        or getattr(selector, "column", None)
-    )
+    col = rank_column or getattr(selector, "rank_column", None) or getattr(selector, "column", None)
 
     for date in sorted(score_frames):
         sf = score_frames[date]
@@ -570,9 +557,7 @@ def run_schedule(
 
         # Apply rebalancing strategies if configured
         if rebalance_strategies and rebalance_params:
-            current_weights = (
-                prev_weights if prev_weights is not None else pd.Series(dtype=float)
-            )
+            current_weights = prev_weights if prev_weights is not None else pd.Series(dtype=float)
             target_weight_series = target_weights["weight"].astype(float)
 
             # Get scores for priority-based strategies
@@ -597,9 +582,7 @@ def run_schedule(
             cost = 0.0
             weights = target_weights
             tw = target_weights["weight"].astype(float)
-            turnover, prev_tidx, prev_tvals = _compute_turnover_state(
-                prev_tidx, prev_tvals, tw
-            )
+            turnover, prev_tidx, prev_tvals = _compute_turnover_state(prev_tidx, prev_tvals, tw)
             prev_weights = tw
 
         pf.rebalance(date, weights, turnover, cost)
@@ -634,9 +617,7 @@ def run_schedule(
                     pv = prev.reindex(u, fill_value=0.0).to_numpy()
                     expected = float(np.abs(dv - pv).sum())
                 got = pf.turnover[d]
-                if not np.isclose(
-                    expected, got, rtol=0, atol=1e-12
-                ):  # pragma: no cover
+                if not np.isclose(expected, got, rtol=0, atol=1e-12):  # pragma: no cover
                     raise AssertionError(
                         f"Turnover mismatch for {d}: expected {expected} got {got}"
                     )
@@ -686,13 +667,9 @@ def run(
             raise TypeError("price_frames must be a dict[str, pd.DataFrame] or None")
         for date_key, frame in price_frames.items():
             if not isinstance(frame, pd.DataFrame):
-                raise TypeError(
-                    f"price_frames['{date_key}'] must be a pandas DataFrame"
-                )
+                raise TypeError(f"price_frames['{date_key}'] must be a pandas DataFrame")
             required_columns = ["Date"]
-            missing_columns = [
-                col for col in required_columns if col not in frame.columns
-            ]
+            missing_columns = [col for col in required_columns if col not in frame.columns]
             if missing_columns:
                 raise ValueError(
                     (
@@ -709,9 +686,7 @@ def run(
         # columns are included, handling missing data gracefully.
         combined_frames = [frame.copy() for frame in price_frames.values()]
         if combined_frames:
-            df = pd.concat(
-                combined_frames, axis=0, join="outer", ignore_index=True, sort=True
-            )
+            df = pd.concat(combined_frames, axis=0, join="outer", ignore_index=True, sort=True)
             # Sort by Date to ensure proper ordering
             df = df.sort_values("Date").reset_index(drop=True)
             # Remove any duplicates created during concatenation
@@ -898,8 +873,7 @@ def run(
         # Persist for debugging/export consumers.
         cleaned.attrs = dict(cleaned.attrs)
         cleaned.attrs["inception_dates"] = {
-            k: (v.strftime("%Y-%m-%d") if v is not None else None)
-            for k, v in inception_raw.items()
+            k: (v.strftime("%Y-%m-%d") if v is not None else None) for k, v in inception_raw.items()
         }
     except Exception:  # pragma: no cover - defensive
         pass
@@ -964,9 +938,7 @@ def run(
 
         periods = generate_periods(cfg_dump)
         if not periods:
-            logger.warning(
-                "generate_periods produced no periods; skipping multi-period run"
-            )
+            logger.warning("generate_periods produced no periods; skipping multi-period run")
             return []
         out_results: List[MultiPeriodPeriodResult] = []
         # Performance flags
@@ -983,9 +955,7 @@ def run(
             except Exception:  # pragma: no cover - defensive
                 cov_cache_obj = None
         prev_in_df = None
-        prev_weights_for_pipeline = _coerce_previous_weights(
-            cfg.portfolio.get("previous_weights")
-        )
+        prev_weights_for_pipeline = _coerce_previous_weights(cfg.portfolio.get("previous_weights"))
 
         for pt in periods:
             analysis_res = _call_pipeline_with_diag(
@@ -1058,9 +1028,7 @@ def run(
                 # Recreate in-sample frame identical to _run_analysis slice
                 date_col = "Date"
                 sub = df.copy()
-                sub[date_col] = pd.to_datetime(sub[date_col], utc=True).dt.tz_localize(
-                    None
-                )
+                sub[date_col] = pd.to_datetime(sub[date_col], utc=True).dt.tz_localize(None)
                 sub.sort_values(date_col, inplace=True)
                 sdate = pd.to_datetime(f"{in_start}-01", utc=True).tz_localize(
                     None
@@ -1068,27 +1036,19 @@ def run(
                 edate = pd.to_datetime(f"{in_end}-01", utc=True).tz_localize(
                     None
                 ) + pd.offsets.MonthEnd(0)
-                in_df_full = sub[
-                    (sub[date_col] >= sdate) & (sub[date_col] <= edate)
-                ].set_index(date_col)
+                in_df_full = sub[(sub[date_col] >= sdate) & (sub[date_col] <= edate)].set_index(
+                    date_col
+                )
                 # Remove benchmark columns if present in result universe
                 fund_cols = [
-                    c
-                    for c in in_df_full.columns
-                    if c not in (cfg.benchmarks or {}).values()
+                    c for c in in_df_full.columns if c not in (cfg.benchmarks or {}).values()
                 ]
                 in_df_full = in_df_full[fund_cols]
                 in_df_prepared = _prepare_returns_frame(in_df_full)
 
-                if (
-                    incremental_cov
-                    and prev_cov_payload is not None
-                    and prev_in_df is not None
-                ):
+                if incremental_cov and prev_cov_payload is not None and prev_in_df is not None:
                     same_len = prev_in_df.shape[0] == in_df_prepared.shape[0]
-                    same_cols = (
-                        prev_in_df.columns.tolist() == in_df_prepared.columns.tolist()
-                    )
+                    same_cols = prev_in_df.columns.tolist() == in_df_prepared.columns.tolist()
                     n_rows = in_df_prepared.shape[0]
                     if same_cols and n_rows >= 3:
                         # Determine shift distance k (number of rows replaced at head and appended at tail)
@@ -1126,12 +1086,10 @@ def run(
                             # Apply k incremental updates sequentially
                             try:
                                 for step in range(k):
-                                    old_row = prev_in_df.iloc[step].to_numpy(
+                                    old_row = prev_in_df.iloc[step].to_numpy(dtype=float)
+                                    new_row = in_df_prepared.iloc[n_rows - k + step].to_numpy(
                                         dtype=float
                                     )
-                                    new_row = in_df_prepared.iloc[
-                                        n_rows - k + step
-                                    ].to_numpy(dtype=float)
                                     prev_cov_payload = incremental_cov_update(
                                         prev_cov_payload, old_row, new_row
                                     )
@@ -1149,9 +1107,7 @@ def run(
                 else:
                     from ..perf.cache import compute_cov_payload as _ccp
 
-                    prev_cov_payload = _ccp(
-                        in_df_prepared, materialise_aggregates=incremental_cov
-                    )
+                    prev_cov_payload = _ccp(in_df_prepared, materialise_aggregates=incremental_cov)
                 prev_in_df = in_df_prepared
                 res_dict["cov_diag"] = prev_cov_payload.cov.diagonal().tolist()
                 if cov_cache_obj is not None:
@@ -1221,14 +1177,12 @@ def run(
                 continue
             seen.add(resolved)
             benchmark_cols.append(resolved)
-    resolved_rf_col, _resolver_fund_cols, resolved_rf_source = (
-        _resolve_risk_free_column(
-            df,
-            date_col="Date",
-            indices_list=indices_list,
-            risk_free_column=risk_free_column_cfg,
-            allow_risk_free_fallback=allow_risk_free_fallback_cfg,
-        )
+    resolved_rf_col, _resolver_fund_cols, resolved_rf_source = _resolve_risk_free_column(
+        df,
+        date_col="Date",
+        indices_list=indices_list,
+        risk_free_column=risk_free_column_cfg,
+        allow_risk_free_fallback=allow_risk_free_fallback_cfg,
     )
 
     # Build a stable investable universe list.
@@ -1241,9 +1195,7 @@ def run(
     idx_set |= {str(c) for c in benchmark_cols}
     resolved_fund_candidates = [c for c in numeric_cols_all if c not in idx_set]
     if resolved_rf_source == "configured" and resolved_rf_col:
-        resolved_fund_candidates = [
-            c for c in resolved_fund_candidates if c != resolved_rf_col
-        ]
+        resolved_fund_candidates = [c for c in resolved_fund_candidates if c != resolved_rf_col]
     elif resolved_rf_source == "fallback" and resolved_rf_col:
         # Fallback RF selection can legitimately pick a true cash proxy (flat
         # zero-return series). Treat such near-constant columns as non-investable
@@ -1260,9 +1212,7 @@ def run(
 
     # --- helpers --------------------------------------------------------
     def _parse_month(s: str) -> pd.Timestamp:
-        return pd.to_datetime(f"{s}-01", utc=True).tz_localize(
-            None
-        ) + pd.offsets.MonthEnd(0)
+        return pd.to_datetime(f"{s}-01", utc=True).tz_localize(None) + pd.offsets.MonthEnd(0)
 
     def _valid_universe(
         full: pd.DataFrame,
@@ -1277,22 +1227,16 @@ def run(
         sub.sort_values(date_col, inplace=True)
         in_sdate, in_edate = _parse_month(in_start), _parse_month(in_end)
         out_sdate, out_edate = _parse_month(out_start), _parse_month(out_end)
-        in_df = sub[
-            (sub[date_col] >= in_sdate) & (sub[date_col] <= in_edate)
-        ].set_index(date_col)
-        out_df = sub[
-            (sub[date_col] >= out_sdate) & (sub[date_col] <= out_edate)
-        ].set_index(date_col)
+        in_df = sub[(sub[date_col] >= in_sdate) & (sub[date_col] <= in_edate)].set_index(date_col)
+        out_df = sub[(sub[date_col] >= out_sdate) & (sub[date_col] <= out_edate)].set_index(
+            date_col
+        )
         if in_df.empty or out_df.empty:
             return in_df, out_df, [], ""
         numeric_cols = [c for c in sub.select_dtypes("number").columns if c != date_col]
         idx_set = {str(c) for c in indices_list}
         idx_set |= {str(c) for c in benchmark_cols}
-        fund_cols = [
-            c
-            for c in resolved_fund_candidates
-            if c in numeric_cols and c not in idx_set
-        ]
+        fund_cols = [c for c in resolved_fund_candidates if c in numeric_cols and c not in idx_set]
 
         if not fund_cols:
             return in_df, out_df, [], resolved_rf_col
@@ -1310,9 +1254,7 @@ def run(
         in_ok = ~in_tail.isna().any()
         out_ok = ~out_df[fund_cols].isna().any()
         fund_cols = [
-            c
-            for c in fund_cols
-            if bool(in_ok.get(c, False)) and bool(out_ok.get(c, False))
+            c for c in fund_cols if bool(in_ok.get(c, False)) and bool(out_ok.get(c, False))
         ]
 
         # Guardrail: exclude funds that are effectively inactive/flatlined at
@@ -1438,15 +1380,11 @@ def run(
     z_exit_hard = _parse_optional_float(th_cfg.get("z_exit_hard"))
 
     target_n = int(
-        th_cfg.get(
-            "target_n", portfolio_cfg.get("target_n", cfg.portfolio.get("random_n", 8))
-        )
+        th_cfg.get("target_n", portfolio_cfg.get("target_n", cfg.portfolio.get("random_n", 8)))
     )
     seed_metric = cast(
         str,
-        (cfg.portfolio.get("selector", {}) or {})
-        .get("params", {})
-        .get("rank_column", "Sharpe"),
+        (cfg.portfolio.get("selector", {}) or {}).get("params", {}).get("rank_column", "Sharpe"),
     )
     selector = create_selector_by_name("rank", top_n=target_n, rank_column=seed_metric)
 
@@ -1491,9 +1429,7 @@ def run(
     if cooldown_periods_raw is None:
         cooldown_periods_raw = mp_cfg.get("cooldown_months")
     try:
-        cooldown_periods = (
-            int(cooldown_periods_raw) if cooldown_periods_raw is not None else 0
-        )
+        cooldown_periods = int(cooldown_periods_raw) if cooldown_periods_raw is not None else 0
     except (TypeError, ValueError):
         cooldown_periods = 0
     cooldown_periods = max(0, cooldown_periods)
@@ -1521,9 +1457,7 @@ def run(
     if raw_max_active is None:
         raw_max_active = constraints.get("max_active")
     try:
-        max_active_positions = (
-            int(raw_max_active) if raw_max_active is not None else None
-        )
+        max_active_positions = int(raw_max_active) if raw_max_active is not None else None
     except (TypeError, ValueError):
         max_active_positions = None
     if max_active_positions is not None and max_active_positions <= 0:
@@ -1568,9 +1502,7 @@ def run(
 
     # Risk-based weighting scheme (risk_parity, hrp) from weighting_scheme config.
     # This overrides the legacy `portfolio.weighting` dict config for primary weights.
-    weighting_scheme = str(
-        cfg.portfolio.get("weighting_scheme", "equal") or "equal"
-    ).lower()
+    weighting_scheme = str(cfg.portfolio.get("weighting_scheme", "equal") or "equal").lower()
     if weighting_scheme == "robust":
         weighting_scheme = "robust_mv"
     use_risk_weighting = weighting_scheme in {
@@ -1593,9 +1525,7 @@ def run(
                 weighting_scheme,
                 robustness_cfg if isinstance(robustness_cfg, Mapping) else None,
             )
-            risk_weight_engine = create_weight_engine(
-                weighting_scheme, **weight_engine_params
-            )
+            risk_weight_engine = create_weight_engine(weighting_scheme, **weight_engine_params)
         except Exception:  # pragma: no cover - best-effort only
             use_risk_weighting = False
             risk_weight_engine = None
@@ -1621,9 +1551,7 @@ def run(
     # --- main loop ------------------------------------------------------
     # Pre-index returns once for intra-period rebalance snapshots.
     df_indexed = df.copy()
-    df_indexed["Date"] = pd.to_datetime(df_indexed["Date"], utc=True).dt.tz_localize(
-        None
-    )
+    df_indexed["Date"] = pd.to_datetime(df_indexed["Date"], utc=True).dt.tz_localize(None)
     df_indexed.sort_values("Date", inplace=True)
     df_indexed = df_indexed.set_index("Date")
 
@@ -1662,9 +1590,7 @@ def run(
             return True
         return int(add_streaks.get(manager, 0)) >= sticky_add_periods
 
-    def _min_tenure_protected(
-        holdings: Iterable[str], score_frame: pd.DataFrame
-    ) -> set[str]:
+    def _min_tenure_protected(holdings: Iterable[str], score_frame: pd.DataFrame) -> set[str]:
         if min_tenure_n <= 0:
             return set()
         protected: set[str] = set()
@@ -1733,9 +1659,7 @@ def run(
                 int(cooldown_periods) + 1,
             )
 
-    def _dedupe_one_per_firm(
-        sf: pd.DataFrame, holdings: list[str], metric: str
-    ) -> list[str]:
+    def _dedupe_one_per_firm(sf: pd.DataFrame, holdings: list[str], metric: str) -> list[str]:
         if not holdings:
             return holdings
         col = metric if metric in sf.columns else "Sharpe"
@@ -1871,9 +1795,7 @@ def run(
         keep = ordered[:-bottom_k]
         return filtered.loc[keep]
 
-    def _filter_entry_candidates(
-        candidates: list[str], score_frame: pd.DataFrame
-    ) -> list[str]:
+    def _filter_entry_candidates(candidates: list[str], score_frame: pd.DataFrame) -> list[str]:
         if not candidates:
             return candidates
         eligible_frame = _filter_entry_frame(score_frame)
@@ -1882,9 +1804,7 @@ def run(
         eligible = {str(ix) for ix in eligible_frame.index}
         return [str(ix) for ix in candidates if str(ix) in eligible]
 
-    def _hard_exit_forced(
-        holdings: Iterable[str], score_frame: pd.DataFrame
-    ) -> set[str]:
+    def _hard_exit_forced(holdings: Iterable[str], score_frame: pd.DataFrame) -> set[str]:
         if z_exit_hard is None or "zscore" not in score_frame.columns:
             return set()
         z = pd.to_numeric(score_frame["zscore"], errors="coerce")
@@ -2007,12 +1927,8 @@ def run(
                 if returns_window is not None and not returns_window.empty:
                     # Only include holdings that have data in returns_window
                     # to avoid NaN columns that would get 0 weight
-                    holdings_in_window = [
-                        h for h in holdings if h in returns_window.columns
-                    ]
-                    subset = returns_window[holdings_in_window].dropna(
-                        axis=1, how="all"
-                    )
+                    holdings_in_window = [h for h in holdings if h in returns_window.columns]
+                    subset = returns_window[holdings_in_window].dropna(axis=1, how="all")
                 else:
                     # Fall back to score frame data if no returns window provided
                     subset = sf.loc[holdings]
@@ -2103,9 +2019,7 @@ def run(
         rf_rate_annual = float(metrics_cfg.get("rf_rate_annual", 0.0) or 0.0)
         # Convert annualised RF to a per-period return.
         # Use geometric conversion so 2% annual becomes ~0.165% monthly.
-        rf_rate_periodic = (1.0 + rf_rate_annual) ** (
-            1.0 / float(periods_per_year)
-        ) - 1.0
+        rf_rate_periodic = (1.0 + rf_rate_annual) ** (1.0 / float(periods_per_year)) - 1.0
 
         # UI semantics:
         # - override disabled: use the selected risk-free column series (if available)
@@ -2174,16 +2088,12 @@ def run(
                     holdings = []
                 else:
                     # Seed varies per period to get different selections
-                    period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(
-                        hash(str(pt)) % 10000
-                    )
+                    period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(hash(str(pt)) % 10000)
                     rng = np.random.default_rng(period_seed)
                     n_select = max(1, min(target_n, len(available)))
                     holdings = list(rng.choice(available, size=n_select, replace=False))
                     # Enforce one-per-firm constraint
-                    holdings = _dedupe_one_per_firm_with_events(
-                        sf, holdings, metric, events
-                    )
+                    holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
                     # If dedupe reduced us, refill with random selection
                     if len(holdings) < n_select:
                         candidates = [c for c in available if c not in holdings]
@@ -2208,15 +2118,11 @@ def run(
                     holdings = []
                 elif buy_hold_initial == "random":
                     # Random initial selection
-                    period_seed = abs(
-                        (getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000
-                    )
+                    period_seed = abs((getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000)
                     rng = np.random.default_rng(period_seed)
                     n_select = max(1, min(buy_hold_n, len(available)))
                     holdings = list(rng.choice(available, size=n_select, replace=False))
-                    holdings = _dedupe_one_per_firm_with_events(
-                        sf, holdings, metric, events
-                    )
+                    holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
                     # Refill if dedupe reduced holdings
                     if len(holdings) < n_select:
                         candidates = [c for c in available if c not in holdings]
@@ -2239,9 +2145,7 @@ def run(
                     if rank_score_by == "blended" and rank_blended_weights:
                         total_w = sum(rank_blended_weights.values())
                         if total_w > 0:
-                            norm_w = {
-                                k: v / total_w for k, v in rank_blended_weights.items()
-                            }
+                            norm_w = {k: v / total_w for k, v in rank_blended_weights.items()}
                         else:
                             norm_w = {"Sharpe": 1.0}
                         combo = pd.Series(0.0, index=eligible_sf.index, dtype=float)
@@ -2261,9 +2165,7 @@ def run(
                         scores = combo
                     else:
                         score_col = (
-                            rank_score_by
-                            if rank_score_by in eligible_sf.columns
-                            else "Sharpe"
+                            rank_score_by if rank_score_by in eligible_sf.columns else "Sharpe"
                         )
                         scores = eligible_sf[score_col].astype(float)
 
@@ -2276,10 +2178,7 @@ def run(
                             scores = pd.Series(0.0, index=scores.index)
 
                     ascending = False
-                    if (
-                        rank_score_by in ASCENDING_METRICS
-                        and buy_hold_initial != "threshold"
-                    ):
+                    if rank_score_by in ASCENDING_METRICS and buy_hold_initial != "threshold":
                         ascending = True
 
                     sorted_scores = scores.sort_values(ascending=ascending)
@@ -2304,9 +2203,7 @@ def run(
                         holdings = all_candidates[:buy_hold_n]
 
                     # Enforce one-per-firm constraint
-                    holdings = _dedupe_one_per_firm_with_events(
-                        sf, holdings, metric, events
-                    )
+                    holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
                     # Historical weighting call
                     if holdings:
                         try:
@@ -2337,9 +2234,7 @@ def run(
                         and rank_col in selected.columns
                     ):
                         ascending = rank_col in ASCENDING_METRICS
-                        ordered = selected.sort_values(
-                            rank_col, ascending=ascending
-                        ).index
+                        ordered = selected.sort_values(rank_col, ascending=ascending).index
                         holdings = [str(x) for x in ordered.tolist()]
                     else:
                         holdings = [str(x) for x in selected.index.tolist()]
@@ -2360,10 +2255,7 @@ def run(
                             # Normalize weights
                             total_w = sum(rank_blended_weights.values())
                             if total_w > 0:
-                                norm_w = {
-                                    k: v / total_w
-                                    for k, v in rank_blended_weights.items()
-                                }
+                                norm_w = {k: v / total_w for k, v in rank_blended_weights.items()}
                             else:
                                 norm_w = {"Sharpe": 1.0}
                             # Compute blended score from the score frame
@@ -2387,9 +2279,7 @@ def run(
                         else:
                             # Single metric
                             score_col = (
-                                rank_score_by
-                                if rank_score_by in score_frame.columns
-                                else "Sharpe"
+                                rank_score_by if rank_score_by in score_frame.columns else "Sharpe"
                             )
                             scores = score_frame[score_col].astype(float)
 
@@ -2403,10 +2293,7 @@ def run(
 
                         # Determine sort order
                         ascending = False  # Higher score is better for blended/zscore
-                        if (
-                            rank_score_by in ASCENDING_METRICS
-                            and rank_transform != "zscore"
-                        ):
+                        if rank_score_by in ASCENDING_METRICS and rank_transform != "zscore":
                             ascending = True
 
                         # Sort scores
@@ -2462,15 +2349,11 @@ def run(
                 if len(holdings) > target_n:
                     holdings = holdings[:target_n]
                 # Enforce one-per-firm on seed
-                holdings = _dedupe_one_per_firm_with_events(
-                    sf, holdings, metric, events
-                )
+                holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
                 desired_seed = min(max_funds, target_n)
                 # If we're still above the desired size, trim by zscore (best-first).
                 if len(holdings) > desired_seed:
-                    zsorted = (
-                        sf.loc[holdings].sort_values("zscore", ascending=False).index
-                    )
+                    zsorted = sf.loc[holdings].sort_values("zscore", ascending=False).index
                     holdings = list(zsorted[:desired_seed])
 
                 # If dedupe reduced us below the target size, fill from the remaining
@@ -2480,12 +2363,8 @@ def run(
                 # that percentage of the universe.
                 if len(holdings) < desired_seed and inclusion_approach != "top_pct":
                     candidates = [c for c in sf.index if c not in holdings]
-                    candidates = _filter_entry_candidates(
-                        [str(c) for c in candidates], sf
-                    )
-                    add_from = (
-                        sf.loc[candidates].sort_values("zscore", ascending=False).index
-                    )
+                    candidates = _filter_entry_candidates([str(c) for c in candidates], sf)
+                    add_from = sf.loc[candidates].sort_values("zscore", ascending=False).index
                     seen_firms = {_firm(h) for h in holdings}
                     for f in add_from:
                         if len(holdings) >= desired_seed:
@@ -2505,9 +2384,7 @@ def run(
                     and resolved_rf_col in holdings
                 ):
                     candidates = [c for c in sf.index if c not in holdings]
-                    candidates = _filter_entry_candidates(
-                        [str(c) for c in candidates], sf
-                    )
+                    candidates = _filter_entry_candidates([str(c) for c in candidates], sf)
                     add_from = (
                         sf.loc[candidates].sort_values("zscore", ascending=False).index
                         if candidates
@@ -2622,10 +2499,7 @@ def run(
                         if rank_score_by == "blended" and rank_blended_weights:
                             total_w = sum(rank_blended_weights.values())
                             if total_w > 0:
-                                norm_w = {
-                                    k: v / total_w
-                                    for k, v in rank_blended_weights.items()
-                                }
+                                norm_w = {k: v / total_w for k, v in rank_blended_weights.items()}
                             else:
                                 norm_w = {"Sharpe": 1.0}
                             combo = pd.Series(0.0, index=sf.index, dtype=float)
@@ -2644,11 +2518,7 @@ def run(
                                     combo += w * z
                             scores = combo
                         else:
-                            score_col = (
-                                rank_score_by
-                                if rank_score_by in sf.columns
-                                else "Sharpe"
-                            )
+                            score_col = rank_score_by if rank_score_by in sf.columns else "Sharpe"
                             scores = sf[score_col].astype(float)
 
                         # Apply zscore transform if threshold mode
@@ -2660,16 +2530,11 @@ def run(
                                 scores = pd.Series(0.0, index=scores.index)
 
                         ascending = False
-                        if (
-                            rank_score_by in ASCENDING_METRICS
-                            and buy_hold_initial != "threshold"
-                        ):
+                        if rank_score_by in ASCENDING_METRICS and buy_hold_initial != "threshold":
                             ascending = True
 
                         # Sort scores and filter to available candidates
-                        sorted_scores = scores.loc[available].sort_values(
-                            ascending=ascending
-                        )
+                        sorted_scores = scores.loc[available].sort_values(ascending=ascending)
 
                         # Select replacements respecting threshold if applicable
                         if buy_hold_initial == "threshold":
@@ -2712,9 +2577,7 @@ def run(
                 # each period. This is essential to avoid survivorship bias - we select
                 # from the available universe at each point in time, not funds we know
                 # will survive.
-                period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(
-                    hash(str(pt)) % 10000
-                )
+                period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(hash(str(pt)) % 10000)
                 rebased = rebalancer.apply_triggers(
                     prev_weights.astype(float),
                     sf,
@@ -2723,14 +2586,10 @@ def run(
                 )
 
                 # Restrict to funds available in this period's score-frame.
-                proposed_holdings = [
-                    str(h) for h in list(rebased.index) if h in sf.index
-                ]
+                proposed_holdings = [str(h) for h in list(rebased.index) if h in sf.index]
 
             if hard_exit_forced:
-                proposed_holdings = [
-                    m for m in proposed_holdings if m not in hard_exit_forced
-                ]
+                proposed_holdings = [m for m in proposed_holdings if m not in hard_exit_forced]
 
             raw_proposed_holdings = [str(h) for h in proposed_holdings]
 
@@ -2803,8 +2662,7 @@ def run(
                                 "firm": _firm(mgr),
                                 "reason": "sticky_add",
                                 "detail": (
-                                    f"streak={add_streaks.get(mgr, 0)}/"
-                                    f"{sticky_add_periods}"
+                                    f"streak={add_streaks.get(mgr, 0)}/" f"{sticky_add_periods}"
                                 ),
                             }
                         )
@@ -2825,8 +2683,7 @@ def run(
                                 "firm": _firm(mgr),
                                 "reason": "sticky_drop",
                                 "detail": (
-                                    f"streak={drop_streaks.get(mgr, 0)}/"
-                                    f"{sticky_drop_periods}"
+                                    f"streak={drop_streaks.get(mgr, 0)}/" f"{sticky_drop_periods}"
                                 ),
                             }
                         )
@@ -2860,8 +2717,7 @@ def run(
                             "firm": _firm(mgr),
                             "reason": "min_tenure",
                             "detail": (
-                                f"tenure={int(holdings_tenure.get(mgr, 0))}/"
-                                f"{min_tenure_n}"
+                                f"tenure={int(holdings_tenure.get(mgr, 0))}/" f"{min_tenure_n}"
                             ),
                         }
                     )
@@ -2925,18 +2781,12 @@ def run(
                 candidates = _filter_entry_candidates(candidates, sf)
                 if candidates:
                     if is_random_mode:
-                        period_seed = abs(
-                            (getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000
-                        )
+                        period_seed = abs((getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000)
                         rng = np.random.default_rng(period_seed)
                         rng.shuffle(candidates)
                         ranked = candidates
                     else:
-                        ranked = (
-                            sf.loc[candidates]
-                            .sort_values("zscore", ascending=False)
-                            .index
-                        )
+                        ranked = sf.loc[candidates].sort_values("zscore", ascending=False).index
                     for c in ranked:
                         if len(proposed_holdings) >= desired_size:
                             break
@@ -2955,12 +2805,8 @@ def run(
             pruned_existing: set[str] = set()
             if desired_size > 0:
                 current_set = {str(x) for x in before_reb}
-                kept_existing = [
-                    str(h) for h in proposed_holdings if str(h) in current_set
-                ]
-                new_candidates = [
-                    str(h) for h in proposed_holdings if str(h) not in current_set
-                ]
+                kept_existing = [str(h) for h in proposed_holdings if str(h) in current_set]
+                new_candidates = [str(h) for h in proposed_holdings if str(h) not in current_set]
 
                 def _zscore(mgr: str) -> float:
                     try:
@@ -2983,20 +2829,14 @@ def run(
                 # not happen), prune incumbents by weakest zscore.
                 # In random mode, prune randomly instead.
                 if len(kept_existing) > desired_size:
-                    protected_existing = [
-                        mgr for mgr in kept_existing if mgr in protected_holdings
-                    ]
+                    protected_existing = [mgr for mgr in kept_existing if mgr in protected_holdings]
                     unprotected_existing = [
                         mgr for mgr in kept_existing if mgr not in protected_holdings
                     ]
                     if is_random_mode:
-                        unprotected_sorted = sorted(
-                            unprotected_existing, key=_random_key
-                        )
+                        unprotected_sorted = sorted(unprotected_existing, key=_random_key)
                     else:
-                        unprotected_sorted = sorted(
-                            unprotected_existing, key=_zscore, reverse=True
-                        )
+                        unprotected_sorted = sorted(unprotected_existing, key=_zscore, reverse=True)
                     if protected_existing:
                         slots = max(0, desired_size - len(protected_existing))
                         if slots > 0:
@@ -3052,9 +2892,7 @@ def run(
                 selected, _ = selector.select(_filter_entry_frame(sf))
                 proposed_holdings = [str(x) for x in selected.index.tolist()]
                 if cooldown_periods > 0 and cooldown_book:
-                    filtered = [
-                        mgr for mgr in proposed_holdings if mgr not in cooldown_book
-                    ]
+                    filtered = [mgr for mgr in proposed_holdings if mgr not in cooldown_book]
                     if filtered:
                         for mgr in proposed_holdings:
                             if mgr in cooldown_book:
@@ -3300,8 +3138,7 @@ def run(
                         "firm": _firm(f),
                         "reason": "low_weight_strikes",
                         "detail": (
-                            f"below min {min_w_bound:.2%} for "
-                            f"{low_min_strikes_req} periods"
+                            f"below min {min_w_bound:.2%} for " f"{low_min_strikes_req} periods"
                         ),
                     }
                 )
@@ -3314,17 +3151,11 @@ def run(
             need = max(0, desired_after_low_weight - len(holdings))
             if need > 0:
                 candidates = [
-                    c
-                    for c in sf.index
-                    if c not in holdings and _eligible_sticky_add(str(c))
+                    c for c in sf.index if c not in holdings and _eligible_sticky_add(str(c))
                 ]
                 if cooldown_periods > 0 and cooldown_book:
                     candidates = [c for c in candidates if str(c) not in cooldown_book]
-                add_from = (
-                    sf.loc[candidates]
-                    .sort_values("zscore", ascending=False)
-                    .index.tolist()
-                )
+                add_from = sf.loc[candidates].sort_values("zscore", ascending=False).index.tolist()
                 for f in add_from:
                     if len(holdings) >= desired_after_low_weight:
                         break
@@ -3348,9 +3179,7 @@ def run(
                     sf, holdings, period_ts, in_df.reindex(columns=holdings_with_data)
                 )
                 raw_weight_series = _as_weight_series(weights_df)
-                signal_slice = (
-                    sf.loc[holdings, metric] if metric in sf.columns else None
-                )
+                signal_slice = sf.loc[holdings, metric] if metric in sf.columns else None
                 weight_series = _apply_policy_to_weights(weights_df, signal_slice)
                 weights_df = weight_series.to_frame("weight")
                 prev_weights = weight_series.astype(float)
@@ -3361,9 +3190,7 @@ def run(
             holdings = _enforce_min_funds(
                 sf,
                 holdings,
-                before_reb=(
-                    set(prev_weights.index) if prev_weights is not None else None
-                ),
+                before_reb=(set(prev_weights.index) if prev_weights is not None else None),
                 cooldowns=cooldown_book,
                 desired_min=min_funds,
                 events=events,
@@ -3376,9 +3203,7 @@ def run(
                     sf, holdings, period_ts, in_df.reindex(columns=holdings_with_data)
                 )
                 raw_weight_series = _as_weight_series(weights_df)
-                signal_slice = (
-                    sf.loc[holdings, metric] if metric in sf.columns else None
-                )
+                signal_slice = sf.loc[holdings, metric] if metric in sf.columns else None
                 weight_series = _apply_policy_to_weights(weights_df, signal_slice)
                 weights_df = weight_series.to_frame("weight")
                 prev_weights = weight_series.astype(float)
@@ -3434,9 +3259,7 @@ def run(
             mandatory = desired_trades.copy()
             if forced_ix:
                 # Keep only forced exit trades in mandatory bucket
-                mandatory.loc[[ix for ix in mandatory.index if ix not in forced_ix]] = (
-                    0.0
-                )
+                mandatory.loc[[ix for ix in mandatory.index if ix not in forced_ix]] = 0.0
             else:
                 mandatory[:] = 0.0
 
@@ -3450,11 +3273,7 @@ def run(
                 final_w = last_aligned + mandatory
             else:
                 remaining_turnover = max_turnover_cap - mandatory_turnover
-                scale = (
-                    remaining_turnover / optional_turnover
-                    if optional_turnover > 0
-                    else 0.0
-                )
+                scale = remaining_turnover / optional_turnover if optional_turnover > 0 else 0.0
                 scale = max(0.0, min(1.0, scale))
                 final_w = last_aligned + mandatory + optional * scale
         # Ensure bounds and normalisation remain satisfied
@@ -3477,12 +3296,8 @@ def run(
             if total > eps and abs(total - 1.0) <= 1e-8:
                 final_w = final_w / total
         # Only pass the selected holdings (if still present after filtering).
-        manual_funds: list[str] = [
-            str(h) for h in manual_holdings if h in final_w.index
-        ]
-        custom: dict[str, float] = {
-            str(k): float(v) * 100.0 for k, v in final_w.items()
-        }
+        manual_funds: list[str] = [str(h) for h in manual_holdings if h in final_w.index]
+        custom: dict[str, float] = {str(k): float(v) * 100.0 for k, v in final_w.items()}
 
         # Construct previous weights dict for pipeline (turnover tracking)
         prev_weights_for_pipeline = _coerce_previous_weights(prev_final_weights)
@@ -3537,10 +3352,7 @@ def run(
         # consumers can audit soft-entry/soft-exit decisions without
         # recomputation.
         score_frame_payload = res_dict.get("score_frame")
-        if (
-            isinstance(score_frame_payload, pd.DataFrame)
-            and not score_frame_payload.empty
-        ):
+        if isinstance(score_frame_payload, pd.DataFrame) and not score_frame_payload.empty:
             score_frame_out = score_frame_payload.copy()
             if "zscore" in sf.columns and "zscore" not in score_frame_out.columns:
                 score_frame_out = score_frame_out.join(sf[["zscore"]], how="left")
@@ -3708,9 +3520,7 @@ def run(
         realised_holdings = [str(x) for x in effective_nonzero.index]
         # Do not emit zero-weight positions: they are not real holdings and
         # confuse downstream audits (e.g., a dropped fund showing up with 0.0).
-        res_dict["fund_weights"] = {
-            str(k): float(v) for k, v in effective_nonzero.items()
-        }
+        res_dict["fund_weights"] = {str(k): float(v) for k, v in effective_nonzero.items()}
 
         # Record cooldowns for any managers that exited based on realised holdings.
         if cooldown_periods > 0 and prev_final_weights is not None:
@@ -3771,8 +3581,7 @@ def run(
                         ) + pd.offsets.MonthEnd(0)
 
                         window = df_indexed.reindex(columns=realised_holdings).loc[
-                            (df_indexed.index >= start_dt)
-                            & (df_indexed.index <= end_dt)
+                            (df_indexed.index >= start_dt) & (df_indexed.index <= end_dt)
                         ]
                         if window.empty:
                             w_row = prev_reb_w
@@ -3820,9 +3629,7 @@ def run(
                             except Exception:  # pragma: no cover - best-effort only
                                 w_row = prev_reb_w
 
-                        rebalance_rows.append(
-                            {str(k): float(v) for k, v in w_row.items()}
-                        )
+                        rebalance_rows.append({str(k): float(v) for k, v in w_row.items()})
 
                     rebalance_frame = pd.DataFrame(
                         rebalance_rows,
@@ -3836,9 +3643,7 @@ def run(
         if rebalance_frame is not None and not rebalance_frame.empty:
             out_scaled = res_dict.get("out_sample_scaled")
             if isinstance(out_scaled, pd.DataFrame) and not out_scaled.empty:
-                weights_by_date = (
-                    rebalance_frame.reindex(out_scaled.index).ffill().fillna(0.0)
-                )
+                weights_by_date = rebalance_frame.reindex(out_scaled.index).ffill().fillna(0.0)
                 weights_by_date = weights_by_date.reindex(
                     columns=out_scaled.columns, fill_value=0.0
                 )
@@ -3859,12 +3664,8 @@ def run(
 
                 out_raw = out_df.reindex(columns=out_scaled.columns)
                 if isinstance(out_raw, pd.DataFrame) and not out_raw.empty:
-                    weights_raw = (
-                        rebalance_frame.reindex(out_raw.index).ffill().fillna(0.0)
-                    )
-                    weights_raw = weights_raw.reindex(
-                        columns=out_raw.columns, fill_value=0.0
-                    )
+                    weights_raw = rebalance_frame.reindex(out_raw.index).ffill().fillna(0.0)
+                    weights_raw = weights_raw.reindex(columns=out_raw.columns, fill_value=0.0)
                     rebalance_raw = (out_raw * weights_raw).sum(axis=1)
                     res_dict["portfolio_user_weight_raw"] = rebalance_raw
                     res_dict["out_user_stats_raw"] = _compute_stats(

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -81,9 +81,7 @@ def _run_analysis(*args: Any, **kwargs: Any) -> PipelineResult:
     return _invoke_analysis_with_diag(*args, **kwargs)
 
 
-def _call_pipeline_with_diag(
-    *args: Any, **kwargs: Any
-) -> DiagnosticResult[dict[str, Any] | None]:
+def _call_pipeline_with_diag(*args: Any, **kwargs: Any) -> DiagnosticResult[dict[str, Any] | None]:
     """Execute ``_run_analysis`` and normalise into a ``DiagnosticResult``.
 
     Tests and legacy callers monkeypatch ``_run_analysis`` to return raw dict
@@ -153,9 +151,7 @@ def _membership_table_from_frame(frame: pd.DataFrame) -> MembershipTable:
     eff_col = lookup.get("effective_date")
     end_col = lookup.get("end_date")
     if not fund_col or not eff_col or not end_col:
-        raise ValueError(
-            "membership data must include fund, effective_date, and end_date columns"
-        )
+        raise ValueError("membership data must include fund, effective_date, and end_date columns")
 
     normalised = frame.rename(
         columns={fund_col: "fund", eff_col: "effective_date", end_col: "end_date"}
@@ -214,9 +210,9 @@ def _compute_turnover_state(
     new_aligned: FloatArray = new_series.reindex(union_index, fill_value=0.0).to_numpy(
         dtype=float, copy=False
     )
-    prev_aligned: FloatArray = prev_series.reindex(
-        union_index, fill_value=0.0
-    ).to_numpy(dtype=float, copy=False)
+    prev_aligned: FloatArray = prev_series.reindex(union_index, fill_value=0.0).to_numpy(
+        dtype=float, copy=False
+    )
 
     turnover = float(np.abs(new_aligned - prev_aligned).sum())
     return turnover, nidx, nvals
@@ -300,9 +296,9 @@ def _apply_weight_bounds(
                 room = (max_w_bound - receivers).clip(lower=0.0)
                 rm = room.sum()
                 if rm > 0:
-                    floored.loc[receivers.index] = (
-                        receivers + (room / rm) * deficit
-                    ).clip(upper=max_w_bound)
+                    floored.loc[receivers.index] = (receivers + (room / rm) * deficit).clip(
+                        upper=max_w_bound
+                    )
 
     return floored
 
@@ -342,12 +338,7 @@ def _enforce_max_active_positions(
                 .index
             )
     else:
-        keep = (
-            active.abs()
-            .sort_values(ascending=False, kind="mergesort")
-            .head(max_active)
-            .index
-        )
+        keep = active.abs().sort_values(ascending=False, kind="mergesort").head(max_active).index
     trimmed = weights.copy()
     trimmed.loc[~trimmed.index.isin(keep)] = 0.0
 
@@ -532,11 +523,7 @@ def run_schedule(
         turnover = float(np.abs(new_aligned - prev_aligned).sum())
         return turnover, nidx, nvals
 
-    col = (
-        rank_column
-        or getattr(selector, "rank_column", None)
-        or getattr(selector, "column", None)
-    )
+    col = rank_column or getattr(selector, "rank_column", None) or getattr(selector, "column", None)
 
     for date in sorted(score_frames):
         sf = score_frames[date]
@@ -570,9 +557,7 @@ def run_schedule(
 
         # Apply rebalancing strategies if configured
         if rebalance_strategies and rebalance_params:
-            current_weights = (
-                prev_weights if prev_weights is not None else pd.Series(dtype=float)
-            )
+            current_weights = prev_weights if prev_weights is not None else pd.Series(dtype=float)
             target_weight_series = target_weights["weight"].astype(float)
 
             # Get scores for priority-based strategies
@@ -597,9 +582,7 @@ def run_schedule(
             cost = 0.0
             weights = target_weights
             tw = target_weights["weight"].astype(float)
-            turnover, prev_tidx, prev_tvals = _compute_turnover_state(
-                prev_tidx, prev_tvals, tw
-            )
+            turnover, prev_tidx, prev_tvals = _compute_turnover_state(prev_tidx, prev_tvals, tw)
             prev_weights = tw
 
         pf.rebalance(date, weights, turnover, cost)
@@ -634,9 +617,7 @@ def run_schedule(
                     pv = prev.reindex(u, fill_value=0.0).to_numpy()
                     expected = float(np.abs(dv - pv).sum())
                 got = pf.turnover[d]
-                if not np.isclose(
-                    expected, got, rtol=0, atol=1e-12
-                ):  # pragma: no cover
+                if not np.isclose(expected, got, rtol=0, atol=1e-12):  # pragma: no cover
                     raise AssertionError(
                         f"Turnover mismatch for {d}: expected {expected} got {got}"
                     )
@@ -686,13 +667,9 @@ def run(
             raise TypeError("price_frames must be a dict[str, pd.DataFrame] or None")
         for date_key, frame in price_frames.items():
             if not isinstance(frame, pd.DataFrame):
-                raise TypeError(
-                    f"price_frames['{date_key}'] must be a pandas DataFrame"
-                )
+                raise TypeError(f"price_frames['{date_key}'] must be a pandas DataFrame")
             required_columns = ["Date"]
-            missing_columns = [
-                col for col in required_columns if col not in frame.columns
-            ]
+            missing_columns = [col for col in required_columns if col not in frame.columns]
             if missing_columns:
                 raise ValueError(
                     (
@@ -709,9 +686,7 @@ def run(
         # columns are included, handling missing data gracefully.
         combined_frames = [frame.copy() for frame in price_frames.values()]
         if combined_frames:
-            df = pd.concat(
-                combined_frames, axis=0, join="outer", ignore_index=True, sort=True
-            )
+            df = pd.concat(combined_frames, axis=0, join="outer", ignore_index=True, sort=True)
             # Sort by Date to ensure proper ordering
             df = df.sort_values("Date").reset_index(drop=True)
             # Remove any duplicates created during concatenation
@@ -898,8 +873,7 @@ def run(
         # Persist for debugging/export consumers.
         cleaned.attrs = dict(cleaned.attrs)
         cleaned.attrs["inception_dates"] = {
-            k: (v.strftime("%Y-%m-%d") if v is not None else None)
-            for k, v in inception_raw.items()
+            k: (v.strftime("%Y-%m-%d") if v is not None else None) for k, v in inception_raw.items()
         }
     except Exception:  # pragma: no cover - defensive
         pass
@@ -964,9 +938,7 @@ def run(
 
         periods = generate_periods(cfg_dump)
         if not periods:
-            logger.warning(
-                "generate_periods produced no periods; skipping multi-period run"
-            )
+            logger.warning("generate_periods produced no periods; skipping multi-period run")
             return []
         out_results: List[MultiPeriodPeriodResult] = []
         # Performance flags
@@ -983,9 +955,7 @@ def run(
             except Exception:  # pragma: no cover - defensive
                 cov_cache_obj = None
         prev_in_df = None
-        prev_weights_for_pipeline = _coerce_previous_weights(
-            cfg.portfolio.get("previous_weights")
-        )
+        prev_weights_for_pipeline = _coerce_previous_weights(cfg.portfolio.get("previous_weights"))
 
         for pt in periods:
             analysis_res = _call_pipeline_with_diag(
@@ -1058,9 +1028,7 @@ def run(
                 # Recreate in-sample frame identical to _run_analysis slice
                 date_col = "Date"
                 sub = df.copy()
-                sub[date_col] = pd.to_datetime(sub[date_col], utc=True).dt.tz_localize(
-                    None
-                )
+                sub[date_col] = pd.to_datetime(sub[date_col], utc=True).dt.tz_localize(None)
                 sub.sort_values(date_col, inplace=True)
                 sdate = pd.to_datetime(f"{in_start}-01", utc=True).tz_localize(
                     None
@@ -1068,27 +1036,19 @@ def run(
                 edate = pd.to_datetime(f"{in_end}-01", utc=True).tz_localize(
                     None
                 ) + pd.offsets.MonthEnd(0)
-                in_df_full = sub[
-                    (sub[date_col] >= sdate) & (sub[date_col] <= edate)
-                ].set_index(date_col)
+                in_df_full = sub[(sub[date_col] >= sdate) & (sub[date_col] <= edate)].set_index(
+                    date_col
+                )
                 # Remove benchmark columns if present in result universe
                 fund_cols = [
-                    c
-                    for c in in_df_full.columns
-                    if c not in (cfg.benchmarks or {}).values()
+                    c for c in in_df_full.columns if c not in (cfg.benchmarks or {}).values()
                 ]
                 in_df_full = in_df_full[fund_cols]
                 in_df_prepared = _prepare_returns_frame(in_df_full)
 
-                if (
-                    incremental_cov
-                    and prev_cov_payload is not None
-                    and prev_in_df is not None
-                ):
+                if incremental_cov and prev_cov_payload is not None and prev_in_df is not None:
                     same_len = prev_in_df.shape[0] == in_df_prepared.shape[0]
-                    same_cols = (
-                        prev_in_df.columns.tolist() == in_df_prepared.columns.tolist()
-                    )
+                    same_cols = prev_in_df.columns.tolist() == in_df_prepared.columns.tolist()
                     n_rows = in_df_prepared.shape[0]
                     if same_cols and n_rows >= 3:
                         # Determine shift distance k (number of rows replaced at head and appended at tail)
@@ -1126,12 +1086,10 @@ def run(
                             # Apply k incremental updates sequentially
                             try:
                                 for step in range(k):
-                                    old_row = prev_in_df.iloc[step].to_numpy(
+                                    old_row = prev_in_df.iloc[step].to_numpy(dtype=float)
+                                    new_row = in_df_prepared.iloc[n_rows - k + step].to_numpy(
                                         dtype=float
                                     )
-                                    new_row = in_df_prepared.iloc[
-                                        n_rows - k + step
-                                    ].to_numpy(dtype=float)
                                     prev_cov_payload = incremental_cov_update(
                                         prev_cov_payload, old_row, new_row
                                     )
@@ -1149,9 +1107,7 @@ def run(
                 else:
                     from ..perf.cache import compute_cov_payload as _ccp
 
-                    prev_cov_payload = _ccp(
-                        in_df_prepared, materialise_aggregates=incremental_cov
-                    )
+                    prev_cov_payload = _ccp(in_df_prepared, materialise_aggregates=incremental_cov)
                 prev_in_df = in_df_prepared
                 res_dict["cov_diag"] = prev_cov_payload.cov.diagonal().tolist()
                 if cov_cache_obj is not None:
@@ -1221,14 +1177,12 @@ def run(
                 continue
             seen.add(resolved)
             benchmark_cols.append(resolved)
-    resolved_rf_col, _resolver_fund_cols, resolved_rf_source = (
-        _resolve_risk_free_column(
-            df,
-            date_col="Date",
-            indices_list=indices_list,
-            risk_free_column=risk_free_column_cfg,
-            allow_risk_free_fallback=allow_risk_free_fallback_cfg,
-        )
+    resolved_rf_col, _resolver_fund_cols, resolved_rf_source = _resolve_risk_free_column(
+        df,
+        date_col="Date",
+        indices_list=indices_list,
+        risk_free_column=risk_free_column_cfg,
+        allow_risk_free_fallback=allow_risk_free_fallback_cfg,
     )
 
     # Build a stable investable universe list.
@@ -1241,9 +1195,7 @@ def run(
     idx_set |= {str(c) for c in benchmark_cols}
     resolved_fund_candidates = [c for c in numeric_cols_all if c not in idx_set]
     if resolved_rf_source == "configured" and resolved_rf_col:
-        resolved_fund_candidates = [
-            c for c in resolved_fund_candidates if c != resolved_rf_col
-        ]
+        resolved_fund_candidates = [c for c in resolved_fund_candidates if c != resolved_rf_col]
     elif resolved_rf_source == "fallback" and resolved_rf_col:
         # Fallback RF selection can legitimately pick a true cash proxy (flat
         # zero-return series). Treat such near-constant columns as non-investable
@@ -1260,9 +1212,7 @@ def run(
 
     # --- helpers --------------------------------------------------------
     def _parse_month(s: str) -> pd.Timestamp:
-        return pd.to_datetime(f"{s}-01", utc=True).tz_localize(
-            None
-        ) + pd.offsets.MonthEnd(0)
+        return pd.to_datetime(f"{s}-01", utc=True).tz_localize(None) + pd.offsets.MonthEnd(0)
 
     def _valid_universe(
         full: pd.DataFrame,
@@ -1277,22 +1227,16 @@ def run(
         sub.sort_values(date_col, inplace=True)
         in_sdate, in_edate = _parse_month(in_start), _parse_month(in_end)
         out_sdate, out_edate = _parse_month(out_start), _parse_month(out_end)
-        in_df = sub[
-            (sub[date_col] >= in_sdate) & (sub[date_col] <= in_edate)
-        ].set_index(date_col)
-        out_df = sub[
-            (sub[date_col] >= out_sdate) & (sub[date_col] <= out_edate)
-        ].set_index(date_col)
+        in_df = sub[(sub[date_col] >= in_sdate) & (sub[date_col] <= in_edate)].set_index(date_col)
+        out_df = sub[(sub[date_col] >= out_sdate) & (sub[date_col] <= out_edate)].set_index(
+            date_col
+        )
         if in_df.empty or out_df.empty:
             return in_df, out_df, [], ""
         numeric_cols = [c for c in sub.select_dtypes("number").columns if c != date_col]
         idx_set = {str(c) for c in indices_list}
         idx_set |= {str(c) for c in benchmark_cols}
-        fund_cols = [
-            c
-            for c in resolved_fund_candidates
-            if c in numeric_cols and c not in idx_set
-        ]
+        fund_cols = [c for c in resolved_fund_candidates if c in numeric_cols and c not in idx_set]
 
         if not fund_cols:
             return in_df, out_df, [], resolved_rf_col
@@ -1310,9 +1254,7 @@ def run(
         in_ok = ~in_tail.isna().any()
         out_ok = ~out_df[fund_cols].isna().any()
         fund_cols = [
-            c
-            for c in fund_cols
-            if bool(in_ok.get(c, False)) and bool(out_ok.get(c, False))
+            c for c in fund_cols if bool(in_ok.get(c, False)) and bool(out_ok.get(c, False))
         ]
 
         # Guardrail: exclude funds that are effectively inactive/flatlined at
@@ -1438,15 +1380,11 @@ def run(
     z_exit_hard = _parse_optional_float(th_cfg.get("z_exit_hard"))
 
     target_n = int(
-        th_cfg.get(
-            "target_n", portfolio_cfg.get("target_n", cfg.portfolio.get("random_n", 8))
-        )
+        th_cfg.get("target_n", portfolio_cfg.get("target_n", cfg.portfolio.get("random_n", 8)))
     )
     seed_metric = cast(
         str,
-        (cfg.portfolio.get("selector", {}) or {})
-        .get("params", {})
-        .get("rank_column", "Sharpe"),
+        (cfg.portfolio.get("selector", {}) or {}).get("params", {}).get("rank_column", "Sharpe"),
     )
     selector = create_selector_by_name("rank", top_n=target_n, rank_column=seed_metric)
 
@@ -1491,9 +1429,7 @@ def run(
     if cooldown_periods_raw is None:
         cooldown_periods_raw = mp_cfg.get("cooldown_months")
     try:
-        cooldown_periods = (
-            int(cooldown_periods_raw) if cooldown_periods_raw is not None else 0
-        )
+        cooldown_periods = int(cooldown_periods_raw) if cooldown_periods_raw is not None else 0
     except (TypeError, ValueError):
         cooldown_periods = 0
     cooldown_periods = max(0, cooldown_periods)
@@ -1521,9 +1457,7 @@ def run(
     if raw_max_active is None:
         raw_max_active = constraints.get("max_active")
     try:
-        max_active_positions = (
-            int(raw_max_active) if raw_max_active is not None else None
-        )
+        max_active_positions = int(raw_max_active) if raw_max_active is not None else None
     except (TypeError, ValueError):
         max_active_positions = None
     if max_active_positions is not None and max_active_positions <= 0:
@@ -1568,9 +1502,7 @@ def run(
 
     # Risk-based weighting scheme (risk_parity, hrp) from weighting_scheme config.
     # This overrides the legacy `portfolio.weighting` dict config for primary weights.
-    weighting_scheme = str(
-        cfg.portfolio.get("weighting_scheme", "equal") or "equal"
-    ).lower()
+    weighting_scheme = str(cfg.portfolio.get("weighting_scheme", "equal") or "equal").lower()
     if weighting_scheme == "robust":
         weighting_scheme = "robust_mv"
     use_risk_weighting = weighting_scheme in {
@@ -1593,9 +1525,7 @@ def run(
                 weighting_scheme,
                 robustness_cfg if isinstance(robustness_cfg, Mapping) else None,
             )
-            risk_weight_engine = create_weight_engine(
-                weighting_scheme, **weight_engine_params
-            )
+            risk_weight_engine = create_weight_engine(weighting_scheme, **weight_engine_params)
         except Exception:  # pragma: no cover - best-effort only
             use_risk_weighting = False
             risk_weight_engine = None
@@ -1621,9 +1551,7 @@ def run(
     # --- main loop ------------------------------------------------------
     # Pre-index returns once for intra-period rebalance snapshots.
     df_indexed = df.copy()
-    df_indexed["Date"] = pd.to_datetime(df_indexed["Date"], utc=True).dt.tz_localize(
-        None
-    )
+    df_indexed["Date"] = pd.to_datetime(df_indexed["Date"], utc=True).dt.tz_localize(None)
     df_indexed.sort_values("Date", inplace=True)
     df_indexed = df_indexed.set_index("Date")
 
@@ -1662,9 +1590,7 @@ def run(
             return True
         return int(add_streaks.get(manager, 0)) >= sticky_add_periods
 
-    def _min_tenure_protected(
-        holdings: Iterable[str], score_frame: pd.DataFrame
-    ) -> set[str]:
+    def _min_tenure_protected(holdings: Iterable[str], score_frame: pd.DataFrame) -> set[str]:
         if min_tenure_n <= 0:
             return set()
         protected: set[str] = set()
@@ -1733,9 +1659,7 @@ def run(
                 int(cooldown_periods) + 1,
             )
 
-    def _dedupe_one_per_firm(
-        sf: pd.DataFrame, holdings: list[str], metric: str
-    ) -> list[str]:
+    def _dedupe_one_per_firm(sf: pd.DataFrame, holdings: list[str], metric: str) -> list[str]:
         if not holdings:
             return holdings
         col = metric if metric in sf.columns else "Sharpe"
@@ -1871,9 +1795,7 @@ def run(
         keep = ordered[:-bottom_k]
         return filtered.loc[keep]
 
-    def _filter_entry_candidates(
-        candidates: list[str], score_frame: pd.DataFrame
-    ) -> list[str]:
+    def _filter_entry_candidates(candidates: list[str], score_frame: pd.DataFrame) -> list[str]:
         if not candidates:
             return candidates
         eligible_frame = _filter_entry_frame(score_frame)
@@ -1882,9 +1804,7 @@ def run(
         eligible = {str(ix) for ix in eligible_frame.index}
         return [str(ix) for ix in candidates if str(ix) in eligible]
 
-    def _hard_exit_forced(
-        holdings: Iterable[str], score_frame: pd.DataFrame
-    ) -> set[str]:
+    def _hard_exit_forced(holdings: Iterable[str], score_frame: pd.DataFrame) -> set[str]:
         if z_exit_hard is None or "zscore" not in score_frame.columns:
             return set()
         z = pd.to_numeric(score_frame["zscore"], errors="coerce")
@@ -2007,12 +1927,8 @@ def run(
                 if returns_window is not None and not returns_window.empty:
                     # Only include holdings that have data in returns_window
                     # to avoid NaN columns that would get 0 weight
-                    holdings_in_window = [
-                        h for h in holdings if h in returns_window.columns
-                    ]
-                    subset = returns_window[holdings_in_window].dropna(
-                        axis=1, how="all"
-                    )
+                    holdings_in_window = [h for h in holdings if h in returns_window.columns]
+                    subset = returns_window[holdings_in_window].dropna(axis=1, how="all")
                 else:
                     # Fall back to score frame data if no returns window provided
                     subset = sf.loc[holdings]
@@ -2103,9 +2019,7 @@ def run(
         rf_rate_annual = float(metrics_cfg.get("rf_rate_annual", 0.0) or 0.0)
         # Convert annualised RF to a per-period return.
         # Use geometric conversion so 2% annual becomes ~0.165% monthly.
-        rf_rate_periodic = (1.0 + rf_rate_annual) ** (
-            1.0 / float(periods_per_year)
-        ) - 1.0
+        rf_rate_periodic = (1.0 + rf_rate_annual) ** (1.0 / float(periods_per_year)) - 1.0
 
         # UI semantics:
         # - override disabled: use the selected risk-free column series (if available)
@@ -2174,16 +2088,12 @@ def run(
                     holdings = []
                 else:
                     # Seed varies per period to get different selections
-                    period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(
-                        hash(str(pt)) % 10000
-                    )
+                    period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(hash(str(pt)) % 10000)
                     rng = np.random.default_rng(period_seed)
                     n_select = max(1, min(target_n, len(available)))
                     holdings = list(rng.choice(available, size=n_select, replace=False))
                     # Enforce one-per-firm constraint
-                    holdings = _dedupe_one_per_firm_with_events(
-                        sf, holdings, metric, events
-                    )
+                    holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
                     # If dedupe reduced us, refill with random selection
                     if len(holdings) < n_select:
                         candidates = [c for c in available if c not in holdings]
@@ -2208,15 +2118,11 @@ def run(
                     holdings = []
                 elif buy_hold_initial == "random":
                     # Random initial selection
-                    period_seed = abs(
-                        (getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000
-                    )
+                    period_seed = abs((getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000)
                     rng = np.random.default_rng(period_seed)
                     n_select = max(1, min(buy_hold_n, len(available)))
                     holdings = list(rng.choice(available, size=n_select, replace=False))
-                    holdings = _dedupe_one_per_firm_with_events(
-                        sf, holdings, metric, events
-                    )
+                    holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
                     # Refill if dedupe reduced holdings
                     if len(holdings) < n_select:
                         candidates = [c for c in available if c not in holdings]
@@ -2239,9 +2145,7 @@ def run(
                     if rank_score_by == "blended" and rank_blended_weights:
                         total_w = sum(rank_blended_weights.values())
                         if total_w > 0:
-                            norm_w = {
-                                k: v / total_w for k, v in rank_blended_weights.items()
-                            }
+                            norm_w = {k: v / total_w for k, v in rank_blended_weights.items()}
                         else:
                             norm_w = {"Sharpe": 1.0}
                         combo = pd.Series(0.0, index=eligible_sf.index, dtype=float)
@@ -2261,9 +2165,7 @@ def run(
                         scores = combo
                     else:
                         score_col = (
-                            rank_score_by
-                            if rank_score_by in eligible_sf.columns
-                            else "Sharpe"
+                            rank_score_by if rank_score_by in eligible_sf.columns else "Sharpe"
                         )
                         scores = eligible_sf[score_col].astype(float)
 
@@ -2276,10 +2178,7 @@ def run(
                             scores = pd.Series(0.0, index=scores.index)
 
                     ascending = False
-                    if (
-                        rank_score_by in ASCENDING_METRICS
-                        and buy_hold_initial != "threshold"
-                    ):
+                    if rank_score_by in ASCENDING_METRICS and buy_hold_initial != "threshold":
                         ascending = True
 
                     sorted_scores = scores.sort_values(ascending=ascending)
@@ -2304,9 +2203,7 @@ def run(
                         holdings = all_candidates[:buy_hold_n]
 
                     # Enforce one-per-firm constraint
-                    holdings = _dedupe_one_per_firm_with_events(
-                        sf, holdings, metric, events
-                    )
+                    holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
                     # Historical weighting call
                     if holdings:
                         try:
@@ -2337,9 +2234,7 @@ def run(
                         and rank_col in selected.columns
                     ):
                         ascending = rank_col in ASCENDING_METRICS
-                        ordered = selected.sort_values(
-                            rank_col, ascending=ascending
-                        ).index
+                        ordered = selected.sort_values(rank_col, ascending=ascending).index
                         holdings = [str(x) for x in ordered.tolist()]
                     else:
                         holdings = [str(x) for x in selected.index.tolist()]
@@ -2360,10 +2255,7 @@ def run(
                             # Normalize weights
                             total_w = sum(rank_blended_weights.values())
                             if total_w > 0:
-                                norm_w = {
-                                    k: v / total_w
-                                    for k, v in rank_blended_weights.items()
-                                }
+                                norm_w = {k: v / total_w for k, v in rank_blended_weights.items()}
                             else:
                                 norm_w = {"Sharpe": 1.0}
                             # Compute blended score from the score frame
@@ -2387,9 +2279,7 @@ def run(
                         else:
                             # Single metric
                             score_col = (
-                                rank_score_by
-                                if rank_score_by in score_frame.columns
-                                else "Sharpe"
+                                rank_score_by if rank_score_by in score_frame.columns else "Sharpe"
                             )
                             scores = score_frame[score_col].astype(float)
 
@@ -2403,10 +2293,7 @@ def run(
 
                         # Determine sort order
                         ascending = False  # Higher score is better for blended/zscore
-                        if (
-                            rank_score_by in ASCENDING_METRICS
-                            and rank_transform != "zscore"
-                        ):
+                        if rank_score_by in ASCENDING_METRICS and rank_transform != "zscore":
                             ascending = True
 
                         # Sort scores
@@ -2462,15 +2349,11 @@ def run(
                 if len(holdings) > target_n:
                     holdings = holdings[:target_n]
                 # Enforce one-per-firm on seed
-                holdings = _dedupe_one_per_firm_with_events(
-                    sf, holdings, metric, events
-                )
+                holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
                 desired_seed = min(max_funds, target_n)
                 # If we're still above the desired size, trim by zscore (best-first).
                 if len(holdings) > desired_seed:
-                    zsorted = (
-                        sf.loc[holdings].sort_values("zscore", ascending=False).index
-                    )
+                    zsorted = sf.loc[holdings].sort_values("zscore", ascending=False).index
                     holdings = list(zsorted[:desired_seed])
 
                 # If dedupe reduced us below the target size, fill from the remaining
@@ -2480,12 +2363,8 @@ def run(
                 # that percentage of the universe.
                 if len(holdings) < desired_seed and inclusion_approach != "top_pct":
                     candidates = [c for c in sf.index if c not in holdings]
-                    candidates = _filter_entry_candidates(
-                        [str(c) for c in candidates], sf
-                    )
-                    add_from = (
-                        sf.loc[candidates].sort_values("zscore", ascending=False).index
-                    )
+                    candidates = _filter_entry_candidates([str(c) for c in candidates], sf)
+                    add_from = sf.loc[candidates].sort_values("zscore", ascending=False).index
                     seen_firms = {_firm(h) for h in holdings}
                     for f in add_from:
                         if len(holdings) >= desired_seed:
@@ -2505,9 +2384,7 @@ def run(
                     and resolved_rf_col in holdings
                 ):
                     candidates = [c for c in sf.index if c not in holdings]
-                    candidates = _filter_entry_candidates(
-                        [str(c) for c in candidates], sf
-                    )
+                    candidates = _filter_entry_candidates([str(c) for c in candidates], sf)
                     add_from = (
                         sf.loc[candidates].sort_values("zscore", ascending=False).index
                         if candidates
@@ -2589,9 +2466,7 @@ def run(
                 # Replace exited funds using the same initial selection method
                 n_needed = buy_hold_n - len(current_holdings)
                 if n_needed > 0:
-                    available = [
-                        str(c) for c in sf.index if str(c) not in current_holdings
-                    ]
+                    available = [str(c) for c in sf.index if str(c) not in current_holdings]
                     if cooldown_periods > 0 and cooldown_book:
                         available = [c for c in available if c not in cooldown_book]
                     available = _filter_entry_candidates(available, sf)
@@ -2618,10 +2493,7 @@ def run(
                         if rank_score_by == "blended" and rank_blended_weights:
                             total_w = sum(rank_blended_weights.values())
                             if total_w > 0:
-                                norm_w = {
-                                    k: v / total_w
-                                    for k, v in rank_blended_weights.items()
-                                }
+                                norm_w = {k: v / total_w for k, v in rank_blended_weights.items()}
                             else:
                                 norm_w = {"Sharpe": 1.0}
                             combo = pd.Series(0.0, index=sf.index, dtype=float)
@@ -2640,11 +2512,7 @@ def run(
                                     combo += w * z
                             scores = combo
                         else:
-                            score_col = (
-                                rank_score_by
-                                if rank_score_by in sf.columns
-                                else "Sharpe"
-                            )
+                            score_col = rank_score_by if rank_score_by in sf.columns else "Sharpe"
                             scores = sf[score_col].astype(float)
 
                         # Apply zscore transform if threshold mode
@@ -2656,16 +2524,11 @@ def run(
                                 scores = pd.Series(0.0, index=scores.index)
 
                         ascending = False
-                        if (
-                            rank_score_by in ASCENDING_METRICS
-                            and buy_hold_initial != "threshold"
-                        ):
+                        if rank_score_by in ASCENDING_METRICS and buy_hold_initial != "threshold":
                             ascending = True
 
                         # Sort scores and filter to available candidates
-                        sorted_scores = scores.loc[available].sort_values(
-                            ascending=ascending
-                        )
+                        sorted_scores = scores.loc[available].sort_values(ascending=ascending)
 
                         # Select replacements respecting threshold if applicable
                         if buy_hold_initial == "threshold":
@@ -2708,9 +2571,7 @@ def run(
                 # each period. This is essential to avoid survivorship bias - we select
                 # from the available universe at each point in time, not funds we know
                 # will survive.
-                period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(
-                    hash(str(pt)) % 10000
-                )
+                period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(hash(str(pt)) % 10000)
                 rebased = rebalancer.apply_triggers(
                     prev_weights.astype(float),
                     sf,
@@ -2719,14 +2580,10 @@ def run(
                 )
 
                 # Restrict to funds available in this period's score-frame.
-                proposed_holdings = [
-                    str(h) for h in list(rebased.index) if h in sf.index
-                ]
+                proposed_holdings = [str(h) for h in list(rebased.index) if h in sf.index]
 
             if hard_exit_forced:
-                proposed_holdings = [
-                    m for m in proposed_holdings if m not in hard_exit_forced
-                ]
+                proposed_holdings = [m for m in proposed_holdings if m not in hard_exit_forced]
 
             raw_proposed_holdings = [str(h) for h in proposed_holdings]
 
@@ -2799,8 +2656,7 @@ def run(
                                 "firm": _firm(mgr),
                                 "reason": "sticky_add",
                                 "detail": (
-                                    f"streak={add_streaks.get(mgr, 0)}/"
-                                    f"{sticky_add_periods}"
+                                    f"streak={add_streaks.get(mgr, 0)}/" f"{sticky_add_periods}"
                                 ),
                             }
                         )
@@ -2821,8 +2677,7 @@ def run(
                                 "firm": _firm(mgr),
                                 "reason": "sticky_drop",
                                 "detail": (
-                                    f"streak={drop_streaks.get(mgr, 0)}/"
-                                    f"{sticky_drop_periods}"
+                                    f"streak={drop_streaks.get(mgr, 0)}/" f"{sticky_drop_periods}"
                                 ),
                             }
                         )
@@ -2856,8 +2711,7 @@ def run(
                             "firm": _firm(mgr),
                             "reason": "min_tenure",
                             "detail": (
-                                f"tenure={int(holdings_tenure.get(mgr, 0))}/"
-                                f"{min_tenure_n}"
+                                f"tenure={int(holdings_tenure.get(mgr, 0))}/" f"{min_tenure_n}"
                             ),
                         }
                     )
@@ -2921,18 +2775,12 @@ def run(
                 candidates = _filter_entry_candidates(candidates, sf)
                 if candidates:
                     if is_random_mode:
-                        period_seed = abs(
-                            (getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000
-                        )
+                        period_seed = abs((getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000)
                         rng = np.random.default_rng(period_seed)
                         rng.shuffle(candidates)
                         ranked = candidates
                     else:
-                        ranked = (
-                            sf.loc[candidates]
-                            .sort_values("zscore", ascending=False)
-                            .index
-                        )
+                        ranked = sf.loc[candidates].sort_values("zscore", ascending=False).index
                     for c in ranked:
                         if len(proposed_holdings) >= desired_size:
                             break
@@ -2951,12 +2799,8 @@ def run(
             pruned_existing: set[str] = set()
             if desired_size > 0:
                 current_set = {str(x) for x in before_reb}
-                kept_existing = [
-                    str(h) for h in proposed_holdings if str(h) in current_set
-                ]
-                new_candidates = [
-                    str(h) for h in proposed_holdings if str(h) not in current_set
-                ]
+                kept_existing = [str(h) for h in proposed_holdings if str(h) in current_set]
+                new_candidates = [str(h) for h in proposed_holdings if str(h) not in current_set]
 
                 def _zscore(mgr: str) -> float:
                     try:
@@ -2979,20 +2823,14 @@ def run(
                 # not happen), prune incumbents by weakest zscore.
                 # In random mode, prune randomly instead.
                 if len(kept_existing) > desired_size:
-                    protected_existing = [
-                        mgr for mgr in kept_existing if mgr in protected_holdings
-                    ]
+                    protected_existing = [mgr for mgr in kept_existing if mgr in protected_holdings]
                     unprotected_existing = [
                         mgr for mgr in kept_existing if mgr not in protected_holdings
                     ]
                     if is_random_mode:
-                        unprotected_sorted = sorted(
-                            unprotected_existing, key=_random_key
-                        )
+                        unprotected_sorted = sorted(unprotected_existing, key=_random_key)
                     else:
-                        unprotected_sorted = sorted(
-                            unprotected_existing, key=_zscore, reverse=True
-                        )
+                        unprotected_sorted = sorted(unprotected_existing, key=_zscore, reverse=True)
                     if protected_existing:
                         slots = max(0, desired_size - len(protected_existing))
                         if slots > 0:
@@ -3048,9 +2886,7 @@ def run(
                 selected, _ = selector.select(_filter_entry_frame(sf))
                 proposed_holdings = [str(x) for x in selected.index.tolist()]
                 if cooldown_periods > 0 and cooldown_book:
-                    filtered = [
-                        mgr for mgr in proposed_holdings if mgr not in cooldown_book
-                    ]
+                    filtered = [mgr for mgr in proposed_holdings if mgr not in cooldown_book]
                     if filtered:
                         for mgr in proposed_holdings:
                             if mgr in cooldown_book:
@@ -3296,8 +3132,7 @@ def run(
                         "firm": _firm(f),
                         "reason": "low_weight_strikes",
                         "detail": (
-                            f"below min {min_w_bound:.2%} for "
-                            f"{low_min_strikes_req} periods"
+                            f"below min {min_w_bound:.2%} for " f"{low_min_strikes_req} periods"
                         ),
                     }
                 )
@@ -3310,17 +3145,11 @@ def run(
             need = max(0, desired_after_low_weight - len(holdings))
             if need > 0:
                 candidates = [
-                    c
-                    for c in sf.index
-                    if c not in holdings and _eligible_sticky_add(str(c))
+                    c for c in sf.index if c not in holdings and _eligible_sticky_add(str(c))
                 ]
                 if cooldown_periods > 0 and cooldown_book:
                     candidates = [c for c in candidates if str(c) not in cooldown_book]
-                add_from = (
-                    sf.loc[candidates]
-                    .sort_values("zscore", ascending=False)
-                    .index.tolist()
-                )
+                add_from = sf.loc[candidates].sort_values("zscore", ascending=False).index.tolist()
                 for f in add_from:
                     if len(holdings) >= desired_after_low_weight:
                         break
@@ -3344,9 +3173,7 @@ def run(
                     sf, holdings, period_ts, in_df.reindex(columns=holdings_with_data)
                 )
                 raw_weight_series = _as_weight_series(weights_df)
-                signal_slice = (
-                    sf.loc[holdings, metric] if metric in sf.columns else None
-                )
+                signal_slice = sf.loc[holdings, metric] if metric in sf.columns else None
                 weight_series = _apply_policy_to_weights(weights_df, signal_slice)
                 weights_df = weight_series.to_frame("weight")
                 prev_weights = weight_series.astype(float)
@@ -3357,9 +3184,7 @@ def run(
             holdings = _enforce_min_funds(
                 sf,
                 holdings,
-                before_reb=(
-                    set(prev_weights.index) if prev_weights is not None else None
-                ),
+                before_reb=(set(prev_weights.index) if prev_weights is not None else None),
                 cooldowns=cooldown_book,
                 desired_min=min_funds,
                 events=events,
@@ -3372,9 +3197,7 @@ def run(
                     sf, holdings, period_ts, in_df.reindex(columns=holdings_with_data)
                 )
                 raw_weight_series = _as_weight_series(weights_df)
-                signal_slice = (
-                    sf.loc[holdings, metric] if metric in sf.columns else None
-                )
+                signal_slice = sf.loc[holdings, metric] if metric in sf.columns else None
                 weight_series = _apply_policy_to_weights(weights_df, signal_slice)
                 weights_df = weight_series.to_frame("weight")
                 prev_weights = weight_series.astype(float)
@@ -3430,9 +3253,7 @@ def run(
             mandatory = desired_trades.copy()
             if forced_ix:
                 # Keep only forced exit trades in mandatory bucket
-                mandatory.loc[[ix for ix in mandatory.index if ix not in forced_ix]] = (
-                    0.0
-                )
+                mandatory.loc[[ix for ix in mandatory.index if ix not in forced_ix]] = 0.0
             else:
                 mandatory[:] = 0.0
 
@@ -3446,11 +3267,7 @@ def run(
                 final_w = last_aligned + mandatory
             else:
                 remaining_turnover = max_turnover_cap - mandatory_turnover
-                scale = (
-                    remaining_turnover / optional_turnover
-                    if optional_turnover > 0
-                    else 0.0
-                )
+                scale = remaining_turnover / optional_turnover if optional_turnover > 0 else 0.0
                 scale = max(0.0, min(1.0, scale))
                 final_w = last_aligned + mandatory + optional * scale
         # Ensure bounds and normalisation remain satisfied
@@ -3473,12 +3290,8 @@ def run(
             if total > eps and abs(total - 1.0) <= 1e-8:
                 final_w = final_w / total
         # Only pass the selected holdings (if still present after filtering).
-        manual_funds: list[str] = [
-            str(h) for h in manual_holdings if h in final_w.index
-        ]
-        custom: dict[str, float] = {
-            str(k): float(v) * 100.0 for k, v in final_w.items()
-        }
+        manual_funds: list[str] = [str(h) for h in manual_holdings if h in final_w.index]
+        custom: dict[str, float] = {str(k): float(v) * 100.0 for k, v in final_w.items()}
 
         # Construct previous weights dict for pipeline (turnover tracking)
         prev_weights_for_pipeline = _coerce_previous_weights(prev_final_weights)
@@ -3533,10 +3346,7 @@ def run(
         # consumers can audit soft-entry/soft-exit decisions without
         # recomputation.
         score_frame_payload = res_dict.get("score_frame")
-        if (
-            isinstance(score_frame_payload, pd.DataFrame)
-            and not score_frame_payload.empty
-        ):
+        if isinstance(score_frame_payload, pd.DataFrame) and not score_frame_payload.empty:
             score_frame_out = score_frame_payload.copy()
             if "zscore" in sf.columns and "zscore" not in score_frame_out.columns:
                 score_frame_out = score_frame_out.join(sf[["zscore"]], how="left")
@@ -3684,9 +3494,7 @@ def run(
         realised_holdings = [str(x) for x in effective_nonzero.index]
         # Do not emit zero-weight positions: they are not real holdings and
         # confuse downstream audits (e.g., a dropped fund showing up with 0.0).
-        res_dict["fund_weights"] = {
-            str(k): float(v) for k, v in effective_nonzero.items()
-        }
+        res_dict["fund_weights"] = {str(k): float(v) for k, v in effective_nonzero.items()}
 
         # Record cooldowns for any managers that exited based on realised holdings.
         if cooldown_periods > 0 and prev_final_weights is not None:
@@ -3747,8 +3555,7 @@ def run(
                         ) + pd.offsets.MonthEnd(0)
 
                         window = df_indexed.reindex(columns=realised_holdings).loc[
-                            (df_indexed.index >= start_dt)
-                            & (df_indexed.index <= end_dt)
+                            (df_indexed.index >= start_dt) & (df_indexed.index <= end_dt)
                         ]
                         if window.empty:
                             w_row = prev_reb_w
@@ -3796,9 +3603,7 @@ def run(
                             except Exception:  # pragma: no cover - best-effort only
                                 w_row = prev_reb_w
 
-                        rebalance_rows.append(
-                            {str(k): float(v) for k, v in w_row.items()}
-                        )
+                        rebalance_rows.append({str(k): float(v) for k, v in w_row.items()})
 
                     rebalance_frame = pd.DataFrame(
                         rebalance_rows,
@@ -3812,9 +3617,7 @@ def run(
         if rebalance_frame is not None and not rebalance_frame.empty:
             out_scaled = res_dict.get("out_sample_scaled")
             if isinstance(out_scaled, pd.DataFrame) and not out_scaled.empty:
-                weights_by_date = (
-                    rebalance_frame.reindex(out_scaled.index).ffill().fillna(0.0)
-                )
+                weights_by_date = rebalance_frame.reindex(out_scaled.index).ffill().fillna(0.0)
                 weights_by_date = weights_by_date.reindex(
                     columns=out_scaled.columns, fill_value=0.0
                 )
@@ -3835,12 +3638,8 @@ def run(
 
                 out_raw = out_df.reindex(columns=out_scaled.columns)
                 if isinstance(out_raw, pd.DataFrame) and not out_raw.empty:
-                    weights_raw = (
-                        rebalance_frame.reindex(out_raw.index).ffill().fillna(0.0)
-                    )
-                    weights_raw = weights_raw.reindex(
-                        columns=out_raw.columns, fill_value=0.0
-                    )
+                    weights_raw = rebalance_frame.reindex(out_raw.index).ffill().fillna(0.0)
+                    weights_raw = weights_raw.reindex(columns=out_raw.columns, fill_value=0.0)
                     rebalance_raw = (out_raw * weights_raw).sum(axis=1)
                     res_dict["portfolio_user_weight_raw"] = rebalance_raw
                     res_dict["out_user_stats_raw"] = _compute_stats(

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -81,7 +81,9 @@ def _run_analysis(*args: Any, **kwargs: Any) -> PipelineResult:
     return _invoke_analysis_with_diag(*args, **kwargs)
 
 
-def _call_pipeline_with_diag(*args: Any, **kwargs: Any) -> DiagnosticResult[dict[str, Any] | None]:
+def _call_pipeline_with_diag(
+    *args: Any, **kwargs: Any
+) -> DiagnosticResult[dict[str, Any] | None]:
     """Execute ``_run_analysis`` and normalise into a ``DiagnosticResult``.
 
     Tests and legacy callers monkeypatch ``_run_analysis`` to return raw dict
@@ -151,7 +153,9 @@ def _membership_table_from_frame(frame: pd.DataFrame) -> MembershipTable:
     eff_col = lookup.get("effective_date")
     end_col = lookup.get("end_date")
     if not fund_col or not eff_col or not end_col:
-        raise ValueError("membership data must include fund, effective_date, and end_date columns")
+        raise ValueError(
+            "membership data must include fund, effective_date, and end_date columns"
+        )
 
     normalised = frame.rename(
         columns={fund_col: "fund", eff_col: "effective_date", end_col: "end_date"}
@@ -210,9 +214,9 @@ def _compute_turnover_state(
     new_aligned: FloatArray = new_series.reindex(union_index, fill_value=0.0).to_numpy(
         dtype=float, copy=False
     )
-    prev_aligned: FloatArray = prev_series.reindex(union_index, fill_value=0.0).to_numpy(
-        dtype=float, copy=False
-    )
+    prev_aligned: FloatArray = prev_series.reindex(
+        union_index, fill_value=0.0
+    ).to_numpy(dtype=float, copy=False)
 
     turnover = float(np.abs(new_aligned - prev_aligned).sum())
     return turnover, nidx, nvals
@@ -296,9 +300,9 @@ def _apply_weight_bounds(
                 room = (max_w_bound - receivers).clip(lower=0.0)
                 rm = room.sum()
                 if rm > 0:
-                    floored.loc[receivers.index] = (receivers + (room / rm) * deficit).clip(
-                        upper=max_w_bound
-                    )
+                    floored.loc[receivers.index] = (
+                        receivers + (room / rm) * deficit
+                    ).clip(upper=max_w_bound)
 
     return floored
 
@@ -338,7 +342,12 @@ def _enforce_max_active_positions(
                 .index
             )
     else:
-        keep = active.abs().sort_values(ascending=False, kind="mergesort").head(max_active).index
+        keep = (
+            active.abs()
+            .sort_values(ascending=False, kind="mergesort")
+            .head(max_active)
+            .index
+        )
     trimmed = weights.copy()
     trimmed.loc[~trimmed.index.isin(keep)] = 0.0
 
@@ -523,7 +532,11 @@ def run_schedule(
         turnover = float(np.abs(new_aligned - prev_aligned).sum())
         return turnover, nidx, nvals
 
-    col = rank_column or getattr(selector, "rank_column", None) or getattr(selector, "column", None)
+    col = (
+        rank_column
+        or getattr(selector, "rank_column", None)
+        or getattr(selector, "column", None)
+    )
 
     for date in sorted(score_frames):
         sf = score_frames[date]
@@ -557,7 +570,9 @@ def run_schedule(
 
         # Apply rebalancing strategies if configured
         if rebalance_strategies and rebalance_params:
-            current_weights = prev_weights if prev_weights is not None else pd.Series(dtype=float)
+            current_weights = (
+                prev_weights if prev_weights is not None else pd.Series(dtype=float)
+            )
             target_weight_series = target_weights["weight"].astype(float)
 
             # Get scores for priority-based strategies
@@ -582,7 +597,9 @@ def run_schedule(
             cost = 0.0
             weights = target_weights
             tw = target_weights["weight"].astype(float)
-            turnover, prev_tidx, prev_tvals = _compute_turnover_state(prev_tidx, prev_tvals, tw)
+            turnover, prev_tidx, prev_tvals = _compute_turnover_state(
+                prev_tidx, prev_tvals, tw
+            )
             prev_weights = tw
 
         pf.rebalance(date, weights, turnover, cost)
@@ -617,7 +634,9 @@ def run_schedule(
                     pv = prev.reindex(u, fill_value=0.0).to_numpy()
                     expected = float(np.abs(dv - pv).sum())
                 got = pf.turnover[d]
-                if not np.isclose(expected, got, rtol=0, atol=1e-12):  # pragma: no cover
+                if not np.isclose(
+                    expected, got, rtol=0, atol=1e-12
+                ):  # pragma: no cover
                     raise AssertionError(
                         f"Turnover mismatch for {d}: expected {expected} got {got}"
                     )
@@ -667,9 +686,13 @@ def run(
             raise TypeError("price_frames must be a dict[str, pd.DataFrame] or None")
         for date_key, frame in price_frames.items():
             if not isinstance(frame, pd.DataFrame):
-                raise TypeError(f"price_frames['{date_key}'] must be a pandas DataFrame")
+                raise TypeError(
+                    f"price_frames['{date_key}'] must be a pandas DataFrame"
+                )
             required_columns = ["Date"]
-            missing_columns = [col for col in required_columns if col not in frame.columns]
+            missing_columns = [
+                col for col in required_columns if col not in frame.columns
+            ]
             if missing_columns:
                 raise ValueError(
                     (
@@ -686,7 +709,9 @@ def run(
         # columns are included, handling missing data gracefully.
         combined_frames = [frame.copy() for frame in price_frames.values()]
         if combined_frames:
-            df = pd.concat(combined_frames, axis=0, join="outer", ignore_index=True, sort=True)
+            df = pd.concat(
+                combined_frames, axis=0, join="outer", ignore_index=True, sort=True
+            )
             # Sort by Date to ensure proper ordering
             df = df.sort_values("Date").reset_index(drop=True)
             # Remove any duplicates created during concatenation
@@ -873,7 +898,8 @@ def run(
         # Persist for debugging/export consumers.
         cleaned.attrs = dict(cleaned.attrs)
         cleaned.attrs["inception_dates"] = {
-            k: (v.strftime("%Y-%m-%d") if v is not None else None) for k, v in inception_raw.items()
+            k: (v.strftime("%Y-%m-%d") if v is not None else None)
+            for k, v in inception_raw.items()
         }
     except Exception:  # pragma: no cover - defensive
         pass
@@ -938,7 +964,9 @@ def run(
 
         periods = generate_periods(cfg_dump)
         if not periods:
-            logger.warning("generate_periods produced no periods; skipping multi-period run")
+            logger.warning(
+                "generate_periods produced no periods; skipping multi-period run"
+            )
             return []
         out_results: List[MultiPeriodPeriodResult] = []
         # Performance flags
@@ -955,7 +983,9 @@ def run(
             except Exception:  # pragma: no cover - defensive
                 cov_cache_obj = None
         prev_in_df = None
-        prev_weights_for_pipeline = _coerce_previous_weights(cfg.portfolio.get("previous_weights"))
+        prev_weights_for_pipeline = _coerce_previous_weights(
+            cfg.portfolio.get("previous_weights")
+        )
 
         for pt in periods:
             analysis_res = _call_pipeline_with_diag(
@@ -1028,7 +1058,9 @@ def run(
                 # Recreate in-sample frame identical to _run_analysis slice
                 date_col = "Date"
                 sub = df.copy()
-                sub[date_col] = pd.to_datetime(sub[date_col], utc=True).dt.tz_localize(None)
+                sub[date_col] = pd.to_datetime(sub[date_col], utc=True).dt.tz_localize(
+                    None
+                )
                 sub.sort_values(date_col, inplace=True)
                 sdate = pd.to_datetime(f"{in_start}-01", utc=True).tz_localize(
                     None
@@ -1036,19 +1068,27 @@ def run(
                 edate = pd.to_datetime(f"{in_end}-01", utc=True).tz_localize(
                     None
                 ) + pd.offsets.MonthEnd(0)
-                in_df_full = sub[(sub[date_col] >= sdate) & (sub[date_col] <= edate)].set_index(
-                    date_col
-                )
+                in_df_full = sub[
+                    (sub[date_col] >= sdate) & (sub[date_col] <= edate)
+                ].set_index(date_col)
                 # Remove benchmark columns if present in result universe
                 fund_cols = [
-                    c for c in in_df_full.columns if c not in (cfg.benchmarks or {}).values()
+                    c
+                    for c in in_df_full.columns
+                    if c not in (cfg.benchmarks or {}).values()
                 ]
                 in_df_full = in_df_full[fund_cols]
                 in_df_prepared = _prepare_returns_frame(in_df_full)
 
-                if incremental_cov and prev_cov_payload is not None and prev_in_df is not None:
+                if (
+                    incremental_cov
+                    and prev_cov_payload is not None
+                    and prev_in_df is not None
+                ):
                     same_len = prev_in_df.shape[0] == in_df_prepared.shape[0]
-                    same_cols = prev_in_df.columns.tolist() == in_df_prepared.columns.tolist()
+                    same_cols = (
+                        prev_in_df.columns.tolist() == in_df_prepared.columns.tolist()
+                    )
                     n_rows = in_df_prepared.shape[0]
                     if same_cols and n_rows >= 3:
                         # Determine shift distance k (number of rows replaced at head and appended at tail)
@@ -1086,10 +1126,12 @@ def run(
                             # Apply k incremental updates sequentially
                             try:
                                 for step in range(k):
-                                    old_row = prev_in_df.iloc[step].to_numpy(dtype=float)
-                                    new_row = in_df_prepared.iloc[n_rows - k + step].to_numpy(
+                                    old_row = prev_in_df.iloc[step].to_numpy(
                                         dtype=float
                                     )
+                                    new_row = in_df_prepared.iloc[
+                                        n_rows - k + step
+                                    ].to_numpy(dtype=float)
                                     prev_cov_payload = incremental_cov_update(
                                         prev_cov_payload, old_row, new_row
                                     )
@@ -1107,7 +1149,9 @@ def run(
                 else:
                     from ..perf.cache import compute_cov_payload as _ccp
 
-                    prev_cov_payload = _ccp(in_df_prepared, materialise_aggregates=incremental_cov)
+                    prev_cov_payload = _ccp(
+                        in_df_prepared, materialise_aggregates=incremental_cov
+                    )
                 prev_in_df = in_df_prepared
                 res_dict["cov_diag"] = prev_cov_payload.cov.diagonal().tolist()
                 if cov_cache_obj is not None:
@@ -1177,12 +1221,14 @@ def run(
                 continue
             seen.add(resolved)
             benchmark_cols.append(resolved)
-    resolved_rf_col, _resolver_fund_cols, resolved_rf_source = _resolve_risk_free_column(
-        df,
-        date_col="Date",
-        indices_list=indices_list,
-        risk_free_column=risk_free_column_cfg,
-        allow_risk_free_fallback=allow_risk_free_fallback_cfg,
+    resolved_rf_col, _resolver_fund_cols, resolved_rf_source = (
+        _resolve_risk_free_column(
+            df,
+            date_col="Date",
+            indices_list=indices_list,
+            risk_free_column=risk_free_column_cfg,
+            allow_risk_free_fallback=allow_risk_free_fallback_cfg,
+        )
     )
 
     # Build a stable investable universe list.
@@ -1195,7 +1241,9 @@ def run(
     idx_set |= {str(c) for c in benchmark_cols}
     resolved_fund_candidates = [c for c in numeric_cols_all if c not in idx_set]
     if resolved_rf_source == "configured" and resolved_rf_col:
-        resolved_fund_candidates = [c for c in resolved_fund_candidates if c != resolved_rf_col]
+        resolved_fund_candidates = [
+            c for c in resolved_fund_candidates if c != resolved_rf_col
+        ]
     elif resolved_rf_source == "fallback" and resolved_rf_col:
         # Fallback RF selection can legitimately pick a true cash proxy (flat
         # zero-return series). Treat such near-constant columns as non-investable
@@ -1212,7 +1260,9 @@ def run(
 
     # --- helpers --------------------------------------------------------
     def _parse_month(s: str) -> pd.Timestamp:
-        return pd.to_datetime(f"{s}-01", utc=True).tz_localize(None) + pd.offsets.MonthEnd(0)
+        return pd.to_datetime(f"{s}-01", utc=True).tz_localize(
+            None
+        ) + pd.offsets.MonthEnd(0)
 
     def _valid_universe(
         full: pd.DataFrame,
@@ -1227,16 +1277,22 @@ def run(
         sub.sort_values(date_col, inplace=True)
         in_sdate, in_edate = _parse_month(in_start), _parse_month(in_end)
         out_sdate, out_edate = _parse_month(out_start), _parse_month(out_end)
-        in_df = sub[(sub[date_col] >= in_sdate) & (sub[date_col] <= in_edate)].set_index(date_col)
-        out_df = sub[(sub[date_col] >= out_sdate) & (sub[date_col] <= out_edate)].set_index(
-            date_col
-        )
+        in_df = sub[
+            (sub[date_col] >= in_sdate) & (sub[date_col] <= in_edate)
+        ].set_index(date_col)
+        out_df = sub[
+            (sub[date_col] >= out_sdate) & (sub[date_col] <= out_edate)
+        ].set_index(date_col)
         if in_df.empty or out_df.empty:
             return in_df, out_df, [], ""
         numeric_cols = [c for c in sub.select_dtypes("number").columns if c != date_col]
         idx_set = {str(c) for c in indices_list}
         idx_set |= {str(c) for c in benchmark_cols}
-        fund_cols = [c for c in resolved_fund_candidates if c in numeric_cols and c not in idx_set]
+        fund_cols = [
+            c
+            for c in resolved_fund_candidates
+            if c in numeric_cols and c not in idx_set
+        ]
 
         if not fund_cols:
             return in_df, out_df, [], resolved_rf_col
@@ -1254,7 +1310,9 @@ def run(
         in_ok = ~in_tail.isna().any()
         out_ok = ~out_df[fund_cols].isna().any()
         fund_cols = [
-            c for c in fund_cols if bool(in_ok.get(c, False)) and bool(out_ok.get(c, False))
+            c
+            for c in fund_cols
+            if bool(in_ok.get(c, False)) and bool(out_ok.get(c, False))
         ]
 
         # Guardrail: exclude funds that are effectively inactive/flatlined at
@@ -1380,11 +1438,15 @@ def run(
     z_exit_hard = _parse_optional_float(th_cfg.get("z_exit_hard"))
 
     target_n = int(
-        th_cfg.get("target_n", portfolio_cfg.get("target_n", cfg.portfolio.get("random_n", 8)))
+        th_cfg.get(
+            "target_n", portfolio_cfg.get("target_n", cfg.portfolio.get("random_n", 8))
+        )
     )
     seed_metric = cast(
         str,
-        (cfg.portfolio.get("selector", {}) or {}).get("params", {}).get("rank_column", "Sharpe"),
+        (cfg.portfolio.get("selector", {}) or {})
+        .get("params", {})
+        .get("rank_column", "Sharpe"),
     )
     selector = create_selector_by_name("rank", top_n=target_n, rank_column=seed_metric)
 
@@ -1429,7 +1491,9 @@ def run(
     if cooldown_periods_raw is None:
         cooldown_periods_raw = mp_cfg.get("cooldown_months")
     try:
-        cooldown_periods = int(cooldown_periods_raw) if cooldown_periods_raw is not None else 0
+        cooldown_periods = (
+            int(cooldown_periods_raw) if cooldown_periods_raw is not None else 0
+        )
     except (TypeError, ValueError):
         cooldown_periods = 0
     cooldown_periods = max(0, cooldown_periods)
@@ -1457,7 +1521,9 @@ def run(
     if raw_max_active is None:
         raw_max_active = constraints.get("max_active")
     try:
-        max_active_positions = int(raw_max_active) if raw_max_active is not None else None
+        max_active_positions = (
+            int(raw_max_active) if raw_max_active is not None else None
+        )
     except (TypeError, ValueError):
         max_active_positions = None
     if max_active_positions is not None and max_active_positions <= 0:
@@ -1502,7 +1568,9 @@ def run(
 
     # Risk-based weighting scheme (risk_parity, hrp) from weighting_scheme config.
     # This overrides the legacy `portfolio.weighting` dict config for primary weights.
-    weighting_scheme = str(cfg.portfolio.get("weighting_scheme", "equal") or "equal").lower()
+    weighting_scheme = str(
+        cfg.portfolio.get("weighting_scheme", "equal") or "equal"
+    ).lower()
     if weighting_scheme == "robust":
         weighting_scheme = "robust_mv"
     use_risk_weighting = weighting_scheme in {
@@ -1525,7 +1593,9 @@ def run(
                 weighting_scheme,
                 robustness_cfg if isinstance(robustness_cfg, Mapping) else None,
             )
-            risk_weight_engine = create_weight_engine(weighting_scheme, **weight_engine_params)
+            risk_weight_engine = create_weight_engine(
+                weighting_scheme, **weight_engine_params
+            )
         except Exception:  # pragma: no cover - best-effort only
             use_risk_weighting = False
             risk_weight_engine = None
@@ -1551,7 +1621,9 @@ def run(
     # --- main loop ------------------------------------------------------
     # Pre-index returns once for intra-period rebalance snapshots.
     df_indexed = df.copy()
-    df_indexed["Date"] = pd.to_datetime(df_indexed["Date"], utc=True).dt.tz_localize(None)
+    df_indexed["Date"] = pd.to_datetime(df_indexed["Date"], utc=True).dt.tz_localize(
+        None
+    )
     df_indexed.sort_values("Date", inplace=True)
     df_indexed = df_indexed.set_index("Date")
 
@@ -1590,7 +1662,9 @@ def run(
             return True
         return int(add_streaks.get(manager, 0)) >= sticky_add_periods
 
-    def _min_tenure_protected(holdings: Iterable[str], score_frame: pd.DataFrame) -> set[str]:
+    def _min_tenure_protected(
+        holdings: Iterable[str], score_frame: pd.DataFrame
+    ) -> set[str]:
         if min_tenure_n <= 0:
             return set()
         protected: set[str] = set()
@@ -1659,7 +1733,9 @@ def run(
                 int(cooldown_periods) + 1,
             )
 
-    def _dedupe_one_per_firm(sf: pd.DataFrame, holdings: list[str], metric: str) -> list[str]:
+    def _dedupe_one_per_firm(
+        sf: pd.DataFrame, holdings: list[str], metric: str
+    ) -> list[str]:
         if not holdings:
             return holdings
         col = metric if metric in sf.columns else "Sharpe"
@@ -1795,7 +1871,9 @@ def run(
         keep = ordered[:-bottom_k]
         return filtered.loc[keep]
 
-    def _filter_entry_candidates(candidates: list[str], score_frame: pd.DataFrame) -> list[str]:
+    def _filter_entry_candidates(
+        candidates: list[str], score_frame: pd.DataFrame
+    ) -> list[str]:
         if not candidates:
             return candidates
         eligible_frame = _filter_entry_frame(score_frame)
@@ -1804,7 +1882,9 @@ def run(
         eligible = {str(ix) for ix in eligible_frame.index}
         return [str(ix) for ix in candidates if str(ix) in eligible]
 
-    def _hard_exit_forced(holdings: Iterable[str], score_frame: pd.DataFrame) -> set[str]:
+    def _hard_exit_forced(
+        holdings: Iterable[str], score_frame: pd.DataFrame
+    ) -> set[str]:
         if z_exit_hard is None or "zscore" not in score_frame.columns:
             return set()
         z = pd.to_numeric(score_frame["zscore"], errors="coerce")
@@ -1927,8 +2007,12 @@ def run(
                 if returns_window is not None and not returns_window.empty:
                     # Only include holdings that have data in returns_window
                     # to avoid NaN columns that would get 0 weight
-                    holdings_in_window = [h for h in holdings if h in returns_window.columns]
-                    subset = returns_window[holdings_in_window].dropna(axis=1, how="all")
+                    holdings_in_window = [
+                        h for h in holdings if h in returns_window.columns
+                    ]
+                    subset = returns_window[holdings_in_window].dropna(
+                        axis=1, how="all"
+                    )
                 else:
                     # Fall back to score frame data if no returns window provided
                     subset = sf.loc[holdings]
@@ -2019,7 +2103,9 @@ def run(
         rf_rate_annual = float(metrics_cfg.get("rf_rate_annual", 0.0) or 0.0)
         # Convert annualised RF to a per-period return.
         # Use geometric conversion so 2% annual becomes ~0.165% monthly.
-        rf_rate_periodic = (1.0 + rf_rate_annual) ** (1.0 / float(periods_per_year)) - 1.0
+        rf_rate_periodic = (1.0 + rf_rate_annual) ** (
+            1.0 / float(periods_per_year)
+        ) - 1.0
 
         # UI semantics:
         # - override disabled: use the selected risk-free column series (if available)
@@ -2088,12 +2174,16 @@ def run(
                     holdings = []
                 else:
                     # Seed varies per period to get different selections
-                    period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(hash(str(pt)) % 10000)
+                    period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(
+                        hash(str(pt)) % 10000
+                    )
                     rng = np.random.default_rng(period_seed)
                     n_select = max(1, min(target_n, len(available)))
                     holdings = list(rng.choice(available, size=n_select, replace=False))
                     # Enforce one-per-firm constraint
-                    holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
+                    holdings = _dedupe_one_per_firm_with_events(
+                        sf, holdings, metric, events
+                    )
                     # If dedupe reduced us, refill with random selection
                     if len(holdings) < n_select:
                         candidates = [c for c in available if c not in holdings]
@@ -2118,11 +2208,15 @@ def run(
                     holdings = []
                 elif buy_hold_initial == "random":
                     # Random initial selection
-                    period_seed = abs((getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000)
+                    period_seed = abs(
+                        (getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000
+                    )
                     rng = np.random.default_rng(period_seed)
                     n_select = max(1, min(buy_hold_n, len(available)))
                     holdings = list(rng.choice(available, size=n_select, replace=False))
-                    holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
+                    holdings = _dedupe_one_per_firm_with_events(
+                        sf, holdings, metric, events
+                    )
                     # Refill if dedupe reduced holdings
                     if len(holdings) < n_select:
                         candidates = [c for c in available if c not in holdings]
@@ -2145,7 +2239,9 @@ def run(
                     if rank_score_by == "blended" and rank_blended_weights:
                         total_w = sum(rank_blended_weights.values())
                         if total_w > 0:
-                            norm_w = {k: v / total_w for k, v in rank_blended_weights.items()}
+                            norm_w = {
+                                k: v / total_w for k, v in rank_blended_weights.items()
+                            }
                         else:
                             norm_w = {"Sharpe": 1.0}
                         combo = pd.Series(0.0, index=eligible_sf.index, dtype=float)
@@ -2165,7 +2261,9 @@ def run(
                         scores = combo
                     else:
                         score_col = (
-                            rank_score_by if rank_score_by in eligible_sf.columns else "Sharpe"
+                            rank_score_by
+                            if rank_score_by in eligible_sf.columns
+                            else "Sharpe"
                         )
                         scores = eligible_sf[score_col].astype(float)
 
@@ -2178,7 +2276,10 @@ def run(
                             scores = pd.Series(0.0, index=scores.index)
 
                     ascending = False
-                    if rank_score_by in ASCENDING_METRICS and buy_hold_initial != "threshold":
+                    if (
+                        rank_score_by in ASCENDING_METRICS
+                        and buy_hold_initial != "threshold"
+                    ):
                         ascending = True
 
                     sorted_scores = scores.sort_values(ascending=ascending)
@@ -2203,7 +2304,9 @@ def run(
                         holdings = all_candidates[:buy_hold_n]
 
                     # Enforce one-per-firm constraint
-                    holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
+                    holdings = _dedupe_one_per_firm_with_events(
+                        sf, holdings, metric, events
+                    )
                     # Historical weighting call
                     if holdings:
                         try:
@@ -2234,7 +2337,9 @@ def run(
                         and rank_col in selected.columns
                     ):
                         ascending = rank_col in ASCENDING_METRICS
-                        ordered = selected.sort_values(rank_col, ascending=ascending).index
+                        ordered = selected.sort_values(
+                            rank_col, ascending=ascending
+                        ).index
                         holdings = [str(x) for x in ordered.tolist()]
                     else:
                         holdings = [str(x) for x in selected.index.tolist()]
@@ -2255,7 +2360,10 @@ def run(
                             # Normalize weights
                             total_w = sum(rank_blended_weights.values())
                             if total_w > 0:
-                                norm_w = {k: v / total_w for k, v in rank_blended_weights.items()}
+                                norm_w = {
+                                    k: v / total_w
+                                    for k, v in rank_blended_weights.items()
+                                }
                             else:
                                 norm_w = {"Sharpe": 1.0}
                             # Compute blended score from the score frame
@@ -2279,7 +2387,9 @@ def run(
                         else:
                             # Single metric
                             score_col = (
-                                rank_score_by if rank_score_by in score_frame.columns else "Sharpe"
+                                rank_score_by
+                                if rank_score_by in score_frame.columns
+                                else "Sharpe"
                             )
                             scores = score_frame[score_col].astype(float)
 
@@ -2293,7 +2403,10 @@ def run(
 
                         # Determine sort order
                         ascending = False  # Higher score is better for blended/zscore
-                        if rank_score_by in ASCENDING_METRICS and rank_transform != "zscore":
+                        if (
+                            rank_score_by in ASCENDING_METRICS
+                            and rank_transform != "zscore"
+                        ):
                             ascending = True
 
                         # Sort scores
@@ -2349,11 +2462,15 @@ def run(
                 if len(holdings) > target_n:
                     holdings = holdings[:target_n]
                 # Enforce one-per-firm on seed
-                holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
+                holdings = _dedupe_one_per_firm_with_events(
+                    sf, holdings, metric, events
+                )
                 desired_seed = min(max_funds, target_n)
                 # If we're still above the desired size, trim by zscore (best-first).
                 if len(holdings) > desired_seed:
-                    zsorted = sf.loc[holdings].sort_values("zscore", ascending=False).index
+                    zsorted = (
+                        sf.loc[holdings].sort_values("zscore", ascending=False).index
+                    )
                     holdings = list(zsorted[:desired_seed])
 
                 # If dedupe reduced us below the target size, fill from the remaining
@@ -2363,8 +2480,12 @@ def run(
                 # that percentage of the universe.
                 if len(holdings) < desired_seed and inclusion_approach != "top_pct":
                     candidates = [c for c in sf.index if c not in holdings]
-                    candidates = _filter_entry_candidates([str(c) for c in candidates], sf)
-                    add_from = sf.loc[candidates].sort_values("zscore", ascending=False).index
+                    candidates = _filter_entry_candidates(
+                        [str(c) for c in candidates], sf
+                    )
+                    add_from = (
+                        sf.loc[candidates].sort_values("zscore", ascending=False).index
+                    )
                     seen_firms = {_firm(h) for h in holdings}
                     for f in add_from:
                         if len(holdings) >= desired_seed:
@@ -2384,7 +2505,9 @@ def run(
                     and resolved_rf_col in holdings
                 ):
                     candidates = [c for c in sf.index if c not in holdings]
-                    candidates = _filter_entry_candidates([str(c) for c in candidates], sf)
+                    candidates = _filter_entry_candidates(
+                        [str(c) for c in candidates], sf
+                    )
                     add_from = (
                         sf.loc[candidates].sort_values("zscore", ascending=False).index
                         if candidates
@@ -2499,7 +2622,10 @@ def run(
                         if rank_score_by == "blended" and rank_blended_weights:
                             total_w = sum(rank_blended_weights.values())
                             if total_w > 0:
-                                norm_w = {k: v / total_w for k, v in rank_blended_weights.items()}
+                                norm_w = {
+                                    k: v / total_w
+                                    for k, v in rank_blended_weights.items()
+                                }
                             else:
                                 norm_w = {"Sharpe": 1.0}
                             combo = pd.Series(0.0, index=sf.index, dtype=float)
@@ -2518,7 +2644,11 @@ def run(
                                     combo += w * z
                             scores = combo
                         else:
-                            score_col = rank_score_by if rank_score_by in sf.columns else "Sharpe"
+                            score_col = (
+                                rank_score_by
+                                if rank_score_by in sf.columns
+                                else "Sharpe"
+                            )
                             scores = sf[score_col].astype(float)
 
                         # Apply zscore transform if threshold mode
@@ -2530,11 +2660,16 @@ def run(
                                 scores = pd.Series(0.0, index=scores.index)
 
                         ascending = False
-                        if rank_score_by in ASCENDING_METRICS and buy_hold_initial != "threshold":
+                        if (
+                            rank_score_by in ASCENDING_METRICS
+                            and buy_hold_initial != "threshold"
+                        ):
                             ascending = True
 
                         # Sort scores and filter to available candidates
-                        sorted_scores = scores.loc[available].sort_values(ascending=ascending)
+                        sorted_scores = scores.loc[available].sort_values(
+                            ascending=ascending
+                        )
 
                         # Select replacements respecting threshold if applicable
                         if buy_hold_initial == "threshold":
@@ -2577,7 +2712,9 @@ def run(
                 # each period. This is essential to avoid survivorship bias - we select
                 # from the available universe at each point in time, not funds we know
                 # will survive.
-                period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(hash(str(pt)) % 10000)
+                period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(
+                    hash(str(pt)) % 10000
+                )
                 rebased = rebalancer.apply_triggers(
                     prev_weights.astype(float),
                     sf,
@@ -2586,10 +2723,14 @@ def run(
                 )
 
                 # Restrict to funds available in this period's score-frame.
-                proposed_holdings = [str(h) for h in list(rebased.index) if h in sf.index]
+                proposed_holdings = [
+                    str(h) for h in list(rebased.index) if h in sf.index
+                ]
 
             if hard_exit_forced:
-                proposed_holdings = [m for m in proposed_holdings if m not in hard_exit_forced]
+                proposed_holdings = [
+                    m for m in proposed_holdings if m not in hard_exit_forced
+                ]
 
             raw_proposed_holdings = [str(h) for h in proposed_holdings]
 
@@ -2662,7 +2803,8 @@ def run(
                                 "firm": _firm(mgr),
                                 "reason": "sticky_add",
                                 "detail": (
-                                    f"streak={add_streaks.get(mgr, 0)}/" f"{sticky_add_periods}"
+                                    f"streak={add_streaks.get(mgr, 0)}/"
+                                    f"{sticky_add_periods}"
                                 ),
                             }
                         )
@@ -2683,7 +2825,8 @@ def run(
                                 "firm": _firm(mgr),
                                 "reason": "sticky_drop",
                                 "detail": (
-                                    f"streak={drop_streaks.get(mgr, 0)}/" f"{sticky_drop_periods}"
+                                    f"streak={drop_streaks.get(mgr, 0)}/"
+                                    f"{sticky_drop_periods}"
                                 ),
                             }
                         )
@@ -2717,7 +2860,8 @@ def run(
                             "firm": _firm(mgr),
                             "reason": "min_tenure",
                             "detail": (
-                                f"tenure={int(holdings_tenure.get(mgr, 0))}/" f"{min_tenure_n}"
+                                f"tenure={int(holdings_tenure.get(mgr, 0))}/"
+                                f"{min_tenure_n}"
                             ),
                         }
                     )
@@ -2781,12 +2925,18 @@ def run(
                 candidates = _filter_entry_candidates(candidates, sf)
                 if candidates:
                     if is_random_mode:
-                        period_seed = abs((getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000)
+                        period_seed = abs(
+                            (getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000
+                        )
                         rng = np.random.default_rng(period_seed)
                         rng.shuffle(candidates)
                         ranked = candidates
                     else:
-                        ranked = sf.loc[candidates].sort_values("zscore", ascending=False).index
+                        ranked = (
+                            sf.loc[candidates]
+                            .sort_values("zscore", ascending=False)
+                            .index
+                        )
                     for c in ranked:
                         if len(proposed_holdings) >= desired_size:
                             break
@@ -2805,8 +2955,12 @@ def run(
             pruned_existing: set[str] = set()
             if desired_size > 0:
                 current_set = {str(x) for x in before_reb}
-                kept_existing = [str(h) for h in proposed_holdings if str(h) in current_set]
-                new_candidates = [str(h) for h in proposed_holdings if str(h) not in current_set]
+                kept_existing = [
+                    str(h) for h in proposed_holdings if str(h) in current_set
+                ]
+                new_candidates = [
+                    str(h) for h in proposed_holdings if str(h) not in current_set
+                ]
 
                 def _zscore(mgr: str) -> float:
                     try:
@@ -2829,14 +2983,20 @@ def run(
                 # not happen), prune incumbents by weakest zscore.
                 # In random mode, prune randomly instead.
                 if len(kept_existing) > desired_size:
-                    protected_existing = [mgr for mgr in kept_existing if mgr in protected_holdings]
+                    protected_existing = [
+                        mgr for mgr in kept_existing if mgr in protected_holdings
+                    ]
                     unprotected_existing = [
                         mgr for mgr in kept_existing if mgr not in protected_holdings
                     ]
                     if is_random_mode:
-                        unprotected_sorted = sorted(unprotected_existing, key=_random_key)
+                        unprotected_sorted = sorted(
+                            unprotected_existing, key=_random_key
+                        )
                     else:
-                        unprotected_sorted = sorted(unprotected_existing, key=_zscore, reverse=True)
+                        unprotected_sorted = sorted(
+                            unprotected_existing, key=_zscore, reverse=True
+                        )
                     if protected_existing:
                         slots = max(0, desired_size - len(protected_existing))
                         if slots > 0:
@@ -2892,7 +3052,9 @@ def run(
                 selected, _ = selector.select(_filter_entry_frame(sf))
                 proposed_holdings = [str(x) for x in selected.index.tolist()]
                 if cooldown_periods > 0 and cooldown_book:
-                    filtered = [mgr for mgr in proposed_holdings if mgr not in cooldown_book]
+                    filtered = [
+                        mgr for mgr in proposed_holdings if mgr not in cooldown_book
+                    ]
                     if filtered:
                         for mgr in proposed_holdings:
                             if mgr in cooldown_book:
@@ -3138,7 +3300,8 @@ def run(
                         "firm": _firm(f),
                         "reason": "low_weight_strikes",
                         "detail": (
-                            f"below min {min_w_bound:.2%} for " f"{low_min_strikes_req} periods"
+                            f"below min {min_w_bound:.2%} for "
+                            f"{low_min_strikes_req} periods"
                         ),
                     }
                 )
@@ -3151,11 +3314,17 @@ def run(
             need = max(0, desired_after_low_weight - len(holdings))
             if need > 0:
                 candidates = [
-                    c for c in sf.index if c not in holdings and _eligible_sticky_add(str(c))
+                    c
+                    for c in sf.index
+                    if c not in holdings and _eligible_sticky_add(str(c))
                 ]
                 if cooldown_periods > 0 and cooldown_book:
                     candidates = [c for c in candidates if str(c) not in cooldown_book]
-                add_from = sf.loc[candidates].sort_values("zscore", ascending=False).index.tolist()
+                add_from = (
+                    sf.loc[candidates]
+                    .sort_values("zscore", ascending=False)
+                    .index.tolist()
+                )
                 for f in add_from:
                     if len(holdings) >= desired_after_low_weight:
                         break
@@ -3179,7 +3348,9 @@ def run(
                     sf, holdings, period_ts, in_df.reindex(columns=holdings_with_data)
                 )
                 raw_weight_series = _as_weight_series(weights_df)
-                signal_slice = sf.loc[holdings, metric] if metric in sf.columns else None
+                signal_slice = (
+                    sf.loc[holdings, metric] if metric in sf.columns else None
+                )
                 weight_series = _apply_policy_to_weights(weights_df, signal_slice)
                 weights_df = weight_series.to_frame("weight")
                 prev_weights = weight_series.astype(float)
@@ -3190,7 +3361,9 @@ def run(
             holdings = _enforce_min_funds(
                 sf,
                 holdings,
-                before_reb=(set(prev_weights.index) if prev_weights is not None else None),
+                before_reb=(
+                    set(prev_weights.index) if prev_weights is not None else None
+                ),
                 cooldowns=cooldown_book,
                 desired_min=min_funds,
                 events=events,
@@ -3203,7 +3376,9 @@ def run(
                     sf, holdings, period_ts, in_df.reindex(columns=holdings_with_data)
                 )
                 raw_weight_series = _as_weight_series(weights_df)
-                signal_slice = sf.loc[holdings, metric] if metric in sf.columns else None
+                signal_slice = (
+                    sf.loc[holdings, metric] if metric in sf.columns else None
+                )
                 weight_series = _apply_policy_to_weights(weights_df, signal_slice)
                 weights_df = weight_series.to_frame("weight")
                 prev_weights = weight_series.astype(float)
@@ -3259,7 +3434,9 @@ def run(
             mandatory = desired_trades.copy()
             if forced_ix:
                 # Keep only forced exit trades in mandatory bucket
-                mandatory.loc[[ix for ix in mandatory.index if ix not in forced_ix]] = 0.0
+                mandatory.loc[[ix for ix in mandatory.index if ix not in forced_ix]] = (
+                    0.0
+                )
             else:
                 mandatory[:] = 0.0
 
@@ -3273,7 +3450,11 @@ def run(
                 final_w = last_aligned + mandatory
             else:
                 remaining_turnover = max_turnover_cap - mandatory_turnover
-                scale = remaining_turnover / optional_turnover if optional_turnover > 0 else 0.0
+                scale = (
+                    remaining_turnover / optional_turnover
+                    if optional_turnover > 0
+                    else 0.0
+                )
                 scale = max(0.0, min(1.0, scale))
                 final_w = last_aligned + mandatory + optional * scale
         # Ensure bounds and normalisation remain satisfied
@@ -3296,8 +3477,12 @@ def run(
             if total > eps and abs(total - 1.0) <= 1e-8:
                 final_w = final_w / total
         # Only pass the selected holdings (if still present after filtering).
-        manual_funds: list[str] = [str(h) for h in manual_holdings if h in final_w.index]
-        custom: dict[str, float] = {str(k): float(v) * 100.0 for k, v in final_w.items()}
+        manual_funds: list[str] = [
+            str(h) for h in manual_holdings if h in final_w.index
+        ]
+        custom: dict[str, float] = {
+            str(k): float(v) * 100.0 for k, v in final_w.items()
+        }
 
         # Construct previous weights dict for pipeline (turnover tracking)
         prev_weights_for_pipeline = _coerce_previous_weights(prev_final_weights)
@@ -3352,7 +3537,10 @@ def run(
         # consumers can audit soft-entry/soft-exit decisions without
         # recomputation.
         score_frame_payload = res_dict.get("score_frame")
-        if isinstance(score_frame_payload, pd.DataFrame) and not score_frame_payload.empty:
+        if (
+            isinstance(score_frame_payload, pd.DataFrame)
+            and not score_frame_payload.empty
+        ):
             score_frame_out = score_frame_payload.copy()
             if "zscore" in sf.columns and "zscore" not in score_frame_out.columns:
                 score_frame_out = score_frame_out.join(sf[["zscore"]], how="left")
@@ -3401,8 +3589,9 @@ def run(
         # Turnover alignment can introduce additional indices (e.g., prior
         # holdings carried at zero then floored by bounds). These should not
         # become realised holdings unless they are part of the manual fund list
-        # passed to the pipeline.
-        if manual_holdings:
+        # passed to the pipeline. If we are using pipeline weights directly,
+        # respect the pipeline's realised holdings instead of filtering them out.
+        if manual_holdings and not used_pipeline_weights:
             manual_set = {str(x) for x in manual_holdings}
             effective_w = effective_w.drop(
                 labels=[c for c in effective_w.index if str(c) not in manual_set],
@@ -3519,7 +3708,9 @@ def run(
         realised_holdings = [str(x) for x in effective_nonzero.index]
         # Do not emit zero-weight positions: they are not real holdings and
         # confuse downstream audits (e.g., a dropped fund showing up with 0.0).
-        res_dict["fund_weights"] = {str(k): float(v) for k, v in effective_nonzero.items()}
+        res_dict["fund_weights"] = {
+            str(k): float(v) for k, v in effective_nonzero.items()
+        }
 
         # Record cooldowns for any managers that exited based on realised holdings.
         if cooldown_periods > 0 and prev_final_weights is not None:
@@ -3580,7 +3771,8 @@ def run(
                         ) + pd.offsets.MonthEnd(0)
 
                         window = df_indexed.reindex(columns=realised_holdings).loc[
-                            (df_indexed.index >= start_dt) & (df_indexed.index <= end_dt)
+                            (df_indexed.index >= start_dt)
+                            & (df_indexed.index <= end_dt)
                         ]
                         if window.empty:
                             w_row = prev_reb_w
@@ -3628,7 +3820,9 @@ def run(
                             except Exception:  # pragma: no cover - best-effort only
                                 w_row = prev_reb_w
 
-                        rebalance_rows.append({str(k): float(v) for k, v in w_row.items()})
+                        rebalance_rows.append(
+                            {str(k): float(v) for k, v in w_row.items()}
+                        )
 
                     rebalance_frame = pd.DataFrame(
                         rebalance_rows,
@@ -3642,7 +3836,9 @@ def run(
         if rebalance_frame is not None and not rebalance_frame.empty:
             out_scaled = res_dict.get("out_sample_scaled")
             if isinstance(out_scaled, pd.DataFrame) and not out_scaled.empty:
-                weights_by_date = rebalance_frame.reindex(out_scaled.index).ffill().fillna(0.0)
+                weights_by_date = (
+                    rebalance_frame.reindex(out_scaled.index).ffill().fillna(0.0)
+                )
                 weights_by_date = weights_by_date.reindex(
                     columns=out_scaled.columns, fill_value=0.0
                 )
@@ -3663,8 +3859,12 @@ def run(
 
                 out_raw = out_df.reindex(columns=out_scaled.columns)
                 if isinstance(out_raw, pd.DataFrame) and not out_raw.empty:
-                    weights_raw = rebalance_frame.reindex(out_raw.index).ffill().fillna(0.0)
-                    weights_raw = weights_raw.reindex(columns=out_raw.columns, fill_value=0.0)
+                    weights_raw = (
+                        rebalance_frame.reindex(out_raw.index).ffill().fillna(0.0)
+                    )
+                    weights_raw = weights_raw.reindex(
+                        columns=out_raw.columns, fill_value=0.0
+                    )
                     rebalance_raw = (out_raw * weights_raw).sum(axis=1)
                     res_dict["portfolio_user_weight_raw"] = rebalance_raw
                     res_dict["out_user_stats_raw"] = _compute_stats(

--- a/streamlit_app/components/explain_results.py
+++ b/streamlit_app/components/explain_results.py
@@ -126,9 +126,7 @@ def _resolve_llm_provider_config(
     base_url: str | None = None,
     organization: str | None = None,
 ) -> LLMProviderConfig:
-    provider_name = (
-        provider or os.environ.get("TREND_LLM_PROVIDER") or "openai"
-    ).lower()
+    provider_name = (provider or os.environ.get("TREND_LLM_PROVIDER") or "openai").lower()
     supported = {"openai", "anthropic", "ollama"}
     if provider_name not in supported:
         raise ValueError(
@@ -153,9 +151,7 @@ def _resolve_llm_provider_config(
     if not resolved_api_key and provider_name == "anthropic":
         resolved_api_key = _sanitize_api_key(os.environ.get("ANTHROPIC_API_KEY"))
     if provider_name in {"openai", "anthropic"} and not resolved_api_key:
-        env_hint = (
-            "OPENAI_API_KEY" if provider_name == "openai" else "ANTHROPIC_API_KEY"
-        )
+        env_hint = "OPENAI_API_KEY" if provider_name == "openai" else "ANTHROPIC_API_KEY"
         raise ValueError(
             f"Missing API key for {provider_name}. "
             f"Set TS_STREAMLIT_API_KEY, OPENAI_API_KEY, TREND_LLM_API_KEY, or {env_hint}."
@@ -245,9 +241,7 @@ def generate_result_explanation(
     compacted_entries = compact_metric_catalog(all_entries, questions=questions)
     metric_catalog = format_metric_catalog(compacted_entries)
     if not all_entries:
-        text = ensure_result_disclaimer(
-            "No metrics were detected in the analysis output."
-        )
+        text = ensure_result_disclaimer("No metrics were detected in the analysis output.")
         return ExplanationResult(
             text=text,
             trace_url=None,

--- a/streamlit_app/components/explain_results.py
+++ b/streamlit_app/components/explain_results.py
@@ -30,9 +30,26 @@ from trend_analysis.llm import (
     serialize_claim_issue,
 )
 
-DEFAULT_QUESTION = "Summarize key findings and notable risks in the results."
+DEFAULT_QUESTION = """Analyze this manager selection backtest:
+1. What drove the selection of specific managers over alternatives?
+2. Which managers persisted across periods and why - true quality or lack of underperformance?
+3. Are there signs the selection rules favored managers that entered during benign periods?
+4. What parameter changes might improve future selection quality?"""
 _CACHE_KEY = "explain_results_cache"
 logger = logging.getLogger(__name__)
+_PLACEHOLDER_PREFIXES = ("YOUR_", "CHANGE_ME", "REPLACE_ME")
+
+
+def _sanitize_api_key(value: str | None) -> str | None:
+    if not value:
+        return None
+    trimmed = value.strip()
+    if not trimmed:
+        return None
+    upper = trimmed.upper()
+    if upper.startswith(_PLACEHOLDER_PREFIXES):
+        return None
+    return trimmed
 
 
 def _read_secret(key: str) -> str | None:
@@ -109,24 +126,36 @@ def _resolve_llm_provider_config(
     base_url: str | None = None,
     organization: str | None = None,
 ) -> LLMProviderConfig:
-    provider_name = (provider or os.environ.get("TREND_LLM_PROVIDER") or "openai").lower()
+    provider_name = (
+        provider or os.environ.get("TREND_LLM_PROVIDER") or "openai"
+    ).lower()
     supported = {"openai", "anthropic", "ollama"}
     if provider_name not in supported:
         raise ValueError(
             f"Unknown LLM provider '{provider_name}'. "
             f"Expected one of: {', '.join(sorted(supported))}."
         )
-    resolved_api_key = api_key
+    resolved_api_key = _sanitize_api_key(api_key)
     if not resolved_api_key:
-        resolved_api_key = os.environ.get("TS_STREAMLIT_API_KEY")
+        resolved_api_key = _sanitize_api_key(_read_secret("TS_STREAMLIT_API_KEY"))
     if not resolved_api_key:
-        resolved_api_key = os.environ.get("OPENAI_API_KEY")
+        resolved_api_key = _sanitize_api_key(_read_secret("OPENAI_API_KEY"))
     if not resolved_api_key:
-        resolved_api_key = os.environ.get("TREND_LLM_API_KEY")
+        resolved_api_key = _sanitize_api_key(_read_secret("TREND_LLM_API_KEY"))
+    if not resolved_api_key:
+        resolved_api_key = _sanitize_api_key(os.environ.get("TS_STREAMLIT_API_KEY"))
+    if not resolved_api_key:
+        resolved_api_key = _sanitize_api_key(os.environ.get("OPENAI_API_KEY"))
+    if not resolved_api_key:
+        resolved_api_key = _sanitize_api_key(os.environ.get("TREND_LLM_API_KEY"))
     if not resolved_api_key and provider_name == "anthropic":
-        resolved_api_key = os.environ.get("ANTHROPIC_API_KEY")
+        resolved_api_key = _sanitize_api_key(_read_secret("ANTHROPIC_API_KEY"))
+    if not resolved_api_key and provider_name == "anthropic":
+        resolved_api_key = _sanitize_api_key(os.environ.get("ANTHROPIC_API_KEY"))
     if provider_name in {"openai", "anthropic"} and not resolved_api_key:
-        env_hint = "OPENAI_API_KEY" if provider_name == "openai" else "ANTHROPIC_API_KEY"
+        env_hint = (
+            "OPENAI_API_KEY" if provider_name == "openai" else "ANTHROPIC_API_KEY"
+        )
         raise ValueError(
             f"Missing API key for {provider_name}. "
             f"Set TS_STREAMLIT_API_KEY, OPENAI_API_KEY, TREND_LLM_API_KEY, or {env_hint}."
@@ -150,30 +179,31 @@ def _default_api_key(provider_name: str) -> str | None:
     proxy_url = os.environ.get("TS_LLM_PROXY_URL")
     if proxy_url:
         token = os.environ.get("TS_LLM_PROXY_TOKEN")
+        token = _sanitize_api_key(token)
         if token:
             return token
-    secrets_key = _read_secret("TS_STREAMLIT_API_KEY")
+    secrets_key = _sanitize_api_key(_read_secret("TS_STREAMLIT_API_KEY"))
     if secrets_key:
         return secrets_key
-    secrets_key = _read_secret("TREND_LLM_API_KEY")
+    secrets_key = _sanitize_api_key(_read_secret("TREND_LLM_API_KEY"))
     if secrets_key:
         return secrets_key
-    secrets_key = _read_secret("OPENAI_API_KEY")
+    secrets_key = _sanitize_api_key(_read_secret("OPENAI_API_KEY"))
     if secrets_key:
         return secrets_key
-    env_key = os.environ.get("TS_STREAMLIT_API_KEY")
+    env_key = _sanitize_api_key(os.environ.get("TS_STREAMLIT_API_KEY"))
     if env_key:
         return env_key
-    env_key = os.environ.get("TREND_LLM_API_KEY")
+    env_key = _sanitize_api_key(os.environ.get("TREND_LLM_API_KEY"))
     if env_key:
         return env_key
     if provider_name == "openai":
-        return os.environ.get("OPENAI_API_KEY")
+        return _sanitize_api_key(os.environ.get("OPENAI_API_KEY"))
     if provider_name == "anthropic":
-        secrets_anthropic = _read_secret("ANTHROPIC_API_KEY")
+        secrets_anthropic = _sanitize_api_key(_read_secret("ANTHROPIC_API_KEY"))
         if secrets_anthropic:
             return secrets_anthropic
-        return os.environ.get("ANTHROPIC_API_KEY")
+        return _sanitize_api_key(os.environ.get("ANTHROPIC_API_KEY"))
     return None
 
 
@@ -215,7 +245,9 @@ def generate_result_explanation(
     compacted_entries = compact_metric_catalog(all_entries, questions=questions)
     metric_catalog = format_metric_catalog(compacted_entries)
     if not all_entries:
-        text = ensure_result_disclaimer("No metrics were detected in the analysis output.")
+        text = ensure_result_disclaimer(
+            "No metrics were detected in the analysis output."
+        )
         return ExplanationResult(
             text=text,
             trace_url=None,
@@ -296,16 +328,24 @@ def render_explain_results(
             key=provider_key,
             help="Defaults to TREND_LLM_PROVIDER if set; otherwise OpenAI.",
         )
-        api_default = st.session_state.get(api_key_key)
-        if not api_default:
-            api_default = _default_api_key(provider_default) or ""
+        # Pre-populate API key from environment if empty or not set
+        current_api_key = st.session_state.get(api_key_key)
+        if not current_api_key or not _sanitize_api_key(current_api_key):
+            env_key = _default_api_key(provider_default)
+            if env_key:
+                st.session_state[api_key_key] = env_key
         st.text_input(
             "API Key",
-            value=api_default,
+            value="",  # Ignored when key is set; session_state takes precedence
             key=api_key_key,
             type="password",
-            help="Stored only in this browser session.",
+            help="Leave blank to use TS_STREAMLIT_API_KEY or OPENAI_API_KEY from environment.",
         )
+        # Show indicator if env key is being used
+        if st.session_state.get(api_key_key):
+            st.caption("✓ API key configured")
+        else:
+            st.caption("⚠️ No API key found in environment or secrets")
         st.text_input(
             "Model (optional)",
             value=st.session_state.get(model_key, ""),
@@ -333,7 +373,7 @@ def render_explain_results(
     def _resolve_api_key_input(raw: str | None) -> str | None:
         if not raw:
             return None
-        trimmed = raw.strip()
+        trimmed = _sanitize_api_key(raw)
         if not trimmed:
             return None
         env_names = {
@@ -343,16 +383,22 @@ def render_explain_results(
             "ANTHROPIC_API_KEY",
         }
         if trimmed in env_names:
-            secret_val = _read_secret(trimmed)
-            return secret_val or os.environ.get(trimmed)
+            secret_val = _sanitize_api_key(_read_secret(trimmed))
+            if secret_val:
+                return secret_val
+            return _sanitize_api_key(os.environ.get(trimmed))
         return trimmed
 
     if clicked:
         with st.spinner("Generating explanation..."):
             try:
-                resolved_key = _resolve_api_key_input(
-                    st.session_state.get("explain_results_api_key")
-                )
+                raw_key = st.session_state.get("explain_results_api_key")
+                resolved_key = _resolve_api_key_input(raw_key)
+                # If empty or placeholder, auto-resolve from environment
+                if not resolved_key:
+                    resolved_key = _default_api_key(
+                        st.session_state.get("explain_results_provider") or "openai"
+                    )
                 cached = generate_result_explanation(
                     details,
                     questions=st.session_state.get(question_key),

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -454,9 +454,7 @@ def _current_run_key(model_state: dict[str, Any], benchmark: str | None) -> str:
     selected_rf = st.session_state.get("selected_risk_free")
     selected_rf_key = selected_rf or "__none__"
     info_ratio_benchmark = (
-        model_state.get("info_ratio_benchmark")
-        if isinstance(model_state, dict)
-        else None
+        model_state.get("info_ratio_benchmark") if isinstance(model_state, dict) else None
     )
     regime_proxy = None
     if bool(model_state.get("regime_enabled", False)):
@@ -569,9 +567,7 @@ def _render_risky_change_dialog() -> None:
         cancel = st.button("Cancel", type="secondary")
         if confirm:
             st.session_state.pop("config_chat_pending_apply", None)
-            _apply_preview_state(
-                preview, run_analysis=bool(pending.get("run_analysis"))
-            )
+            _apply_preview_state(preview, run_analysis=bool(pending.get("run_analysis")))
         elif cancel:
             st.session_state.pop("config_chat_pending_apply", None)
 
@@ -671,12 +667,8 @@ def _render_unified_diff(diff_text: str) -> None:
     st.markdown(_diff_text_to_html(diff_text), unsafe_allow_html=True)
 
 
-def _render_side_by_side_diff(
-    before: Mapping[str, Any], after: Mapping[str, Any]
-) -> None:
-    before_yaml = yaml.safe_dump(
-        dict(before), sort_keys=False, default_flow_style=False
-    )
+def _render_side_by_side_diff(before: Mapping[str, Any], after: Mapping[str, Any]) -> None:
+    before_yaml = yaml.safe_dump(dict(before), sort_keys=False, default_flow_style=False)
     after_yaml = yaml.safe_dump(dict(after), sort_keys=False, default_flow_style=False)
     differ = difflib.HtmlDiff(tabsize=2, wrapcolumn=80)
     diff_table = differ.make_table(
@@ -780,9 +772,7 @@ def _render_config_chat_contents(model_state: Mapping[str, Any] | None) -> None:
             st.session_state["config_chat_last_instruction"] = trimmed
             st.success("Instruction captured. Preview coming next.")
     preview = st.session_state.get("config_chat_preview")
-    has_preview = isinstance(preview, Mapping) and isinstance(
-        preview.get("after"), Mapping
-    )
+    has_preview = isinstance(preview, Mapping) and isinstance(preview.get("after"), Mapping)
     action_cols = st.columns(4)
     with action_cols[0]:
         preview_clicked = st.button(
@@ -1429,9 +1419,7 @@ def render_model_page() -> None:
             applied_funds = st.session_state.get("fund_columns")
 
         if isinstance(applied_funds, list) and applied_funds:
-            fund_cols = [
-                c for c in applied_funds if c in df.columns and c not in system_cols
-            ]
+            fund_cols = [c for c in applied_funds if c in df.columns and c not in system_cols]
         else:
             # Fallback: count only fund columns (exclude benchmarks/indices)
             fund_cols = [
@@ -1514,18 +1502,14 @@ def render_model_page() -> None:
                         else "Disabled until a duplicate name is entered."
                     ),
                 )
-                save_clicked = st.form_submit_button(
-                    "Save Current Settings", type="primary"
-                )
+                save_clicked = st.form_submit_button("Save Current Settings", type="primary")
 
             if save_clicked:
                 trimmed = save_name.strip()
                 if not trimmed:
                     st.error("Enter a name to save your configuration.")
                 elif overwrite_required and not overwrite_confirmed:
-                    st.warning(
-                        "This name already exists. Check 'Confirm overwrite' to replace it."
-                    )
+                    st.warning("This name already exists. Check 'Confirm overwrite' to replace it.")
                 else:
                     app_state.save_model_state(trimmed, st.session_state["model_state"])
                     app_state.save_config_wrapper(
@@ -1541,9 +1525,7 @@ def render_model_page() -> None:
         with manage_col:
             st.markdown("**Load or manage saved configurations**")
             if not saved_names:
-                st.info(
-                    "No saved configurations yet. Save one to enable loading and export."
-                )
+                st.info("No saved configurations yet. Save one to enable loading and export.")
             else:
                 selected_index = 0
                 active_saved_name = st.session_state.get("active_saved_model_name")
@@ -1556,9 +1538,7 @@ def render_model_page() -> None:
                     key="saved_configuration_selector",
                 )
 
-                if st.button(
-                    "Load selected configuration", key="load_saved_config_button"
-                ):
+                if st.button("Load selected configuration", key="load_saved_config_button"):
                     wrapper = app_state.load_saved_config_wrapper(selected_saved)
                     if isinstance(wrapper, Mapping):
                         _apply_config_wrapper(wrapper)
@@ -1586,18 +1566,12 @@ def render_model_page() -> None:
 
                 if rename_clicked:
                     try:
-                        app_state.rename_saved_model_state(
-                            selected_saved, rename_target
-                        )
+                        app_state.rename_saved_model_state(selected_saved, rename_target)
                     except (KeyError, ValueError) as exc:
                         st.error(str(exc))
                     else:
-                        st.session_state["active_saved_model_name"] = (
-                            rename_target.strip()
-                        )
-                        st.success(
-                            f"Renamed configuration to '{rename_target.strip()}'."
-                        )
+                        st.session_state["active_saved_model_name"] = rename_target.strip()
+                        st.success(f"Renamed configuration to '{rename_target.strip()}'.")
                         st.rerun()
 
                 if st.button(
@@ -1606,10 +1580,7 @@ def render_model_page() -> None:
                     type="secondary",
                 ):
                     app_state.delete_saved_model_state(selected_saved)
-                    if (
-                        st.session_state.get("active_saved_model_name")
-                        == selected_saved
-                    ):
+                    if st.session_state.get("active_saved_model_name") == selected_saved:
                         st.session_state.pop("active_saved_model_name", None)
                     st.success(f"Deleted configuration '{selected_saved}'.")
                     st.rerun()
@@ -1619,9 +1590,7 @@ def render_model_page() -> None:
         # Quick download of current configuration (without saving)
         st.markdown("**Download Current Configuration**")
         current_wrapper = _build_config_wrapper(st.session_state["model_state"])
-        current_payload = json.dumps(
-            current_wrapper, indent=2, sort_keys=True, default=str
-        )
+        current_payload = json.dumps(current_wrapper, indent=2, sort_keys=True, default=str)
         # Use active saved name if set, else uploaded filename, else "config"
         config_name = (
             st.session_state.get("active_saved_model_name")
@@ -1645,9 +1614,7 @@ def render_model_page() -> None:
             if saved_names:
                 export_index = 0
                 if st.session_state.get("active_saved_model_name") in saved_names:
-                    export_index = saved_names.index(
-                        st.session_state["active_saved_model_name"]
-                    )
+                    export_index = saved_names.index(st.session_state["active_saved_model_name"])
                 export_target = st.selectbox(
                     "Choose configuration to export",
                     saved_names,
@@ -1675,9 +1642,7 @@ def render_model_page() -> None:
 
         with import_col:
             st.markdown("**Import configuration from JSON**")
-            import_name = st.text_input(
-                "Name for imported configuration", key="import_config_name"
-            )
+            import_name = st.text_input("Name for imported configuration", key="import_config_name")
             uploaded_config = st.file_uploader(
                 "Upload JSON file",
                 type=["json"],
@@ -1688,9 +1653,7 @@ def render_model_page() -> None:
                 try:
                     raw_value = uploaded_config.getvalue()
                     if isinstance(raw_value, bytes):
-                        st.session_state["import_config_payload"] = raw_value.decode(
-                            "utf-8-sig"
-                        )
+                        st.session_state["import_config_payload"] = raw_value.decode("utf-8-sig")
                     else:
                         st.session_state["import_config_payload"] = str(raw_value)
                 except UnicodeDecodeError:
@@ -1699,38 +1662,26 @@ def render_model_page() -> None:
                         "Please upload a UTF-8 encoded JSON file."
                     )
                 except (AttributeError, TypeError):
-                    st.error(
-                        "Unable to read uploaded JSON file due to an unexpected file format."
-                    )
+                    st.error("Unable to read uploaded JSON file due to an unexpected file format.")
                 except OSError as exc:
                     st.error(f"Unable to read uploaded file: {exc}")
-            import_payload = st.text_area(
-                "Paste JSON to import", key="import_config_payload"
-            )
+            import_payload = st.text_area("Paste JSON to import", key="import_config_payload")
             if st.button("Import JSON configuration", key="import_config_button"):
                 if not import_payload.strip():
                     st.error("Paste a JSON payload to import a configuration.")
                 else:
                     try:
-                        imported_state = app_state.import_model_state(
-                            import_name, import_payload
-                        )
+                        imported_state = app_state.import_model_state(import_name, import_payload)
                     except ValueError as exc:
                         st.error(str(exc))
                     else:
-                        st.session_state["active_saved_model_name"] = (
-                            import_name.strip()
-                        )
-                        wrapper = app_state.load_saved_config_wrapper(
-                            import_name.strip()
-                        )
+                        st.session_state["active_saved_model_name"] = import_name.strip()
+                        wrapper = app_state.load_saved_config_wrapper(import_name.strip())
                         if isinstance(wrapper, Mapping):
                             _apply_config_wrapper(wrapper)
                         else:
                             st.session_state["model_state"] = imported_state
-                            st.session_state["last_loaded_model_state"] = dict(
-                                imported_state
-                            )
+                            st.session_state["last_loaded_model_state"] = dict(imported_state)
                             _reset_model_widget_state()
                             _sync_model_widgets_from_state(imported_state)
                         analysis_runner.clear_cached_analysis()
@@ -1770,9 +1721,7 @@ def render_model_page() -> None:
                     saved_model_states[config_b_name],
                 )
                 if not diffs:
-                    st.success(
-                        "No differences found. The selected configurations match."
-                    )
+                    st.success("No differences found. The selected configurations match.")
                 else:
                     diff_rows = []
                     for entry in diffs:
@@ -1892,9 +1841,7 @@ def render_model_page() -> None:
                 import datetime
 
                 original_end_str = current_end
-                current_end = datetime.datetime.strptime(
-                    current_end[:7] + "-01", "%Y-%m-%d"
-                ).date()
+                current_end = datetime.datetime.strptime(current_end[:7] + "-01", "%Y-%m-%d").date()
             except (ValueError, TypeError):
                 current_end = max_date
         elif current_end is None:
@@ -1921,14 +1868,10 @@ def render_model_page() -> None:
             )
             # Show warning if date was auto-corrected
             if start_was_corrected and original_start_str:
-                st.caption(
-                    f"⚠️ Adjusted from {original_start_str[:10]} to nearest available date"
-                )
+                st.caption(f"⚠️ Adjusted from {original_start_str[:10]} to nearest available date")
             # Update model state
             if sim_start_date:
-                st.session_state["model_state"]["start_date"] = sim_start_date.strftime(
-                    "%Y-%m-%d"
-                )
+                st.session_state["model_state"]["start_date"] = sim_start_date.strftime("%Y-%m-%d")
 
         with date_col2:
             sim_end_date = st.date_input(
@@ -1941,14 +1884,10 @@ def render_model_page() -> None:
             )
             # Show warning if date was auto-corrected
             if end_was_corrected and original_end_str:
-                st.caption(
-                    f"⚠️ Adjusted from {original_end_str[:10]} to nearest available date"
-                )
+                st.caption(f"⚠️ Adjusted from {original_end_str[:10]} to nearest available date")
             # Update model state
             if sim_end_date:
-                st.session_state["model_state"]["end_date"] = sim_end_date.strftime(
-                    "%Y-%m-%d"
-                )
+                st.session_state["model_state"]["end_date"] = sim_end_date.strftime("%Y-%m-%d")
 
         # Validate date range
         if sim_start_date and sim_end_date and sim_start_date > sim_end_date:
@@ -1960,9 +1899,7 @@ def render_model_page() -> None:
                     sim_end_date.month - sim_start_date.month
                 )
                 if months_span > 600:  # 50 years * 12 months
-                    st.warning(
-                        "Date range exceeds 50 years - please verify your selection."
-                    )
+                    st.warning("Date range exceeds 50 years - please verify your selection.")
                 else:
                     st.info(
                         f"📊 Selected period: {sim_start_date.strftime('%Y-%m')} to {sim_end_date.strftime('%Y-%m')} ({months_span} months)"
@@ -2075,9 +2012,7 @@ def render_model_page() -> None:
 
     # Show description for selected weighting scheme (updates dynamically)
     with st.expander("ℹ️ About this weighting scheme", expanded=False):
-        st.markdown(
-            WEIGHTING_DESCRIPTIONS.get(weighting_value, "No description available.")
-        )
+        st.markdown(WEIGHTING_DESCRIPTIONS.get(weighting_value, "No description available."))
 
     # Update model_state if weighting changed
     if weighting_value != current_weighting:
@@ -2207,9 +2142,7 @@ def render_model_page() -> None:
         # =====================================================================
         st.divider()
         st.subheader("📋 Fund Selection & Time Windows")
-        st.caption(
-            "Configure time windows for fund evaluation and walk-forward analysis."
-        )
+        st.caption("Configure time windows for fund evaluation and walk-forward analysis.")
 
         # Row 1: Frequency (sets the period unit for all time windows)
         # Note: This is inside the form, so labels won't update until form is submitted.
@@ -2273,9 +2206,7 @@ def render_model_page() -> None:
                 min_value=1,
                 max_value=20,
                 value=int(
-                    model_state.get(
-                        "min_history_periods", model_state.get("lookback_periods", 3)
-                    )
+                    model_state.get("min_history_periods", model_state.get("lookback_periods", 3))
                 ),
                 help=HELP_TEXT.get(
                     "min_history",
@@ -2387,9 +2318,7 @@ def render_model_page() -> None:
                 "🎲 **Random Mode**: Metric weights are not used for selection in random mode. "
                 "Funds are selected randomly. Metrics are still calculated for reporting purposes."
             )
-        st.caption(
-            "Relative importance of each metric when ranking funds for selection."
-        )
+        st.caption("Relative importance of each metric when ranking funds for selection.")
 
         metric_weights: dict[str, float] = {}
         # Create two rows for the 6 metrics
@@ -2414,9 +2343,7 @@ def render_model_page() -> None:
                     min_value=0.0,
                     value=float(model_state.get("metric_weights", {}).get(code, 1.0)),
                     step=0.1,
-                    help=HELP_TEXT.get(
-                        help_key, "Weight for this metric in fund ranking."
-                    ),
+                    help=HELP_TEXT.get(help_key, "Weight for this metric in fund ranking."),
                     key=f"metric_{code}",
                 )
 
@@ -2431,13 +2358,9 @@ def render_model_page() -> None:
                     metric_weights[code] = st.number_input(
                         label,
                         min_value=0.0,
-                        value=float(
-                            model_state.get("metric_weights", {}).get(code, 1.0)
-                        ),
+                        value=float(model_state.get("metric_weights", {}).get(code, 1.0)),
                         step=0.1,
-                        help=HELP_TEXT.get(
-                            help_key, "Weight for this metric in fund ranking."
-                        ),
+                        help=HELP_TEXT.get(help_key, "Weight for this metric in fund ranking."),
                         key=f"metric_{code}",
                     )
 
@@ -2453,9 +2376,7 @@ def render_model_page() -> None:
         # Benchmark selector for Info Ratio - always show when info_ratio weight > 0
         # Check both form value AND saved state for info_ratio weight
         info_ratio_weight = metric_weights.get("info_ratio", 0)
-        saved_info_ratio_weight = model_state.get("metric_weights", {}).get(
-            "info_ratio", 0
-        )
+        saved_info_ratio_weight = model_state.get("metric_weights", {}).get("info_ratio", 0)
         show_benchmark_selector = info_ratio_weight > 0 or saved_info_ratio_weight > 0
 
         info_ratio_benchmark = model_state.get("info_ratio_benchmark", "")
@@ -2593,9 +2514,7 @@ def render_model_page() -> None:
                     options=decay_methods,
                     format_func=lambda x: decay_labels.get(x, x),
                     index=(
-                        decay_methods.index(current_decay)
-                        if current_decay in decay_methods
-                        else 0
+                        decay_methods.index(current_decay) if current_decay in decay_methods else 0
                     ),
                     help=HELP_TEXT["vol_window_decay"],
                     disabled=not vol_adj_enabled,
@@ -2738,9 +2657,7 @@ def render_model_page() -> None:
             with reg_c2:
                 # Use benchmark columns as regime proxy options
                 regime_proxy_options = ["SPX", "TSX", "MSCI", "ACWI"] + [
-                    c
-                    for c in benchmark_options
-                    if c.upper() not in ["SPX", "TSX", "MSCI", "ACWI"]
+                    c for c in benchmark_options if c.upper() not in ["SPX", "TSX", "MSCI", "ACWI"]
                 ][
                     :10
                 ]  # Limit to 14 options
@@ -2903,9 +2820,7 @@ def render_model_page() -> None:
                         help=HELP_TEXT["sticky_add_periods"],
                         disabled=not mp_enabled_state,
                     )
-                    st.caption(
-                        f"Fund must rank in top-K for {sticky_add_periods} period(s)."
-                    )
+                    st.caption(f"Fund must rank in top-K for {sticky_add_periods} period(s).")
 
                 with rank_c2:
                     sticky_drop_periods = st.number_input(
@@ -2916,9 +2831,7 @@ def render_model_page() -> None:
                         help=HELP_TEXT["sticky_drop_periods"],
                         disabled=not mp_enabled_state,
                     )
-                    st.caption(
-                        f"Fund must fall out of top-K for {sticky_drop_periods} period(s)."
-                    )
+                    st.caption(f"Fund must fall out of top-K for {sticky_drop_periods} period(s).")
             elif is_random_mode:
                 # Random mode: no ranking stability needed
                 st.info(
@@ -2984,9 +2897,7 @@ def render_model_page() -> None:
                     help="Fund must fail threshold for this many consecutive periods.",
                     disabled=not mp_enabled_state,
                 )
-                st.caption(
-                    f"Score ≤ {z_exit_soft:.2f}σ for {soft_strikes} period(s) to exit."
-                )
+                st.caption(f"Score ≤ {z_exit_soft:.2f}σ for {soft_strikes} period(s) to exit.")
 
             st.markdown("**Underweight Exit (Weight-based)**")
             min_weight_strikes = st.number_input(
@@ -3019,9 +2930,7 @@ def render_model_page() -> None:
                     "Hard Entry Z-Score",
                     min_value=0.0,
                     max_value=5.0,
-                    value=float(
-                        z_entry_hard_val if z_entry_hard_val is not None else 2.0
-                    ),
+                    value=float(z_entry_hard_val if z_entry_hard_val is not None else 2.0),
                     step=0.25,
                     format="%.2f",
                     help=HELP_TEXT["z_entry_hard"],
@@ -3046,9 +2955,7 @@ def render_model_page() -> None:
                     "Hard Exit Z-Score",
                     min_value=-5.0,
                     max_value=0.0,
-                    value=float(
-                        z_exit_hard_val if z_exit_hard_val is not None else -2.0
-                    ),
+                    value=float(z_exit_hard_val if z_exit_hard_val is not None else -2.0),
                     step=0.25,
                     format="%.2f",
                     help=HELP_TEXT["z_exit_hard"],
@@ -3131,18 +3038,14 @@ def render_model_page() -> None:
                     help=HELP_TEXT["bottom_k"],
                 )
                 if bottom_k > 0:
-                    st.caption(
-                        f"Bottom {bottom_k} ranked funds will always be excluded."
-                    )
+                    st.caption(f"Bottom {bottom_k} ranked funds will always be excluded.")
 
         # =====================================================================
         # Reporting Options
         # =====================================================================
         st.markdown("---")
         with st.expander("📊 Reporting Options", expanded=False):
-            st.markdown(
-                "Configure what additional information to include in the Results page."
-            )
+            st.markdown("Configure what additional information to include in the Results page.")
 
             report_c1, report_c2 = st.columns(2)
             with report_c1:
@@ -3270,18 +3173,14 @@ def render_model_page() -> None:
                 "report_attribution": show_attribution,
                 "report_rolling_metrics": show_rolling_metrics,
             }
-            errors = _validate_model(
-                candidate_state, len(fund_cols) if fund_cols else 0
-            )
+            errors = _validate_model(candidate_state, len(fund_cols) if fund_cols else 0)
             if errors:
                 _render_validation_errors(errors)
             else:
                 st.session_state["model_state"] = candidate_state
                 analysis_runner.clear_cached_analysis()
                 app_state.clear_analysis_results()
-                st.success(
-                    "✅ Model configuration saved. Go to Results to run analysis."
-                )
+                st.success("✅ Model configuration saved. Go to Results to run analysis.")
 
 
 render_model_page()

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -1605,7 +1605,10 @@ def render_model_page() -> None:
             help="Download all current parameters including model settings, fund selections, and benchmark choices.",
         )
         with st.expander("Preview current configuration", expanded=False):
-            st.json(current_wrapper)
+            if hasattr(st, "json"):
+                st.json(current_wrapper)
+            else:
+                st.write(current_wrapper)
 
         st.markdown("---")
         export_col, import_col = st.columns(2)

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -9,7 +9,7 @@ import json
 import os
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
-from datetime import datetime
+from datetime import date, datetime
 from time import monotonic, sleep
 from typing import Any, Mapping
 
@@ -232,11 +232,102 @@ def _build_config_wrapper(model_state: Mapping[str, Any]) -> dict[str, Any]:
     return wrapper
 
 
+_MODEL_WIDGET_KEYS = {
+    "date_mode_radio",
+    "sim_start_date",
+    "sim_end_date",
+    "preset_selector",
+    "weighting_scheme_selector",
+    "inclusion_approach_select",
+    "buy_hold_initial_select",
+    "rank_pct_primary",
+    "mp_min_funds_input",
+    "mp_max_funds_input",
+    "benchmark_selector",
+}
+
+
+def _reset_model_widget_state() -> None:
+    for key in _MODEL_WIDGET_KEYS:
+        st.session_state.pop(key, None)
+    for key in list(st.session_state.keys()):
+        if isinstance(key, str) and key.startswith("metric_"):
+            st.session_state.pop(key, None)
+
+
+def _parse_date(value: Any) -> date | None:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str) and value:
+        try:
+            return datetime.strptime(value[:10], "%Y-%m-%d").date()
+        except ValueError:
+            return None
+    return None
+
+
+def _sync_model_widgets_from_state(model_state: Mapping[str, Any]) -> None:
+    """Sync widget session_state keys from model_state values.
+
+    This ensures widgets with explicit keys reflect imported config values.
+    """
+    date_mode = model_state.get("date_mode")
+    if date_mode in {"relative", "explicit"}:
+        st.session_state["date_mode_radio"] = date_mode
+
+    start_date = _parse_date(model_state.get("start_date"))
+    if start_date is not None:
+        st.session_state["sim_start_date"] = start_date
+
+    end_date = _parse_date(model_state.get("end_date"))
+    if end_date is not None:
+        st.session_state["sim_end_date"] = end_date
+
+    preset = model_state.get("preset")
+    if isinstance(preset, str) and preset:
+        st.session_state["preset_selector"] = preset
+
+    weighting = model_state.get("weighting_scheme")
+    if isinstance(weighting, str) and weighting:
+        st.session_state["weighting_scheme_selector"] = weighting
+
+    inclusion = model_state.get("inclusion_approach")
+    if isinstance(inclusion, str) and inclusion:
+        st.session_state["inclusion_approach_select"] = inclusion
+
+    buy_hold = model_state.get("buy_hold_initial")
+    if isinstance(buy_hold, str) and buy_hold:
+        st.session_state["buy_hold_initial_select"] = buy_hold
+
+    rank_pct = model_state.get("rank_pct")
+    if isinstance(rank_pct, (int, float)):
+        st.session_state["rank_pct_primary"] = int(float(rank_pct) * 100)
+
+    mp_min = model_state.get("mp_min_funds")
+    if isinstance(mp_min, (int, float)):
+        st.session_state["mp_min_funds_input"] = int(mp_min)
+
+    mp_max = model_state.get("mp_max_funds")
+    if isinstance(mp_max, (int, float)):
+        st.session_state["mp_max_funds_input"] = int(mp_max)
+
+    info_benchmark = model_state.get("info_ratio_benchmark")
+    if isinstance(info_benchmark, str) and info_benchmark:
+        st.session_state["benchmark_selector"] = info_benchmark
+
+    metric_weights = model_state.get("metric_weights")
+    if isinstance(metric_weights, Mapping):
+        for key, value in metric_weights.items():
+            st.session_state[f"metric_{key}"] = value
+
+
 def _apply_config_wrapper(wrapper: Mapping[str, Any]) -> None:
     model_state = wrapper.get("model_state")
     if isinstance(model_state, Mapping):
         st.session_state["model_state"] = dict(model_state)
         st.session_state["last_loaded_model_state"] = dict(model_state)
+        _reset_model_widget_state()
+        _sync_model_widgets_from_state(model_state)
     for key in (
         "analysis_fund_columns",
         "fund_columns",
@@ -363,7 +454,9 @@ def _current_run_key(model_state: dict[str, Any], benchmark: str | None) -> str:
     selected_rf = st.session_state.get("selected_risk_free")
     selected_rf_key = selected_rf or "__none__"
     info_ratio_benchmark = (
-        model_state.get("info_ratio_benchmark") if isinstance(model_state, dict) else None
+        model_state.get("info_ratio_benchmark")
+        if isinstance(model_state, dict)
+        else None
     )
     regime_proxy = None
     if bool(model_state.get("regime_enabled", False)):
@@ -476,7 +569,9 @@ def _render_risky_change_dialog() -> None:
         cancel = st.button("Cancel", type="secondary")
         if confirm:
             st.session_state.pop("config_chat_pending_apply", None)
-            _apply_preview_state(preview, run_analysis=bool(pending.get("run_analysis")))
+            _apply_preview_state(
+                preview, run_analysis=bool(pending.get("run_analysis"))
+            )
         elif cancel:
             st.session_state.pop("config_chat_pending_apply", None)
 
@@ -576,8 +671,12 @@ def _render_unified_diff(diff_text: str) -> None:
     st.markdown(_diff_text_to_html(diff_text), unsafe_allow_html=True)
 
 
-def _render_side_by_side_diff(before: Mapping[str, Any], after: Mapping[str, Any]) -> None:
-    before_yaml = yaml.safe_dump(dict(before), sort_keys=False, default_flow_style=False)
+def _render_side_by_side_diff(
+    before: Mapping[str, Any], after: Mapping[str, Any]
+) -> None:
+    before_yaml = yaml.safe_dump(
+        dict(before), sort_keys=False, default_flow_style=False
+    )
     after_yaml = yaml.safe_dump(dict(after), sort_keys=False, default_flow_style=False)
     differ = difflib.HtmlDiff(tabsize=2, wrapcolumn=80)
     diff_table = differ.make_table(
@@ -681,7 +780,9 @@ def _render_config_chat_contents(model_state: Mapping[str, Any] | None) -> None:
             st.session_state["config_chat_last_instruction"] = trimmed
             st.success("Instruction captured. Preview coming next.")
     preview = st.session_state.get("config_chat_preview")
-    has_preview = isinstance(preview, Mapping) and isinstance(preview.get("after"), Mapping)
+    has_preview = isinstance(preview, Mapping) and isinstance(
+        preview.get("after"), Mapping
+    )
     action_cols = st.columns(4)
     with action_cols[0]:
         preview_clicked = st.button(
@@ -1328,7 +1429,9 @@ def render_model_page() -> None:
             applied_funds = st.session_state.get("fund_columns")
 
         if isinstance(applied_funds, list) and applied_funds:
-            fund_cols = [c for c in applied_funds if c in df.columns and c not in system_cols]
+            fund_cols = [
+                c for c in applied_funds if c in df.columns and c not in system_cols
+            ]
         else:
             # Fallback: count only fund columns (exclude benchmarks/indices)
             fund_cols = [
@@ -1411,14 +1514,18 @@ def render_model_page() -> None:
                         else "Disabled until a duplicate name is entered."
                     ),
                 )
-                save_clicked = st.form_submit_button("Save Current Settings", type="primary")
+                save_clicked = st.form_submit_button(
+                    "Save Current Settings", type="primary"
+                )
 
             if save_clicked:
                 trimmed = save_name.strip()
                 if not trimmed:
                     st.error("Enter a name to save your configuration.")
                 elif overwrite_required and not overwrite_confirmed:
-                    st.warning("This name already exists. Check 'Confirm overwrite' to replace it.")
+                    st.warning(
+                        "This name already exists. Check 'Confirm overwrite' to replace it."
+                    )
                 else:
                     app_state.save_model_state(trimmed, st.session_state["model_state"])
                     app_state.save_config_wrapper(
@@ -1434,7 +1541,9 @@ def render_model_page() -> None:
         with manage_col:
             st.markdown("**Load or manage saved configurations**")
             if not saved_names:
-                st.info("No saved configurations yet. Save one to enable loading and export.")
+                st.info(
+                    "No saved configurations yet. Save one to enable loading and export."
+                )
             else:
                 selected_index = 0
                 active_saved_name = st.session_state.get("active_saved_model_name")
@@ -1447,17 +1556,18 @@ def render_model_page() -> None:
                     key="saved_configuration_selector",
                 )
 
-                if st.button("Load selected configuration", key="load_saved_config_button"):
+                if st.button(
+                    "Load selected configuration", key="load_saved_config_button"
+                ):
                     wrapper = app_state.load_saved_config_wrapper(selected_saved)
                     if isinstance(wrapper, Mapping):
                         _apply_config_wrapper(wrapper)
                     else:
-                        st.session_state["model_state"] = app_state.load_saved_model_state(
-                            selected_saved
-                        )
-                        st.session_state["last_loaded_model_state"] = dict(
-                            st.session_state["model_state"]
-                        )
+                        loaded_state = app_state.load_saved_model_state(selected_saved)
+                        st.session_state["model_state"] = loaded_state
+                        st.session_state["last_loaded_model_state"] = dict(loaded_state)
+                        _reset_model_widget_state()
+                        _sync_model_widgets_from_state(loaded_state)
                     st.session_state["active_saved_model_name"] = selected_saved
                     analysis_runner.clear_cached_analysis()
                     app_state.clear_analysis_results()
@@ -1476,12 +1586,18 @@ def render_model_page() -> None:
 
                 if rename_clicked:
                     try:
-                        app_state.rename_saved_model_state(selected_saved, rename_target)
+                        app_state.rename_saved_model_state(
+                            selected_saved, rename_target
+                        )
                     except (KeyError, ValueError) as exc:
                         st.error(str(exc))
                     else:
-                        st.session_state["active_saved_model_name"] = rename_target.strip()
-                        st.success(f"Renamed configuration to '{rename_target.strip()}'.")
+                        st.session_state["active_saved_model_name"] = (
+                            rename_target.strip()
+                        )
+                        st.success(
+                            f"Renamed configuration to '{rename_target.strip()}'."
+                        )
                         st.rerun()
 
                 if st.button(
@@ -1490,10 +1606,37 @@ def render_model_page() -> None:
                     type="secondary",
                 ):
                     app_state.delete_saved_model_state(selected_saved)
-                    if st.session_state.get("active_saved_model_name") == selected_saved:
+                    if (
+                        st.session_state.get("active_saved_model_name")
+                        == selected_saved
+                    ):
                         st.session_state.pop("active_saved_model_name", None)
                     st.success(f"Deleted configuration '{selected_saved}'.")
                     st.rerun()
+
+        st.markdown("---")
+
+        # Quick download of current configuration (without saving)
+        st.markdown("**Download Current Configuration**")
+        current_wrapper = _build_config_wrapper(st.session_state["model_state"])
+        current_payload = json.dumps(
+            current_wrapper, indent=2, sort_keys=True, default=str
+        )
+        # Use active saved name if set, else uploaded filename, else "config"
+        config_name = (
+            st.session_state.get("active_saved_model_name")
+            or st.session_state.get("uploaded_filename")
+            or "config"
+        )
+        st.download_button(
+            "📥 Download Configuration (JSON)",
+            data=current_payload.encode("utf-8"),
+            file_name=f"{config_name}_parameters.json",
+            mime="application/json",
+            help="Download all current parameters including model settings, fund selections, and benchmark choices.",
+        )
+        with st.expander("Preview current configuration", expanded=False):
+            st.json(current_wrapper)
 
         st.markdown("---")
         export_col, import_col = st.columns(2)
@@ -1502,7 +1645,9 @@ def render_model_page() -> None:
             if saved_names:
                 export_index = 0
                 if st.session_state.get("active_saved_model_name") in saved_names:
-                    export_index = saved_names.index(st.session_state["active_saved_model_name"])
+                    export_index = saved_names.index(
+                        st.session_state["active_saved_model_name"]
+                    )
                 export_target = st.selectbox(
                     "Choose configuration to export",
                     saved_names,
@@ -1510,19 +1655,29 @@ def render_model_page() -> None:
                     key="export_config_selector",
                 )
                 export_payload = app_state.export_model_state(export_target)
-                st.text_area(
-                    "Exported JSON",
-                    value=export_payload,
-                    height=160,
-                    key="exported_config_payload",
-                    help="Copy this JSON to share or reuse the configuration.",
+                st.download_button(
+                    "📥 Download Saved Configuration",
+                    data=export_payload.encode("utf-8"),
+                    file_name=f"{export_target}_parameters.json",
+                    mime="application/json",
+                    key="download_saved_config_button",
                 )
+                with st.expander("Preview saved configuration", expanded=False):
+                    st.text_area(
+                        "Exported JSON",
+                        value=export_payload,
+                        height=160,
+                        key="exported_config_payload",
+                        help="Copy this JSON to share or reuse the configuration.",
+                    )
             else:
                 st.info("Save a configuration to enable export.")
 
         with import_col:
             st.markdown("**Import configuration from JSON**")
-            import_name = st.text_input("Name for imported configuration", key="import_config_name")
+            import_name = st.text_input(
+                "Name for imported configuration", key="import_config_name"
+            )
             uploaded_config = st.file_uploader(
                 "Upload JSON file",
                 type=["json"],
@@ -1533,7 +1688,9 @@ def render_model_page() -> None:
                 try:
                     raw_value = uploaded_config.getvalue()
                     if isinstance(raw_value, bytes):
-                        st.session_state["import_config_payload"] = raw_value.decode("utf-8")
+                        st.session_state["import_config_payload"] = raw_value.decode(
+                            "utf-8-sig"
+                        )
                     else:
                         st.session_state["import_config_payload"] = str(raw_value)
                 except UnicodeDecodeError:
@@ -1542,28 +1699,40 @@ def render_model_page() -> None:
                         "Please upload a UTF-8 encoded JSON file."
                     )
                 except (AttributeError, TypeError):
-                    st.error("Unable to read uploaded JSON file due to an unexpected file format.")
+                    st.error(
+                        "Unable to read uploaded JSON file due to an unexpected file format."
+                    )
                 except OSError as exc:
                     st.error(f"Unable to read uploaded file: {exc}")
-            import_payload = st.text_area("Paste JSON to import", key="import_config_payload")
+            import_payload = st.text_area(
+                "Paste JSON to import", key="import_config_payload"
+            )
             if st.button("Import JSON configuration", key="import_config_button"):
                 if not import_payload.strip():
                     st.error("Paste a JSON payload to import a configuration.")
                 else:
                     try:
-                        imported_state = app_state.import_model_state(import_name, import_payload)
+                        imported_state = app_state.import_model_state(
+                            import_name, import_payload
+                        )
                     except ValueError as exc:
                         st.error(str(exc))
                     else:
-                        st.session_state["active_saved_model_name"] = import_name.strip()
-                        wrapper = app_state.load_saved_config_wrapper(import_name.strip())
+                        st.session_state["active_saved_model_name"] = (
+                            import_name.strip()
+                        )
+                        wrapper = app_state.load_saved_config_wrapper(
+                            import_name.strip()
+                        )
                         if isinstance(wrapper, Mapping):
                             _apply_config_wrapper(wrapper)
                         else:
                             st.session_state["model_state"] = imported_state
                             st.session_state["last_loaded_model_state"] = dict(
-                                st.session_state["model_state"]
+                                imported_state
                             )
+                            _reset_model_widget_state()
+                            _sync_model_widgets_from_state(imported_state)
                         analysis_runner.clear_cached_analysis()
                         app_state.clear_analysis_results()
                         st.success(
@@ -1601,7 +1770,9 @@ def render_model_page() -> None:
                     saved_model_states[config_b_name],
                 )
                 if not diffs:
-                    st.success("No differences found. The selected configurations match.")
+                    st.success(
+                        "No differences found. The selected configurations match."
+                    )
                 else:
                     diff_rows = []
                     for entry in diffs:
@@ -1721,7 +1892,9 @@ def render_model_page() -> None:
                 import datetime
 
                 original_end_str = current_end
-                current_end = datetime.datetime.strptime(current_end[:7] + "-01", "%Y-%m-%d").date()
+                current_end = datetime.datetime.strptime(
+                    current_end[:7] + "-01", "%Y-%m-%d"
+                ).date()
             except (ValueError, TypeError):
                 current_end = max_date
         elif current_end is None:
@@ -1748,10 +1921,14 @@ def render_model_page() -> None:
             )
             # Show warning if date was auto-corrected
             if start_was_corrected and original_start_str:
-                st.caption(f"⚠️ Adjusted from {original_start_str[:10]} to nearest available date")
+                st.caption(
+                    f"⚠️ Adjusted from {original_start_str[:10]} to nearest available date"
+                )
             # Update model state
             if sim_start_date:
-                st.session_state["model_state"]["start_date"] = sim_start_date.strftime("%Y-%m-%d")
+                st.session_state["model_state"]["start_date"] = sim_start_date.strftime(
+                    "%Y-%m-%d"
+                )
 
         with date_col2:
             sim_end_date = st.date_input(
@@ -1764,10 +1941,14 @@ def render_model_page() -> None:
             )
             # Show warning if date was auto-corrected
             if end_was_corrected and original_end_str:
-                st.caption(f"⚠️ Adjusted from {original_end_str[:10]} to nearest available date")
+                st.caption(
+                    f"⚠️ Adjusted from {original_end_str[:10]} to nearest available date"
+                )
             # Update model state
             if sim_end_date:
-                st.session_state["model_state"]["end_date"] = sim_end_date.strftime("%Y-%m-%d")
+                st.session_state["model_state"]["end_date"] = sim_end_date.strftime(
+                    "%Y-%m-%d"
+                )
 
         # Validate date range
         if sim_start_date and sim_end_date and sim_start_date > sim_end_date:
@@ -1779,7 +1960,9 @@ def render_model_page() -> None:
                     sim_end_date.month - sim_start_date.month
                 )
                 if months_span > 600:  # 50 years * 12 months
-                    st.warning("Date range exceeds 50 years - please verify your selection.")
+                    st.warning(
+                        "Date range exceeds 50 years - please verify your selection."
+                    )
                 else:
                     st.info(
                         f"📊 Selected period: {sim_start_date.strftime('%Y-%m')} to {sim_end_date.strftime('%Y-%m')} ({months_span} months)"
@@ -1892,7 +2075,9 @@ def render_model_page() -> None:
 
     # Show description for selected weighting scheme (updates dynamically)
     with st.expander("ℹ️ About this weighting scheme", expanded=False):
-        st.markdown(WEIGHTING_DESCRIPTIONS.get(weighting_value, "No description available."))
+        st.markdown(
+            WEIGHTING_DESCRIPTIONS.get(weighting_value, "No description available.")
+        )
 
     # Update model_state if weighting changed
     if weighting_value != current_weighting:
@@ -2022,7 +2207,9 @@ def render_model_page() -> None:
         # =====================================================================
         st.divider()
         st.subheader("📋 Fund Selection & Time Windows")
-        st.caption("Configure time windows for fund evaluation and walk-forward analysis.")
+        st.caption(
+            "Configure time windows for fund evaluation and walk-forward analysis."
+        )
 
         # Row 1: Frequency (sets the period unit for all time windows)
         # Note: This is inside the form, so labels won't update until form is submitted.
@@ -2086,7 +2273,9 @@ def render_model_page() -> None:
                 min_value=1,
                 max_value=20,
                 value=int(
-                    model_state.get("min_history_periods", model_state.get("lookback_periods", 3))
+                    model_state.get(
+                        "min_history_periods", model_state.get("lookback_periods", 3)
+                    )
                 ),
                 help=HELP_TEXT.get(
                     "min_history",
@@ -2198,7 +2387,9 @@ def render_model_page() -> None:
                 "🎲 **Random Mode**: Metric weights are not used for selection in random mode. "
                 "Funds are selected randomly. Metrics are still calculated for reporting purposes."
             )
-        st.caption("Relative importance of each metric when ranking funds for selection.")
+        st.caption(
+            "Relative importance of each metric when ranking funds for selection."
+        )
 
         metric_weights: dict[str, float] = {}
         # Create two rows for the 6 metrics
@@ -2223,7 +2414,9 @@ def render_model_page() -> None:
                     min_value=0.0,
                     value=float(model_state.get("metric_weights", {}).get(code, 1.0)),
                     step=0.1,
-                    help=HELP_TEXT.get(help_key, "Weight for this metric in fund ranking."),
+                    help=HELP_TEXT.get(
+                        help_key, "Weight for this metric in fund ranking."
+                    ),
                     key=f"metric_{code}",
                 )
 
@@ -2238,9 +2431,13 @@ def render_model_page() -> None:
                     metric_weights[code] = st.number_input(
                         label,
                         min_value=0.0,
-                        value=float(model_state.get("metric_weights", {}).get(code, 1.0)),
+                        value=float(
+                            model_state.get("metric_weights", {}).get(code, 1.0)
+                        ),
                         step=0.1,
-                        help=HELP_TEXT.get(help_key, "Weight for this metric in fund ranking."),
+                        help=HELP_TEXT.get(
+                            help_key, "Weight for this metric in fund ranking."
+                        ),
                         key=f"metric_{code}",
                     )
 
@@ -2256,7 +2453,9 @@ def render_model_page() -> None:
         # Benchmark selector for Info Ratio - always show when info_ratio weight > 0
         # Check both form value AND saved state for info_ratio weight
         info_ratio_weight = metric_weights.get("info_ratio", 0)
-        saved_info_ratio_weight = model_state.get("metric_weights", {}).get("info_ratio", 0)
+        saved_info_ratio_weight = model_state.get("metric_weights", {}).get(
+            "info_ratio", 0
+        )
         show_benchmark_selector = info_ratio_weight > 0 or saved_info_ratio_weight > 0
 
         info_ratio_benchmark = model_state.get("info_ratio_benchmark", "")
@@ -2394,7 +2593,9 @@ def render_model_page() -> None:
                     options=decay_methods,
                     format_func=lambda x: decay_labels.get(x, x),
                     index=(
-                        decay_methods.index(current_decay) if current_decay in decay_methods else 0
+                        decay_methods.index(current_decay)
+                        if current_decay in decay_methods
+                        else 0
                     ),
                     help=HELP_TEXT["vol_window_decay"],
                     disabled=not vol_adj_enabled,
@@ -2537,7 +2738,9 @@ def render_model_page() -> None:
             with reg_c2:
                 # Use benchmark columns as regime proxy options
                 regime_proxy_options = ["SPX", "TSX", "MSCI", "ACWI"] + [
-                    c for c in benchmark_options if c.upper() not in ["SPX", "TSX", "MSCI", "ACWI"]
+                    c
+                    for c in benchmark_options
+                    if c.upper() not in ["SPX", "TSX", "MSCI", "ACWI"]
                 ][
                     :10
                 ]  # Limit to 14 options
@@ -2700,7 +2903,9 @@ def render_model_page() -> None:
                         help=HELP_TEXT["sticky_add_periods"],
                         disabled=not mp_enabled_state,
                     )
-                    st.caption(f"Fund must rank in top-K for {sticky_add_periods} period(s).")
+                    st.caption(
+                        f"Fund must rank in top-K for {sticky_add_periods} period(s)."
+                    )
 
                 with rank_c2:
                     sticky_drop_periods = st.number_input(
@@ -2711,7 +2916,9 @@ def render_model_page() -> None:
                         help=HELP_TEXT["sticky_drop_periods"],
                         disabled=not mp_enabled_state,
                     )
-                    st.caption(f"Fund must fall out of top-K for {sticky_drop_periods} period(s).")
+                    st.caption(
+                        f"Fund must fall out of top-K for {sticky_drop_periods} period(s)."
+                    )
             elif is_random_mode:
                 # Random mode: no ranking stability needed
                 st.info(
@@ -2777,7 +2984,9 @@ def render_model_page() -> None:
                     help="Fund must fail threshold for this many consecutive periods.",
                     disabled=not mp_enabled_state,
                 )
-                st.caption(f"Score ≤ {z_exit_soft:.2f}σ for {soft_strikes} period(s) to exit.")
+                st.caption(
+                    f"Score ≤ {z_exit_soft:.2f}σ for {soft_strikes} period(s) to exit."
+                )
 
             st.markdown("**Underweight Exit (Weight-based)**")
             min_weight_strikes = st.number_input(
@@ -2810,7 +3019,9 @@ def render_model_page() -> None:
                     "Hard Entry Z-Score",
                     min_value=0.0,
                     max_value=5.0,
-                    value=float(z_entry_hard_val if z_entry_hard_val is not None else 2.0),
+                    value=float(
+                        z_entry_hard_val if z_entry_hard_val is not None else 2.0
+                    ),
                     step=0.25,
                     format="%.2f",
                     help=HELP_TEXT["z_entry_hard"],
@@ -2835,7 +3046,9 @@ def render_model_page() -> None:
                     "Hard Exit Z-Score",
                     min_value=-5.0,
                     max_value=0.0,
-                    value=float(z_exit_hard_val if z_exit_hard_val is not None else -2.0),
+                    value=float(
+                        z_exit_hard_val if z_exit_hard_val is not None else -2.0
+                    ),
                     step=0.25,
                     format="%.2f",
                     help=HELP_TEXT["z_exit_hard"],
@@ -2918,14 +3131,18 @@ def render_model_page() -> None:
                     help=HELP_TEXT["bottom_k"],
                 )
                 if bottom_k > 0:
-                    st.caption(f"Bottom {bottom_k} ranked funds will always be excluded.")
+                    st.caption(
+                        f"Bottom {bottom_k} ranked funds will always be excluded."
+                    )
 
         # =====================================================================
         # Reporting Options
         # =====================================================================
         st.markdown("---")
         with st.expander("📊 Reporting Options", expanded=False):
-            st.markdown("Configure what additional information to include in the Results page.")
+            st.markdown(
+                "Configure what additional information to include in the Results page."
+            )
 
             report_c1, report_c2 = st.columns(2)
             with report_c1:
@@ -3053,14 +3270,18 @@ def render_model_page() -> None:
                 "report_attribution": show_attribution,
                 "report_rolling_metrics": show_rolling_metrics,
             }
-            errors = _validate_model(candidate_state, len(fund_cols) if fund_cols else 0)
+            errors = _validate_model(
+                candidate_state, len(fund_cols) if fund_cols else 0
+            )
             if errors:
                 _render_validation_errors(errors)
             else:
                 st.session_state["model_state"] = candidate_state
                 analysis_runner.clear_cached_analysis()
                 app_state.clear_analysis_results()
-                st.success("✅ Model configuration saved. Go to Results to run analysis.")
+                st.success(
+                    "✅ Model configuration saved. Go to Results to run analysis."
+                )
 
 
 render_model_page()

--- a/streamlit_app/pages/3_Results.py
+++ b/streamlit_app/pages/3_Results.py
@@ -160,9 +160,7 @@ def _current_run_key(model_state: dict[str, Any], benchmark: str | None) -> str:
         applied_funds = []
 
     info_ratio_benchmark = (
-        model_state.get("info_ratio_benchmark")
-        if isinstance(model_state, dict)
-        else None
+        model_state.get("info_ratio_benchmark") if isinstance(model_state, dict) else None
     )
     prohibited = {selected_rf, benchmark, info_ratio_benchmark} - {None}
     sanitized_funds = [c for c in applied_funds if c not in prohibited]
@@ -647,20 +645,14 @@ def _render_manager_changes(result) -> None:
     # Debug expander for period-by-period breakdown
     with st.expander("📊 Period-by-Period Diagnostic", expanded=False):
         # Show period breakdown
-        period_stats = (
-            changes_df.groupby("Date")["Action"].value_counts().unstack(fill_value=0)
-        )
+        period_stats = changes_df.groupby("Date")["Action"].value_counts().unstack(fill_value=0)
         st.caption("Changes by period:")
         st.dataframe(period_stats, use_container_width=True)
 
         # Show unique manager counts
-        unique_initial = changes_df[changes_df["Action"] == "Initial"][
-            "Manager"
-        ].nunique()
+        unique_initial = changes_df[changes_df["Action"] == "Initial"]["Manager"].nunique()
         unique_hired = changes_df[changes_df["Action"] == "Hired"]["Manager"].nunique()
-        unique_terminated = changes_df[changes_df["Action"] == "Terminated"][
-            "Manager"
-        ].nunique()
+        unique_terminated = changes_df[changes_df["Action"] == "Terminated"]["Manager"].nunique()
 
         st.caption(
             f"Unique managers: {unique_initial} initial, {unique_hired} ever hired, "
@@ -668,9 +660,7 @@ def _render_manager_changes(result) -> None:
         )
 
         # Check for managers hired multiple times
-        hire_counts = changes_df[changes_df["Action"] == "Hired"][
-            "Manager"
-        ].value_counts()
+        hire_counts = changes_df[changes_df["Action"] == "Hired"]["Manager"].value_counts()
         multi_hired = hire_counts[hire_counts > 1]
         if not multi_hired.empty:
             st.caption(f"Managers hired multiple times: {len(multi_hired)}")
@@ -782,10 +772,7 @@ def _compute_fund_holding_periods(result) -> tuple[pd.DataFrame, pd.DataFrame]:
                     }
                     fund_returns[manager] = []
             elif action == "dropped":
-                if (
-                    manager in fund_tenures
-                    and fund_tenures[manager]["Exit Date"] is None
-                ):
+                if manager in fund_tenures and fund_tenures[manager]["Exit Date"] is None:
                     fund_tenures[manager]["Exit Date"] = out_start
 
         # Accumulate returns for funds held this period
@@ -841,9 +828,7 @@ def _render_fund_holdings(result) -> None:
 
     # Format summary
     display_summary = summary_df.copy()
-    display_summary["Years Held"] = display_summary["Years Held"].apply(
-        lambda x: f"{x:.1f}"
-    )
+    display_summary["Years Held"] = display_summary["Years Held"].apply(lambda x: f"{x:.1f}")
 
     def highlight_current(row):
         if row["Exit"] == "Current":
@@ -881,9 +866,7 @@ def _get_selection_config(result) -> dict[str, Any]:
 
     # Portfolio sizing source of truth (multi-period runs): mp_min_funds/mp_max_funds.
     # Avoid legacy/duplicate sizing knobs here.
-    max_funds = int(
-        model_state.get("mp_max_funds") or model_state.get("selection_count") or 10
-    )
+    max_funds = int(model_state.get("mp_max_funds") or model_state.get("selection_count") or 10)
     min_funds = int(model_state.get("mp_min_funds") or 0)
 
     config = {
@@ -936,9 +919,7 @@ def _render_selection_criteria(result) -> None:
         st.markdown("**Time Parameters**")
         st.markdown(f"- Rebalance frequency: **{freq}**")
         st.markdown(f"- In-sample (lookback): **{config['lookback_periods']}** periods")
-        st.markdown(
-            f"- Out-of-sample (eval): **{config['evaluation_periods']}** period(s)"
-        )
+        st.markdown(f"- Out-of-sample (eval): **{config['evaluation_periods']}** period(s)")
 
 
 def _build_period_detail(res: dict[str, Any], period_num: int) -> dict[str, Any]:
@@ -1000,16 +981,10 @@ def _render_single_period(period_data: dict[str, Any]) -> None:
     """Render detailed view for a single period."""
     pn = period_data["period_num"]
 
-    st.markdown(
-        f"### Period {pn}: {period_data['out_start']} to {period_data['out_end']}"
-    )
-    st.caption(
-        f"In-sample window: {period_data['in_start']} to {period_data['in_end']}"
-    )
+    st.markdown(f"### Period {pn}: {period_data['out_start']} to {period_data['out_end']}")
+    st.caption(f"In-sample window: {period_data['in_start']} to {period_data['in_end']}")
 
-    tabs = st.tabs(
-        ["📊 In-Sample Metrics", "✅ Selection", "📈 Out-of-Sample", "💰 Period Return"]
-    )
+    tabs = st.tabs(["📊 In-Sample Metrics", "✅ Selection", "📈 Out-of-Sample", "💰 Period Return"])
 
     with tabs[0]:
         # In-sample metrics (score frame)
@@ -1031,9 +1006,7 @@ def _render_single_period(period_data: dict[str, Any]) -> None:
                 return [""] * len(row)
 
             # Sort by zscore if available, else by first column
-            sort_col = (
-                "zscore" if "zscore" in sf_display.columns else sf_display.columns[0]
-            )
+            sort_col = "zscore" if "zscore" in sf_display.columns else sf_display.columns[0]
             sf_sorted = sf_display.sort_values(sort_col, ascending=False)
 
             # Format numeric columns
@@ -1057,9 +1030,7 @@ def _render_single_period(period_data: dict[str, Any]) -> None:
                         lambda x: _fmt_pct(x, 1) if pd.notna(x) else "—"
                     )
 
-            st.markdown(
-                "**All candidates ranked by in-sample metrics** (green = selected)"
-            )
+            st.markdown("**All candidates ranked by in-sample metrics** (green = selected)")
             styled = sf_sorted.style.apply(highlight_selected, axis=1)
             st.dataframe(styled, use_container_width=True, height=300)
         else:
@@ -1125,16 +1096,9 @@ def _render_single_period(period_data: dict[str, Any]) -> None:
                         expected = pd.period_range(out_start, out_end, freq="M")
                         expected_labels = [str(p) for p in expected]
                         actual_labels = sorted(
-                            {
-                                str(p)
-                                for p in pd.to_datetime(out_df.index)
-                                .to_period("M")
-                                .tolist()
-                            }
+                            {str(p) for p in pd.to_datetime(out_df.index).to_period("M").tolist()}
                         )
-                        missing = [
-                            m for m in expected_labels if m not in set(actual_labels)
-                        ]
+                        missing = [m for m in expected_labels if m not in set(actual_labels)]
                         if missing:
                             st.warning(
                                 "Missing months inside this out-of-sample window: "
@@ -1214,9 +1178,7 @@ def _render_single_period(period_data: dict[str, Any]) -> None:
                 # Show raw returns in expander
                 with st.expander("View monthly returns detail"):
                     display_oos = out_df[cols_to_show].copy()
-                    display_oos.index = pd.to_datetime(display_oos.index).strftime(
-                        "%Y-%m"
-                    )
+                    display_oos.index = pd.to_datetime(display_oos.index).strftime("%Y-%m")
                     for col in display_oos.columns:
                         display_oos[col] = display_oos[col].apply(
                             lambda x: _fmt_pct(x, 2) if pd.notna(x) else "—"
@@ -1273,9 +1235,7 @@ def _render_period_breakdown(result) -> None:
         return
 
     # Build period data
-    periods_data = [
-        _build_period_detail(res, i + 1) for i, res in enumerate(period_results)
-    ]
+    periods_data = [_build_period_detail(res, i + 1) for i, res in enumerate(period_results)]
 
     # Show weights across all rebalance dates (sub-period visibility)
     try:
@@ -1297,8 +1257,7 @@ def _render_period_breakdown(result) -> None:
 
     # Period selector
     period_options = [
-        f"Period {p['period_num']}: {p['out_start']} to {p['out_end']}"
-        for p in periods_data
+        f"Period {p['period_num']}: {p['out_start']} to {p['out_end']}" for p in periods_data
     ]
 
     selected_period = st.selectbox(
@@ -1650,19 +1609,13 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
             col_lower = col.lower()
 
             # Check column type
-            is_already_pct = col in already_pct_cols or any(
-                p in col for p in already_pct_patterns
-            )
+            is_already_pct = col in already_pct_cols or any(p in col for p in already_pct_patterns)
             is_raw_pct = col in raw_pct_cols
             is_ratio = (
-                col in ratio_cols
-                or any(p in col for p in ratio_patterns)
-                or ir_pattern in col
+                col in ratio_cols or any(p in col for p in ratio_patterns) or ir_pattern in col
             )
             is_decimal_1 = col in decimal_1_cols
-            is_decimal_2 = col in decimal_2_cols or any(
-                p in col_lower for p in decimal_2_patterns
-            )
+            is_decimal_2 = col in decimal_2_cols or any(p in col_lower for p in decimal_2_patterns)
             is_int = col in int_cols or any(p in col for p in int_patterns)
 
             if is_already_pct and not is_ratio:
@@ -1670,9 +1623,7 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
                 out[col] = out[col].apply(
                     lambda x: (
                         f"{float(x):.1f}%"
-                        if pd.notna(x)
-                        and isinstance(x, (int, float))
-                        and np.isfinite(x)
+                        if pd.notna(x) and isinstance(x, (int, float)) and np.isfinite(x)
                         else ""
                     )
                 )
@@ -1681,9 +1632,7 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
                 out[col] = out[col].apply(
                     lambda x: (
                         f"{float(x) * 100:.1f}%"
-                        if pd.notna(x)
-                        and isinstance(x, (int, float))
-                        and np.isfinite(x)
+                        if pd.notna(x) and isinstance(x, (int, float)) and np.isfinite(x)
                         else ""
                     )
                 )
@@ -1691,9 +1640,7 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
                 out[col] = out[col].apply(
                     lambda x: (
                         f"{float(x):.2f}"
-                        if pd.notna(x)
-                        and isinstance(x, (int, float))
-                        and np.isfinite(x)
+                        if pd.notna(x) and isinstance(x, (int, float)) and np.isfinite(x)
                         else ""
                     )
                 )
@@ -1701,9 +1648,7 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
                 out[col] = out[col].apply(
                     lambda x: (
                         f"{float(x):.1f}"
-                        if pd.notna(x)
-                        and isinstance(x, (int, float))
-                        and np.isfinite(x)
+                        if pd.notna(x) and isinstance(x, (int, float)) and np.isfinite(x)
                         else ""
                     )
                 )
@@ -1711,9 +1656,7 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
                 out[col] = out[col].apply(
                     lambda x: (
                         f"{float(x):.2f}"
-                        if pd.notna(x)
-                        and isinstance(x, (int, float))
-                        and np.isfinite(x)
+                        if pd.notna(x) and isinstance(x, (int, float)) and np.isfinite(x)
                         else ""
                     )
                 )
@@ -1721,9 +1664,7 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
                 out[col] = out[col].apply(
                     lambda x: (
                         f"{int(x)}"
-                        if pd.notna(x)
-                        and isinstance(x, (int, float))
-                        and np.isfinite(x)
+                        if pd.notna(x) and isinstance(x, (int, float)) and np.isfinite(x)
                         else ""
                     )
                 )
@@ -1913,9 +1854,7 @@ def render_results_page() -> None:
 
     # Policy: benchmark/index columns (including Info Ratio benchmark) and RF
     # are never investable funds.
-    sanitized_funds = [
-        c for c in applied_funds if c in df.columns and c not in prohibited
-    ]
+    sanitized_funds = [c for c in applied_funds if c in df.columns and c not in prohibited]
     removed = [c for c in applied_funds if c in df.columns and c in prohibited]
     keep_cols = list(sanitized_funds)
     for extra in (selected_rf, benchmark, regime_proxy):
@@ -2179,9 +2118,7 @@ def render_results_page() -> None:
                     "Weight",
                 ]
                 metric_cols = [c for c in full_df.columns if c.startswith("InSample_")]
-                ordered_cols = [
-                    c for c in base_cols if c in full_df.columns
-                ] + metric_cols
+                ordered_cols = [c for c in base_cols if c in full_df.columns] + metric_cols
                 full_df = full_df.loc[:, ordered_cols]
 
                 # Format the DataFrame to match Excel styling
@@ -2189,9 +2126,7 @@ def render_results_page() -> None:
                 # Format Weight as percentage
                 if "Weight" in export_df.columns:
                     export_df["Weight"] = export_df["Weight"].apply(
-                        lambda x: (
-                            f"{x * 100:.1f}%" if pd.notna(x) and np.isfinite(x) else ""
-                        )
+                        lambda x: (f"{x * 100:.1f}%" if pd.notna(x) and np.isfinite(x) else "")
                     )
                 # Format metric columns based on their names
                 for col in metric_cols:
@@ -2201,9 +2136,7 @@ def render_results_page() -> None:
                         export_df[col] = export_df[col].apply(
                             lambda x: (
                                 f"{float(x) * 100:.1f}%"
-                                if pd.notna(x)
-                                and isinstance(x, (int, float))
-                                and np.isfinite(x)
+                                if pd.notna(x) and isinstance(x, (int, float)) and np.isfinite(x)
                                 else ""
                             )
                         )
@@ -2212,9 +2145,7 @@ def render_results_page() -> None:
                         export_df[col] = export_df[col].apply(
                             lambda x: (
                                 f"{float(x):.2f}"
-                                if pd.notna(x)
-                                and isinstance(x, (int, float))
-                                and np.isfinite(x)
+                                if pd.notna(x) and isinstance(x, (int, float)) and np.isfinite(x)
                                 else ""
                             )
                         )
@@ -2240,9 +2171,7 @@ def render_results_page() -> None:
         saved_names = sorted(saved_states)
 
         if len(saved_names) < 2:
-            st.info(
-                "Save at least two configurations on the Model page to enable A/B comparison."
-            )
+            st.info("Save at least two configurations on the Model page to enable A/B comparison.")
         else:
             col_a, col_b = st.columns(2)
             with col_a:

--- a/streamlit_app/state.py
+++ b/streamlit_app/state.py
@@ -127,7 +127,9 @@ def has_valid_upload() -> bool:
 
     df, meta = get_uploaded_data()
     return (
-        df is not None and meta is not None and st.session_state.get("upload_status") == "success"
+        df is not None
+        and meta is not None
+        and st.session_state.get("upload_status") == "success"
     )
 
 
@@ -270,6 +272,7 @@ def import_model_state(name: str, payload: str) -> dict[str, Any]:
 
     if not name or not name.strip():
         raise ValueError("Provide a name for the imported configuration.")
+    payload = payload.lstrip("\ufeff").strip()
     try:
         parsed = json.loads(payload)
     except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
@@ -302,7 +305,9 @@ class ModelStateDiff:
 
 
 def _is_sequence(value: Any) -> bool:
-    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))
+    return isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    )
 
 
 def _stringify_value(value: Any) -> str:
@@ -320,7 +325,9 @@ def _values_equal(left: Any, right: Any, float_tol: float) -> bool:
     if isinstance(left, Mapping) and isinstance(right, Mapping):
         if set(left.keys()) != set(right.keys()):
             return False
-        return all(_values_equal(left[key], right[key], float_tol) for key in left.keys())
+        return all(
+            _values_equal(left[key], right[key], float_tol) for key in left.keys()
+        )
     if _is_sequence(left) and _is_sequence(right):
         if len(left) != len(right):
             return False
@@ -449,5 +456,7 @@ def format_model_state_diff(
             lines.append(f"- {entry.path}: ({label_a}) {left}")
         else:
             type_note = " [type changed]" if entry.type_changed else ""
-            lines.append(f"~ {entry.path}: ({label_a}) {left} -> ({label_b}) {right}{type_note}")
+            lines.append(
+                f"~ {entry.path}: ({label_a}) {left} -> ({label_b}) {right}{type_note}"
+            )
     return "\n".join(lines)

--- a/streamlit_app/state.py
+++ b/streamlit_app/state.py
@@ -127,9 +127,7 @@ def has_valid_upload() -> bool:
 
     df, meta = get_uploaded_data()
     return (
-        df is not None
-        and meta is not None
-        and st.session_state.get("upload_status") == "success"
+        df is not None and meta is not None and st.session_state.get("upload_status") == "success"
     )
 
 
@@ -305,9 +303,7 @@ class ModelStateDiff:
 
 
 def _is_sequence(value: Any) -> bool:
-    return isinstance(value, Sequence) and not isinstance(
-        value, (str, bytes, bytearray)
-    )
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))
 
 
 def _stringify_value(value: Any) -> str:
@@ -325,9 +321,7 @@ def _values_equal(left: Any, right: Any, float_tol: float) -> bool:
     if isinstance(left, Mapping) and isinstance(right, Mapping):
         if set(left.keys()) != set(right.keys()):
             return False
-        return all(
-            _values_equal(left[key], right[key], float_tol) for key in left.keys()
-        )
+        return all(_values_equal(left[key], right[key], float_tol) for key in left.keys())
     if _is_sequence(left) and _is_sequence(right):
         if len(left) != len(right):
             return False
@@ -456,7 +450,5 @@ def format_model_state_diff(
             lines.append(f"- {entry.path}: ({label_a}) {left}")
         else:
             type_note = " [type changed]" if entry.type_changed else ""
-            lines.append(
-                f"~ {entry.path}: ({label_a}) {left} -> ({label_b}) {right}{type_note}"
-            )
+            lines.append(f"~ {entry.path}: ({label_a}) {left} -> ({label_b}) {right}{type_note}")
     return "\n".join(lines)


### PR DESCRIPTION
- Fixed _compute_weights to use holdings_in_window instead of reindexing to all holdings
- Fixed effective_w to use final_w (engine-computed weights) instead of pipeline_weights_raw
- Removed obsolete used_pipeline_weights logic
- Ensures newly added funds get proper weights and their returns are included in out-of-sample results

Also includes LLM/Streamlit UI improvements from earlier commits.