### PR TITLE
Auto Pilot Pause bootstrap for #4655

### DIFF
--- a/agents/auto-pilot-pause-4655.md
+++ b/agents/auto-pilot-pause-4655.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for auto-pilot-pause on issue #4655 -->

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -95,9 +95,6 @@ portfolio:
     name: score_prop_bayes
     params:
       shrink_tau: 0.25
-      column: Sharpe
-      half_life: 90
-      obs_sigma: 0.25
   constraints:
     long_only: true
     max_weight: 0.25

--- a/config/scenarios/monte_carlo/strategies/hf_equity_curated.yml
+++ b/config/scenarios/monte_carlo/strategies/hf_equity_curated.yml
@@ -57,7 +57,7 @@ curated:
           pct: 0.20
           score_by: sharpe_ratio
           transform: raw
-        weighting_scheme: equal
+        weighting_scheme: custom
         weighting:
           name: score_prop
           params:
@@ -76,7 +76,7 @@ curated:
           threshold: 0.75
           score_by: sharpe_ratio
           transform: zscore
-        weighting_scheme: equal
+        weighting_scheme: custom
         weighting:
           name: score_prop_bayes
           params:
@@ -96,7 +96,7 @@ curated:
           n: 10
           score_by: sharpe_ratio
           transform: raw
-        weighting_scheme: equal
+        weighting_scheme: custom
         weighting:
           name: adaptive_bayes
           params:

--- a/src/trend_analysis/monte_carlo/strategy/variant.py
+++ b/src/trend_analysis/monte_carlo/strategy/variant.py
@@ -52,6 +52,11 @@ def _format_path(path: tuple[str, ...]) -> str:
     return ".".join(path)
 
 
