### PR TITLE
Implement regime-conditional turnover caps in Monte Carlo simulation

### DIFF
--- a/agents/codex-4735.md
+++ b/agents/codex-4735.md
@@ -1,0 +1,10 @@
+# Codex Agent Session - Issue #4735
+
+## Issue
+Implement regime-conditional turnover caps in Monte Carlo simulation
+
+## Status
+Setup - Initial PR created
+
+## Context
+This PR addresses verification failures from PR #4729 that did not fully implement regime-conditional turnover caps required for issue #4704.

--- a/src/trend_analysis/pipeline.py
+++ b/src/trend_analysis/pipeline.py
@@ -246,7 +246,7 @@ def run_analysis(
     periods_per_year: float | None = None,
     previous_weights: Mapping[str, float] | None = None,
     lambda_tc: float | None = None,
-    max_turnover: float | None = None,
+    max_turnover: float | Mapping[str, float] | None = None,
     signal_spec: TrendSpec | None = None,
     regime_cfg: Mapping[str, Any] | None = None,
     calendar_frequency: str | None = None,

--- a/src/trend_analysis/pipeline_helpers.py
+++ b/src/trend_analysis/pipeline_helpers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, Mapping
+from typing import Any, Mapping, SupportsFloat, SupportsIndex, cast
 
 import numpy as np
 import pandas as pd
@@ -149,6 +149,18 @@ def _normalize_regime_key(value: Any) -> str | None:
     return re.sub(r"[^a-z0-9]+", "", text.casefold())
 
 
+def _coerce_float(value: object) -> float | None:
+    if isinstance(value, (int, float, str, bytes, bytearray)):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+    try:
+        return float(cast(SupportsFloat | SupportsIndex, value))
+    except (TypeError, ValueError):
+        return None
+
+
 def _resolve_regime_turnover_cap(
     max_turnover: object | None,
     regime_label: str | None,
@@ -157,10 +169,7 @@ def _resolve_regime_turnover_cap(
     if max_turnover is None:
         return None
     if not isinstance(max_turnover, Mapping):
-        try:
-            return float(max_turnover)
-        except (TypeError, ValueError):
-            return None
+        return _coerce_float(max_turnover)
 
     normalized: dict[str, object] = {}
     for key, value in max_turnover.items():
@@ -174,25 +183,16 @@ def _resolve_regime_turnover_cap(
     if regime_label:
         label_key = _normalize_regime_key(regime_label)
         if label_key and label_key in normalized:
-            try:
-                return float(normalized[label_key])
-            except (TypeError, ValueError):
-                return None
+            return _coerce_float(normalized[label_key])
 
     default_label = getattr(settings, "default_label", None)
     default_key = _normalize_regime_key(default_label)
     if default_key and default_key in normalized:
-        try:
-            return float(normalized[default_key])
-        except (TypeError, ValueError):
-            return None
+        return _coerce_float(normalized[default_key])
 
     for fallback in ("default", "all", "any"):
         if fallback in normalized:
-            try:
-                return float(normalized[fallback])
-            except (TypeError, ValueError):
-                return None
+            return _coerce_float(normalized[fallback])
     return None
 
 

--- a/src/trend_analysis/pipeline_helpers.py
+++ b/src/trend_analysis/pipeline_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, Mapping
 
 import numpy as np
@@ -27,6 +28,7 @@ __all__ = [
     "_empty_run_full_result",
     "_format_period",
     "_policy_from_config",
+    "_resolve_regime_turnover_cap",
     "_resolve_regime_label",
     "_resolve_sample_split",
     "_resolve_target_vol",
@@ -136,6 +138,62 @@ def _resolve_regime_label(
     if aligned.empty:
         return None, settings
     return str(aligned.iloc[-1]), settings
+
+
+def _normalize_regime_key(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return re.sub(r"[^a-z0-9]+", "", text.casefold())
+
+
+def _resolve_regime_turnover_cap(
+    max_turnover: object | None,
+    regime_label: str | None,
+    settings: Any,
+) -> float | None:
+    if max_turnover is None:
+        return None
+    if not isinstance(max_turnover, Mapping):
+        try:
+            return float(max_turnover)
+        except (TypeError, ValueError):
+            return None
+
+    normalized: dict[str, object] = {}
+    for key, value in max_turnover.items():
+        normalized_key = _normalize_regime_key(key)
+        if not normalized_key:
+            continue
+        normalized[normalized_key] = value
+    if not normalized:
+        return None
+
+    if regime_label:
+        label_key = _normalize_regime_key(regime_label)
+        if label_key and label_key in normalized:
+            try:
+                return float(normalized[label_key])
+            except (TypeError, ValueError):
+                return None
+
+    default_label = getattr(settings, "default_label", None)
+    default_key = _normalize_regime_key(default_label)
+    if default_key and default_key in normalized:
+        try:
+            return float(normalized[default_key])
+        except (TypeError, ValueError):
+            return None
+
+    for fallback in ("default", "all", "any"):
+        if fallback in normalized:
+            try:
+                return float(normalized[fallback])
+            except (TypeError, ValueError):
+                return None
+    return None
 
 
 def _apply_regime_overrides(

--- a/src/trend_analysis/pipeline_runner.py
+++ b/src/trend_analysis/pipeline_runner.py
@@ -10,6 +10,7 @@ from .pipeline_helpers import (
     _apply_regime_overrides,
     _apply_regime_weight_overrides,
     _resolve_regime_label,
+    _resolve_regime_turnover_cap,
 )
 from .signals import TrendSpec
 from .stages import portfolio as portfolio_stage
@@ -47,7 +48,7 @@ def _run_analysis_with_diagnostics(
     periods_per_year_override: float | None = None,
     previous_weights: Mapping[str, float] | None = None,
     lambda_tc: float | None = None,
-    max_turnover: float | None = None,
+    max_turnover: float | Mapping[str, float] | None = None,
     signal_spec: TrendSpec | None = None,
     regime_cfg: Mapping[str, Any] | None = None,
     weight_policy: Mapping[str, Any] | None = None,
@@ -99,6 +100,11 @@ def _run_analysis_with_diagnostics(
         settings=regime_settings,
         regime_cfg=regime_cfg,
     )
+    resolved_max_turnover = _resolve_regime_turnover_cap(
+        max_turnover,
+        regime_label,
+        regime_settings,
+    )
 
     selection_stage_result = selection_stage._select_universe(
         preprocess_stage,
@@ -133,7 +139,7 @@ def _run_analysis_with_diagnostics(
         risk_window=risk_window,
         previous_weights=previous_weights,
         lambda_tc=lambda_tc,
-        max_turnover=max_turnover,
+        max_turnover=resolved_max_turnover,
         signal_spec=signal_spec,
         weight_policy=weight_policy,
         warmup=preprocess_stage.warmup,
@@ -184,7 +190,7 @@ def _run_analysis(
     periods_per_year_override: float | None = None,
     previous_weights: Mapping[str, float] | None = None,
     lambda_tc: float | None = None,
-    max_turnover: float | None = None,
+    max_turnover: float | Mapping[str, float] | None = None,
     signal_spec: TrendSpec | None = None,
     regime_cfg: Mapping[str, Any] | None = None,
     weight_policy: Mapping[str, Any] | None = None,

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -845,6 +845,7 @@ def _maybe_reset_config_chat_cache(snapshot: Mapping[str, Any]) -> None:
     st.session_state.pop("config_chat_last_instruction", None)
     st.session_state.pop(_CONFIG_CHAIN_METRICS_KEY, None)
     st.session_state.pop(_CONFIG_CHAIN_STATS_KEY, None)
+    st.session_state[_CONFIG_CHAIN_STATE_KEY] = {"entries": {}}
     _LOGGER.info(
         "Config chat cache reset due to settings change: %s -> %s",
         previous_normalized,

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -840,7 +840,9 @@ def _maybe_reset_config_chat_cache(snapshot: Mapping[str, Any]) -> list[str]:
     previous_normalized = {key: previous.get(key) for key in normalized}
     if previous_normalized == normalized:
         return []
-    changed_fields = [key for key in normalized if previous_normalized.get(key) != normalized.get(key)]
+    changed_fields = [
+        key for key in normalized if previous_normalized.get(key) != normalized.get(key)
+    ]
     st.session_state[_LLM_OVERRIDE_SNAPSHOT_KEY] = normalized
     st.session_state.pop("config_chat_preview", None)
     st.session_state.pop("config_chat_last_instruction", None)

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -184,12 +184,16 @@ def _build_chain_cache_key(
     *,
     provider: str,
     model: str,
+    base_url: str | None,
+    organization: str | None,
     temperature: float,
 ) -> dict[str, Any]:
     return {
         "cache_version": _CONFIG_CHAIN_CACHE_VERSION,
         "provider": provider,
         "model": model,
+        "base_url": base_url,
+        "organization": organization,
         "temperature": temperature,
     }
 
@@ -1162,6 +1166,8 @@ def _build_chain_cache_context_from_config(
     cache_key = _build_chain_cache_key(
         provider=provider,
         model=resolved_model,
+        base_url=base_url,
+        organization=organization,
         temperature=temperature,
     )
     return {

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -236,7 +236,7 @@ def _record_config_change(preview: Mapping[str, Any]) -> None:
 def _record_preview_timing(preview: Mapping[str, Any], total_seconds: float) -> None:
     timings = preview.get("timings")
     if not isinstance(timings, Mapping):
-        return
+        timings = {}
     chain_key = timings.get("chain_cache_key")
     provider = None
     model = None

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -161,12 +161,17 @@ def _chain_resource_signature(
     return _chain_cache_signature({"chain": dict(chain_cache_key), "llm": dict(llm_cache_key)})
 
 
-def _chain_cache_summary(cache_key: Mapping[str, Any]) -> str:
+def _chain_cache_summary(
+    cache_key: Mapping[str, Any],
+    *,
+    base_url: str | None = None,
+    organization: str | None = None,
+) -> str:
     provider = cache_key.get("provider") or "default"
     model = cache_key.get("model") or "default"
     temperature = cache_key.get("temperature")
-    base_url = cache_key.get("base_url")
-    organization = cache_key.get("organization")
+    base_url = base_url or cache_key.get("base_url")
+    organization = organization or cache_key.get("organization")
     summary = f"{provider}:{model}@{_format_value(temperature)}"
     if base_url:
         summary = f"{summary} | base_url={base_url}"
@@ -179,16 +184,12 @@ def _build_chain_cache_key(
     *,
     provider: str,
     model: str,
-    base_url: str | None,
-    organization: str | None,
     temperature: float,
 ) -> dict[str, Any]:
     return {
         "cache_version": _CONFIG_CHAIN_CACHE_VERSION,
         "provider": provider,
         "model": model,
-        "base_url": base_url,
-        "organization": organization,
         "temperature": temperature,
     }
 
@@ -1161,8 +1162,6 @@ def _build_chain_cache_context_from_config(
     cache_key = _build_chain_cache_key(
         provider=provider,
         model=resolved_model,
-        base_url=base_url,
-        organization=organization,
         temperature=temperature,
     )
     return {
@@ -1188,9 +1187,8 @@ def _build_chain_cache_context() -> dict[str, Any]:
 def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
     config = _resolve_llm_provider_config()
     temperature = _resolve_llm_temperature()
-    snapshot_changes = _maybe_reset_config_chat_cache(
-        _build_chain_settings_snapshot(config, temperature)
-    )
+    settings_snapshot = _build_chain_settings_snapshot(config, temperature)
+    snapshot_changes = _maybe_reset_config_chat_cache(settings_snapshot)
     context = _build_chain_cache_context_from_config(config, temperature)
     api_key = context["api_key"]
     api_key_fingerprint = context["api_key_fingerprint"]
@@ -1199,21 +1197,28 @@ def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
     cache_key = context["cache_key"]
     cache_state = _get_chain_cache_state()
     signature = _chain_cache_signature(cache_key)
+    settings_signature = _chain_cache_signature(settings_snapshot)
     resource_signature = _chain_resource_signature(cache_key, llm_cache_key)
-    previous_signature = cache_state.get("last_signature")
+    previous_settings_signature = cache_state.get("last_settings_signature")
     previous_resource_signature = cache_state.get("last_resource_signature")
-    settings_changed = bool(previous_signature and previous_signature != signature)
-    previous_cache_key = cache_state.get("last_cache_key")
+    settings_changed = bool(
+        previous_settings_signature and previous_settings_signature != settings_signature
+    )
+    previous_settings_snapshot = cache_state.get("last_settings_snapshot")
     previous_llm_cache_key = cache_state.get("last_llm_cache_key")
-    changed_fields = _cache_key_changes(previous_cache_key, cache_key, _CONFIG_CHAIN_CORE_FIELDS)
+    changed_fields = _cache_key_changes(
+        previous_settings_snapshot,
+        settings_snapshot,
+        _CONFIG_CHAIN_CORE_FIELDS,
+    )
     llm_changed_fields = _cache_key_changes(
         previous_llm_cache_key,
         llm_cache_key,
         _CONFIG_CHAIN_LLM_FIELDS,
     )
     invalidation_fields = _cache_key_changes(
-        previous_cache_key,
-        cache_key,
+        previous_settings_snapshot,
+        settings_snapshot,
         _CONFIG_CHAIN_REBUILD_FIELDS,
     )
     if snapshot_changes:
@@ -1266,8 +1271,10 @@ def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
             cache_miss_reason = "first_build"
     entries[signature] = id(chain)
     cache_state["last_signature"] = signature
+    cache_state["last_settings_signature"] = settings_signature
     cache_state["last_resource_signature"] = resource_signature
     cache_state["last_cache_key"] = cache_key
+    cache_state["last_settings_snapshot"] = settings_snapshot
     cache_state["last_llm_cache_key"] = llm_cache_key
     cache_state["last_chain_id"] = id(chain)
     st.session_state["config_chat_chain_key"] = cache_key
@@ -1277,7 +1284,11 @@ def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
         "chain_cache_key": cache_key,
         "chain_cache_signature": signature,
         "chain_resource_signature": resource_signature,
-        "chain_cache_summary": _chain_cache_summary(cache_key),
+        "chain_cache_summary": _chain_cache_summary(
+            cache_key,
+            base_url=context.get("base_url"),
+            organization=context.get("organization"),
+        ),
         "chain_cache_miss_reason": cache_miss_reason,
         "chain_cache_invalidation_fields": invalidation_fields,
         "chain_settings_changed": settings_changed,

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 import streamlit as st
 import yaml
+import pandas as pd
 
 from streamlit_app import state as app_state
 from streamlit_app.components import analysis_runner, nl_operation_viewer
@@ -97,6 +98,31 @@ _LLM_BASE_URL_OVERRIDE_KEY = "llm_base_url_override"
 _LLM_ORG_OVERRIDE_KEY = "llm_org_override"
 _LLM_TEMPERATURE_OVERRIDE_KEY = "llm_temperature_override"
 _LLM_OVERRIDE_SNAPSHOT_KEY = "llm_override_snapshot"
+_WHAT_IF_VARIANTS_KEY = "what_if_variants"
+_WHAT_IF_RESULTS_KEY = "what_if_results"
+_WHAT_IF_ERRORS_KEY = "what_if_errors"
+_WHAT_IF_INSTRUCTION_KEY = "what_if_instruction"
+_WHAT_IF_VARIANT_LABELS = ("Conservative", "Baseline", "Aggressive")
+_WHAT_IF_VARIANT_HINTS = {
+    "Conservative": (
+        "Create a conservative variant of the instruction. Favor lower risk, "
+        "more stability, and tighter constraints while still honoring the request."
+    ),
+    "Baseline": "Create a baseline variant that applies the instruction as-is with minimal changes.",
+    "Aggressive": (
+        "Create an aggressive variant of the instruction. Favor higher responsiveness, "
+        "more risk tolerance, or stronger signal emphasis while still honoring the request."
+    ),
+}
+_WHAT_IF_METRIC_KEYS = {
+    "CAGR": ("cagr", "return_ann", "ann_return"),
+    "Volatility": ("vol", "volatility"),
+    "Sharpe": ("sharpe",),
+    "Sortino": ("sortino",),
+    "Info Ratio": ("information_ratio", "info_ratio", "ir"),
+    "Max Drawdown": ("max_drawdown", "maxdd", "drawdown"),
+    "Total Return": ("total_return", "return_total", "return"),
+}
 
 
 def _get_chain_cache_state() -> dict[str, Any]:
@@ -497,6 +523,82 @@ def _format_value(value: Any) -> str:
     if isinstance(value, float):
         return f"{value:.3f}"
     return str(value)
+
+
+def _build_variant_instruction(base_instruction: str, label: str) -> str:
+    hint = _WHAT_IF_VARIANT_HINTS.get(label, "")
+    trimmed = (base_instruction or "").strip()
+    if not trimmed:
+        return hint
+    return f"{hint}\n\nUser instruction: {trimmed}".strip()
+
+
+def _select_metric_value(
+    metrics: Mapping[str, float | None], keys: tuple[str, ...]
+) -> float | None:
+    for key in keys:
+        if key in metrics:
+            return metrics.get(key)
+    return None
+
+
+def _format_variant_metric_value(metric_name: str, value: float | None) -> str:
+    if value is None:
+        return "—"
+    if metric_name in {"CAGR", "Volatility", "Max Drawdown", "Total Return"}:
+        return f"{value * 100:.2f}%"
+    return f"{value:.2f}"
+
+
+def _extract_variant_metrics(result: Any) -> dict[str, float | None]:
+    details = getattr(result, "details", {}) or {}
+    metrics_dict: dict[str, float | None] = {}
+
+    user_stats = details.get("out_user_stats")
+    if user_stats is not None:
+        if hasattr(user_stats, "__dict__"):
+            for key, value in vars(user_stats).items():
+                if not str(key).startswith("_"):
+                    try:
+                        metrics_dict[str(key)] = float(value)
+                    except (TypeError, ValueError):
+                        metrics_dict[str(key)] = None
+        elif hasattr(user_stats, "items"):
+            for key, value in user_stats.items():
+                try:
+                    metrics_dict[str(key)] = float(value)
+                except (TypeError, ValueError):
+                    metrics_dict[str(key)] = None
+
+    if metrics_dict:
+        return metrics_dict
+
+    metrics = getattr(result, "metrics", None)
+    if isinstance(metrics, pd.DataFrame) and not metrics.empty:
+        series = metrics.iloc[0]
+        for key, value in series.items():
+            try:
+                metrics_dict[str(key)] = float(value)
+            except (TypeError, ValueError):
+                metrics_dict[str(key)] = None
+        if metrics_dict:
+            return metrics_dict
+
+    stats_obj = details.get("out_sample_stats") or {}
+    if hasattr(stats_obj, "items"):
+        for key, value in stats_obj.items():
+            try:
+                metrics_dict[str(key)] = float(value)
+            except (TypeError, ValueError):
+                metrics_dict[str(key)] = None
+    elif hasattr(stats_obj, "__dict__"):
+        for key, value in vars(stats_obj).items():
+            try:
+                metrics_dict[str(key)] = float(value)
+            except (TypeError, ValueError):
+                metrics_dict[str(key)] = None
+
+    return metrics_dict
 
 
 def _render_validation_error_styles() -> None:
@@ -1267,6 +1369,183 @@ def _generate_preview_with_progress(
         timings["total_seconds"] = duration
     _record_preview_timing(result, duration)
     return result
+
+
+def _generate_what_if_variants(
+    model_state: Mapping[str, Any],
+    instruction: str,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    chain, _meta = _build_nl_chain()
+    variants: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for label in _WHAT_IF_VARIANT_LABELS:
+        variant_instruction = _build_variant_instruction(instruction, label)
+        try:
+            patch = chain.run(current_config=dict(model_state), instruction=variant_instruction)
+            after = apply_config_patch(deepcopy(dict(model_state)), patch)
+            variants.append(
+                {
+                    "label": label,
+                    "instruction": variant_instruction,
+                    "summary": patch.summary,
+                    "risk_flags": [flag.value for flag in patch.risk_flags],
+                    "needs_review": patch.needs_review,
+                    "patch": patch.model_dump(),
+                    "after": after,
+                }
+            )
+        except Exception as exc:
+            errors.append(f"{label}: {exc}")
+    return variants, errors
+
+
+def _run_what_if_analysis(
+    variants: list[dict[str, Any]],
+    *,
+    df: Any,
+    benchmark: str | None,
+    data_hash: str | None,
+    selected_rf: str | None,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    results: dict[str, Any] = {}
+    errors: dict[str, str] = {}
+    progress = st.progress(0.0, text="Running what-if analyses...")
+    total = len(variants)
+    for idx, variant in enumerate(variants, start=1):
+        label = str(variant.get("label") or f"Variant {idx}")
+        after = variant.get("after")
+        if not isinstance(after, Mapping):
+            errors[label] = "Missing configuration data for this variant."
+            continue
+        effective_model_state = dict(after)
+        if selected_rf:
+            effective_model_state["risk_free_column"] = selected_rf
+        try:
+            result = analysis_runner.run_analysis(
+                df,
+                effective_model_state,
+                benchmark,
+                data_hash=data_hash,
+            )
+            results[label] = result
+        except Exception as exc:
+            errors[label] = str(exc)
+        progress.progress(idx / total, text=f"Running what-if analyses... ({idx}/{total})")
+    progress.empty()
+    return results, errors
+
+
+def _build_what_if_comparison_tables(
+    results: Mapping[str, Any],
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    display_rows: list[dict[str, Any]] = []
+    raw_rows: list[dict[str, Any]] = []
+    for label in _WHAT_IF_VARIANT_LABELS:
+        if label not in results:
+            continue
+        metrics = _extract_variant_metrics(results[label])
+        display_row = {"Variant": label}
+        raw_row = {"Variant": label}
+        for display_name, metric_keys in _WHAT_IF_METRIC_KEYS.items():
+            value = _select_metric_value(metrics, metric_keys)
+            raw_row[display_name] = value
+            display_row[display_name] = _format_variant_metric_value(display_name, value)
+        display_rows.append(display_row)
+        raw_rows.append(raw_row)
+    return pd.DataFrame(display_rows), pd.DataFrame(raw_rows)
+
+
+def _render_what_if_variants_panel(
+    *,
+    model_state: Mapping[str, Any],
+    df: Any,
+    benchmark: str | None,
+    data_hash: str | None,
+) -> None:
+    st.subheader("What-if Variants (3)")
+    st.caption(
+        "Generate three labeled config variants from one instruction, "
+        "run analyses, and compare key metrics."
+    )
+    instruction = st.text_area(
+        "Instruction for variants",
+        key=_WHAT_IF_INSTRUCTION_KEY,
+        placeholder="Example: Increase lookback to improve stability.",
+    )
+    cols = st.columns(2)
+    with cols[0]:
+        generate_clicked = st.button("Generate variants", key="what_if_generate")
+    with cols[1]:
+        run_clicked = st.button("Run what-if analysis", key="what_if_run")
+
+    if generate_clicked:
+        if not instruction or not instruction.strip():
+            st.warning("Enter an instruction to generate variants.")
+        else:
+            with st.spinner("Generating variants..."):
+                variants, errors = _generate_what_if_variants(model_state, instruction)
+            st.session_state[_WHAT_IF_VARIANTS_KEY] = variants
+            st.session_state[_WHAT_IF_ERRORS_KEY] = errors
+            st.session_state.pop(_WHAT_IF_RESULTS_KEY, None)
+
+    variants = st.session_state.get(_WHAT_IF_VARIANTS_KEY)
+    if not isinstance(variants, list) or not variants:
+        st.info("Generate variants to compare alternative configurations.")
+        return
+
+    for variant in variants:
+        label = variant.get("label") or "Variant"
+        st.markdown(f"**{label}**")
+        summary = variant.get("summary") or "No summary provided."
+        st.caption(summary)
+        risk_flags = variant.get("risk_flags") or []
+        if risk_flags:
+            st.warning(f"Risk flags: {', '.join(str(flag) for flag in risk_flags)}")
+
+    errors = st.session_state.get(_WHAT_IF_ERRORS_KEY)
+    if isinstance(errors, list) and errors:
+        st.warning("Some variants failed to generate:")
+        for message in errors:
+            st.caption(str(message))
+
+    if run_clicked:
+        if df is None:
+            st.error("Load data before running what-if analysis.")
+            return
+        selected_rf = st.session_state.get("selected_risk_free")
+        with st.spinner("Running what-if analyses..."):
+            results, run_errors = _run_what_if_analysis(
+                variants,
+                df=df,
+                benchmark=benchmark,
+                data_hash=data_hash,
+                selected_rf=selected_rf,
+            )
+        st.session_state[_WHAT_IF_RESULTS_KEY] = results
+        st.session_state[_WHAT_IF_ERRORS_KEY] = run_errors
+
+    results = st.session_state.get(_WHAT_IF_RESULTS_KEY)
+    if not isinstance(results, Mapping) or not results:
+        st.info("Run what-if analysis to see a comparison table.")
+        return
+
+    run_errors = st.session_state.get(_WHAT_IF_ERRORS_KEY)
+    if isinstance(run_errors, Mapping) and run_errors:
+        st.warning("Some analyses failed:")
+        for label, message in run_errors.items():
+            st.caption(f"{label}: {message}")
+
+    display_df, raw_df = _build_what_if_comparison_tables(results)
+    if display_df.empty:
+        st.info("No comparison data available.")
+        return
+    st.dataframe(display_df, use_container_width=True, hide_index=True)
+    st.download_button(
+        "Download comparison CSV",
+        data=raw_df.to_csv(index=False),
+        file_name="what_if_comparison.csv",
+        mime="text/csv",
+    )
 
 
 def _current_run_key(model_state: dict[str, Any], benchmark: str | None) -> str:
@@ -2351,6 +2630,15 @@ def render_model_page() -> None:
         st.write(", ".join(fund_cols[:50]))
         if len(fund_cols) > 50:
             st.caption(f"...and {len(fund_cols) - 50} more")
+
+    st.markdown("---")
+
+    _render_what_if_variants_panel(
+        model_state=model_state,
+        df=df,
+        benchmark=st.session_state.get("selected_benchmark"),
+        data_hash=st.session_state.get("data_hash"),
+    )
 
     st.markdown("---")
 

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -1132,9 +1132,10 @@ def _build_chain_settings_snapshot(
     config: LLMProviderConfig,
     temperature: float,
 ) -> dict[str, Any]:
+    resolved_model = _normalize_cache_str(config.model) or _DEFAULT_CONFIG_CHAT_MODEL
     return {
         "provider": _normalize_cache_str(config.provider),
-        "model": _normalize_cache_str(config.model),
+        "model": resolved_model,
         "base_url": _normalize_cache_str(config.base_url),
         "organization": _normalize_cache_str(config.organization),
         "temperature": _normalize_temperature(temperature),

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -17,9 +17,9 @@ from time import monotonic, sleep
 from typing import Any, Mapping
 from uuid import uuid4
 
+import pandas as pd
 import streamlit as st
 import yaml
-import pandas as pd
 
 from streamlit_app import state as app_state
 from streamlit_app.components import analysis_runner, nl_operation_viewer

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -827,13 +827,8 @@ def _resolve_llm_session_overrides() -> dict[str, str | None]:
 
 def _current_chain_settings_snapshot() -> dict[str, Any]:
     config = _resolve_llm_provider_config()
-    return {
-        "provider": _normalize_cache_str(config.provider),
-        "model": _normalize_cache_str(config.model),
-        "base_url": _normalize_cache_str(config.base_url),
-        "organization": _normalize_cache_str(config.organization),
-        "temperature": _normalize_temperature(_resolve_llm_temperature()),
-    }
+    temperature = _resolve_llm_temperature()
+    return _build_chain_settings_snapshot(config, temperature)
 
 
 def _maybe_reset_config_chat_cache(snapshot: Mapping[str, Any]) -> None:
@@ -848,10 +843,8 @@ def _maybe_reset_config_chat_cache(snapshot: Mapping[str, Any]) -> None:
     st.session_state[_LLM_OVERRIDE_SNAPSHOT_KEY] = normalized
     st.session_state.pop("config_chat_preview", None)
     st.session_state.pop("config_chat_last_instruction", None)
-    st.session_state.pop(_CONFIG_CHAIN_STATE_KEY, None)
     st.session_state.pop(_CONFIG_CHAIN_METRICS_KEY, None)
     st.session_state.pop(_CONFIG_CHAIN_STATS_KEY, None)
-    _reset_config_chat_session_id()
     _LOGGER.info(
         "Config chat cache reset due to settings change: %s -> %s",
         previous_normalized,
@@ -1023,10 +1016,25 @@ def _cached_config_patch_chain(
     )
 
 
-def _build_chain_cache_context() -> dict[str, Any]:
-    config = _resolve_llm_provider_config()
+def _build_chain_settings_snapshot(
+    config: LLMProviderConfig,
+    temperature: float,
+) -> dict[str, Any]:
+    return {
+        "provider": _normalize_cache_str(config.provider),
+        "model": _normalize_cache_str(config.model),
+        "base_url": _normalize_cache_str(config.base_url),
+        "organization": _normalize_cache_str(config.organization),
+        "temperature": _normalize_temperature(temperature),
+    }
+
+
+def _build_chain_cache_context_from_config(
+    config: LLMProviderConfig,
+    temperature: float,
+) -> dict[str, Any]:
     provider = _normalize_cache_str(config.provider) or "openai"
-    temperature = _normalize_temperature(_resolve_llm_temperature())
+    temperature = _normalize_temperature(temperature)
     base_url = _normalize_cache_str(config.base_url)
     organization = _normalize_cache_str(config.organization)
     api_key_fingerprint = _hash_api_key(config.api_key)
@@ -1064,9 +1072,17 @@ def _build_chain_cache_context() -> dict[str, Any]:
     }
 
 
+def _build_chain_cache_context() -> dict[str, Any]:
+    config = _resolve_llm_provider_config()
+    temperature = _resolve_llm_temperature()
+    return _build_chain_cache_context_from_config(config, temperature)
+
+
 def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
-    _maybe_reset_config_chat_cache(_current_chain_settings_snapshot())
-    context = _build_chain_cache_context()
+    config = _resolve_llm_provider_config()
+    temperature = _resolve_llm_temperature()
+    _maybe_reset_config_chat_cache(_build_chain_settings_snapshot(config, temperature))
+    context = _build_chain_cache_context_from_config(config, temperature)
     api_key = context["api_key"]
     api_key_fingerprint = context["api_key_fingerprint"]
     extra_payload = context["extra_payload"]
@@ -1118,6 +1134,7 @@ def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
     reused = cached_chain_id == id(chain)
     cache_miss_reason = None
     if not reused:
+        had_cached_entry = cached_chain_id is not None
         if settings_changed:
             if invalidation_fields:
                 cache_miss_reason = f"settings_changed: {', '.join(invalidation_fields)}"
@@ -1129,6 +1146,8 @@ def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
             cache_miss_reason = f"llm_settings_changed: {', '.join(llm_changed_fields)}"
         elif resource_changed:
             cache_miss_reason = "llm_settings_changed"
+        elif had_cached_entry:
+            cache_miss_reason = "cache_evicted"
         else:
             cache_miss_reason = "first_build"
     entries[signature] = id(chain)

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -1065,6 +1065,7 @@ def _build_chain_cache_context() -> dict[str, Any]:
 
 
 def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
+    _maybe_reset_config_chat_cache(_current_chain_settings_snapshot())
     context = _build_chain_cache_context()
     api_key = context["api_key"]
     api_key_fingerprint = context["api_key_fingerprint"]

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -831,15 +831,16 @@ def _current_chain_settings_snapshot() -> dict[str, Any]:
     return _build_chain_settings_snapshot(config, temperature)
 
 
-def _maybe_reset_config_chat_cache(snapshot: Mapping[str, Any]) -> None:
+def _maybe_reset_config_chat_cache(snapshot: Mapping[str, Any]) -> list[str]:
     previous = st.session_state.get(_LLM_OVERRIDE_SNAPSHOT_KEY)
     normalized = dict(snapshot)
     if not isinstance(previous, Mapping):
         st.session_state[_LLM_OVERRIDE_SNAPSHOT_KEY] = normalized
-        return
+        return []
     previous_normalized = {key: previous.get(key) for key in normalized}
     if previous_normalized == normalized:
-        return
+        return []
+    changed_fields = [key for key in normalized if previous_normalized.get(key) != normalized.get(key)]
     st.session_state[_LLM_OVERRIDE_SNAPSHOT_KEY] = normalized
     st.session_state.pop("config_chat_preview", None)
     st.session_state.pop("config_chat_last_instruction", None)
@@ -851,6 +852,7 @@ def _maybe_reset_config_chat_cache(snapshot: Mapping[str, Any]) -> None:
         previous_normalized,
         normalized,
     )
+    return changed_fields
 
 
 def _llm_env_var_hints(provider: str) -> list[str]:
@@ -1082,7 +1084,9 @@ def _build_chain_cache_context() -> dict[str, Any]:
 def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
     config = _resolve_llm_provider_config()
     temperature = _resolve_llm_temperature()
-    _maybe_reset_config_chat_cache(_build_chain_settings_snapshot(config, temperature))
+    snapshot_changes = _maybe_reset_config_chat_cache(
+        _build_chain_settings_snapshot(config, temperature)
+    )
     context = _build_chain_cache_context_from_config(config, temperature)
     api_key = context["api_key"]
     api_key_fingerprint = context["api_key_fingerprint"]
@@ -1108,6 +1112,11 @@ def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
         cache_key,
         _CONFIG_CHAIN_REBUILD_FIELDS,
     )
+    if snapshot_changes:
+        if invalidation_fields:
+            invalidation_fields = list(dict.fromkeys((*invalidation_fields, *snapshot_changes)))
+        else:
+            invalidation_fields = list(snapshot_changes)
     resource_changed = bool(
         previous_resource_signature and previous_resource_signature != resource_signature
     )

--- a/tests/app/test_model_page_helpers.py
+++ b/tests/app/test_model_page_helpers.py
@@ -1248,6 +1248,72 @@ def test_build_nl_chain_invalidation_on_model_change(
     assert "config_chat_last_instruction" not in stub.session_state
 
 
+def test_maybe_reset_config_chat_cache_resets_on_change(
+    model_module: ModuleType,
+) -> None:
+    stub = model_module.st
+    stub.session_state.clear()
+
+    snapshot = {
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "base_url": None,
+        "organization": None,
+        "temperature": 0.2,
+    }
+
+    assert model_module._maybe_reset_config_chat_cache(snapshot) == []
+
+    stub.session_state.update(
+        {
+            "config_chat_preview": {"before": {}, "after": {}},
+            "config_chat_last_instruction": "old",
+            model_module._CONFIG_CHAIN_METRICS_KEY: {"hits": 1},
+            model_module._CONFIG_CHAIN_STATS_KEY: {"misses": 1},
+            model_module._CONFIG_CHAIN_STATE_KEY: {"entries": {"old": "entry"}},
+        }
+    )
+
+    updated_snapshot = dict(snapshot)
+    updated_snapshot["model"] = "gpt-4o"
+    changed = model_module._maybe_reset_config_chat_cache(updated_snapshot)
+
+    assert "model" in changed
+    assert "config_chat_preview" not in stub.session_state
+    assert "config_chat_last_instruction" not in stub.session_state
+    assert model_module._CONFIG_CHAIN_METRICS_KEY not in stub.session_state
+    assert model_module._CONFIG_CHAIN_STATS_KEY not in stub.session_state
+    assert stub.session_state[model_module._CONFIG_CHAIN_STATE_KEY] == {"entries": {}}
+
+
+def test_maybe_reset_config_chat_cache_no_change_keeps_state(
+    model_module: ModuleType,
+) -> None:
+    stub = model_module.st
+    stub.session_state.clear()
+
+    snapshot = {
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "base_url": None,
+        "organization": None,
+        "temperature": 0.2,
+    }
+
+    assert model_module._maybe_reset_config_chat_cache(snapshot) == []
+
+    stub.session_state.update(
+        {
+            "config_chat_preview": {"before": {}, "after": {}},
+            "config_chat_last_instruction": "old",
+        }
+    )
+
+    assert model_module._maybe_reset_config_chat_cache(dict(snapshot)) == []
+    assert "config_chat_preview" in stub.session_state
+    assert "config_chat_last_instruction" in stub.session_state
+
+
 def test_llm_session_overrides_win_over_env(
     monkeypatch: pytest.MonkeyPatch, model_module: ModuleType
 ) -> None:

--- a/tests/app/test_model_page_helpers.py
+++ b/tests/app/test_model_page_helpers.py
@@ -1110,6 +1110,43 @@ def test_build_nl_chain_reuses_cached_chain(
     assert api_key_secret.value == "sk-test"
 
 
+def test_build_nl_chain_reports_evicted_cache(
+    monkeypatch: pytest.MonkeyPatch, model_module: ModuleType
+) -> None:
+    stub = model_module.st
+    stub.session_state.clear()
+
+    chain_objects = iter([object(), object()])
+
+    def fake_cached_config_patch_chain(
+        session_cache_key: str,
+        chain_cache_key: dict[str, object],
+        llm_cache_key: dict[str, object],
+        api_key: object,
+        extra_payload: str,
+    ) -> object:
+        return next(chain_objects)
+
+    monkeypatch.setattr(
+        model_module,
+        "_resolve_llm_provider_config",
+        lambda: model_module.LLMProviderConfig(
+            provider="openai",
+            model="gpt-4o-mini",
+            api_key="sk-test",
+        ),
+    )
+    monkeypatch.setattr(model_module, "_resolve_llm_temperature", lambda: 0.0)
+    monkeypatch.setattr(model_module, "_cached_config_patch_chain", fake_cached_config_patch_chain)
+
+    _chain_first, meta_first = model_module._build_nl_chain()
+    _chain_second, meta_second = model_module._build_nl_chain()
+
+    assert meta_first["chain_reused"] is False
+    assert meta_second["chain_reused"] is False
+    assert meta_second["chain_cache_miss_reason"] == "cache_evicted"
+
+
 def test_build_nl_chain_invalidation_on_model_change(
     monkeypatch: pytest.MonkeyPatch, model_module: ModuleType
 ) -> None:

--- a/tests/app/test_model_page_helpers.py
+++ b/tests/app/test_model_page_helpers.py
@@ -355,6 +355,36 @@ def test_build_nl_chain_invalidates_on_temperature_env_change(
     assert "config_chat_last_instruction" not in stub.session_state
 
 
+def test_build_nl_chain_cache_key_defaults_provider_model_temperature(
+    monkeypatch: pytest.MonkeyPatch, model_module: ModuleType
+) -> None:
+    stub = model_module.st
+    stub.session_state.clear()
+    captured: dict[str, object] = {}
+
+    def fake_cached_config_patch_chain(
+        _session_cache_key,
+        chain_cache_key,
+        _llm_cache_key,
+        _api_key,
+        _extra_payload,
+    ):
+        captured["chain_cache_key"] = dict(chain_cache_key)
+        return object()
+
+    monkeypatch.setattr(model_module, "_cached_config_patch_chain", fake_cached_config_patch_chain)
+    monkeypatch.delenv("TREND_LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("TREND_LLM_MODEL", raising=False)
+    monkeypatch.delenv("TREND_LLM_TEMPERATURE", raising=False)
+
+    model_module._build_nl_chain()
+
+    cache_key = captured["chain_cache_key"]
+    assert cache_key["provider"] == "openai"
+    assert cache_key["model"] == model_module._DEFAULT_CONFIG_CHAT_MODEL
+    assert cache_key["temperature"] == 0.0
+
+
 def test_build_nl_chain_passes_api_key_to_cache(
     monkeypatch: pytest.MonkeyPatch, model_module: ModuleType
 ) -> None:

--- a/tests/app/test_model_page_helpers.py
+++ b/tests/app/test_model_page_helpers.py
@@ -1288,9 +1288,7 @@ def test_llm_session_override_normalizes_whitespace(model_module: ModuleType) ->
 def test_build_variant_instruction_includes_hint_and_instruction(
     model_module: ModuleType,
 ) -> None:
-    instruction = model_module._build_variant_instruction(
-        "Increase lookback to 24", "Conservative"
-    )
+    instruction = model_module._build_variant_instruction("Increase lookback to 24", "Conservative")
     assert "Increase lookback to 24" in instruction
     assert "conservative" in instruction.lower()
 

--- a/tests/app/test_model_page_helpers.py
+++ b/tests/app/test_model_page_helpers.py
@@ -385,6 +385,26 @@ def test_build_nl_chain_cache_key_defaults_provider_model_temperature(
     assert cache_key["temperature"] == 0.0
 
 
+def test_record_preview_timing_records_entry_without_timings(
+    model_module: ModuleType,
+) -> None:
+    stub = model_module.st
+    stub.session_state.clear()
+
+    preview = {"instruction": "Try something", "before": {}, "after": {}}
+    model_module._record_preview_timing(preview, 1.23)
+
+    history = stub.session_state.get(model_module._CONFIG_PREVIEW_TIMINGS_KEY)
+    assert isinstance(history, list)
+    assert history
+    entry = history[-1]
+    assert entry["instruction"] == "Try something"
+    assert entry["total_seconds"] == pytest.approx(1.23)
+    metrics = stub.session_state.get(model_module._CONFIG_CHAIN_METRICS_KEY)
+    assert isinstance(metrics, dict)
+    assert metrics["total_seconds"] == pytest.approx(1.23)
+
+
 def test_build_nl_chain_passes_api_key_to_cache(
     monkeypatch: pytest.MonkeyPatch, model_module: ModuleType
 ) -> None:

--- a/tests/app/test_model_page_helpers.py
+++ b/tests/app/test_model_page_helpers.py
@@ -1283,3 +1283,39 @@ def test_llm_session_override_normalizes_whitespace(model_module: ModuleType) ->
 
     assert overrides["provider"] == "openai"
     assert overrides["model"] == "gpt-4o-mini"
+
+
+def test_build_variant_instruction_includes_hint_and_instruction(
+    model_module: ModuleType,
+) -> None:
+    instruction = model_module._build_variant_instruction(
+        "Increase lookback to 24", "Conservative"
+    )
+    assert "Increase lookback to 24" in instruction
+    assert "conservative" in instruction.lower()
+
+
+def test_select_metric_value_prefers_first_key(model_module: ModuleType) -> None:
+    metrics = {"return_ann": 0.08, "cagr": 0.12}
+    value = model_module._select_metric_value(metrics, ("cagr", "return_ann"))
+    assert value == 0.12
+
+
+def test_extract_variant_metrics_reads_out_user_stats(model_module: ModuleType) -> None:
+    class DummyStats:
+        def __init__(self) -> None:
+            self.cagr = 0.15
+            self.vol = 0.2
+            self.sharpe = 1.4
+            self.sortino = 1.8
+            self.information_ratio = 0.3
+            self.max_drawdown = -0.25
+            self.total_return = 0.5
+
+    result = SimpleNamespace(details={"out_user_stats": DummyStats()})
+
+    metrics = model_module._extract_variant_metrics(result)
+
+    assert metrics["cagr"] == 0.15
+    assert metrics["vol"] == 0.2
+    assert metrics["sharpe"] == 1.4

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -169,6 +169,31 @@ def test_run_propagates_max_turnover_to_risk(tmp_path, monkeypatch):
     assert captured["max_turnover"] == pytest.approx(0.33)
 
 
+def test_run_resolves_regime_max_turnover_mapping(tmp_path, monkeypatch):
+    df = make_df()
+    cfg = make_cfg(tmp_path, df)
+    cfg.regime = {
+        "enabled": True,
+        "proxy": "A",
+        "lookback": 1,
+        "smoothing": 1,
+        "threshold": 0.0,
+    }
+    cfg.portfolio["max_turnover"] = {"risk_on": 0.12, "risk_off": 0.05}
+    captured = {}
+
+    def _stub_enforce(target, prev, max_turnover):
+        captured["max_turnover"] = max_turnover
+        turnover = float(target.abs().sum())
+        return target, turnover
+
+    monkeypatch.setattr(risk, "_enforce_turnover_cap", _stub_enforce)
+
+    result = pipeline.run(cfg)
+    assert not result.empty
+    assert captured["max_turnover"] == pytest.approx(0.12)
+
+
 def test_run_file_missing(tmp_path, monkeypatch):
     cfg = make_cfg(tmp_path, make_df())
     cfg.data["csv_path"] = str(tmp_path / "missing.csv")


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #4735

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #4729 aimed to resolve issue #4704 but failed verification due to incomplete implementation of regime-conditional turnover caps. This follow-up addresses the gaps by refining the task structure to ensure the Monte Carlo simulation correctly applies turnover caps based on the current regime.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#4729](https://github.com/stranske/Trend_Model_Project/issues/4729)
- [#4704](https://github.com/stranske/Trend_Model_Project/issues/4704)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Modify the simulation module to parse the scenario config for regime-conditional turnover cap syntax and apply the correct turnover cap based on the current regime
- [ ] Update the runner module to record and persist the realized turnover for each period and simulation path
- [ ] Enhance the simulation output to include an indicator for when turnover caps were binding during the simulation
- [ ] Develop unit tests to validate the parsing of regime-specific turnover cap configurations, application of turnover caps in simulation logic, recording of turnover values, and presence of the cap-binding indicator in the output
- [ ] Modify the simulation module to parse the scenario config for regime-conditional turnover cap syntax and apply the correct turnover cap based on the current regime
- [ ] Update the runner module to record and persist the realized turnover for each period and simulation path
- [ ] Enhance the simulation output to include an indicator for when turnover caps were binding during the simulation
- [ ] Develop unit tests to validate the parsing of regime-specific turnover cap configurations, application of turnover caps in simulation logic, recording of turnover values, and presence of the cap-binding indicator in the output

#### Acceptance criteria
- [ ] The simulation module correctly parses the scenario config for regime-conditional turnover caps using the syntax `max_turnover: {calm: 0.15, stress: 0.08}` and applies the correct turnover cap based on the current regime during the Monte Carlo simulations
- [ ] The runner module records and persists the actual turnover applied for every period and for each Monte Carlo simulation path, and this data is accessible for post-simulation diagnostics
- [ ] The simulation output includes a specific flag or diagnostic field indicating whether the turnover cap was binding in any given period during the simulation
- [ ] Unit tests verify that regime-conditional turnover caps are correctly interpreted and applied in the simulation logic, that the runner correctly records the realized turnover per period and strategy path, and that the simulation output includes an accurate indicator for when turnover caps are binding
- [ ] The simulation module correctly parses the scenario config for regime-conditional turnover caps using the syntax `max_turnover: {calm: 0.15, stress: 0.08}` and applies the correct turnover cap based on the current regime during the Monte Carlo simulations
- [ ] The runner module records and persists the actual turnover applied for every period and for each Monte Carlo simulation path, and this data is accessible for post-simulation diagnostics
- [ ] The simulation output includes a specific flag or diagnostic field indicating whether the turnover cap was binding in any given period during the simulation
- [ ] Unit tests verify that regime-conditional turnover caps are correctly interpreted and applied in the simulation logic, that the runner correctly records the realized turnover per period and strategy path, and that the simulation output includes an accurate indicator for when turnover caps are binding

<!-- auto-status-summary:end -->