### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -1748,6 +1748,7 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
       core?.info?.(`Rate limits exhausted - deferring. Recommendation: ${rateLimitStatus.recommendation}`);
       return {
         prNumber: overridePrNumber || 0,
+        baseRef: '',
         action: 'defer',
         reason: 'rate-limit-exhausted',
         rateLimitStatus,
@@ -1762,6 +1763,7 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     if (!prNumber) {
       return {
         prNumber: 0,
+        baseRef: '',
         action: 'skip',
         reason: 'pr-not-found',
       };
@@ -1997,6 +1999,7 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     return {
       prNumber,
       prRef: pr.head.ref || '',
+      baseRef: pr.base?.ref || '',
       headSha: pr.head.sha || '',
       action,
       reason,

--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -42,6 +42,7 @@ jobs:
     outputs:
       pr_number: ${{ steps.evaluate.outputs.pr_number }}
       pr_ref: ${{ steps.evaluate.outputs.pr_ref }}
+      base_ref: ${{ steps.evaluate.outputs.base_ref }}
       head_sha: ${{ steps.evaluate.outputs.head_sha }}
       action: ${{ steps.evaluate.outputs.action }}
       reason: ${{ steps.evaluate.outputs.reason }}
@@ -235,6 +236,7 @@ jobs:
             const output = {
               pr_number: String(result.prNumber || ''),
               pr_ref: String(result.prRef || ''),
+              base_ref: String(result.baseRef || ''),
               head_sha: String(result.headSha || ''),
               action: result.action || '',
               reason: result.reason || '',
@@ -393,6 +395,7 @@ jobs:
       mode: keepalive
       pr_number: ${{ needs.evaluate.outputs.pr_number }}
       pr_ref: ${{ needs.evaluate.outputs.pr_ref }}
+      base_ref: ${{ needs.evaluate.outputs.base_ref }}
       appendix: ${{ needs.evaluate.outputs.task_appendix }}
       iteration: ${{ needs.evaluate.outputs.iteration }}
       environment: ${{ needs.evaluate.outputs.has_high_privilege == 'true' && 'agent-high-privilege' || 'agent-standard' }}

--- a/tools/resolve_mypy_pin.py
+++ b/tools/resolve_mypy_pin.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import os
 import sys
-from collections.abc import Mapping
 from pathlib import Path
 
 
@@ -34,9 +33,9 @@ def get_mypy_python_version() -> str | None:
         tool_raw = data.get("tool")
         # Use dict() to normalize tomlkit types and satisfy mypy
         # tomlkit returns Table objects that act like dicts but mypy doesn't know this
-        tool: dict[str, object] = dict(tool_raw) if isinstance(tool_raw, Mapping) else {}
+        tool: dict[str, object] = dict(tool_raw) if hasattr(tool_raw, "get") else {}  # type: ignore[arg-type,call-overload]
         mypy_raw = tool.get("mypy")
-        mypy: dict[str, object] = dict(mypy_raw) if isinstance(mypy_raw, Mapping) else {}
+        mypy: dict[str, object] = dict(mypy_raw) if hasattr(mypy_raw, "get") else {}  # type: ignore[arg-type,call-overload]
         version = mypy.get("python_version")
         # Validate type before conversion - TOML can parse various types
         if isinstance(version, (str, int, float)):


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-keepalive-loop.yml: Keepalive loop - continues agent work until tasks complete (deprecated; replaced by agents-81-gate-followups.yml, removal no earlier than 2026-02-15)
- resolve_mypy_pin.py: Resolves mypy version pinning - required by reusable CI workflow
- keepalive_loop.js: Core keepalive loop logic

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** [stranske/Workflows](https://github.com/stranske/Workflows)
**Manifest:** [`.github/sync-manifest.yml`](https://github.com/stranske/Workflows/blob/main/.github/sync-manifest.yml)