+_FREEFORM_OVERRIDE_PATHS: set[tuple[str, ...]] = {
+    ("portfolio", "weighting", "params"),
+}
+
+
 def _deep_merge_overrides(
     base: Mapping[str, Any],
     overrides: Mapping[str, Any],
@@ -63,6 +68,9 @@ def _deep_merge_overrides(
         next_path = path + (key,)
         path_label = _format_path(next_path)
         if key not in merged:
+            if path in _FREEFORM_OVERRIDE_PATHS:
+                merged[key] = deepcopy(override_value)
+                continue
             raise ValueError(f"override path '{path_label}' does not exist in base config")
         base_value = merged[key]
         if isinstance(override_value, Mapping):

--- a/tests/monte_carlo/strategy/test_variant.py
+++ b/tests/monte_carlo/strategy/test_variant.py
@@ -149,6 +149,29 @@ def test_to_trend_config_allows_only_weighting_name_override(tmp_path: Path) -> 
     assert cfg.portfolio.max_turnover == 0.5
 
 
+def test_apply_to_allows_weighting_params_extension(tmp_path: Path) -> None:
+    base = _base_config(tmp_path)
+    variant = StrategyVariant(
+        name="ExtendParams",
+        overrides={
+            "portfolio": {
+                "weighting": {
+                    "params": {"column": "Sharpe", "half_life": 30, "obs_sigma": 0.15}
+                }
+            }
+        },
+    )
+
+    merged = variant.apply_to(base)
+
+    assert merged["portfolio"]["weighting"]["params"]["shrink_tau"] == 0.25
+    assert merged["portfolio"]["weighting"]["params"]["column"] == "Sharpe"
+    assert merged["portfolio"]["weighting"]["params"]["half_life"] == 30
+    assert merged["portfolio"]["weighting"]["params"]["obs_sigma"] == 0.15
+    assert "half_life" not in base["portfolio"]["weighting"]["params"]
+    assert "obs_sigma" not in base["portfolio"]["weighting"]["params"]
+
+
 def test_to_trend_config_rejects_invalid_weighting_scheme_type(tmp_path: Path) -> None:
     base = _base_config(tmp_path)
     variant = StrategyVariant(

--- a/tests/monte_carlo/strategy/test_variant.py
+++ b/tests/monte_carlo/strategy/test_variant.py
@@ -23,6 +23,8 @@ def _base_config(tmp_path: Path) -> dict[str, object]:
             "max_turnover": 0.5,
             "transaction_cost_bps": 10,
             "rank": {"n": 5, "metric": "Sharpe"},
+            "weighting_scheme": "equal",
+            "weighting": {"name": "equal", "params": {"column": "Sharpe", "shrink_tau": 0.25}},
         },
         "vol_adjust": {"target_vol": 0.1},
         "extra": {"list": [1, 2, 3]},
@@ -94,6 +96,79 @@ def test_to_trend_config_accepts_trend_config(tmp_path: Path) -> None:
     cfg = variant.to_trend_config(base_cfg, base_path=tmp_path)
 
     assert cfg.portfolio.max_turnover == 0.4
+
+
+def test_to_trend_config_accepts_weighting_scheme_and_name(tmp_path: Path) -> None:
+    base = _base_config(tmp_path)
+    variant = StrategyVariant(
+        name="Weighted",
+        overrides={
+            "portfolio": {
+                "weighting_scheme": "risk_parity",
+                "weighting": {"name": "score_prop_bayes", "params": {"column": "Sharpe"}},
+            }
+        },
+    )
+
+    merged = variant.apply_to(base)
+    assert merged["portfolio"]["weighting_scheme"] == "risk_parity"
+    assert merged["portfolio"]["weighting"]["name"] == "score_prop_bayes"
+    assert merged["portfolio"]["weighting"]["params"]["column"] == "Sharpe"
+
+    cfg = variant.to_trend_config(base, base_path=tmp_path)
+    assert cfg.portfolio.rebalance_calendar == "NYSE"
+
+
+def test_to_trend_config_allows_only_weighting_scheme_override(tmp_path: Path) -> None:
+    base = _base_config(tmp_path)
+    variant = StrategyVariant(
+        name="SchemeOnly",
+        overrides={"portfolio": {"weighting_scheme": "hrp"}},
+    )
+
+    merged = variant.apply_to(base)
+    assert merged["portfolio"]["weighting_scheme"] == "hrp"
+    assert merged["portfolio"]["weighting"]["name"] == "equal"
+
+    cfg = variant.to_trend_config(base, base_path=tmp_path)
+    assert cfg.portfolio.max_turnover == 0.5
+
+
+def test_to_trend_config_allows_only_weighting_name_override(tmp_path: Path) -> None:
+    base = _base_config(tmp_path)
+    variant = StrategyVariant(
+        name="NameOnly",
+        overrides={"portfolio": {"weighting": {"name": "score_prop"}}},
+    )
+
+    merged = variant.apply_to(base)
+    assert merged["portfolio"]["weighting_scheme"] == "equal"
+    assert merged["portfolio"]["weighting"]["name"] == "score_prop"
+
+    cfg = variant.to_trend_config(base, base_path=tmp_path)
+    assert cfg.portfolio.max_turnover == 0.5
+
+
+def test_to_trend_config_rejects_invalid_weighting_scheme_type(tmp_path: Path) -> None:
+    base = _base_config(tmp_path)
+    variant = StrategyVariant(
+        name="BadScheme",
+        overrides={"portfolio": {"weighting_scheme": ["risk_parity"]}},
+    )
+
+    with pytest.raises(ValueError, match="portfolio.weighting_scheme"):
+        variant.to_trend_config(base, base_path=tmp_path)
+
+
+def test_to_trend_config_rejects_invalid_weighting_name_type(tmp_path: Path) -> None:
+    base = _base_config(tmp_path)
+    variant = StrategyVariant(
+        name="BadName",
+        overrides={"portfolio": {"weighting": {"name": None}}},
+    )
+
+    with pytest.raises(ValueError, match="portfolio.weighting.name"):
+        variant.to_trend_config(base, base_path=tmp_path)
 
 
 def test_apply_to_type_mismatch_raises(tmp_path: Path) -> None:

--- a/tests/monte_carlo/strategy/test_variant.py
+++ b/tests/monte_carlo/strategy/test_variant.py
@@ -155,9 +155,7 @@ def test_apply_to_allows_weighting_params_extension(tmp_path: Path) -> None:
         name="ExtendParams",
         overrides={
             "portfolio": {
-                "weighting": {
-                    "params": {"column": "Sharpe", "half_life": 30, "obs_sigma": 0.15}
-                }
+                "weighting": {"params": {"column": "Sharpe", "half_life": 30, "obs_sigma": 0.15}}
             }
         },
     )


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #4647 addressed issue #4165 but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps with improved task structure to ensure proper application of weighting parameters and consistency in strategy configurations.

PR #4647 addressed issue #4165 but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps with improved task structure to ensure proper application of weighting parameters and consistency in strategy configurations.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#4647](https://github.com/stranske/Trend_Model_Project/issues/4647)
- [#4165](https://github.com/stranske/Trend_Model_Project/issues/4165)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Update the `config/defaults.yml` to ensure weighting parameters (column, half_life, obs_sigma) under `portfolio.weighting.params` for `score_prop_bayes` are applied only to curated strategies.
- [x] Define scope for: Modify `config/defaults.yml` to update weighting parameters for `score_prop_bayes`. (verify: config validated)
- [x] Implement focused slice for: Modify `config/defaults.yml` to update weighting parameters for `score_prop_bayes`. (verify: config validated)
- [x] Validate focused slice for: Modify `config/defaults.yml` to update weighting parameters for `score_prop_bayes`. (verify: config validated)
- [x] Define scope for: Ensure that the updated weighting parameters are scoped only to curated strategies (verify: confirm completion in repo)
- [x] Implement focused slice for: Ensure that the updated weighting parameters are scoped only to curated strategies (verify: confirm completion in repo)
- [x] Validate focused slice for: Ensure that the updated weighting parameters are scoped only to curated strategies (verify: confirm completion in repo)
- [x] do not affect global defaults. (verify: confirm completion in repo)
- [x] Review and modify strategy YAML definitions in `config/scenarios/monte_carlo/strategies/hf_equity_curated.yml` to resolve inconsistencies between `portfolio.weighting_scheme` and `portfolio.weighting.name`.
- [x] Define scope for: Review strategy YAML definitions in `hf_equity_curated.yml` for inconsistencies between `portfolio.weighting_scheme` (verify: confirm completion in repo)
- [x] Implement focused slice for: Review strategy YAML definitions in `hf_equity_curated.yml` for inconsistencies between `portfolio.weighting_scheme` (verify: confirm completion in repo)
- [x] Validate focused slice for: Review strategy YAML definitions in `hf_equity_curated.yml` for inconsistencies between `portfolio.weighting_scheme` (verify: confirm completion in repo)
- [x] `portfolio.weighting.name`. (verify: confirm completion in repo)
- [x] Define scope for: Modify the YAML definitions to resolve identified inconsistencies. (verify: confirm completion in repo)
- [x] Implement focused slice for: Modify the YAML definitions to resolve identified inconsistencies. (verify: confirm completion in repo)
- [x] Validate focused slice for: Modify the YAML definitions to resolve identified inconsistencies. (verify: confirm completion in repo)
- [x] Add test cases for `StrategyVariant.to_trend_config` to verify correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided.
- [x] Define scope for: Add test cases for `StrategyVariant.to_trend_config` to verify correct application of weighting methods when both `portfolio.weighting_scheme`
- [x] Implement focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify correct application of weighting methods when both `portfolio.weighting_scheme`
- [x] Validate focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify correct application of weighting methods when both `portfolio.weighting_scheme`
- [x] `portfolio.weighting.name` are provided. (verify: confirm completion in repo)
- [x] Define scope for: Add edge case tests for scenarios where one or both parameters are missing or invalid. (verify: tests pass)
- [x] Implement focused slice for: Add edge case tests for scenarios where one or both parameters are missing or invalid. (verify: tests pass)
- [x] Validate focused slice for: Add edge case tests for scenarios where one or both parameters are missing or invalid. (verify: tests pass)
- [x] Update the `config/defaults.yml` to ensure weighting parameters (column, half_life, obs_sigma) under `portfolio.weighting.params` for `score_prop_bayes` are applied only to curated strategies.
- [x] Define scope for: Modify `config/defaults.yml` to update weighting parameters for `score_prop_bayes`. (verify: config validated)
- [x] Implement focused slice for: Modify `config/defaults.yml` to update weighting parameters for `score_prop_bayes`. (verify: config validated)
- [x] Validate focused slice for: Modify `config/defaults.yml` to update weighting parameters for `score_prop_bayes`. (verify: config validated)
- [x] Define scope for: Ensure that the updated weighting parameters are scoped only to curated strategies (verify: confirm completion in repo)
- [x] Implement focused slice for: Ensure that the updated weighting parameters are scoped only to curated strategies (verify: confirm completion in repo)
- [x] Validate focused slice for: Ensure that the updated weighting parameters are scoped only to curated strategies (verify: confirm completion in repo)
- [x] do not affect global defaults. (verify: confirm completion in repo)
- [x] Review and modify strategy YAML definitions in `config/scenarios/monte_carlo/strategies/hf_equity_curated.yml` to resolve inconsistencies between `portfolio.weighting_scheme` and `portfolio.weighting.name`.
- [x] Define scope for: Review strategy YAML definitions in `hf_equity_curated.yml` for inconsistencies between `portfolio.weighting_scheme` (verify: confirm completion in repo)
- [x] Implement focused slice for: Review strategy YAML definitions in `hf_equity_curated.yml` for inconsistencies between `portfolio.weighting_scheme` (verify: confirm completion in repo)
- [x] Validate focused slice for: Review strategy YAML definitions in `hf_equity_curated.yml` for inconsistencies between `portfolio.weighting_scheme` (verify: confirm completion in repo)
- [x] `portfolio.weighting.name`. (verify: confirm completion in repo)
- [x] Define scope for: Modify the YAML definitions to resolve identified inconsistencies. (verify: confirm completion in repo)
- [x] Implement focused slice for: Modify the YAML definitions to resolve identified inconsistencies. (verify: confirm completion in repo)
- [x] Validate focused slice for: Modify the YAML definitions to resolve identified inconsistencies. (verify: confirm completion in repo)
- [x] Add test cases for `StrategyVariant.to_trend_config` to verify correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided.
- [x] Define scope for: Add test cases for `StrategyVariant.to_trend_config` to verify correct application of weighting methods when both `portfolio.weighting_scheme`
- [x] Implement focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify correct application of weighting methods when both `portfolio.weighting_scheme`
- [x] Validate focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify correct application of weighting methods when both `portfolio.weighting_scheme`
- [x] `portfolio.weighting.name` are provided. (verify: confirm completion in repo)
- [x] Define scope for: Add edge case tests for scenarios where one or both parameters are missing or invalid. (verify: tests pass)
- [x] Implement focused slice for: Add edge case tests for scenarios where one or both parameters are missing or invalid. (verify: tests pass)
- [x] Validate focused slice for: Add edge case tests for scenarios where one or both parameters are missing or invalid. (verify: tests pass)

#### Acceptance criteria
- [x] Each strategy in the `hf_equity_curated.yml` file validates successfully against the schema without causing any unintended modifications to global defaults.
- [x] Weighting parameters (column, half_life, obs_sigma) under `portfolio.weighting.params` for `score_prop_bayes` are only applied to curated strategies and do not affect global defaults.
- [x] The `hf_equity_curated.yml` file is included and properly referenced in at least one example scenario, demonstrating its intended behavior without altering global configuration defaults.
- [x] Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided.
- [x] Each strategy in the `hf_equity_curated.yml` file validates successfully against the schema without causing any unintended modifications to global defaults.
- [x] Weighting parameters (column, half_life, obs_sigma) under `portfolio.weighting.params` for `score_prop_bayes` are only applied to curated strategies and do not affect global defaults.
- [x] The `hf_equity_curated.yml` file is included and properly referenced in at least one example scenario, demonstrating its intended behavior without altering global configuration defaults.
- [x] Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

PR #4647 addressed issue #4165 but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps with improved task structure to ensure proper application of weighting parameters and consistency in strategy configurations.

PR #4647 addressed issue #4165 but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps with improved task structure to ensure proper application of weighting parameters and consistency in strategy configurations.

## Source
Original PR: #4647
Parent issue: #4165

## Scope

Original PR: #4647
Parent issue: #4165

## Non-Goals

_Not provided._

## Tasks

- [ ] Update the `config/defaults.yml` to ensure weighting parameters (column, half_life, obs_sigma) under `portfolio.weighting.params` for `score_prop_bayes` are applied only to curated strategies.
  - [ ] Define scope for: Modify `config/defaults.yml` to update weighting parameters for `score_prop_bayes`. (verify: config validated)
  - [ ] Implement focused slice for: Modify `config/defaults.yml` to update weighting parameters for `score_prop_bayes`. (verify: config validated)
  - [ ] Validate focused slice for: Modify `config/defaults.yml` to update weighting parameters for `score_prop_bayes`. (verify: config validated)
  - [ ] Define scope for: Ensure that the updated weighting parameters are scoped only to curated strategies (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Ensure that the updated weighting parameters are scoped only to curated strategies (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Ensure that the updated weighting parameters are scoped only to curated strategies (verify: confirm completion in repo)
  - [ ] do not affect global defaults. (verify: confirm completion in repo)
- [ ] Review and modify strategy YAML definitions in `config/scenarios/monte_carlo/strategies/hf_equity_curated.yml` to resolve inconsistencies between `portfolio.weighting_scheme` and `portfolio.weighting.name`.
  - [ ] Define scope for: Review strategy YAML definitions in `hf_equity_curated.yml` for inconsistencies between `portfolio.weighting_scheme` (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Review strategy YAML definitions in `hf_equity_curated.yml` for inconsistencies between `portfolio.weighting_scheme` (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Review strategy YAML definitions in `hf_equity_curated.yml` for inconsistencies between `portfolio.weighting_scheme` (verify: confirm completion in repo)
  - [ ] `portfolio.weighting.name`. (verify: confirm completion in repo)
  - [ ] Define scope for: Modify the YAML definitions to resolve identified inconsistencies. (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Modify the YAML definitions to resolve identified inconsistencies. (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Modify the YAML definitions to resolve identified inconsistencies. (verify: confirm completion in repo)
- [ ] Add test cases for `StrategyVariant.to_trend_config` to verify correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided.
  - [ ] Define scope for: Add test cases for `StrategyVariant.to_trend_config` to verify correct application of weighting methods when both `portfolio.weighting_scheme`
  - [ ] Implement focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify correct application of weighting methods when both `portfolio.weighting_scheme`
  - [ ] Validate focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify correct application of weighting methods when both `portfolio.weighting_scheme`
  - [ ] `portfolio.weighting.name` are provided. (verify: confirm completion in repo)
  - [ ] Define scope for: Add edge case tests for scenarios where one or both parameters are missing or invalid. (verify: tests pass)
  - [ ] Implement focused slice for: Add edge case tests for scenarios where one or both parameters are missing or invalid. (verify: tests pass)
  - [ ] Validate focused slice for: Add edge case tests for scenarios where one or both parameters are missing or invalid. (verify: tests pass)
- [ ] Update the `config/defaults.yml` to ensure weighting parameters (column, half_life, obs_sigma) under `portfolio.weighting.params` for `score_prop_bayes` are applied only to curated strategies.
  - [ ] Define scope for: Modify `config/defaults.yml` to update weighting parameters for `score_prop_bayes`. (verify: config validated)
  - [ ] Implement focused slice for: Modify `config/defaults.yml` to update weighting parameters for `score_prop_bayes`. (verify: config validated)
  - [ ] Validate focused slice for: Modify `config/defaults.yml` to update weighting parameters for `score_prop_bayes`. (verify: config validated)
  - [ ] Define scope for: Ensure that the updated weighting parameters are scoped only to curated strategies (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Ensure that the updated weighting parameters are scoped only to curated strategies (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Ensure that the updated weighting parameters are scoped only to curated strategies (verify: confirm completion in repo)
  - [ ] do not affect global defaults. (verify: confirm completion in repo)
- [ ] Review and modify strategy YAML definitions in `config/scenarios/monte_carlo/strategies/hf_equity_curated.yml` to resolve inconsistencies between `portfolio.weighting_scheme` and `portfolio.weighting.name`.
  - [ ] Define scope for: Review strategy YAML definitions in `hf_equity_curated.yml` for inconsistencies between `portfolio.weighting_scheme` (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Review strategy YAML definitions in `hf_equity_curated.yml` for inconsistencies between `portfolio.weighting_scheme` (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Review strategy YAML definitions in `hf_equity_curated.yml` for inconsistencies between `portfolio.weighting_scheme` (verify: confirm completion in repo)
  - [ ] `portfolio.weighting.name`. (verify: confirm completion in repo)
  - [ ] Define scope for: Modify the YAML definitions to resolve identified inconsistencies. (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Modify the YAML definitions to resolve identified inconsistencies. (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Modify the YAML definitions to resolve identified inconsistencies. (verify: confirm completion in repo)
- [ ] Add test cases for `StrategyVariant.to_trend_config` to verify correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided.
  - [ ] Define scope for: Add test cases for `StrategyVariant.to_trend_config` to verify correct application of weighting methods when both `portfolio.weighting_scheme`
  - [ ] Implement focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify correct application of weighting methods when both `portfolio.weighting_scheme`
  - [ ] Validate focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify correct application of weighting methods when both `portfolio.weighting_scheme`
  - [ ] `portfolio.weighting.name` are provided. (verify: confirm completion in repo)
  - [ ] Define scope for: Add edge case tests for scenarios where one or both parameters are missing or invalid. (verify: tests pass)
  - [ ] Implement focused slice for: Add edge case tests for scenarios where one or both parameters are missing or invalid. (verify: tests pass)
  - [ ] Validate focused slice for: Add edge case tests for scenarios where one or both parameters are missing or invalid. (verify: tests pass)

## Acceptance Criteria

- [ ] Each strategy in the `hf_equity_curated.yml` file validates successfully against the schema without causing any unintended modifications to global defaults.
- [ ] Weighting parameters (column, half_life, obs_sigma) under `portfolio.weighting.params` for `score_prop_bayes` are only applied to curated strategies and do not affect global defaults.
- [ ] The `hf_equity_curated.yml` file is included and properly referenced in at least one example scenario, demonstrating its intended behavior without altering global configuration defaults.
- [ ] Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided.
- [ ] Each strategy in the `hf_equity_curated.yml` file validates successfully against the schema without causing any unintended modifications to global defaults.
- [ ] Weighting parameters (column, half_life, obs_sigma) under `portfolio.weighting.params` for `score_prop_bayes` are only applied to curated strategies and do not affect global defaults.
- [ ] The `hf_equity_curated.yml` file is included and properly referenced in at least one example scenario, demonstrating its intended behavior without altering global configuration defaults.
- [ ] Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided.

## Implementation Notes

Ensure that changes to `config/defaults.yml` are scoped to curated strategies to prevent unintended global changes.
Validate strategy YAML definitions against the schema to ensure consistency and correctness.
Develop comprehensive test cases to cover scenarios where both `portfolio.weighting_scheme` and `portfolio.weighting.name` are specified, ensuring that the correct logic is applied.
```

<details>
<summary>Original Issue</summary>

```text
Ensure that changes to `config/defaults.yml` are scoped to curated strategies to prevent unintended global changes.
Validate strategy YAML definitions against the schema to ensure consistency and correctness.
Develop comprehensive test cases to cover scenarios where both `portfolio.weighting_scheme` and `portfolio.weighting.name` are specified, ensuring that the correct logic is applied.

<details>
<summary>Background (previous attempt context)</summary>

**LLM evaluation could not run:** The testing framework or environment may not have been properly configured to execute LLM evaluation routines. Ensure the evaluation pipeline is properly set up (or mocked) so that tests dependent on LLM evaluation do not block the overall validation process. Consider isolating non-critical LLM evaluations from core logic tests.
**Over-reliance on StrategyVariant.to_trend_config for catching bad overrides without explicit pack-level verification:** Pack-level validation did not include concrete checks for consistency between provided parameters, leading to ambiguity when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are specified. Augment the pack-level validation with specific rules checking for conflicts between weight-related fields, or document the precedence clearly, so that future modifications are aware of these constraints.

</details>

## Critical Rules
Do NOT include "Remaining Unchecked Items" or "Iteration Details" sections unless they contain specific, useful failure context.
Tasks should be concrete actions, not verification concerns restated.
Acceptance criteria must be testable (not "all concerns addressed").
Keep the main body focused - hide background/history in the collapsible section.
Do NOT include the entire analysis object - only include specific failure contexts from `blockers_to_avoid`.
```
</details>

## Deferred Tasks (Requires Human)

- [ ] Ensure that changes to `config/defaults.yml` are scoped to curated strategies to prevent unintended global changes. (The agent cannot guarantee that changes to configuration files will not have unintended side effects due to AGENT_LIMITATIONS. | Recommend manual review by a human to verify that changes are correctly scoped.)
- [ ] Validate strategy YAML definitions against the schema to ensure consistency and correctness. (The agent cannot directly validate YAML files against a schema unless the schema and validation tools are explicitly provided. | Provide the schema and validation tools or assign this task to a human reviewer.)



</details>

—
PR created automatically to engage Auto Pilot Pause.

<!-- pr-preamble:start -->
> **Source:** Issue #4655

<!-- pr-preamble:end -->