### PR TITLE
Codex bootstrap for #4724

### DIFF
--- a/agents/codex-4724.md
+++ b/agents/codex-4724.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #4724 -->

--- a/tests/monte_carlo/strategy/test_curated_pack.py
+++ b/tests/monte_carlo/strategy/test_curated_pack.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import yaml
 
 from trend_analysis.config.model import TrendConfig
+from trend_analysis.config.schema_validation import load_schema, validate_config_data
 from trend_analysis.monte_carlo.strategy import StrategyVariant
 
 
@@ -13,6 +14,7 @@ def test_hf_equity_curated_strategies_validate_against_schema() -> None:
     base_path = Path("config/defaults.yml")
     base_config = yaml.safe_load(base_path.read_text(encoding="utf-8"))
     baseline = deepcopy(base_config)
+    schema = load_schema()
 
     strategy_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
     payload = yaml.safe_load(strategy_path.read_text(encoding="utf-8"))
@@ -28,6 +30,10 @@ def test_hf_equity_curated_strategies_validate_against_schema() -> None:
             tags=entry.get("tags", ()),
             curated=True,
         )
+        working_copy = deepcopy(base_config)
+        merged = variant.apply_to(working_copy)
+        schema_errors = validate_config_data(merged, schema)
+        assert schema_errors == []
         validated = variant.to_trend_config(base_config, base_path=base_path.parent)
         assert isinstance(validated, TrendConfig)
         assert base_config == baseline

--- a/tests/monte_carlo/strategy/test_curated_pack.py
+++ b/tests/monte_carlo/strategy/test_curated_pack.py
@@ -62,6 +62,30 @@ def test_hf_equity_curated_strategies_do_not_mutate_defaults() -> None:
         assert base_config == base_snapshot
 
 
+def test_hf_equity_curated_to_trend_config_does_not_mutate_defaults() -> None:
+    base_path = Path("config/defaults.yml")
+    base_config = yaml.safe_load(base_path.read_text(encoding="utf-8"))
+    base_snapshot = deepcopy(base_config)
+
+    strategy_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    payload = yaml.safe_load(strategy_path.read_text(encoding="utf-8"))
+
+    curated = payload.get("curated")
+    assert isinstance(curated, list)
+    assert len(curated) == 12
+
+    for entry in curated:
+        variant = StrategyVariant(
+            name=entry["name"],
+            overrides=entry.get("overrides", {}),
+            tags=entry.get("tags", ()),
+            curated=True,
+        )
+        validated = variant.to_trend_config(base_config, base_path=base_path.parent)
+        assert isinstance(validated, TrendConfig)
+        assert base_config == base_snapshot
+
+
 def test_hf_equity_curated_strategies_compatible_with_strategy_guards() -> None:
     base_path = Path("config/defaults.yml")
     base_config = yaml.safe_load(base_path.read_text(encoding="utf-8"))

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -16,6 +16,29 @@ def test_validate_strategy_pack_accepts_hf_equity_curated() -> None:
     assert errors == []
 
 
