### PR TITLE
Codex bootstrap for #4687

### DIFF
--- a/agents/codex-4687.md
+++ b/agents/codex-4687.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #4687 -->

--- a/docs/keepalive/PR4684_Status.md
+++ b/docs/keepalive/PR4684_Status.md
@@ -8,6 +8,7 @@ PR #4684 addressed issue #4683 but verification identified concerns (verdict: CO
 
 ## Checklist Reconciliation
 Checklist reconciled on 2026-02-03 after reviewing commit b7222116 and running `pytest tests/monte_carlo/test_results.py -m "not slow"`. Export outputs are implemented in `src/trend_analysis/monte_carlo/results.py` (no standalone `export.py`), and the export points are results, summary, cross-fold summary, and pooled summary frames.
+Checklist refreshed on 2026-02-04 after reviewing commit b85001fa and running `pytest tests/monte_carlo/test_results.py -m "not slow"`. Added coverage for fold_id handling in results frames and validated cross-fold summary export labeling.
 Additional fold-aware output tables live outside Monte Carlo exports in `src/trend_analysis/walk_forward.py` (folds/summary CSVs) and `analysis/cv.py` (cv_folds/cv_summary CSVs). These should include a `fold_id` column while keeping existing `fold`/`folds` fields for compatibility. Validated updates on 2026-02-03 with `pytest tests/test_walk_forward_grid.py tests/test_walk_forward_helpers_additional.py tests/test_walk_forward_settings.py tests/test_cv.py -m "not slow"`.
 
 ## Tasks
@@ -46,7 +47,7 @@ Additional fold-aware output tables live outside Monte Carlo exports in `src/tre
 - [ ] The scenario configuration includes a flag that enables or disables fold runs, and when disabled, no fold-related code paths are executed.
 - [ ] Explicit, rolling, and count_spaced fold modes are fully functional and covered by unit tests that verify expected fold start, calibration, and window calculations.
 - [ ] For each fold, the calibration window is correctly calculated and applied for return model fitting, with unit tests checking both typical and edge-case scenarios.
-- [ ] Every result table that is part of fold-aware output includes a fold_id column.
-- [ ] A cross-fold comparison summary frame is generated and exported via the designated export interface, with unit tests verifying its presence and correctness.
-- [ ] Pooled output clearly indicates whether it represents a distribution of full data or only summary statistics, with outputs labeled with scope 'pooled'.
+- [x] Every result table that is part of fold-aware output includes a fold_id column.
+- [x] A cross-fold comparison summary frame is generated and exported via the designated export interface, with unit tests verifying its presence and correctness.
+- [x] Pooled output clearly indicates whether it represents a distribution of full data or only summary statistics, with outputs labeled with scope 'pooled'.
 - [ ] FoldGenerator._align_to_index and FoldGenerator._previous_in_index are covered by unit tests that include edge cases.

--- a/docs/keepalive/PR4684_Status.md
+++ b/docs/keepalive/PR4684_Status.md
@@ -4,7 +4,7 @@
 PR #4684 addressed issue #4683 but verification identified concerns (verdict: CONCERNS). This follow-up addresses the remaining gaps with improved task structure to ensure comprehensive coverage of fold-aware outputs and robust testing of fold modes.
 
 ## Progress
-30/31 tasks complete, 1 remaining.
+31/31 tasks complete, 0 remaining.
 
 ## Checklist Reconciliation
 Checklist reconciled on 2026-02-03 after reviewing commit b7222116 and running `pytest tests/monte_carlo/test_results.py -m "not slow"`. Export outputs are implemented in `src/trend_analysis/monte_carlo/results.py` (no standalone `export.py`), and the export points are results, summary, cross-fold summary, and pooled summary frames.
@@ -14,6 +14,7 @@ Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_r
 Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Verified pooled-distribution toggles record metadata when disabled.
 Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_folds.py -m "not slow"` and `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Added coverage to ensure rolling and count_spaced fold calibration windows are passed into the Monte Carlo runner.
 Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Added pooled scope metadata to clarify pooled summary outputs.
+Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_results.py -m "not slow"`. Added cross-fold summary coverage for per-strategy fold counts.
 Additional fold-aware output tables live outside Monte Carlo exports in `src/trend_analysis/walk_forward.py` (folds/summary CSVs) and `analysis/cv.py` (cv_folds/cv_summary CSVs). These should include a `fold_id` column while keeping existing `fold`/`folds` fields for compatibility. Validated updates on 2026-02-03 with `pytest tests/test_walk_forward_grid.py tests/test_walk_forward_helpers_additional.py tests/test_walk_forward_settings.py tests/test_cv.py -m "not slow"`.
 
 ## Tasks

--- a/docs/keepalive/PR4684_Status.md
+++ b/docs/keepalive/PR4684_Status.md
@@ -4,7 +4,7 @@
 PR #4684 addressed issue #4683 but verification identified concerns (verdict: CONCERNS). This follow-up addresses the remaining gaps with improved task structure to ensure comprehensive coverage of fold-aware outputs and robust testing of fold modes.
 
 ## Progress
-31/31 tasks complete, 0 remaining.
+32/32 tasks complete, 0 remaining.
 
 ## Checklist Reconciliation
 Checklist reconciled on 2026-02-03 after reviewing commit b7222116 and running `pytest tests/monte_carlo/test_results.py -m "not slow"`. Export outputs are implemented in `src/trend_analysis/monte_carlo/results.py` (no standalone `export.py`), and the export points are results, summary, cross-fold summary, and pooled summary frames.
@@ -16,6 +16,7 @@ Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_f
 Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Added pooled scope metadata to clarify pooled summary outputs.
 Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_results.py -m "not slow"`. Added cross-fold summary coverage for per-strategy fold counts.
 Additional fold-aware output tables live outside Monte Carlo exports in `src/trend_analysis/walk_forward.py` (folds/summary CSVs) and `analysis/cv.py` (cv_folds/cv_summary CSVs). These should include a `fold_id` column while keeping existing `fold`/`folds` fields for compatibility. Validated updates on 2026-02-03 with `pytest tests/test_walk_forward_grid.py tests/test_walk_forward_helpers_additional.py tests/test_walk_forward_settings.py tests/test_cv.py -m "not slow"`.
+Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Added coverage to ensure fold labels propagate to Monte Carlo error records during fold runs.
 
 ## Tasks
 - [x] Review and update export-related code to ensure fold_id columns are included in all relevant export points, including export.py if necessary.
@@ -49,6 +50,7 @@ Additional fold-aware output tables live outside Monte Carlo exports in `src/tre
 - [x] Write unit tests to verify optional pooled distributions are included.
 - [x] Clarify and update implementation regarding pooled output to determine if full distribution artifacts are needed, and update tests accordingly.
 - [x] Add or enhance tests to verify that the scenario configuration flag properly enables and disables fold runs.
+- [x] Ensure fold labels are included in Monte Carlo path error records.
 
 ## Acceptance Criteria
 - [x] The scenario configuration includes a flag that enables or disables fold runs, and when disabled, no fold-related code paths are executed.

--- a/docs/keepalive/PR4684_Status.md
+++ b/docs/keepalive/PR4684_Status.md
@@ -4,7 +4,7 @@
 PR #4684 addressed issue #4683 but verification identified concerns (verdict: CONCERNS). This follow-up addresses the remaining gaps with improved task structure to ensure comprehensive coverage of fold-aware outputs and robust testing of fold modes.
 
 ## Progress
-25/38 tasks complete, 13 remaining.
+30/31 tasks complete, 1 remaining.
 
 ## Checklist Reconciliation
 Checklist reconciled on 2026-02-03 after reviewing commit b7222116 and running `pytest tests/monte_carlo/test_results.py -m "not slow"`. Export outputs are implemented in `src/trend_analysis/monte_carlo/results.py` (no standalone `export.py`), and the export points are results, summary, cross-fold summary, and pooled summary frames.
@@ -12,6 +12,7 @@ Checklist refreshed on 2026-02-04 after reviewing commit b85001fa and running `p
 Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Added coverage for cross-fold summary generation without pooled distributions and verified fold run enablement tests.
 Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Added coverage to ensure pooled summaries include fold counts when pooled distributions are enabled.
 Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Verified pooled-distribution toggles record metadata when disabled.
+Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_folds.py -m "not slow"` and `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Added coverage to ensure rolling and count_spaced fold calibration windows are passed into the Monte Carlo runner.
 Additional fold-aware output tables live outside Monte Carlo exports in `src/trend_analysis/walk_forward.py` (folds/summary CSVs) and `analysis/cv.py` (cv_folds/cv_summary CSVs). These should include a `fold_id` column while keeping existing `fold`/`folds` fields for compatibility. Validated updates on 2026-02-03 with `pytest tests/test_walk_forward_grid.py tests/test_walk_forward_helpers_additional.py tests/test_walk_forward_settings.py tests/test_cv.py -m "not slow"`.
 
 ## Tasks
@@ -49,9 +50,9 @@ Additional fold-aware output tables live outside Monte Carlo exports in `src/tre
 
 ## Acceptance Criteria
 - [x] The scenario configuration includes a flag that enables or disables fold runs, and when disabled, no fold-related code paths are executed.
-- [ ] Explicit, rolling, and count_spaced fold modes are fully functional and covered by unit tests that verify expected fold start, calibration, and window calculations.
-- [ ] For each fold, the calibration window is correctly calculated and applied for return model fitting, with unit tests checking both typical and edge-case scenarios.
+- [x] Explicit, rolling, and count_spaced fold modes are fully functional and covered by unit tests that verify expected fold start, calibration, and window calculations.
+- [x] For each fold, the calibration window is correctly calculated and applied for return model fitting, with unit tests checking both typical and edge-case scenarios.
 - [x] Every result table that is part of fold-aware output includes a fold_id column.
 - [x] A cross-fold comparison summary frame is generated and exported via the designated export interface, with unit tests verifying its presence and correctness.
 - [x] Pooled output clearly indicates whether it represents a distribution of full data or only summary statistics, with outputs labeled with scope 'pooled'.
-- [ ] FoldGenerator._align_to_index and FoldGenerator._previous_in_index are covered by unit tests that include edge cases.
+- [x] FoldGenerator._align_to_index and FoldGenerator._previous_in_index are covered by unit tests that include edge cases.

--- a/docs/keepalive/PR4684_Status.md
+++ b/docs/keepalive/PR4684_Status.md
@@ -4,13 +4,14 @@
 PR #4684 addressed issue #4683 but verification identified concerns (verdict: CONCERNS). This follow-up addresses the remaining gaps with improved task structure to ensure comprehensive coverage of fold-aware outputs and robust testing of fold modes.
 
 ## Progress
