### PR TITLE
chore: sync workflow templates

### DIFF
--- a/tools/resolve_mypy_pin.py
+++ b/tools/resolve_mypy_pin.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import Mapping
 
 
 def get_mypy_python_version() -> str | None:
@@ -32,10 +31,11 @@ def get_mypy_python_version() -> str | None:
         content = pyproject_path.read_text()
         data = tomlkit.parse(content)
         tool_raw = data.get("tool")
-        # Normalize tomlkit tables into standard dicts for typing clarity.
-        tool: dict[str, object] = dict(tool_raw) if isinstance(tool_raw, Mapping) else {}
+        # Use dict() to normalize tomlkit types and satisfy mypy
+        # tomlkit returns Table objects that act like dicts but mypy doesn't know this
+        tool: dict[str, object] = dict(tool_raw) if hasattr(tool_raw, "get") else {}  # type: ignore[arg-type,call-overload]
         mypy_raw = tool.get("mypy")
-        mypy: dict[str, object] = dict(mypy_raw) if isinstance(mypy_raw, Mapping) else {}
+        mypy: dict[str, object] = dict(mypy_raw) if hasattr(mypy_raw, "get") else {}  # type: ignore[arg-type,call-overload]
         version = mypy.get("python_version")
         # Validate type before conversion - TOML can parse various types
         if isinstance(version, (str, int, float)):


### PR DESCRIPTION
## Sync Summary

### Files Updated
- resolve_mypy_pin.py: Resolves mypy version pinning - required by reusable CI workflow

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** [stranske/Workflows](https://github.com/stranske/Workflows)
**Manifest:** [`.github/sync-manifest.yml`](https://github.com/stranske/Workflows/blob/main/.github/sync-manifest.yml)