+def test_validate_strategy_pack_hf_equity_curated_does_not_mutate_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_config_path = Path("config/defaults.yml")
+    base_config = yaml.safe_load(base_config_path.read_text(encoding="utf-8"))
+    base_snapshot = deepcopy(base_config)
+
+    pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+
+    def _load_yaml_mapping(path: Path, label: str) -> dict[str, object]:
+        if label == "base_config":
+            return base_config
+        return payload
+
+    monkeypatch.setattr(validation_module, "_load_yaml_mapping", _load_yaml_mapping)
+
+    errors = validate_strategy_pack(pack_path, base_config_path=base_config_path)
+
+    assert errors == []
+    assert base_config == base_snapshot
+
+
 def test_validate_strategy_pack_reports_base_config_mutation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -24,12 +24,12 @@ def test_validate_strategy_pack_hf_equity_curated_does_not_mutate_defaults(
     base_snapshot = deepcopy(base_config)
 
     pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
-    payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+    real_loader = validation_module._load_yaml_mapping
 
     def _load_yaml_mapping(path: Path, label: str) -> dict[str, object]:
         if label == "base_config":
             return base_config
-        return payload
+        return real_loader(path, label)
 
     monkeypatch.setattr(validation_module, "_load_yaml_mapping", _load_yaml_mapping)
 

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -39,6 +39,30 @@ def test_validate_strategy_pack_hf_equity_curated_does_not_mutate_defaults(
     assert base_config == base_snapshot
 
 
+def test_validate_strategy_pack_hf_equity_curated_schema_and_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_config_path = Path("config/defaults.yml")
+    base_config = yaml.safe_load(base_config_path.read_text(encoding="utf-8"))
+    base_snapshot = deepcopy(base_config)
+
+    pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+
+    def _load_yaml_mapping(path: Path, label: str) -> dict[str, object]:
+        if label == "base_config":
+            return base_config
+        assert path == pack_path
+        return payload
+
+    monkeypatch.setattr(validation_module, "_load_yaml_mapping", _load_yaml_mapping)
+
+    errors = validate_strategy_pack(pack_path, base_config_path=base_config_path)
+
+    assert errors == []
+    assert base_config == base_snapshot
+
+
 def test_validate_strategy_pack_reports_base_config_mutation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/monte_carlo/strategy/test_variant.py
+++ b/tests/monte_carlo/strategy/test_variant.py
@@ -146,6 +146,40 @@ def test_to_trend_config_accepts_weighting_scheme_and_name(
     assert captured["portfolio"]["weighting"]["name"] == "score_prop_bayes"
 
 
+def test_to_trend_config_applies_weighting_scheme_and_name_without_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = _base_config(tmp_path)
+    base_snapshot = deepcopy(base)
+    variant = StrategyVariant(
+        name="SchemeNameApply",
+        overrides={
+            "portfolio": {
+                "weighting_scheme": "robust_mv",
+                "weighting": {"name": "score_prop"},
+            }
+        },
+    )
+
+    captured: dict[str, object] = {}
+    real_validate = validate_trend_config
+
+    def _wrapped(data: dict[str, object], *, base_path: Path) -> object:
+        captured.update(data)
+        return real_validate(data, base_path=base_path)
+
+    monkeypatch.setattr(
+        "trend_analysis.monte_carlo.strategy.variant.validate_trend_config", _wrapped
+    )
+
+    cfg = variant.to_trend_config(base, base_path=tmp_path)
+
+    assert cfg.portfolio.max_turnover == 0.5
+    assert captured["portfolio"]["weighting_scheme"] == "robust_mv"
+    assert captured["portfolio"]["weighting"]["name"] == "score_prop"
+    assert base == base_snapshot
+
+
 def test_to_trend_config_merges_weighting_scheme_name_and_params(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/monte_carlo/strategy/test_variant.py
+++ b/tests/monte_carlo/strategy/test_variant.py
@@ -186,6 +186,40 @@ def test_to_trend_config_merges_weighting_scheme_name_and_params(
     assert base == base_snapshot
 
 
+def test_to_trend_config_uses_scheme_and_name_without_mutating_base(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = _base_config(tmp_path)
+    base_snapshot = deepcopy(base)
+    variant = StrategyVariant(
+        name="SchemeAndName",
+        overrides={
+            "portfolio": {
+                "weighting_scheme": "robust_mv",
+                "weighting": {"name": "score_prop_bayes"},
+            }
+        },
+    )
+
+    captured: dict[str, object] = {}
+    real_validate = validate_trend_config
+
+    def _wrapped(data: dict[str, object], *, base_path: Path) -> object:
+        captured.update(data)
+        return real_validate(data, base_path=base_path)
+
+    monkeypatch.setattr(
+        "trend_analysis.monte_carlo.strategy.variant.validate_trend_config", _wrapped
+    )
+
+    cfg = variant.to_trend_config(base, base_path=tmp_path)
+
+    assert cfg.portfolio.rebalance_calendar == "NYSE"
+    assert captured["portfolio"]["weighting_scheme"] == "robust_mv"
+    assert captured["portfolio"]["weighting"]["name"] == "score_prop_bayes"
+    assert base == base_snapshot
+
+
 def test_to_trend_config_preserves_weighting_params_when_scheme_and_name_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/monte_carlo/strategy/test_variant.py
+++ b/tests/monte_carlo/strategy/test_variant.py
@@ -150,6 +150,7 @@ def test_to_trend_config_merges_weighting_scheme_name_and_params(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     base = _base_config(tmp_path)
+    base_snapshot = deepcopy(base)
     variant = StrategyVariant(
         name="WeightedParams",
         overrides={
@@ -182,14 +183,14 @@ def test_to_trend_config_merges_weighting_scheme_name_and_params(
     assert captured["portfolio"]["weighting"]["params"]["column"] == "Return"
     assert captured["portfolio"]["weighting"]["params"]["half_life"] == 12
     assert captured["portfolio"]["weighting"]["params"]["shrink_tau"] == 0.25
-    assert base["portfolio"]["weighting_scheme"] == "equal"
-    assert base["portfolio"]["weighting"]["name"] == "equal"
+    assert base == base_snapshot
 
 
 def test_to_trend_config_preserves_weighting_params_when_scheme_and_name_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     base = _base_config(tmp_path)
+    base_snapshot = deepcopy(base)
     variant = StrategyVariant(
         name="SchemeAndNameNoParams",
         overrides={
@@ -218,8 +219,7 @@ def test_to_trend_config_preserves_weighting_params_when_scheme_and_name_overrid
     assert captured["portfolio"]["weighting"]["name"] == "score_prop"
     assert captured["portfolio"]["weighting"]["params"]["column"] == "Sharpe"
     assert captured["portfolio"]["weighting"]["params"]["shrink_tau"] == 0.25
-    assert base["portfolio"]["weighting_scheme"] == "equal"
-    assert base["portfolio"]["weighting"]["name"] == "equal"
+    assert base == base_snapshot
 
 
 def test_to_trend_config_applies_scheme_and_name_overrides(


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Not provided._

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Trend_Model_Project#4723](https://github.com/stranske/Trend_Model_Project/issues/4723)
- [#4723](https://github.com/stranske/Trend_Model_Project/issues/4723)
- [#4671](https://github.com/stranske/Trend_Model_Project/issues/4671)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] <!-- Incomplete tasks from original issue -->
- [ ] Write unit tests to load `hf_equity_curated.yml`, validate each strategy against the schema, and confirm that global defaults remain unaffected.
- [ ] Write unit tests to load `hf_equity_curated.yml` (verify: tests pass)
- [ ] validate each strategy against the schema (verify: confirm completion in repo)
- [x] (verify: tests pass)
- [ ] confirm that global defaults remain unaffected. (verify: confirm completion in repo)
- [x] Define scope for: Write unit tests to validate each strategy in `hf_equity_curated.yml` against the schema. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Implement focused slice for: Write unit tests to validate each strategy in `hf_equity_curated.yml` against the schema. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Validate focused slice for: Write unit tests to validate each strategy in `hf_equity_curated.yml` against the schema. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] Define scope for: Write unit tests to confirm that global defaults remain unaffected when loading `hf_equity_curated.yml`. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] Implement focused slice for: Write unit tests to confirm that global defaults remain unaffected when loading `hf_equity_curated.yml`. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] Validate focused slice for: Write unit tests to confirm that global defaults remain unaffected when loading `hf_equity_curated.yml`. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided, ensuring no unintended global modifications.
- [ ] Define scope for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [x] Implement focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Validate focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] `portfolio.weighting.name` are provided (verify: confirm completion in repo)
- [ ] ensuring no unintended global modifications. (verify: confirm completion in repo)
- [ ] Define scope for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Implement focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] Validate focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] `portfolio.weighting.name` are provided. (verify: confirm completion in repo)
- [x] Define scope for: Add test cases for `StrategyVariant.to_trend_config` to ensure no unintended global modifications occur. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Implement focused slice for: Add test cases for `StrategyVariant.to_trend_config` to ensure no unintended global modifications occur. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Validate focused slice for: Add test cases for `StrategyVariant.to_trend_config` to ensure no unintended global modifications occur. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] <!-- New tasks to address unmet acceptance criteria -->
- [ ] Unit tests load `hf_equity_curated.yml`, validate each strategy against the schema, and confirm that global defaults remain unaffected.
- [x] Unit tests load `hf_equity_curated.yml` (verify: tests pass)
- [ ] validate each strategy against the schema (verify: confirm completion in repo)
- [x] (verify: tests pass)
- [ ] confirm that global defaults remain unaffected. (verify: confirm completion in repo)
- [ ] Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided, and ensure no unintended global modifications.
- [ ] Define scope for: Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Implement focused slice for: Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Validate focused slice for: Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] `portfolio.weighting.name` are provided (verify: confirm completion in repo)
- [ ] (verify: confirm completion in repo)
- [ ] ensure no unintended global modifications. (verify: confirm completion in repo)
- [ ] <!-- Incomplete tasks from original issue -->
- [ ] Write unit tests to load `hf_equity_curated.yml`, validate each strategy against the schema, and confirm that global defaults remain unaffected.
- [ ] Write unit tests to load `hf_equity_curated.yml` (verify: tests pass)
- [ ] validate each strategy against the schema (verify: confirm completion in repo)
- [x] (verify: tests pass)
- [ ] confirm that global defaults remain unaffected. (verify: confirm completion in repo)
- [x] Define scope for: Write unit tests to validate each strategy in `hf_equity_curated.yml` against the schema. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Implement focused slice for: Write unit tests to validate each strategy in `hf_equity_curated.yml` against the schema. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Validate focused slice for: Write unit tests to validate each strategy in `hf_equity_curated.yml` against the schema. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] Define scope for: Write unit tests to confirm that global defaults remain unaffected when loading `hf_equity_curated.yml`. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] Implement focused slice for: Write unit tests to confirm that global defaults remain unaffected when loading `hf_equity_curated.yml`. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] Validate focused slice for: Write unit tests to confirm that global defaults remain unaffected when loading `hf_equity_curated.yml`. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided, ensuring no unintended global modifications.
- [ ] Define scope for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [x] Implement focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Validate focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] `portfolio.weighting.name` are provided (verify: confirm completion in repo)
- [ ] ensuring no unintended global modifications. (verify: confirm completion in repo)
- [ ] Define scope for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Implement focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] Validate focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] `portfolio.weighting.name` are provided. (verify: confirm completion in repo)
- [x] Define scope for: Add test cases for `StrategyVariant.to_trend_config` to ensure no unintended global modifications occur. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Implement focused slice for: Add test cases for `StrategyVariant.to_trend_config` to ensure no unintended global modifications occur. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Validate focused slice for: Add test cases for `StrategyVariant.to_trend_config` to ensure no unintended global modifications occur. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] <!-- New tasks to address unmet acceptance criteria -->
- [ ] Unit tests load `hf_equity_curated.yml`, validate each strategy against the schema, and confirm that global defaults remain unaffected.
- [x] Unit tests load `hf_equity_curated.yml` (verify: tests pass)
- [ ] validate each strategy against the schema (verify: confirm completion in repo)
- [x] (verify: tests pass)
- [ ] confirm that global defaults remain unaffected. (verify: confirm completion in repo)
- [ ] Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided, and ensure no unintended global modifications.
- [ ] Define scope for: Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Implement focused slice for: Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Validate focused slice for: Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] `portfolio.weighting.name` are provided (verify: confirm completion in repo)
- [ ] (verify: confirm completion in repo)
- [ ] ensure no unintended global modifications. (verify: confirm completion in repo)

#### Acceptance criteria
- [ ] <!-- Criteria verified as unmet by verifier -->
- [ ] Unit tests load `hf_equity_curated.yml`, validate each strategy against the schema, and confirm that global defaults remain unaffected.
- [ ] Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided, and ensure no unintended global modifications.
- [ ] <!-- Criteria verified as unmet by verifier -->
- [ ] Unit tests load `hf_equity_curated.yml`, validate each strategy against the schema, and confirm that global defaults remain unaffected.
- [ ] Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided, and ensure no unintended global modifications.

<!-- auto-status-summary:end -->

## Implementation Notes

Verifier confirmed these criteria were met:
✓ The `hf_equity_curated.yml` file is referenced in the `config/scenarios/example_scenario.yml` file, and executing this scenario loads and applies the curated strategies without modifying global defaults.

Original implementation in PR #4723.

<details>
<summary>Original Issue Context</summary>

## Source
- Original PR: [#4723](https://github.com/stranske/Trend_Model_Project/pull/4723)
- Verifier verdict: FAIL
- Verifier run: [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/21713662912)

## Original Scope
Address unmet acceptance criteria from PR #4671 to ensure curated strategies are properly referenced and applied without affecting global defaults.

</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #4724

<!-- pr-preamble:end -->