### PR TITLE
fix: align agent ledgers to phase-3

### DIFF
--- a/.agents/issue-4447-ledger.yml
+++ b/.agents/issue-4447-ledger.yml
@@ -1,6 +1,6 @@
 version: 1
 issue: 4447
-base: main
+base: phase-3
 branch: codex/issue-4447
 tasks:
   - id: task-01

--- a/.agents/issue-4449-ledger.yml
+++ b/.agents/issue-4449-ledger.yml
@@ -1,6 +1,6 @@
 version: 1
 issue: 4449
-base: main
+base: phase-3
 branch: codex/issue-4449
 tasks:
   - id: task-01

--- a/.agents/issue-4450-ledger.yml
+++ b/.agents/issue-4450-ledger.yml
@@ -1,6 +1,6 @@
 version: 1
 issue: 4450
-base: main
+base: phase-3
 branch: codex/issue-4450
 tasks:
   - id: task-01

--- a/.agents/issue-4451-ledger.yml
+++ b/.agents/issue-4451-ledger.yml
@@ -1,6 +1,6 @@
 version: 1
 issue: 4451
-base: main
+base: phase-3
 branch: codex/issue-4451
 tasks:
   - id: task-01

--- a/.agents/issue-4452-ledger.yml
+++ b/.agents/issue-4452-ledger.yml
@@ -1,6 +1,6 @@
 version: 1
 issue: 4452
-base: main
+base: phase-3
 branch: codex/issue-4452
 tasks:
   - id: task-01

--- a/.agents/issue-4453-ledger.yml
+++ b/.agents/issue-4453-ledger.yml
@@ -1,6 +1,6 @@
 version: 1
 issue: 4453
-base: main
+base: phase-3
 branch: codex/issue-4453
 tasks:
   - id: task-01

--- a/.agents/issue-4454-ledger.yml
+++ b/.agents/issue-4454-ledger.yml
@@ -1,6 +1,6 @@
 version: 1
 issue: 4454
-base: main
+base: phase-3
 branch: codex/issue-4454
 tasks:
   - id: task-01

--- a/.agents/issue-4455-ledger.yml
+++ b/.agents/issue-4455-ledger.yml
@@ -1,6 +1,6 @@
 version: 1
 issue: 4455
-base: main
+base: phase-3
 branch: codex/issue-4455
 tasks:
   - id: task-01

--- a/.agents/issue-4456-ledger.yml
+++ b/.agents/issue-4456-ledger.yml
@@ -1,6 +1,6 @@
 version: 1
 issue: 4456
-base: main
+base: phase-3
 branch: codex/issue-4456
 tasks:
   - id: task-01

--- a/.agents/issue-4457-ledger.yml
+++ b/.agents/issue-4457-ledger.yml
@@ -1,6 +1,6 @@
 version: 1
 issue: 4457
-base: main
+base: phase-3
 branch: codex/issue-4457
 tasks:
   - id: task-01

--- a/.agents/issue-4458-ledger.yml
+++ b/.agents/issue-4458-ledger.yml
@@ -1,6 +1,6 @@
 version: 1
 issue: 4458
-base: main
+base: phase-3
 branch: codex/issue-4458
 tasks:
   - id: task-01

--- a/.agents/issue-4461-ledger.yml
+++ b/.agents/issue-4461-ledger.yml
@@ -1,6 +1,6 @@
 version: 1
 issue: 4461
-base: main
+base: phase-3
 branch: codex/issue-4461
 tasks:
   - id: task-01

--- a/.agents/issue-4498-ledger.yml
+++ b/.agents/issue-4498-ledger.yml
@@ -1,6 +1,6 @@
 version: 1
 issue: 4498
-base: main
+base: phase-3
 branch: codex/issue-4498
 tasks:
   - id: task-01


### PR DESCRIPTION
Align .agents ledger base to phase-3 to unblock Codex belt worker dispatch.