-24/38 tasks complete, 14 remaining.
+25/38 tasks complete, 13 remaining.
 
 ## Checklist Reconciliation
 Checklist reconciled on 2026-02-03 after reviewing commit b7222116 and running `pytest tests/monte_carlo/test_results.py -m "not slow"`. Export outputs are implemented in `src/trend_analysis/monte_carlo/results.py` (no standalone `export.py`), and the export points are results, summary, cross-fold summary, and pooled summary frames.
 Checklist refreshed on 2026-02-04 after reviewing commit b85001fa and running `pytest tests/monte_carlo/test_results.py -m "not slow"`. Added coverage for fold_id handling in results frames and validated cross-fold summary export labeling.
 Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Added coverage for cross-fold summary generation without pooled distributions and verified fold run enablement tests.
 Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Added coverage to ensure pooled summaries include fold counts when pooled distributions are enabled.
+Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Verified pooled-distribution toggles record metadata when disabled.
 Additional fold-aware output tables live outside Monte Carlo exports in `src/trend_analysis/walk_forward.py` (folds/summary CSVs) and `analysis/cv.py` (cv_folds/cv_summary CSVs). These should include a `fold_id` column while keeping existing `fold`/`folds` fields for compatibility. Validated updates on 2026-02-03 with `pytest tests/test_walk_forward_grid.py tests/test_walk_forward_helpers_additional.py tests/test_walk_forward_settings.py tests/test_cv.py -m "not slow"`.
 
 ## Tasks

--- a/docs/keepalive/PR4684_Status.md
+++ b/docs/keepalive/PR4684_Status.md
@@ -4,11 +4,12 @@
 PR #4684 addressed issue #4683 but verification identified concerns (verdict: CONCERNS). This follow-up addresses the remaining gaps with improved task structure to ensure comprehensive coverage of fold-aware outputs and robust testing of fold modes.
 
 ## Progress
-22/37 tasks complete, 15 remaining.
+23/37 tasks complete, 14 remaining.
 
 ## Checklist Reconciliation
 Checklist reconciled on 2026-02-03 after reviewing commit b7222116 and running `pytest tests/monte_carlo/test_results.py -m "not slow"`. Export outputs are implemented in `src/trend_analysis/monte_carlo/results.py` (no standalone `export.py`), and the export points are results, summary, cross-fold summary, and pooled summary frames.
 Checklist refreshed on 2026-02-04 after reviewing commit b85001fa and running `pytest tests/monte_carlo/test_results.py -m "not slow"`. Added coverage for fold_id handling in results frames and validated cross-fold summary export labeling.
+Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Added coverage for cross-fold summary generation without pooled distributions and verified fold run enablement tests.
 Additional fold-aware output tables live outside Monte Carlo exports in `src/trend_analysis/walk_forward.py` (folds/summary CSVs) and `analysis/cv.py` (cv_folds/cv_summary CSVs). These should include a `fold_id` column while keeping existing `fold`/`folds` fields for compatibility. Validated updates on 2026-02-03 with `pytest tests/test_walk_forward_grid.py tests/test_walk_forward_helpers_additional.py tests/test_walk_forward_settings.py tests/test_cv.py -m "not slow"`.
 
 ## Tasks
@@ -41,10 +42,10 @@ Additional fold-aware output tables live outside Monte Carlo exports in `src/tre
 - [x] Implement unit tests for FoldGenerator._previous_in_index (verify: tests pass)
 - [x] including edge cases. (verify: confirm completion in repo)
 - [ ] Clarify and update implementation regarding pooled output to determine if full distribution artifacts are needed, and update tests accordingly.
-- [ ] Add or enhance tests to verify that the scenario configuration flag properly enables and disables fold runs.
+- [x] Add or enhance tests to verify that the scenario configuration flag properly enables and disables fold runs.
 
 ## Acceptance Criteria
-- [ ] The scenario configuration includes a flag that enables or disables fold runs, and when disabled, no fold-related code paths are executed.
+- [x] The scenario configuration includes a flag that enables or disables fold runs, and when disabled, no fold-related code paths are executed.
 - [ ] Explicit, rolling, and count_spaced fold modes are fully functional and covered by unit tests that verify expected fold start, calibration, and window calculations.
 - [ ] For each fold, the calibration window is correctly calculated and applied for return model fitting, with unit tests checking both typical and edge-case scenarios.
 - [x] Every result table that is part of fold-aware output includes a fold_id column.

--- a/docs/keepalive/PR4684_Status.md
+++ b/docs/keepalive/PR4684_Status.md
@@ -4,12 +4,13 @@
 PR #4684 addressed issue #4683 but verification identified concerns (verdict: CONCERNS). This follow-up addresses the remaining gaps with improved task structure to ensure comprehensive coverage of fold-aware outputs and robust testing of fold modes.
 
 ## Progress
-23/37 tasks complete, 14 remaining.
+24/38 tasks complete, 14 remaining.
 
 ## Checklist Reconciliation
 Checklist reconciled on 2026-02-03 after reviewing commit b7222116 and running `pytest tests/monte_carlo/test_results.py -m "not slow"`. Export outputs are implemented in `src/trend_analysis/monte_carlo/results.py` (no standalone `export.py`), and the export points are results, summary, cross-fold summary, and pooled summary frames.
 Checklist refreshed on 2026-02-04 after reviewing commit b85001fa and running `pytest tests/monte_carlo/test_results.py -m "not slow"`. Added coverage for fold_id handling in results frames and validated cross-fold summary export labeling.
 Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Added coverage for cross-fold summary generation without pooled distributions and verified fold run enablement tests.
+Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Added coverage to ensure pooled summaries include fold counts when pooled distributions are enabled.
 Additional fold-aware output tables live outside Monte Carlo exports in `src/trend_analysis/walk_forward.py` (folds/summary CSVs) and `analysis/cv.py` (cv_folds/cv_summary CSVs). These should include a `fold_id` column while keeping existing `fold`/`folds` fields for compatibility. Validated updates on 2026-02-03 with `pytest tests/test_walk_forward_grid.py tests/test_walk_forward_helpers_additional.py tests/test_walk_forward_settings.py tests/test_cv.py -m "not slow"`.
 
 ## Tasks
@@ -41,6 +42,7 @@ Additional fold-aware output tables live outside Monte Carlo exports in `src/tre
 - [x] including edge cases. (verify: confirm completion in repo)
 - [x] Implement unit tests for FoldGenerator._previous_in_index (verify: tests pass)
 - [x] including edge cases. (verify: confirm completion in repo)
+- [x] Write unit tests to verify optional pooled distributions are included.
 - [ ] Clarify and update implementation regarding pooled output to determine if full distribution artifacts are needed, and update tests accordingly.
 - [x] Add or enhance tests to verify that the scenario configuration flag properly enables and disables fold runs.
 

--- a/docs/keepalive/PR4684_Status.md
+++ b/docs/keepalive/PR4684_Status.md
@@ -13,6 +13,7 @@ Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_r
 Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Added coverage to ensure pooled summaries include fold counts when pooled distributions are enabled.
 Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Verified pooled-distribution toggles record metadata when disabled.
 Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_folds.py -m "not slow"` and `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Added coverage to ensure rolling and count_spaced fold calibration windows are passed into the Monte Carlo runner.
+Checklist refreshed on 2026-02-04 after running `pytest tests/monte_carlo/test_runner.py -m "not slow"`. Added pooled scope metadata to clarify pooled summary outputs.
 Additional fold-aware output tables live outside Monte Carlo exports in `src/trend_analysis/walk_forward.py` (folds/summary CSVs) and `analysis/cv.py` (cv_folds/cv_summary CSVs). These should include a `fold_id` column while keeping existing `fold`/`folds` fields for compatibility. Validated updates on 2026-02-03 with `pytest tests/test_walk_forward_grid.py tests/test_walk_forward_helpers_additional.py tests/test_walk_forward_settings.py tests/test_cv.py -m "not slow"`.
 
 ## Tasks
@@ -45,7 +46,7 @@ Additional fold-aware output tables live outside Monte Carlo exports in `src/tre
 - [x] Implement unit tests for FoldGenerator._previous_in_index (verify: tests pass)
 - [x] including edge cases. (verify: confirm completion in repo)
 - [x] Write unit tests to verify optional pooled distributions are included.
-- [ ] Clarify and update implementation regarding pooled output to determine if full distribution artifacts are needed, and update tests accordingly.
+- [x] Clarify and update implementation regarding pooled output to determine if full distribution artifacts are needed, and update tests accordingly.
 - [x] Add or enhance tests to verify that the scenario configuration flag properly enables and disables fold runs.
 
 ## Acceptance Criteria

--- a/src/trend_analysis/monte_carlo/results.py
+++ b/src/trend_analysis/monte_carlo/results.py
@@ -21,6 +21,7 @@ __all__ = [
 
 RESULT_BASE_COLUMNS = (
     "fold_id",
+    "fold_label",
     "path_id",
     "strategy",
     "path_hash",
@@ -39,6 +40,7 @@ class StrategyEvaluation:
     metrics: Mapping[str, float]
     metric_source: str | None
     path_hash: str
+    fold_label: str | None = None
     seed: int | None = None
     diagnostic: Mapping[str, Any] | None = None
 
@@ -75,6 +77,7 @@ def build_results_frame(evaluations: Iterable[StrategyEvaluation]) -> pd.DataFra
     for evaluation in evaluations:
         row: dict[str, Any] = {
             "fold_id": (int(evaluation.fold_id) if evaluation.fold_id is not None else None),
+            "fold_label": evaluation.fold_label,
             "path_id": int(evaluation.path_id),
             "strategy": evaluation.strategy_name,
             "path_hash": evaluation.path_hash,
@@ -94,10 +97,16 @@ def build_results_frame(evaluations: Iterable[StrategyEvaluation]) -> pd.DataFra
 def build_summary_frame(results_frame: pd.DataFrame) -> pd.DataFrame:
     """Aggregate results per strategy."""
 
+    fold_group_cols: list[str] = []
+    if "fold_id" in results_frame.columns:
+        fold_group_cols.append("fold_id")
+        if "fold_label" in results_frame.columns:
+            fold_group_cols.append("fold_label")
+
     if results_frame.empty:
         base_cols = ["strategy", "paths"]
-        if "fold_id" in results_frame.columns:
-            base_cols = ["fold_id", "strategy", "paths"]
+        if fold_group_cols:
+            base_cols = [*fold_group_cols, "strategy", "paths"]
         return pd.DataFrame(columns=base_cols)
     numeric_cols = results_frame.select_dtypes(include="number").columns.tolist()
     if "fold_id" in numeric_cols:
@@ -106,8 +115,8 @@ def build_summary_frame(results_frame: pd.DataFrame) -> pd.DataFrame:
         numeric_cols.remove("path_id")
     if "seed" in numeric_cols:
         numeric_cols.remove("seed")
-    if "fold_id" in results_frame.columns:
-        grouped = results_frame.groupby(["fold_id", "strategy"], dropna=False)
+    if fold_group_cols:
+        grouped = results_frame.groupby([*fold_group_cols, "strategy"], dropna=False)
     else:
         grouped = results_frame.groupby("strategy", dropna=False)
     summary = grouped[numeric_cols].mean(numeric_only=True)
@@ -120,7 +129,15 @@ def build_pooled_summary_frame(results_frame: pd.DataFrame) -> pd.DataFrame:
 
     if results_frame.empty:
         return pd.DataFrame(
-            columns=["scope", "pooled_scope", "fold_id", "strategy", "paths", "folds"]
+            columns=[
+                "scope",
+                "pooled_scope",
+                "fold_id",
+                "fold_label",
+                "strategy",
+                "paths",
+                "folds",
+            ]
         )
 
     numeric_cols = results_frame.select_dtypes(include="number").columns.tolist()
@@ -137,6 +154,7 @@ def build_pooled_summary_frame(results_frame: pd.DataFrame) -> pd.DataFrame:
     pooled.insert(0, "scope", "pooled")
     pooled.insert(1, "pooled_scope", "summary")
     pooled.insert(2, "fold_id", None)
+    pooled.insert(3, "fold_label", None)
     return pooled
 
 

--- a/src/trend_analysis/monte_carlo/results.py
+++ b/src/trend_analysis/monte_carlo/results.py
@@ -54,6 +54,7 @@ class MonteCarloPathError:
     strategy_name: str | None
     error_type: str
     message: str
+    fold_label: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/trend_analysis/monte_carlo/results.py
+++ b/src/trend_analysis/monte_carlo/results.py
@@ -13,6 +13,7 @@ __all__ = [
     "MonteCarloResults",
     "StrategyEvaluation",
     "build_cross_fold_summary_frame",
+    "build_pooled_distribution_frame",
     "build_pooled_summary_frame",
     "build_results_frame",
     "build_summary_frame",
@@ -68,6 +69,7 @@ class MonteCarloResults:
     summary_frame: pd.DataFrame
     cross_fold_summary_frame: pd.DataFrame | None = None
     pooled_summary_frame: pd.DataFrame | None = None
+    pooled_distribution_frame: pd.DataFrame | None = None
     metadata: Mapping[str, Any] | None = None
 
 
@@ -159,6 +161,17 @@ def build_pooled_summary_frame(results_frame: pd.DataFrame) -> pd.DataFrame:
     return pooled
 
 
+def build_pooled_distribution_frame(results_frame: pd.DataFrame) -> pd.DataFrame:
+    """Return a pooled distribution table across all folds."""
+
+    if results_frame.empty:
+        return pd.DataFrame(columns=["scope", "pooled_scope", *RESULT_BASE_COLUMNS])
+    pooled = results_frame.copy()
+    pooled.insert(0, "scope", "pooled")
+    pooled.insert(1, "pooled_scope", "distribution")
+    return pooled
+
+
 def build_cross_fold_summary_frame(results_frame: pd.DataFrame) -> pd.DataFrame:
     """Summarize fold-level results for cross-fold comparison."""
 
@@ -219,6 +232,10 @@ def export_results(
             pooled_path = out_dir / f"pooled_summary.{ext}"
             _export_frame(results.pooled_summary_frame, pooled_path, ext)
             exported[f"pooled_summary_{ext}"] = pooled_path
+        if results.pooled_distribution_frame is not None:
+            pooled_path = out_dir / f"pooled_distributions.{ext}"
+            _export_frame(results.pooled_distribution_frame, pooled_path, ext)
+            exported[f"pooled_distributions_{ext}"] = pooled_path
         exported[f"results_{ext}"] = results_path
         exported[f"summary_{ext}"] = summary_path
     return exported

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -234,6 +234,7 @@ class MonteCarloRunner:
         )
         if folds:
             metadata["pooled_distributions"] = pooled_distributions
+            metadata["pooled_scope"] = "summary" if pooled_distributions else "none"
         results = MonteCarloResults(
             mode=mode,
             evaluations=evaluations,

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -354,7 +354,9 @@ class MonteCarloRunner:
                 )
             except Exception as exc:
                 for path_id in range(total):
-                    self._log_path_error(path_id, None, exc)
+                    self._log_path_error(
+                        path_id, None, exc, fold_id=fold_id, fold_label=fold_label
+                    )
                     errors.append(
                         self._error_record(
                             path_id, None, exc, fold_id=fold_id, fold_label=fold_label
@@ -377,7 +379,7 @@ class MonteCarloRunner:
                     fold_label=fold_label,
                 )
             except Exception as exc:
-                self._log_path_error(path_id, None, exc)
+                self._log_path_error(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
                 return [], [
                     self._error_record(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
                 ]
@@ -389,7 +391,13 @@ class MonteCarloRunner:
                     evaluation = self._evaluate_strategy(strategy, context)
                     path_evals.append(evaluation)
                 except Exception as exc:
-                    self._log_path_error(path_id, strategy.name, exc)
+                    self._log_path_error(
+                        path_id,
+                        strategy.name,
+                        exc,
+                        fold_id=fold_id,
+                        fold_label=fold_label,
+                    )
                     path_errors.append(
                         self._error_record(
                             path_id,
@@ -439,7 +447,7 @@ class MonteCarloRunner:
             )
         except Exception as exc:
             for path_id in range(total):
-                self._log_path_error(path_id, None, exc)
+                self._log_path_error(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
                 errors.append(
                     self._error_record(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
                 )
@@ -461,7 +469,7 @@ class MonteCarloRunner:
                     fold_label=fold_label,
                 )
             except Exception as exc:
-                self._log_path_error(path_id, None, exc)
+                self._log_path_error(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
                 return [], [
                     self._error_record(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
                 ]
@@ -470,7 +478,13 @@ class MonteCarloRunner:
                 evaluation = self._evaluate_strategy(strategy, context)
                 return [evaluation], []
             except Exception as exc:
-                self._log_path_error(path_id, strategy.name, exc)
+                self._log_path_error(
+                    path_id,
+                    strategy.name,
+                    exc,
+                    fold_id=fold_id,
+                    fold_label=fold_label,
+                )
                 return [], [
                     self._error_record(
                         path_id,
@@ -1047,8 +1061,23 @@ class MonteCarloRunner:
             }
         )
 
-    def _log_path_error(self, path_id: int, strategy_name: str | None, exc: Exception) -> None:
+    def _log_path_error(
+        self,
+        path_id: int,
+        strategy_name: str | None,
+        exc: Exception,
+        *,
+        fold_id: int | None = None,
+        fold_label: str | None = None,
+    ) -> None:
         label = f"path {path_id}"
+        if fold_id is not None or fold_label:
+            if fold_id is not None and fold_label:
+                label = f"fold {fold_id} ({fold_label}) {label}"
+            elif fold_id is not None:
+                label = f"fold {fold_id} {label}"
+            else:
+                label = f"fold {fold_label} {label}"
         if strategy_name:
             label += f" strategy {strategy_name}"
         self._logger.exception("Monte Carlo evaluation failed for %s: %s", label, exc)

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -100,6 +100,7 @@ class _PathContext:
     path_hash: str
     seed: int | None
     fold_id: int | None = None
+    fold_label: str | None = None
 
 
 def evaluate_strategies_for_path(
@@ -192,6 +193,7 @@ class MonteCarloRunner:
                     progress_callback=progress_callback,
                     jobs=worker_count,
                     fold_id=fold.fold_id,
+                    fold_label=fold.label,
                 )
                 evaluations.extend(fold_evals)
                 errors.extend(fold_errors)
@@ -207,6 +209,7 @@ class MonteCarloRunner:
                 progress_callback=progress_callback,
                 jobs=worker_count,
                 fold_id=None,
+                fold_label=None,
             )
 
         results_frame = build_results_frame(evaluations)
@@ -275,6 +278,7 @@ class MonteCarloRunner:
         progress_callback: Callable[[Mapping[str, Any]], None] | None,
         jobs: int,
         fold_id: int | None,
+        fold_label: str | None,
     ) -> tuple[list[StrategyEvaluation], list[MonteCarloPathError]]:
         if mode == "two_layer":
             return self._run_two_layer(
@@ -285,6 +289,7 @@ class MonteCarloRunner:
                 progress_callback=progress_callback,
                 jobs=jobs,
                 fold_id=fold_id,
+                fold_label=fold_label,
             )
         if mode == "mixture":
             return self._run_mixture(
@@ -296,6 +301,7 @@ class MonteCarloRunner:
                 progress_callback=progress_callback,
                 jobs=jobs,
                 fold_id=fold_id,
+                fold_label=fold_label,
             )
         raise ValueError(f"Unsupported Monte Carlo mode '{mode}'")
 
@@ -309,6 +315,7 @@ class MonteCarloRunner:
         progress_callback: Callable[[Mapping[str, Any]], None] | None,
         jobs: int,
         fold_id: int | None = None,
+        fold_label: str | None = None,
     ) -> tuple[list[StrategyEvaluation], list[MonteCarloPathError]]:
         total = len(path_seeds)
         evaluations: list[StrategyEvaluation] = []
@@ -351,6 +358,7 @@ class MonteCarloRunner:
                     path_result=path_result,
                     path_index=path_id,
                     fold_id=fold_id,
+                    fold_label=fold_label,
                 )
             except Exception as exc:
                 self._log_path_error(path_id, None, exc)
@@ -389,6 +397,7 @@ class MonteCarloRunner:
         progress_callback: Callable[[Mapping[str, Any]], None] | None,
         jobs: int,
         fold_id: int | None = None,
+        fold_label: str | None = None,
     ) -> tuple[list[StrategyEvaluation], list[MonteCarloPathError]]:
         if len(strategy_seeds) != len(path_seeds):
             raise ValueError("strategy_seeds must align with path_seeds")
@@ -423,6 +432,7 @@ class MonteCarloRunner:
                     path_result=path_result,
                     path_index=path_id,
                     fold_id=fold_id,
+                    fold_label=fold_label,
                 )
             except Exception as exc:
                 self._log_path_error(path_id, None, exc)
@@ -454,6 +464,7 @@ class MonteCarloRunner:
         path_result: Any | None = None,
         path_index: int = 0,
         fold_id: int | None,
+        fold_label: str | None,
     ) -> _PathContext:
         if path_result is None:
             result = model.sample_prices(
@@ -473,6 +484,7 @@ class MonteCarloRunner:
         path_hash = self._hash_frame(prices)
         return _PathContext(
             fold_id=fold_id,
+            fold_label=fold_label,
             path_id=path_id,
             prices=prices,
             returns=returns_df,
@@ -514,6 +526,7 @@ class MonteCarloRunner:
             diagnostic["costs"] = self._cost_payload_dict(cost_payload)
         return StrategyEvaluation(
             fold_id=context.fold_id,
+            fold_label=context.fold_label,
             path_id=context.path_id,
             strategy_name=strategy.name,
             metrics=metrics,

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -46,6 +46,7 @@ from .results import (
     MonteCarloResults,
     StrategyEvaluation,
     build_cross_fold_summary_frame,
+    build_pooled_distribution_frame,
     build_pooled_summary_frame,
     build_results_frame,
     build_summary_frame,
@@ -235,9 +236,12 @@ class MonteCarloRunner:
         pooled_summary_frame = (
             build_pooled_summary_frame(results_frame) if folds and pooled_distributions else None
         )
+        pooled_distribution_frame = (
+            build_pooled_distribution_frame(results_frame) if folds and pooled_distributions else None
+        )
         if folds:
             metadata["pooled_distributions"] = pooled_distributions
-            metadata["pooled_scope"] = "summary" if pooled_distributions else "none"
+            metadata["pooled_scope"] = "distribution" if pooled_distributions else "none"
         results = MonteCarloResults(
             mode=mode,
             evaluations=evaluations,
@@ -246,6 +250,7 @@ class MonteCarloRunner:
             summary_frame=summary_frame,
             cross_fold_summary_frame=cross_fold_summary_frame,
             pooled_summary_frame=pooled_summary_frame,
+            pooled_distribution_frame=pooled_distribution_frame,
             metadata=metadata,
         )
         self._maybe_export(results)

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -243,7 +243,12 @@ class MonteCarloRunner:
         )
         if folds:
             metadata["pooled_distributions"] = pooled_distributions
-            metadata["pooled_scope"] = "distribution" if pooled_distributions else "none"
+            if pooled_distributions:
+                metadata["pooled_scope"] = "summary+distribution"
+                metadata["pooled_outputs"] = ["summary", "distribution"]
+            else:
+                metadata["pooled_scope"] = "none"
+                metadata["pooled_outputs"] = []
         results = MonteCarloResults(
             mode=mode,
             evaluations=evaluations,

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -354,9 +354,7 @@ class MonteCarloRunner:
                 )
             except Exception as exc:
                 for path_id in range(total):
-                    self._log_path_error(
-                        path_id, None, exc, fold_id=fold_id, fold_label=fold_label
-                    )
+                    self._log_path_error(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
                     errors.append(
                         self._error_record(
                             path_id, None, exc, fold_id=fold_id, fold_label=fold_label

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -237,7 +237,9 @@ class MonteCarloRunner:
             build_pooled_summary_frame(results_frame) if folds and pooled_distributions else None
         )
         pooled_distribution_frame = (
-            build_pooled_distribution_frame(results_frame) if folds and pooled_distributions else None
+            build_pooled_distribution_frame(results_frame)
+            if folds and pooled_distributions
+            else None
         )
         if folds:
             metadata["pooled_distributions"] = pooled_distributions

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -367,9 +367,7 @@ class MonteCarloRunner:
             except Exception as exc:
                 self._log_path_error(path_id, None, exc)
                 return [], [
-                    self._error_record(
-                        path_id, None, exc, fold_id=fold_id, fold_label=fold_label
-                    )
+                    self._error_record(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
                 ]
 
             path_evals: list[StrategyEvaluation] = []
@@ -431,9 +429,7 @@ class MonteCarloRunner:
             for path_id in range(total):
                 self._log_path_error(path_id, None, exc)
                 errors.append(
-                    self._error_record(
-                        path_id, None, exc, fold_id=fold_id, fold_label=fold_label
-                    )
+                    self._error_record(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
                 )
             return evaluations, errors
 
@@ -455,9 +451,7 @@ class MonteCarloRunner:
             except Exception as exc:
                 self._log_path_error(path_id, None, exc)
                 return [], [
-                    self._error_record(
-                        path_id, None, exc, fold_id=fold_id, fold_label=fold_label
-                    )
+                    self._error_record(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
                 ]
 
             try:

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -343,7 +343,11 @@ class MonteCarloRunner:
             except Exception as exc:
                 for path_id in range(total):
                     self._log_path_error(path_id, None, exc)
-                    errors.append(self._error_record(path_id, None, exc, fold_id=fold_id))
+                    errors.append(
+                        self._error_record(
+                            path_id, None, exc, fold_id=fold_id, fold_label=fold_label
+                        )
+                    )
                 return evaluations, errors
 
         def _evaluate_path(
@@ -362,7 +366,11 @@ class MonteCarloRunner:
                 )
             except Exception as exc:
                 self._log_path_error(path_id, None, exc)
-                return [], [self._error_record(path_id, None, exc, fold_id=fold_id)]
+                return [], [
+                    self._error_record(
+                        path_id, None, exc, fold_id=fold_id, fold_label=fold_label
+                    )
+                ]
 
             path_evals: list[StrategyEvaluation] = []
             path_errors: list[MonteCarloPathError] = []
@@ -373,7 +381,13 @@ class MonteCarloRunner:
                 except Exception as exc:
                     self._log_path_error(path_id, strategy.name, exc)
                     path_errors.append(
-                        self._error_record(path_id, strategy.name, exc, fold_id=fold_id)
+                        self._error_record(
+                            path_id,
+                            strategy.name,
+                            exc,
+                            fold_id=fold_id,
+                            fold_label=fold_label,
+                        )
                     )
             return path_evals, path_errors
 
@@ -416,7 +430,11 @@ class MonteCarloRunner:
         except Exception as exc:
             for path_id in range(total):
                 self._log_path_error(path_id, None, exc)
-                errors.append(self._error_record(path_id, None, exc, fold_id=fold_id))
+                errors.append(
+                    self._error_record(
+                        path_id, None, exc, fold_id=fold_id, fold_label=fold_label
+                    )
+                )
             return evaluations, errors
 
         def _evaluate_path(
@@ -436,14 +454,26 @@ class MonteCarloRunner:
                 )
             except Exception as exc:
                 self._log_path_error(path_id, None, exc)
-                return [], [self._error_record(path_id, None, exc, fold_id=fold_id)]
+                return [], [
+                    self._error_record(
+                        path_id, None, exc, fold_id=fold_id, fold_label=fold_label
+                    )
+                ]
 
             try:
                 evaluation = self._evaluate_strategy(strategy, context)
                 return [evaluation], []
             except Exception as exc:
                 self._log_path_error(path_id, strategy.name, exc)
-                return [], [self._error_record(path_id, strategy.name, exc, fold_id=fold_id)]
+                return [], [
+                    self._error_record(
+                        path_id,
+                        strategy.name,
+                        exc,
+                        fold_id=fold_id,
+                        fold_label=fold_label,
+                    )
+                ]
 
         completed = 0
         for path_id, path_eval, path_err in self._execute_paths(path_seeds, _evaluate_path, jobs):
@@ -1024,9 +1054,11 @@ class MonteCarloRunner:
         exc: Exception,
         *,
         fold_id: int | None = None,
+        fold_label: str | None = None,
     ) -> MonteCarloPathError:
         return MonteCarloPathError(
             fold_id=fold_id,
+            fold_label=fold_label,
             path_id=path_id,
             strategy_name=strategy_name,
             error_type=type(exc).__name__,

--- a/tests/monte_carlo/test_folds.py
+++ b/tests/monte_carlo/test_folds.py
@@ -10,6 +10,29 @@ from trend_analysis.monte_carlo.folds import (
 )
 
 
+def test_from_config_returns_none_when_disabled() -> None:
+    generator = FoldGenerator.from_config({"enabled": False, "mode": "explicit"})
+
+    assert generator is None
+
+
+def test_generate_sorts_and_drops_timezone_from_index() -> None:
+    index = pd.DatetimeIndex(
+        [
+            "2021-03-31",
+            "2021-01-31",
+            "2021-02-28",
+        ]
+    ).tz_localize("UTC")
+    generator = FoldGenerator(mode="count_spaced", start="2021-02-15", n_folds=1)
+
+    folds = generator.generate(index)
+
+    assert folds[0].forecast_start == pd.Timestamp("2021-02-28")
+    assert folds[0].calibration_end == pd.Timestamp("2021-01-31")
+    assert folds[0].calibration_start == pd.Timestamp("2021-01-31")
+
+
 def test_explicit_mode_requires_fold_starts() -> None:
     index = pd.date_range("2020-01-31", periods=6, freq="ME")
 

--- a/tests/monte_carlo/test_folds.py
+++ b/tests/monte_carlo/test_folds.py
@@ -142,6 +142,24 @@ def test_count_spaced_mode_shifts_start_for_lookback() -> None:
     assert folds[0].calibration_start == pd.Timestamp("2020-01-31")
 
 
+def test_count_spaced_mode_single_fold_respects_lookback() -> None:
+    index = pd.date_range("2020-01-31", periods=36, freq="ME")
+    generator = FoldGenerator(
+        mode="count_spaced",
+        start="2020-01-31",
+        end="2022-12-31",
+        n_folds=1,
+        calibration_lookback_years=1.0,
+    )
+
+    folds = generator.generate(index)
+
+    assert len(folds) == 1
+    assert folds[0].forecast_start == pd.Timestamp("2021-01-31")
+    assert folds[0].calibration_end == pd.Timestamp("2020-12-31")
+    assert folds[0].calibration_start == pd.Timestamp("2020-01-31")
+
+
 def test_count_spaced_mode_rejects_invalid_range() -> None:
     index = pd.date_range("2020-01-31", periods=6, freq="ME")
     generator = FoldGenerator(

--- a/tests/monte_carlo/test_results.py
+++ b/tests/monte_carlo/test_results.py
@@ -165,8 +165,8 @@ def test_build_cross_fold_summary_frame_counts_folds_per_strategy() -> None:
         ]
     )
 
-    cross_fold = build_cross_fold_summary_frame(frame).sort_values("strategy").reset_index(
-        drop=True
+    cross_fold = (
+        build_cross_fold_summary_frame(frame).sort_values("strategy").reset_index(drop=True)
     )
 
     assert cross_fold.loc[0, "strategy"] == "A"

--- a/tests/monte_carlo/test_results.py
+++ b/tests/monte_carlo/test_results.py
@@ -89,6 +89,13 @@ def test_build_pooled_summary_frame_ignores_folds() -> None:
     assert pooled.loc[0, "folds"] == 2
 
 
+def test_build_pooled_summary_frame_empty_returns_columns() -> None:
+    pooled = build_pooled_summary_frame(pd.DataFrame())
+
+    assert list(pooled.columns) == ["scope", "pooled_scope", "fold_id", "strategy", "paths", "folds"]
+    assert pooled.empty
+
+
 def test_build_cross_fold_summary_frame_reports_fold_stats() -> None:
     frame = pd.DataFrame(
         [
@@ -123,6 +130,20 @@ def test_build_cross_fold_summary_frame_reports_fold_stats() -> None:
     assert cross_fold.loc[0, "paths_min"] == 2.0
     assert cross_fold.loc[0, "paths_max"] == 2.0
     assert cross_fold.loc[0, "paths_median"] == 2.0
+
+
+def test_build_cross_fold_summary_frame_empty_without_fold_id() -> None:
+    frame = pd.DataFrame(
+        [
+            {"path_id": 1, "strategy": "A", "metric": 1.0},
+            {"path_id": 2, "strategy": "A", "metric": 2.0},
+        ]
+    )
+
+    cross_fold = build_cross_fold_summary_frame(frame)
+
+    assert list(cross_fold.columns) == ["scope", "fold_id", "strategy", "folds"]
+    assert cross_fold.empty
 
 
 def test_export_results_writes_pooled_summary(tmp_path) -> None:

--- a/tests/monte_carlo/test_results.py
+++ b/tests/monte_carlo/test_results.py
@@ -17,6 +17,7 @@ from trend_analysis.monte_carlo.results import (
 def test_build_results_frame_includes_fold_id_and_base_columns() -> None:
     evaluation = StrategyEvaluation(
         fold_id=2,
+        fold_label="2020-02",
         path_id=7,
         strategy_name="StrategyA",
         metrics={"alpha": 1.5, "beta": 0.8},
@@ -30,6 +31,7 @@ def test_build_results_frame_includes_fold_id_and_base_columns() -> None:
     assert "fold_id" in frame.columns
     assert list(frame.columns[: len(RESULT_BASE_COLUMNS)]) == list(RESULT_BASE_COLUMNS)
     assert frame.loc[0, "fold_id"] == 2
+    assert frame.loc[0, "fold_label"] == "2020-02"
     assert frame.loc[0, "path_id"] == 7
     assert frame.loc[0, "strategy"] == "StrategyA"
 
@@ -56,21 +58,22 @@ def test_build_results_frame_missing_fold_id_keeps_column() -> None:
 
     assert "fold_id" in frame.columns
     assert pd.isna(frame.loc[0, "fold_id"])
+    assert pd.isna(frame.loc[0, "fold_label"])
 
 
 def test_build_summary_frame_groups_by_fold_id() -> None:
     frame = pd.DataFrame(
         [
-            {"fold_id": 1, "path_id": 1, "strategy": "A", "metric": 1.0},
-            {"fold_id": 1, "path_id": 2, "strategy": "A", "metric": 3.0},
-            {"fold_id": 2, "path_id": 3, "strategy": "A", "metric": 2.0},
-            {"fold_id": 2, "path_id": 4, "strategy": "B", "metric": 4.0},
+            {"fold_id": 1, "fold_label": "2020-01", "path_id": 1, "strategy": "A", "metric": 1.0},
+            {"fold_id": 1, "fold_label": "2020-01", "path_id": 2, "strategy": "A", "metric": 3.0},
+            {"fold_id": 2, "fold_label": "2020-02", "path_id": 3, "strategy": "A", "metric": 2.0},
+            {"fold_id": 2, "fold_label": "2020-02", "path_id": 4, "strategy": "B", "metric": 4.0},
         ]
     )
 
     summary = build_summary_frame(frame).sort_values(["fold_id", "strategy"]).reset_index(drop=True)
 
-    assert list(summary.columns[:2]) == ["fold_id", "strategy"]
+    assert list(summary.columns[:3]) == ["fold_id", "fold_label", "strategy"]
     assert summary.loc[0, "paths"] == 2
     assert summary.loc[0, "metric"] == 2.0
 
@@ -80,17 +83,17 @@ def test_build_summary_frame_empty_includes_fold_id_if_present() -> None:
 
     summary = build_summary_frame(frame)
 
-    assert list(summary.columns) == ["fold_id", "strategy", "paths"]
+    assert list(summary.columns) == ["fold_id", "fold_label", "strategy", "paths"]
     assert summary.empty
 
 
 def test_build_pooled_summary_frame_ignores_folds() -> None:
     frame = pd.DataFrame(
         [
-            {"fold_id": 1, "path_id": 1, "strategy": "A", "metric": 1.0},
-            {"fold_id": 1, "path_id": 2, "strategy": "A", "metric": 3.0},
-            {"fold_id": 2, "path_id": 3, "strategy": "A", "metric": 5.0},
-            {"fold_id": 2, "path_id": 4, "strategy": "A", "metric": 7.0},
+            {"fold_id": 1, "fold_label": "2020-01", "path_id": 1, "strategy": "A", "metric": 1.0},
+            {"fold_id": 1, "fold_label": "2020-01", "path_id": 2, "strategy": "A", "metric": 3.0},
+            {"fold_id": 2, "fold_label": "2020-02", "path_id": 3, "strategy": "A", "metric": 5.0},
+            {"fold_id": 2, "fold_label": "2020-02", "path_id": 4, "strategy": "A", "metric": 7.0},
         ]
     )
 
@@ -100,6 +103,8 @@ def test_build_pooled_summary_frame_ignores_folds() -> None:
     assert pooled.loc[0, "pooled_scope"] == "summary"
     assert "fold_id" in pooled.columns
     assert pd.isna(pooled.loc[0, "fold_id"])
+    assert "fold_label" in pooled.columns
+    assert pd.isna(pooled.loc[0, "fold_label"])
     assert pooled.loc[0, "strategy"] == "A"
     assert pooled.loc[0, "metric"] == 4.0
     assert pooled.loc[0, "paths"] == 4
@@ -113,6 +118,7 @@ def test_build_pooled_summary_frame_empty_returns_columns() -> None:
         "scope",
         "pooled_scope",
         "fold_id",
+        "fold_label",
         "strategy",
         "paths",
         "folds",
@@ -192,9 +198,9 @@ def test_build_cross_fold_summary_frame_empty_without_fold_id() -> None:
 def test_export_results_writes_pooled_summary(tmp_path) -> None:
     frame = pd.DataFrame(
         [
-            {"fold_id": 1, "path_id": 1, "strategy": "A", "metric": 1.0},
-            {"fold_id": 1, "path_id": 2, "strategy": "A", "metric": 3.0},
-            {"fold_id": 2, "path_id": 3, "strategy": "A", "metric": 5.0},
+            {"fold_id": 1, "fold_label": "2020-01", "path_id": 1, "strategy": "A", "metric": 1.0},
+            {"fold_id": 1, "fold_label": "2020-01", "path_id": 2, "strategy": "A", "metric": 3.0},
+            {"fold_id": 2, "fold_label": "2020-02", "path_id": 3, "strategy": "A", "metric": 5.0},
         ]
     )
     summary = build_summary_frame(frame)
@@ -216,12 +222,16 @@ def test_export_results_writes_pooled_summary(tmp_path) -> None:
     results_path = exported["results_csv"]
     results_frame = pd.read_csv(results_path)
     assert "fold_id" in results_frame.columns
+    assert "fold_label" in results_frame.columns
     assert set(results_frame["fold_id"].tolist()) == {1, 2}
+    assert set(results_frame["fold_label"].tolist()) == {"2020-01", "2020-02"}
 
     summary_path = exported["summary_csv"]
     summary_frame = pd.read_csv(summary_path)
     assert "fold_id" in summary_frame.columns
+    assert "fold_label" in summary_frame.columns
     assert set(summary_frame["fold_id"].tolist()) == {1, 2}
+    assert set(summary_frame["fold_label"].tolist()) == {"2020-01", "2020-02"}
 
     cross_path = exported["cross_fold_summary_csv"]
     cross_frame = pd.read_csv(cross_path)
@@ -236,6 +246,8 @@ def test_export_results_writes_pooled_summary(tmp_path) -> None:
     assert pooled_frame.loc[0, "pooled_scope"] == "summary"
     assert "fold_id" in pooled_frame.columns
     assert pd.isna(pooled_frame.loc[0, "fold_id"])
+    assert "fold_label" in pooled_frame.columns
+    assert pd.isna(pooled_frame.loc[0, "fold_label"])
     assert pooled_frame.loc[0, "paths"] == 3
     assert pooled_frame.loc[0, "folds"] == 2
 

--- a/tests/monte_carlo/test_results.py
+++ b/tests/monte_carlo/test_results.py
@@ -217,6 +217,8 @@ def test_export_results_writes_pooled_summary(tmp_path) -> None:
     assert pooled_frame.loc[0, "pooled_scope"] == "summary"
     assert "fold_id" in pooled_frame.columns
     assert pd.isna(pooled_frame.loc[0, "fold_id"])
+    assert pooled_frame.loc[0, "paths"] == 3
+    assert pooled_frame.loc[0, "folds"] == 2
 
 
 def test_export_results_skips_pooled_summary_when_missing(tmp_path) -> None:

--- a/tests/monte_carlo/test_results.py
+++ b/tests/monte_carlo/test_results.py
@@ -92,7 +92,14 @@ def test_build_pooled_summary_frame_ignores_folds() -> None:
 def test_build_pooled_summary_frame_empty_returns_columns() -> None:
     pooled = build_pooled_summary_frame(pd.DataFrame())
 
-    assert list(pooled.columns) == ["scope", "pooled_scope", "fold_id", "strategy", "paths", "folds"]
+    assert list(pooled.columns) == [
+        "scope",
+        "pooled_scope",
+        "fold_id",
+        "strategy",
+        "paths",
+        "folds",
+    ]
     assert pooled.empty
 
 

--- a/tests/monte_carlo/test_results.py
+++ b/tests/monte_carlo/test_results.py
@@ -41,6 +41,23 @@ def test_build_results_frame_empty_has_base_columns() -> None:
     assert frame.empty
 
 
+def test_build_results_frame_missing_fold_id_keeps_column() -> None:
+    evaluation = StrategyEvaluation(
+        fold_id=None,
+        path_id=9,
+        strategy_name="StrategyB",
+        metrics={"alpha": 2.5},
+        metric_source="unit_test",
+        path_hash="hash-2",
+        seed=456,
+    )
+
+    frame = build_results_frame([evaluation])
+
+    assert "fold_id" in frame.columns
+    assert pd.isna(frame.loc[0, "fold_id"])
+
+
 def test_build_summary_frame_groups_by_fold_id() -> None:
     frame = pd.DataFrame(
         [
@@ -189,6 +206,7 @@ def test_export_results_writes_pooled_summary(tmp_path) -> None:
 
     cross_path = exported["cross_fold_summary_csv"]
     cross_frame = pd.read_csv(cross_path)
+    assert cross_frame.loc[0, "scope"] == "cross_fold"
     assert "fold_id" in cross_frame.columns
     assert pd.isna(cross_frame.loc[0, "fold_id"])
 

--- a/tests/monte_carlo/test_results.py
+++ b/tests/monte_carlo/test_results.py
@@ -7,6 +7,7 @@ from trend_analysis.monte_carlo.results import (
     MonteCarloResults,
     StrategyEvaluation,
     build_cross_fold_summary_frame,
+    build_pooled_distribution_frame,
     build_pooled_summary_frame,
     build_results_frame,
     build_summary_frame,
@@ -126,6 +127,41 @@ def test_build_pooled_summary_frame_empty_returns_columns() -> None:
     assert pooled.empty
 
 
+def test_build_pooled_distribution_frame_includes_labels() -> None:
+    frame = pd.DataFrame(
+        [
+            {
+                "fold_id": 1,
+                "fold_label": "2020-01",
+                "path_id": 1,
+                "strategy": "A",
+                "metric": 1.0,
+            },
+            {
+                "fold_id": 2,
+                "fold_label": "2020-02",
+                "path_id": 2,
+                "strategy": "A",
+                "metric": 2.0,
+            },
+        ]
+    )
+
+    pooled = build_pooled_distribution_frame(frame)
+
+    assert pooled.loc[0, "scope"] == "pooled"
+    assert pooled.loc[0, "pooled_scope"] == "distribution"
+    assert pooled.loc[0, "fold_id"] == 1
+    assert pooled.loc[0, "fold_label"] == "2020-01"
+
+
+def test_build_pooled_distribution_frame_empty_returns_columns() -> None:
+    pooled = build_pooled_distribution_frame(pd.DataFrame())
+
+    assert list(pooled.columns) == ["scope", "pooled_scope", *RESULT_BASE_COLUMNS]
+    assert pooled.empty
+
+
 def test_build_cross_fold_summary_frame_reports_fold_stats() -> None:
     frame = pd.DataFrame(
         [
@@ -205,6 +241,7 @@ def test_export_results_writes_pooled_summary(tmp_path) -> None:
     )
     summary = build_summary_frame(frame)
     pooled = build_pooled_summary_frame(frame)
+    pooled_distribution = build_pooled_distribution_frame(frame)
     cross_fold = build_cross_fold_summary_frame(frame)
     results = MonteCarloResults(
         mode="two_layer",
@@ -214,6 +251,7 @@ def test_export_results_writes_pooled_summary(tmp_path) -> None:
         summary_frame=summary,
         cross_fold_summary_frame=cross_fold,
         pooled_summary_frame=pooled,
+        pooled_distribution_frame=pooled_distribution,
         metadata={},
     )
 
@@ -251,6 +289,13 @@ def test_export_results_writes_pooled_summary(tmp_path) -> None:
     assert pooled_frame.loc[0, "paths"] == 3
     assert pooled_frame.loc[0, "folds"] == 2
 
+    pooled_dist_path = exported["pooled_distributions_csv"]
+    assert pooled_dist_path.exists()
+    pooled_dist = pd.read_csv(pooled_dist_path)
+    assert pooled_dist.loc[0, "scope"] == "pooled"
+    assert pooled_dist.loc[0, "pooled_scope"] == "distribution"
+    assert "fold_id" in pooled_dist.columns
+
 
 def test_export_results_skips_pooled_summary_when_missing(tmp_path) -> None:
     frame = pd.DataFrame(
@@ -269,9 +314,11 @@ def test_export_results_skips_pooled_summary_when_missing(tmp_path) -> None:
         summary_frame=summary,
         cross_fold_summary_frame=cross_fold,
         pooled_summary_frame=None,
+        pooled_distribution_frame=None,
         metadata={},
     )
 
     exported = export_results(results, tmp_path, formats=["csv"])
 
     assert "pooled_summary_csv" not in exported
+    assert "pooled_distributions_csv" not in exported

--- a/tests/monte_carlo/test_results.py
+++ b/tests/monte_carlo/test_results.py
@@ -156,6 +156,25 @@ def test_build_cross_fold_summary_frame_reports_fold_stats() -> None:
     assert cross_fold.loc[0, "paths_median"] == 2.0
 
 
+def test_build_cross_fold_summary_frame_counts_folds_per_strategy() -> None:
+    frame = pd.DataFrame(
+        [
+            {"fold_id": 1, "path_id": 1, "strategy": "A", "metric": 1.0},
+            {"fold_id": 2, "path_id": 2, "strategy": "A", "metric": 2.0},
+            {"fold_id": 2, "path_id": 3, "strategy": "B", "metric": 3.0},
+        ]
+    )
+
+    cross_fold = build_cross_fold_summary_frame(frame).sort_values("strategy").reset_index(
+        drop=True
+    )
+
+    assert cross_fold.loc[0, "strategy"] == "A"
+    assert cross_fold.loc[0, "folds"] == 2
+    assert cross_fold.loc[1, "strategy"] == "B"
+    assert cross_fold.loc[1, "folds"] == 1
+
+
 def test_build_cross_fold_summary_frame_empty_without_fold_id() -> None:
     frame = pd.DataFrame(
         [

--- a/tests/monte_carlo/test_runner.py
+++ b/tests/monte_carlo/test_runner.py
@@ -464,6 +464,7 @@ def test_runner_builds_cross_fold_summary_without_pooled_distributions(
     results = runner.run(jobs=1)
 
     assert results.pooled_summary_frame is None
+    assert results.metadata.get("pooled_distributions") is False
     cross_fold = results.cross_fold_summary_frame
     assert cross_fold is not None
     assert cross_fold.loc[0, "scope"] == "cross_fold"

--- a/tests/monte_carlo/test_runner.py
+++ b/tests/monte_carlo/test_runner.py
@@ -506,8 +506,7 @@ def test_runner_logs_fold_context_for_errors(caplog: pytest.LogCaptureFixture) -
         )
 
     assert any(
-        "fold 2 (2022-01) path 3 strategy StrategyA" in record.message
-        for record in caplog.records
+        "fold 2 (2022-01) path 3 strategy StrategyA" in record.message for record in caplog.records
     )
 
 

--- a/tests/monte_carlo/test_runner.py
+++ b/tests/monte_carlo/test_runner.py
@@ -530,9 +530,12 @@ def test_runner_builds_pooled_summary_when_enabled(
     assert results.pooled_summary_frame is not None
     assert results.pooled_summary_frame.loc[0, "scope"] == "pooled"
     assert results.pooled_summary_frame.loc[0, "pooled_scope"] == "summary"
+    assert results.pooled_distribution_frame is not None
+    assert results.pooled_distribution_frame.loc[0, "scope"] == "pooled"
+    assert results.pooled_distribution_frame.loc[0, "pooled_scope"] == "distribution"
     assert results.cross_fold_summary_frame is not None
     assert results.metadata.get("pooled_distributions") is True
-    assert results.metadata.get("pooled_scope") == "summary"
+    assert results.metadata.get("pooled_scope") == "distribution"
 
 
 def test_runner_builds_cross_fold_summary_without_pooled_distributions(
@@ -651,6 +654,8 @@ def test_runner_cross_fold_summary_stats_include_pooled_labels(
     assert pooled.loc[0, "scope"] == "pooled"
     assert pooled.loc[0, "pooled_scope"] == "summary"
     assert results.metadata.get("pooled_distributions") is True
+    assert results.pooled_distribution_frame is not None
+    assert results.pooled_distribution_frame.loc[0, "pooled_scope"] == "distribution"
 
 
 def test_runner_pooled_summary_includes_fold_count_when_enabled(
@@ -700,6 +705,7 @@ def test_runner_pooled_summary_includes_fold_count_when_enabled(
     assert pooled.loc[0, "pooled_scope"] == "summary"
     assert pooled.loc[0, "folds"] == 2
     assert results.metadata.get("pooled_distributions") is True
+    assert results.pooled_distribution_frame is not None
 
 
 def test_runner_exports_pooled_summary_when_enabled(
@@ -754,6 +760,12 @@ def test_runner_exports_pooled_summary_when_enabled(
     pooled_frame = pd.read_csv(pooled_path)
     assert pooled_frame.loc[0, "scope"] == "pooled"
     assert pooled_frame.loc[0, "pooled_scope"] == "summary"
+
+    pooled_dist_path = output_dir / "pooled_distributions.csv"
+    assert pooled_dist_path.exists()
+    pooled_dist = pd.read_csv(pooled_dist_path)
+    assert pooled_dist.loc[0, "scope"] == "pooled"
+    assert pooled_dist.loc[0, "pooled_scope"] == "distribution"
 
 
 def test_runner_includes_fold_ids_in_results_frame(

--- a/tests/monte_carlo/test_runner.py
+++ b/tests/monte_carlo/test_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import random
 from pathlib import Path
 from typing import Any
@@ -483,6 +484,31 @@ def test_runner_errors_include_fold_label(monkeypatch: pytest.MonkeyPatch) -> No
     assert results.errors
     assert {error.fold_id for error in results.errors} == {1}
     assert {error.fold_label for error in results.errors} == {"2022-01"}
+
+
+def test_runner_logs_fold_context_for_errors(caplog: pytest.LogCaptureFixture) -> None:
+    scenario = _scenario(mode="two_layer")
+    logger = logging.getLogger("trend_analysis.monte_carlo")
+    runner = MonteCarloRunner(
+        scenario,
+        base_config=_base_config(),
+        price_history=_price_history(),
+        logger=logger,
+    )
+
+    with caplog.at_level(logging.ERROR, logger="trend_analysis.monte_carlo"):
+        runner._log_path_error(
+            3,
+            "StrategyA",
+            RuntimeError("boom"),
+            fold_id=2,
+            fold_label="2022-01",
+        )
+
+    assert any(
+        "fold 2 (2022-01) path 3 strategy StrategyA" in record.message
+        for record in caplog.records
+    )
 
 
 def test_runner_builds_pooled_summary_when_enabled(

--- a/tests/monte_carlo/test_runner.py
+++ b/tests/monte_carlo/test_runner.py
@@ -509,6 +509,7 @@ def test_runner_builds_pooled_summary_when_enabled(
     assert results.pooled_summary_frame.loc[0, "pooled_scope"] == "summary"
     assert results.cross_fold_summary_frame is not None
     assert results.metadata.get("pooled_distributions") is True
+    assert results.metadata.get("pooled_scope") == "summary"
 
 
 def test_runner_builds_cross_fold_summary_without_pooled_distributions(
@@ -556,6 +557,7 @@ def test_runner_builds_cross_fold_summary_without_pooled_distributions(
 
     assert results.pooled_summary_frame is None
     assert results.metadata.get("pooled_distributions") is False
+    assert results.metadata.get("pooled_scope") == "none"
     cross_fold = results.cross_fold_summary_frame
     assert cross_fold is not None
     assert cross_fold.loc[0, "scope"] == "cross_fold"

--- a/tests/monte_carlo/test_runner.py
+++ b/tests/monte_carlo/test_runner.py
@@ -419,6 +419,62 @@ def test_runner_builds_pooled_summary_when_enabled(
     assert results.metadata.get("pooled_distributions") is True
 
 
+def test_runner_builds_cross_fold_summary_without_pooled_distributions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = _scenario_with_folds(
+        mode="two_layer",
+        folds={"mode": "explicit", "fold_starts": ["2022-01-31", "2023-01-31"]},
+    )
+    history = _price_history()
+    runner = MonteCarloRunner(
+        scenario,
+        base_config=_base_config(),
+        price_history=history,
+    )
+    seen_fold_ids: list[int] = []
+
+    def _fake_build_price_model(
+        self: MonteCarloRunner,
+        _history_slice: pd.DataFrame,
+        *,
+        calibration_start: pd.Timestamp | None = None,
+        calibration_end: pd.Timestamp | None = None,
+    ) -> object:
+        return object()
+
+    def _fake_run_mode(self: MonteCarloRunner, **kwargs: Any) -> tuple[list[Any], list[Any]]:
+        fold_id = int(kwargs.get("fold_id") or 0)
+        seen_fold_ids.append(fold_id)
+        evaluation = StrategyEvaluation(
+            fold_id=fold_id,
+            path_id=0,
+            strategy_name="StrategyA",
+            metrics={"metric": 1.0 + (fold_id * 2.0)},
+            metric_source="unit_test",
+            path_hash=f"hash-{fold_id}",
+            seed=0,
+        )
+        return [evaluation], []
+
+    monkeypatch.setattr(MonteCarloRunner, "_build_price_model", _fake_build_price_model)
+    monkeypatch.setattr(MonteCarloRunner, "_run_mode", _fake_run_mode)
+
+    results = runner.run(jobs=1)
+
+    assert results.pooled_summary_frame is None
+    cross_fold = results.cross_fold_summary_frame
+    assert cross_fold is not None
+    assert cross_fold.loc[0, "scope"] == "cross_fold"
+    assert pd.isna(cross_fold.loc[0, "fold_id"])
+    assert cross_fold.loc[0, "folds"] == 2
+    metric_values = [1.0 + (fold_id * 2.0) for fold_id in seen_fold_ids]
+    assert cross_fold.loc[0, "metric_mean"] == pytest.approx(float(np.mean(metric_values)))
+    assert cross_fold.loc[0, "metric_min"] == pytest.approx(float(np.min(metric_values)))
+    assert cross_fold.loc[0, "metric_max"] == pytest.approx(float(np.max(metric_values)))
+    assert cross_fold.loc[0, "metric_median"] == pytest.approx(float(np.median(metric_values)))
+
+
 def test_runner_includes_fold_ids_in_results_frame(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/monte_carlo/test_runner.py
+++ b/tests/monte_carlo/test_runner.py
@@ -535,6 +535,55 @@ def test_runner_cross_fold_summary_stats_include_pooled_labels(
     assert results.metadata.get("pooled_distributions") is True
 
 
+def test_runner_pooled_summary_includes_fold_count_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = _scenario_with_folds(
+        mode="two_layer",
+        folds={"mode": "explicit", "fold_starts": ["2022-01-31", "2023-01-31"]},
+        outputs={"pooled_distributions": True},
+    )
+    runner = MonteCarloRunner(
+        scenario,
+        base_config=_base_config(),
+        price_history=_price_history(),
+    )
+
+    def _fake_build_price_model(
+        self: MonteCarloRunner,
+        _history_slice: pd.DataFrame,
+        *,
+        calibration_start: pd.Timestamp | None = None,
+        calibration_end: pd.Timestamp | None = None,
+    ) -> object:
+        return object()
+
+    def _fake_run_mode(self: MonteCarloRunner, **kwargs: Any) -> tuple[list[Any], list[Any]]:
+        fold_id = int(kwargs.get("fold_id") or 0)
+        evaluation = StrategyEvaluation(
+            fold_id=fold_id,
+            path_id=0,
+            strategy_name="StrategyA",
+            metrics={"metric": 5.0 + fold_id},
+            metric_source="unit_test",
+            path_hash=f"hash-{fold_id}",
+            seed=0,
+        )
+        return [evaluation], []
+
+    monkeypatch.setattr(MonteCarloRunner, "_build_price_model", _fake_build_price_model)
+    monkeypatch.setattr(MonteCarloRunner, "_run_mode", _fake_run_mode)
+
+    results = runner.run(jobs=1)
+
+    pooled = results.pooled_summary_frame
+    assert pooled is not None
+    assert pooled.loc[0, "scope"] == "pooled"
+    assert pooled.loc[0, "pooled_scope"] == "summary"
+    assert pooled.loc[0, "folds"] == 2
+    assert results.metadata.get("pooled_distributions") is True
+
+
 def test_runner_includes_fold_ids_in_results_frame(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/monte_carlo/test_runner.py
+++ b/tests/monte_carlo/test_runner.py
@@ -763,10 +763,12 @@ def test_runner_includes_fold_ids_in_results_frame(
         self: MonteCarloRunner,
         *,
         fold_id: int | None,
+        fold_label: str | None,
         **_kwargs: Any,
     ) -> tuple[list[StrategyEvaluation], list[Any]]:
         evaluation = StrategyEvaluation(
             fold_id=fold_id,
+            fold_label=fold_label,
             path_id=0,
             strategy_name="StrategyA",
             metrics={"metric": 1.0},
@@ -782,6 +784,7 @@ def test_runner_includes_fold_ids_in_results_frame(
     results = runner.run(jobs=1)
 
     assert results.results_frame["fold_id"].dropna().tolist() == [1, 2]
+    assert results.results_frame["fold_label"].dropna().tolist() == ["2022-01", "2023-01"]
 
 
 def test_resolve_strategies_includes_sampled_turnover_caps() -> None:

--- a/tests/monte_carlo/test_runner.py
+++ b/tests/monte_carlo/test_runner.py
@@ -462,6 +462,29 @@ def test_runner_respects_enable_fold_runs_flag(monkeypatch: pytest.MonkeyPatch) 
     assert captured_calibration == [(None, None)]
 
 
+def test_runner_errors_include_fold_label(monkeypatch: pytest.MonkeyPatch) -> None:
+    scenario = _scenario_with_folds(
+        mode="two_layer",
+        folds={"mode": "explicit", "fold_starts": ["2022-01-31"]},
+    )
+    runner = MonteCarloRunner(
+        scenario,
+        base_config=_base_config(),
+        price_history=_price_history(),
+    )
+
+    def _boom(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(runner, "_generate_path_context", _boom)
+
+    results = runner.run(jobs=1)
+
+    assert results.errors
+    assert {error.fold_id for error in results.errors} == {1}
+    assert {error.fold_label for error in results.errors} == {"2022-01"}
+
+
 def test_runner_builds_pooled_summary_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/monte_carlo/test_runner.py
+++ b/tests/monte_carlo/test_runner.py
@@ -475,6 +475,66 @@ def test_runner_builds_cross_fold_summary_without_pooled_distributions(
     assert cross_fold.loc[0, "metric_median"] == pytest.approx(float(np.median(metric_values)))
 
 
+def test_runner_cross_fold_summary_stats_include_pooled_labels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = _scenario_with_folds(
+        mode="two_layer",
+        folds={"mode": "explicit", "fold_starts": ["2022-01-31", "2023-01-31"]},
+        outputs={"pooled_distributions": True},
+    )
+    runner = MonteCarloRunner(
+        scenario,
+        base_config=_base_config(),
+        price_history=_price_history(),
+    )
+    seen_fold_ids: list[int] = []
+
+    def _fake_build_price_model(
+        self: MonteCarloRunner,
+        _history_slice: pd.DataFrame,
+        *,
+        calibration_start: pd.Timestamp | None = None,
+        calibration_end: pd.Timestamp | None = None,
+    ) -> object:
+        return object()
+
+    def _fake_run_mode(self: MonteCarloRunner, **kwargs: Any) -> tuple[list[Any], list[Any]]:
+        fold_id = int(kwargs.get("fold_id") or 0)
+        seen_fold_ids.append(fold_id)
+        evaluation = StrategyEvaluation(
+            fold_id=fold_id,
+            path_id=0,
+            strategy_name="StrategyA",
+            metrics={"metric": 10.0 + fold_id},
+            metric_source="unit_test",
+            path_hash=f"hash-{fold_id}",
+            seed=0,
+        )
+        return [evaluation], []
+
+    monkeypatch.setattr(MonteCarloRunner, "_build_price_model", _fake_build_price_model)
+    monkeypatch.setattr(MonteCarloRunner, "_run_mode", _fake_run_mode)
+
+    results = runner.run(jobs=1)
+
+    cross_fold = results.cross_fold_summary_frame
+    assert cross_fold is not None
+    assert cross_fold.loc[0, "scope"] == "cross_fold"
+    assert cross_fold.loc[0, "folds"] == 2
+    metric_values = [10.0 + fold_id for fold_id in seen_fold_ids]
+    assert cross_fold.loc[0, "metric_mean"] == pytest.approx(float(np.mean(metric_values)))
+    assert cross_fold.loc[0, "metric_min"] == pytest.approx(float(np.min(metric_values)))
+    assert cross_fold.loc[0, "metric_max"] == pytest.approx(float(np.max(metric_values)))
+    assert cross_fold.loc[0, "metric_median"] == pytest.approx(float(np.median(metric_values)))
+
+    pooled = results.pooled_summary_frame
+    assert pooled is not None
+    assert pooled.loc[0, "scope"] == "pooled"
+    assert pooled.loc[0, "pooled_scope"] == "summary"
+    assert results.metadata.get("pooled_distributions") is True
+
+
 def test_runner_includes_fold_ids_in_results_frame(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/monte_carlo/test_runner.py
+++ b/tests/monte_carlo/test_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import random
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -582,6 +583,60 @@ def test_runner_pooled_summary_includes_fold_count_when_enabled(
     assert pooled.loc[0, "pooled_scope"] == "summary"
     assert pooled.loc[0, "folds"] == 2
     assert results.metadata.get("pooled_distributions") is True
+
+
+def test_runner_exports_pooled_summary_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "mc_outputs"
+    scenario = _scenario_with_folds(
+        mode="two_layer",
+        folds={"mode": "explicit", "fold_starts": ["2022-01-31"]},
+        outputs={
+            "directory": str(output_dir),
+            "formats": ["csv"],
+            "pooled_distributions": True,
+        },
+    )
+    runner = MonteCarloRunner(
+        scenario,
+        base_config=_base_config(),
+        price_history=_price_history(),
+    )
+
+    def _fake_build_price_model(
+        self: MonteCarloRunner,
+        _history_slice: pd.DataFrame,
+        *,
+        calibration_start: pd.Timestamp | None = None,
+        calibration_end: pd.Timestamp | None = None,
+    ) -> object:
+        return object()
+
+    def _fake_run_mode(self: MonteCarloRunner, **kwargs: Any) -> tuple[list[Any], list[Any]]:
+        fold_id = kwargs.get("fold_id")
+        evaluation = StrategyEvaluation(
+            fold_id=fold_id,
+            path_id=0,
+            strategy_name="StrategyA",
+            metrics={"metric": 1.0},
+            metric_source="unit_test",
+            path_hash="hash",
+            seed=0,
+        )
+        return [evaluation], []
+
+    monkeypatch.setattr(MonteCarloRunner, "_build_price_model", _fake_build_price_model)
+    monkeypatch.setattr(MonteCarloRunner, "_run_mode", _fake_run_mode)
+
+    runner.run(jobs=1)
+
+    pooled_path = output_dir / "pooled_summary.csv"
+    assert pooled_path.exists()
+    pooled_frame = pd.read_csv(pooled_path)
+    assert pooled_frame.loc[0, "scope"] == "pooled"
+    assert pooled_frame.loc[0, "pooled_scope"] == "summary"
 
 
 def test_runner_includes_fold_ids_in_results_frame(

--- a/tests/monte_carlo/test_runner.py
+++ b/tests/monte_carlo/test_runner.py
@@ -283,6 +283,97 @@ def test_runner_uses_fold_calibration_window(monkeypatch: pytest.MonkeyPatch) ->
     assert captured[0]["calibration_end"] == pd.Timestamp("2021-12-31")
 
 
+def test_runner_uses_rolling_fold_calibration_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = _scenario_with_folds(
+        mode="two_layer",
+        folds={
+            "mode": "rolling",
+            "start": "2021-03-15",
+            "end": "2021-09-30",
+            "step_months": 3,
+            "calibration_lookback_years": 1.0,
+        },
+    )
+    history = _price_history()
+    runner = MonteCarloRunner(
+        scenario,
+        base_config=_base_config(),
+        price_history=history,
+    )
+    captured: list[tuple[pd.Timestamp | None, pd.Timestamp | None]] = []
+
+    def _fake_build_price_model(
+        self: MonteCarloRunner,
+        _history_slice: pd.DataFrame,
+        *,
+        calibration_start: pd.Timestamp | None = None,
+        calibration_end: pd.Timestamp | None = None,
+    ) -> object:
+        captured.append((calibration_start, calibration_end))
+        return object()
+
+    def _fake_run_mode(self: MonteCarloRunner, **_kwargs: Any) -> tuple[list[Any], list[Any]]:
+        return [], []
+
+    monkeypatch.setattr(MonteCarloRunner, "_build_price_model", _fake_build_price_model)
+    monkeypatch.setattr(MonteCarloRunner, "_run_mode", _fake_run_mode)
+
+    runner.run(jobs=1)
+
+    assert captured == [
+        (pd.Timestamp("2020-02-29"), pd.Timestamp("2021-02-28")),
+        (pd.Timestamp("2020-05-31"), pd.Timestamp("2021-05-31")),
+        (pd.Timestamp("2020-08-31"), pd.Timestamp("2021-08-31")),
+    ]
+
+
+def test_runner_uses_count_spaced_fold_calibration_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = _scenario_with_folds(
+        mode="two_layer",
+        folds={
+            "mode": "count_spaced",
+            "start": "2021-01-31",
+            "end": "2021-12-31",
+            "n_folds": 2,
+            "calibration_lookback_years": 1.0,
+        },
+    )
+    history = _price_history()
+    runner = MonteCarloRunner(
+        scenario,
+        base_config=_base_config(),
+        price_history=history,
+    )
+    captured: list[tuple[pd.Timestamp | None, pd.Timestamp | None]] = []
+
+    def _fake_build_price_model(
+        self: MonteCarloRunner,
+        _history_slice: pd.DataFrame,
+        *,
+        calibration_start: pd.Timestamp | None = None,
+        calibration_end: pd.Timestamp | None = None,
+    ) -> object:
+        captured.append((calibration_start, calibration_end))
+        return object()
+
+    def _fake_run_mode(self: MonteCarloRunner, **_kwargs: Any) -> tuple[list[Any], list[Any]]:
+        return [], []
+
+    monkeypatch.setattr(MonteCarloRunner, "_build_price_model", _fake_build_price_model)
+    monkeypatch.setattr(MonteCarloRunner, "_run_mode", _fake_run_mode)
+
+    runner.run(jobs=1)
+
+    assert captured == [
+        (pd.Timestamp("2020-01-31"), pd.Timestamp("2020-12-31")),
+        (pd.Timestamp("2020-11-30"), pd.Timestamp("2021-11-30")),
+    ]
+
+
 def test_build_price_model_applies_calibration_window_after_normalization() -> None:
     scenario = _scenario("two_layer")
     history = _daily_price_history()

--- a/tests/monte_carlo/test_runner.py
+++ b/tests/monte_carlo/test_runner.py
@@ -535,7 +535,8 @@ def test_runner_builds_pooled_summary_when_enabled(
     assert results.pooled_distribution_frame.loc[0, "pooled_scope"] == "distribution"
     assert results.cross_fold_summary_frame is not None
     assert results.metadata.get("pooled_distributions") is True
-    assert results.metadata.get("pooled_scope") == "distribution"
+    assert results.metadata.get("pooled_scope") == "summary+distribution"
+    assert results.metadata.get("pooled_outputs") == ["summary", "distribution"]
 
 
 def test_runner_builds_cross_fold_summary_without_pooled_distributions(
@@ -584,6 +585,7 @@ def test_runner_builds_cross_fold_summary_without_pooled_distributions(
     assert results.pooled_summary_frame is None
     assert results.metadata.get("pooled_distributions") is False
     assert results.metadata.get("pooled_scope") == "none"
+    assert results.metadata.get("pooled_outputs") == []
     cross_fold = results.cross_fold_summary_frame
     assert cross_fold is not None
     assert cross_fold.loc[0, "scope"] == "cross_fold"


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Support multiple folds (vintages) in Monte Carlo scenarios to test robustness across different calibration/forecast periods.


<!-- Preserved from parent issue -->
Support multiple folds (vintages) in Monte Carlo scenarios to test robustness across different calibration/forecast periods.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Trend_Model_Project#4684](https://github.com/stranske/Trend_Model_Project/issues/4684)
- [#4684](https://github.com/stranske/Trend_Model_Project/issues/4684)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Create unit tests for fold generation logic in the relevant test file.
- [x] Write unit tests for explicit fold generation logic. (verify: tests pass)
- [x] Write unit tests for rolling fold generation logic. (verify: tests pass)
- [x] Write unit tests for count_spaced fold generation logic. (verify: tests pass)
- [x] Add unit tests for fold-aware outputs in the appropriate test file.
- [x] Write unit tests to verify fold IDs are included in result tables.
- [x] Write unit tests to verify cross-fold comparison summaries are generated.
- [x] Write unit tests to verify optional pooled distributions are included
- [ ] labeled. (verify: confirm completion in repo)
- [ ] <!-- New tasks to address unmet acceptance criteria -->
- [x] Unit tests for fold generation logic pass.
- [x] Unit tests for fold-aware outputs pass.

#### Acceptance criteria
- [x] Unit tests for fold generation logic pass.
- [x] Unit tests for fold-aware outputs pass.
- [ ] <!-- Criteria verified as unmet by verifier -->
- [x] Unit tests for fold generation logic pass.
- [x] Unit tests for fold-aware outputs pass.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Source

- Original PR: [#4684](https://github.com/stranske/Trend_Model_Project/pull/4684)
- Verifier verdict: FAIL
- Verifier run: [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/21619883359)

## Why

<!-- Preserved from parent issue -->
Support multiple folds (vintages) in Monte Carlo scenarios to test robustness across different calibration/forecast periods.

## Scope

<!-- Updated scope for this follow-up -->
Address unmet acceptance criteria from PR #4684.

Original scope:
Support multiple folds (vintages) in Monte Carlo scenarios to test robustness across different calibration/forecast periods.

## Non-Goals

<!-- Preserved from parent issue -->
_Not provided._

## Tasks

<!-- New tasks to address unmet acceptance criteria -->
- [ ] Unit tests for fold generation logic pass.
- [ ] Unit tests for fold-aware outputs pass.

## Acceptance Criteria

<!-- Criteria verified as unmet by verifier -->
- [ ] Unit tests for fold generation logic pass.
- [ ] Unit tests for fold-aware outputs pass.

## Implementation Notes


Verifier confirmed these criteria were met:
- ✓ Fold runs can be enabled/disabled by scenario config.
- ✓ All three fold modes work (explicit, rolling, count_spaced).
- ✓ Each fold uses correct calibration window for return model fitting.
- ✓ Output includes fold ID in all result tables.
- ✓ Cross-fold comparison summary is generated.
- ✓ Optional pooled distributions are included and clearly labeled.

Original implementation in PR #4684.



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #4687

<!-- pr-preamble:end -->