### PR TITLE
Codex bootstrap for #4724

### DIFF
--- a/agents/codex-4724.md
+++ b/agents/codex-4724.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #4724 -->

--- a/tests/monte_carlo/strategy/test_curated_pack.py
+++ b/tests/monte_carlo/strategy/test_curated_pack.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import yaml
 
 from trend_analysis.config.model import TrendConfig
+from trend_analysis.config.schema_validation import load_schema, validate_config_data
 from trend_analysis.monte_carlo.strategy import StrategyVariant
 
 
@@ -13,6 +14,7 @@ def test_hf_equity_curated_strategies_validate_against_schema() -> None:
     base_path = Path("config/defaults.yml")
     base_config = yaml.safe_load(base_path.read_text(encoding="utf-8"))
     baseline = deepcopy(base_config)
+    schema = load_schema()
 
     strategy_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
     payload = yaml.safe_load(strategy_path.read_text(encoding="utf-8"))
@@ -28,6 +30,10 @@ def test_hf_equity_curated_strategies_validate_against_schema() -> None:
             tags=entry.get("tags", ()),
             curated=True,
         )
+        working_copy = deepcopy(base_config)
+        merged = variant.apply_to(working_copy)
+        schema_errors = validate_config_data(merged, schema)
+        assert schema_errors == []
         validated = variant.to_trend_config(base_config, base_path=base_path.parent)
         assert isinstance(validated, TrendConfig)
         assert base_config == baseline

--- a/tests/monte_carlo/strategy/test_curated_pack.py
+++ b/tests/monte_carlo/strategy/test_curated_pack.py
@@ -64,7 +64,8 @@ def test_hf_equity_curated_strategies_do_not_mutate_defaults() -> None:
 
 def test_hf_equity_curated_to_trend_config_does_not_mutate_defaults() -> None:
     base_path = Path("config/defaults.yml")
-    base_config = yaml.safe_load(base_path.read_text(encoding="utf-8"))
+    before_text = base_path.read_text(encoding="utf-8")
+    base_config = yaml.safe_load(before_text)
     base_snapshot = deepcopy(base_config)
 
     strategy_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
@@ -84,6 +85,9 @@ def test_hf_equity_curated_to_trend_config_does_not_mutate_defaults() -> None:
         validated = variant.to_trend_config(base_config, base_path=base_path.parent)
         assert isinstance(validated, TrendConfig)
         assert base_config == base_snapshot
+
+    after_text = base_path.read_text(encoding="utf-8")
+    assert after_text == before_text
 
 
 def test_hf_equity_curated_strategies_compatible_with_strategy_guards() -> None:

--- a/tests/monte_carlo/strategy/test_curated_pack.py
+++ b/tests/monte_carlo/strategy/test_curated_pack.py
@@ -62,6 +62,30 @@ def test_hf_equity_curated_strategies_do_not_mutate_defaults() -> None:
         assert base_config == base_snapshot
 
 
+def test_hf_equity_curated_to_trend_config_does_not_mutate_defaults() -> None:
+    base_path = Path("config/defaults.yml")
+    base_config = yaml.safe_load(base_path.read_text(encoding="utf-8"))
+    base_snapshot = deepcopy(base_config)
+
+    strategy_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    payload = yaml.safe_load(strategy_path.read_text(encoding="utf-8"))
+
+    curated = payload.get("curated")
+    assert isinstance(curated, list)
+    assert len(curated) == 12
+
+    for entry in curated:
+        variant = StrategyVariant(
+            name=entry["name"],
+            overrides=entry.get("overrides", {}),
+            tags=entry.get("tags", ()),
+            curated=True,
+        )
+        validated = variant.to_trend_config(base_config, base_path=base_path.parent)
+        assert isinstance(validated, TrendConfig)
+        assert base_config == base_snapshot
+
+
 def test_hf_equity_curated_strategies_compatible_with_strategy_guards() -> None:
     base_path = Path("config/defaults.yml")
     base_config = yaml.safe_load(base_path.read_text(encoding="utf-8"))

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -16,6 +16,29 @@ def test_validate_strategy_pack_accepts_hf_equity_curated() -> None:
     assert errors == []
 
 
+def test_validate_strategy_pack_hf_equity_curated_does_not_mutate_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_config_path = Path("config/defaults.yml")
+    base_config = yaml.safe_load(base_config_path.read_text(encoding="utf-8"))
+    base_snapshot = deepcopy(base_config)
+
+    pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+
+    def _load_yaml_mapping(path: Path, label: str) -> dict[str, object]:
+        if label == "base_config":
+            return base_config
+        return payload
+
+    monkeypatch.setattr(validation_module, "_load_yaml_mapping", _load_yaml_mapping)
+
+    errors = validate_strategy_pack(pack_path, base_config_path=base_config_path)
+
+    assert errors == []
+    assert base_config == base_snapshot
+
+
 def test_validate_strategy_pack_reports_base_config_mutation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from trend_analysis.config.schema_validation import validate_config_data
+from trend_analysis.monte_carlo.strategy import StrategyVariant
 from trend_analysis.monte_carlo.strategy import validation as validation_module
 from trend_analysis.monte_carlo.strategy.validation import validate_strategy_pack
 
@@ -112,6 +114,34 @@ def test_validate_strategy_pack_hf_equity_curated_validates_each_strategy_schema
     assert errors == []
     assert len(calls) == len(curated)
     assert all(call_schema is schema for _, call_schema in calls)
+    assert base_config == base_snapshot
+
+
+def test_validate_strategy_pack_hf_equity_curated_validates_schema_and_preserves_defaults() -> None:
+    base_config_path = Path("config/defaults.yml")
+    base_config = yaml.safe_load(base_config_path.read_text(encoding="utf-8"))
+    base_snapshot = deepcopy(base_config)
+    schema = validation_module.load_schema()
+
+    pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+    curated = payload.get("curated")
+    assert isinstance(curated, list)
+
+    errors = validate_strategy_pack(pack_path, base_config_path=base_config_path)
+    assert errors == []
+
+    for entry in curated:
+        variant = StrategyVariant(
+            name=entry["name"],
+            overrides=entry.get("overrides", {}),
+            tags=entry.get("tags", ()),
+            curated=True,
+        )
+        merged = variant.apply_to(deepcopy(base_config))
+        schema_errors = validate_config_data(merged, schema)
+        assert schema_errors == []
+
     assert base_config == base_snapshot
 
 

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -117,6 +117,40 @@ def test_validate_strategy_pack_hf_equity_curated_validates_each_strategy_schema
     assert base_config == base_snapshot
 
 
+def test_validate_strategy_pack_hf_equity_curated_schema_validation_preserves_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_config_path = Path("config/defaults.yml")
+    before_text = base_config_path.read_text(encoding="utf-8")
+    base_config = yaml.safe_load(before_text)
+    base_snapshot = deepcopy(base_config)
+
+    pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+    curated = payload.get("curated")
+    assert isinstance(curated, list)
+
+    schema = validation_module.load_schema()
+    calls: list[dict[str, object]] = []
+    real_validate = validation_module.validate_config_data
+
+    def _validate_config_data(config: dict[str, object], call_schema: dict[str, object]) -> list[str]:
+        calls.append(config)
+        assert call_schema is schema
+        return real_validate(config, call_schema)
+
+    monkeypatch.setattr(validation_module, "load_schema", lambda: schema)
+    monkeypatch.setattr(validation_module, "validate_config_data", _validate_config_data)
+
+    errors = validate_strategy_pack(pack_path, base_config_path=base_config_path)
+    after_text = base_config_path.read_text(encoding="utf-8")
+
+    assert errors == []
+    assert len(calls) == len(curated)
+    assert after_text == before_text
+    assert base_config == base_snapshot
+
+
 def test_validate_strategy_pack_hf_equity_curated_schema_and_defaults_round_trip_validation() -> (
     None
 ):

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -117,6 +117,37 @@ def test_validate_strategy_pack_hf_equity_curated_validates_each_strategy_schema
     assert base_config == base_snapshot
 
 
+def test_validate_strategy_pack_hf_equity_curated_schema_and_defaults_round_trip() -> None:
+    base_config_path = Path("config/defaults.yml")
+    before_text = base_config_path.read_text(encoding="utf-8")
+    base_config = yaml.safe_load(before_text)
+    base_snapshot = deepcopy(base_config)
+    schema = validation_module.load_schema()
+
+    pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+    curated = payload.get("curated")
+    assert isinstance(curated, list)
+
+    errors = validate_strategy_pack(pack_path, base_config_path=base_config_path)
+    after_text = base_config_path.read_text(encoding="utf-8")
+
+    assert errors == []
+    assert after_text == before_text
+    assert base_config == base_snapshot
+
+    for entry in curated:
+        variant = StrategyVariant(
+            name=entry["name"],
+            overrides=entry.get("overrides", {}),
+            tags=entry.get("tags", ()),
+            curated=True,
+        )
+        merged = variant.apply_to(deepcopy(base_config))
+        schema_errors = validate_config_data(merged, schema)
+        assert schema_errors == []
+
+
 def test_validate_strategy_pack_hf_equity_curated_validates_schema_and_preserves_defaults() -> None:
     base_config_path = Path("config/defaults.yml")
     base_config = yaml.safe_load(base_config_path.read_text(encoding="utf-8"))

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -117,6 +117,36 @@ def test_validate_strategy_pack_hf_equity_curated_validates_each_strategy_schema
     assert base_config == base_snapshot
 
 
+def test_validate_strategy_pack_hf_equity_curated_schema_and_defaults_round_trip_validation() -> None:
+    base_config_path = Path("config/defaults.yml")
+    before_text = base_config_path.read_text(encoding="utf-8")
+    base_config = yaml.safe_load(before_text)
+    base_snapshot = deepcopy(base_config)
+    schema = validation_module.load_schema()
+
+    pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+    curated = payload.get("curated")
+    assert isinstance(curated, list)
+
+    errors = validate_strategy_pack(pack_path, base_config_path=base_config_path)
+    after_text = base_config_path.read_text(encoding="utf-8")
+
+    assert errors == []
+    assert after_text == before_text
+    assert base_config == base_snapshot
+
+    for entry in curated:
+        variant = StrategyVariant(
+            name=entry["name"],
+            overrides=entry.get("overrides", {}),
+            tags=entry.get("tags", ()),
+            curated=True,
+        )
+        merged = variant.apply_to(deepcopy(base_config))
+        assert validate_config_data(merged, schema) == []
+
+
 def test_validate_strategy_pack_hf_equity_curated_schema_and_defaults_round_trip() -> None:
     base_config_path = Path("config/defaults.yml")
     before_text = base_config_path.read_text(encoding="utf-8")

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -16,6 +16,19 @@ def test_validate_strategy_pack_accepts_hf_equity_curated() -> None:
     assert errors == []
 
 
+def test_validate_strategy_pack_hf_equity_curated_does_not_modify_defaults_file() -> None:
+    base_config_path = Path("config/defaults.yml")
+    before = base_config_path.read_text(encoding="utf-8")
+
+    pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    errors = validate_strategy_pack(pack_path, base_config_path=base_config_path)
+
+    after = base_config_path.read_text(encoding="utf-8")
+
+    assert errors == []
+    assert after == before
+
+
 def test_validate_strategy_pack_hf_equity_curated_does_not_mutate_defaults(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -63,6 +63,43 @@ def test_validate_strategy_pack_hf_equity_curated_schema_and_defaults(
     assert base_config == base_snapshot
 
 
+def test_validate_strategy_pack_hf_equity_curated_validates_each_strategy_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_config_path = Path("config/defaults.yml")
+    base_config = yaml.safe_load(base_config_path.read_text(encoding="utf-8"))
+    base_snapshot = deepcopy(base_config)
+
+    pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+    curated = payload.get("curated")
+    assert isinstance(curated, list)
+
+    def _load_yaml_mapping(path: Path, label: str) -> dict[str, object]:
+        if label == "base_config":
+            return base_config
+        assert path == pack_path
+        return payload
+
+    calls: list[dict[str, object]] = []
+    real_validate = validation_module.validate_config_data
+
+    def _validate_config_data(
+        config: dict[str, object], schema: dict[str, object]
+    ) -> list[str]:
+        calls.append(config)
+        return real_validate(config, schema)
+
+    monkeypatch.setattr(validation_module, "_load_yaml_mapping", _load_yaml_mapping)
+    monkeypatch.setattr(validation_module, "validate_config_data", _validate_config_data)
+
+    errors = validate_strategy_pack(pack_path, base_config_path=base_config_path)
+
+    assert errors == []
+    assert len(calls) == len(curated)
+    assert base_config == base_snapshot
+
+
 def test_validate_strategy_pack_reports_base_config_mutation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -175,6 +175,7 @@ def test_validate_strategy_pack_hf_equity_curated_validates_each_strategy_and_pr
 ) -> None:
     base_config_path = Path("config/defaults.yml")
     before_text = base_config_path.read_text(encoding="utf-8")
+    before_config = yaml.safe_load(before_text)
 
     pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
     payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
@@ -192,10 +193,12 @@ def test_validate_strategy_pack_hf_equity_curated_validates_each_strategy_and_pr
 
     errors = validate_strategy_pack(pack_path, base_config_path=base_config_path)
     after_text = base_config_path.read_text(encoding="utf-8")
+    after_config = yaml.safe_load(after_text)
 
     assert errors == []
     assert call_count["count"] == len(curated)
     assert after_text == before_text
+    assert after_config == before_config
 
 
 def test_validate_strategy_pack_reports_base_config_mutation(

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -24,12 +24,12 @@ def test_validate_strategy_pack_hf_equity_curated_does_not_mutate_defaults(
     base_snapshot = deepcopy(base_config)
 
     pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
-    payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+    real_loader = validation_module._load_yaml_mapping
 
     def _load_yaml_mapping(path: Path, label: str) -> dict[str, object]:
         if label == "base_config":
             return base_config
-        return payload
+        return real_loader(path, label)
 
     monkeypatch.setattr(validation_module, "_load_yaml_mapping", _load_yaml_mapping)
 

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -75,17 +75,20 @@ def test_validate_strategy_pack_hf_equity_curated_validates_each_strategy_schema
     curated = payload.get("curated")
     assert isinstance(curated, list)
 
+    schema = validation_module.load_schema()
+    monkeypatch.setattr(validation_module, "load_schema", lambda: schema)
+
     def _load_yaml_mapping(path: Path, label: str) -> dict[str, object]:
         if label == "base_config":
             return base_config
         assert path == pack_path
         return payload
 
-    calls: list[dict[str, object]] = []
+    calls: list[tuple[dict[str, object], dict[str, object]]] = []
     real_validate = validation_module.validate_config_data
 
     def _validate_config_data(config: dict[str, object], schema: dict[str, object]) -> list[str]:
-        calls.append(config)
+        calls.append((config, schema))
         return real_validate(config, schema)
 
     monkeypatch.setattr(validation_module, "_load_yaml_mapping", _load_yaml_mapping)
@@ -95,6 +98,7 @@ def test_validate_strategy_pack_hf_equity_curated_validates_each_strategy_schema
 
     assert errors == []
     assert len(calls) == len(curated)
+    assert all(call_schema is schema for _, call_schema in calls)
     assert base_config == base_snapshot
 
 

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -201,6 +201,34 @@ def test_validate_strategy_pack_hf_equity_curated_validates_each_strategy_and_pr
     assert after_config == before_config
 
 
+def test_validate_strategy_pack_hf_equity_curated_loads_schema_and_preserves_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_config_path = Path("config/defaults.yml")
+    before_text = base_config_path.read_text(encoding="utf-8")
+
+    pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+    curated = payload.get("curated")
+    assert isinstance(curated, list)
+
+    call_count = {"count": 0}
+    real_validate = validation_module.validate_config_data
+
+    def _validate_config_data(config: dict[str, object], schema: dict[str, object]) -> list[str]:
+        call_count["count"] += 1
+        return real_validate(config, schema)
+
+    monkeypatch.setattr(validation_module, "validate_config_data", _validate_config_data)
+
+    errors = validate_strategy_pack(pack_path, base_config_path=base_config_path)
+    after_text = base_config_path.read_text(encoding="utf-8")
+
+    assert errors == []
+    assert call_count["count"] == len(curated)
+    assert after_text == before_text
+
+
 def test_validate_strategy_pack_reports_base_config_mutation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -170,6 +170,34 @@ def test_validate_strategy_pack_hf_equity_curated_loads_pack_and_preserves_defau
     assert after_text == before_text
 
 
+def test_validate_strategy_pack_hf_equity_curated_validates_each_strategy_and_preserves_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_config_path = Path("config/defaults.yml")
+    before_text = base_config_path.read_text(encoding="utf-8")
+
+    pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+    curated = payload.get("curated")
+    assert isinstance(curated, list)
+
+    call_count = {"count": 0}
+    real_validate = validation_module.validate_config_data
+
+    def _validate_config_data(config: dict[str, object], schema: dict[str, object]) -> list[str]:
+        call_count["count"] += 1
+        return real_validate(config, schema)
+
+    monkeypatch.setattr(validation_module, "validate_config_data", _validate_config_data)
+
+    errors = validate_strategy_pack(pack_path, base_config_path=base_config_path)
+    after_text = base_config_path.read_text(encoding="utf-8")
+
+    assert errors == []
+    assert call_count["count"] == len(curated)
+    assert after_text == before_text
+
+
 def test_validate_strategy_pack_reports_base_config_mutation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -39,6 +39,30 @@ def test_validate_strategy_pack_hf_equity_curated_does_not_mutate_defaults(
     assert base_config == base_snapshot
 
 
+def test_validate_strategy_pack_hf_equity_curated_schema_and_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_config_path = Path("config/defaults.yml")
+    base_config = yaml.safe_load(base_config_path.read_text(encoding="utf-8"))
+    base_snapshot = deepcopy(base_config)
+
+    pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+
+    def _load_yaml_mapping(path: Path, label: str) -> dict[str, object]:
+        if label == "base_config":
+            return base_config
+        assert path == pack_path
+        return payload
+
+    monkeypatch.setattr(validation_module, "_load_yaml_mapping", _load_yaml_mapping)
+
+    errors = validate_strategy_pack(pack_path, base_config_path=base_config_path)
+
+    assert errors == []
+    assert base_config == base_snapshot
+
+
 def test_validate_strategy_pack_reports_base_config_mutation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -115,6 +115,33 @@ def test_validate_strategy_pack_hf_equity_curated_validates_each_strategy_schema
     assert base_config == base_snapshot
 
 
+def test_validate_strategy_pack_hf_equity_curated_preserves_defaults_file_and_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_config_path = Path("config/defaults.yml")
+    before_text = base_config_path.read_text(encoding="utf-8")
+    base_config = yaml.safe_load(before_text)
+    base_snapshot = deepcopy(base_config)
+
+    pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+
+    def _load_yaml_mapping(path: Path, label: str) -> dict[str, object]:
+        if label == "base_config":
+            return base_config
+        assert path == pack_path
+        return payload
+
+    monkeypatch.setattr(validation_module, "_load_yaml_mapping", _load_yaml_mapping)
+
+    errors = validate_strategy_pack(pack_path, base_config_path=base_config_path)
+    after_text = base_config_path.read_text(encoding="utf-8")
+
+    assert errors == []
+    assert base_config == base_snapshot
+    assert after_text == before_text
+
+
 def test_validate_strategy_pack_reports_base_config_mutation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -117,7 +117,9 @@ def test_validate_strategy_pack_hf_equity_curated_validates_each_strategy_schema
     assert base_config == base_snapshot
 
 
-def test_validate_strategy_pack_hf_equity_curated_schema_and_defaults_round_trip_validation() -> None:
+def test_validate_strategy_pack_hf_equity_curated_schema_and_defaults_round_trip_validation() -> (
+    None
+):
     base_config_path = Path("config/defaults.yml")
     before_text = base_config_path.read_text(encoding="utf-8")
     base_config = yaml.safe_load(before_text)

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -164,7 +164,9 @@ def test_validate_strategy_pack_hf_equity_curated_schema_validation_preserves_de
     calls: list[dict[str, object]] = []
     real_validate = validation_module.validate_config_data
 
-    def _validate_config_data(config: dict[str, object], call_schema: dict[str, object]) -> list[str]:
+    def _validate_config_data(
+        config: dict[str, object], call_schema: dict[str, object]
+    ) -> list[str]:
         calls.append(config)
         assert call_schema is schema
         return real_validate(config, call_schema)

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -84,9 +84,7 @@ def test_validate_strategy_pack_hf_equity_curated_validates_each_strategy_schema
     calls: list[dict[str, object]] = []
     real_validate = validation_module.validate_config_data
 
-    def _validate_config_data(
-        config: dict[str, object], schema: dict[str, object]
-    ) -> list[str]:
+    def _validate_config_data(config: dict[str, object], schema: dict[str, object]) -> list[str]:
         calls.append(config)
         return real_validate(config, schema)
 

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -18,6 +18,36 @@ def test_validate_strategy_pack_accepts_hf_equity_curated() -> None:
     assert errors == []
 
 
+def test_hf_equity_curated_pack_schema_validation_preserves_defaults() -> None:
+    base_config_path = Path("config/defaults.yml")
+    before_text = base_config_path.read_text(encoding="utf-8")
+    base_config = yaml.safe_load(before_text)
+    base_snapshot = deepcopy(base_config)
+    schema = validation_module.load_schema()
+
+    pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+    curated = payload.get("curated")
+    assert isinstance(curated, list)
+
+    errors = validate_strategy_pack(pack_path, base_config_path=base_config_path)
+    assert errors == []
+
+    for entry in curated:
+        variant = StrategyVariant(
+            name=entry["name"],
+            overrides=entry.get("overrides", {}),
+            tags=entry.get("tags", ()),
+            curated=True,
+        )
+        merged = variant.apply_to(deepcopy(base_config))
+        assert validate_config_data(merged, schema) == []
+
+    after_text = base_config_path.read_text(encoding="utf-8")
+    assert after_text == before_text
+    assert base_config == base_snapshot
+
+
 def test_validate_strategy_pack_hf_equity_curated_does_not_modify_defaults_file() -> None:
     base_config_path = Path("config/defaults.yml")
     before = base_config_path.read_text(encoding="utf-8")

--- a/tests/monte_carlo/strategy/test_validation.py
+++ b/tests/monte_carlo/strategy/test_validation.py
@@ -142,6 +142,34 @@ def test_validate_strategy_pack_hf_equity_curated_preserves_defaults_file_and_da
     assert after_text == before_text
 
 
+def test_validate_strategy_pack_hf_equity_curated_loads_pack_and_preserves_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_config_path = Path("config/defaults.yml")
+    before_text = base_config_path.read_text(encoding="utf-8")
+
+    pack_path = Path("config/scenarios/monte_carlo/strategies/hf_equity_curated.yml")
+    payload = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+    curated = payload.get("curated")
+    assert isinstance(curated, list)
+
+    call_count = {"count": 0}
+    real_validate = validation_module.validate_config_data
+
+    def _validate_config_data(config: dict[str, object], schema: dict[str, object]) -> list[str]:
+        call_count["count"] += 1
+        return real_validate(config, schema)
+
+    monkeypatch.setattr(validation_module, "validate_config_data", _validate_config_data)
+
+    errors = validate_strategy_pack(pack_path, base_config_path=base_config_path)
+    after_text = base_config_path.read_text(encoding="utf-8")
+
+    assert errors == []
+    assert call_count["count"] == len(curated)
+    assert after_text == before_text
+
+
 def test_validate_strategy_pack_reports_base_config_mutation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/monte_carlo/strategy/test_variant.py
+++ b/tests/monte_carlo/strategy/test_variant.py
@@ -146,6 +146,40 @@ def test_to_trend_config_accepts_weighting_scheme_and_name(
     assert captured["portfolio"]["weighting"]["name"] == "score_prop_bayes"
 
 
+def test_to_trend_config_applies_weighting_scheme_and_name_without_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = _base_config(tmp_path)
+    base_snapshot = deepcopy(base)
+    variant = StrategyVariant(
+        name="SchemeNameApply",
+        overrides={
+            "portfolio": {
+                "weighting_scheme": "robust_mv",
+                "weighting": {"name": "score_prop"},
+            }
+        },
+    )
+
+    captured: dict[str, object] = {}
+    real_validate = validate_trend_config
+
+    def _wrapped(data: dict[str, object], *, base_path: Path) -> object:
+        captured.update(data)
+        return real_validate(data, base_path=base_path)
+
+    monkeypatch.setattr(
+        "trend_analysis.monte_carlo.strategy.variant.validate_trend_config", _wrapped
+    )
+
+    cfg = variant.to_trend_config(base, base_path=tmp_path)
+
+    assert cfg.portfolio.max_turnover == 0.5
+    assert captured["portfolio"]["weighting_scheme"] == "robust_mv"
+    assert captured["portfolio"]["weighting"]["name"] == "score_prop"
+    assert base == base_snapshot
+
+
 def test_to_trend_config_merges_weighting_scheme_name_and_params(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/monte_carlo/strategy/test_variant.py
+++ b/tests/monte_carlo/strategy/test_variant.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from pathlib import Path
 
 import pytest
+import yaml
 
 from trend_analysis.config.model import validate_trend_config
 from trend_analysis.monte_carlo.strategy import StrategyVariant
@@ -323,6 +324,43 @@ def test_to_trend_config_applies_scheme_and_name_overrides(
     assert captured["portfolio"]["weighting"]["params"]["column"] == "Return"
     assert base["portfolio"]["weighting_scheme"] == "equal"
     assert base["portfolio"]["weighting"]["name"] == "equal"
+
+
+def test_to_trend_config_uses_defaults_without_mutation_when_weighting_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    defaults_path = Path("config/defaults.yml")
+    base_config = yaml.safe_load(defaults_path.read_text(encoding="utf-8"))
+    base_snapshot = deepcopy(base_config)
+    variant = StrategyVariant(
+        name="DefaultsWeighted",
+        overrides={
+            "portfolio": {
+                "weighting_scheme": "risk_parity",
+                "weighting": {"name": "score_prop"},
+            }
+        },
+    )
+
+    captured: dict[str, object] = {}
+    real_validate = validate_trend_config
+
+    def _wrapped(data: dict[str, object], *, base_path: Path) -> object:
+        captured.update(data)
+        return real_validate(data, base_path=base_path)
+
+    monkeypatch.setattr(
+        "trend_analysis.monte_carlo.strategy.variant.validate_trend_config", _wrapped
+    )
+
+    cfg = variant.to_trend_config(base_config, base_path=defaults_path.parent)
+
+    assert cfg.portfolio.rebalance_calendar == "NYSE"
+    assert captured["portfolio"]["weighting_scheme"] == "risk_parity"
+    assert captured["portfolio"]["weighting"]["name"] == "score_prop"
+    assert base_config == base_snapshot
+    assert base_config["portfolio"]["weighting_scheme"] == "equal"
+    assert base_config["portfolio"]["weighting"]["name"] == "score_prop_bayes"
 
 
 def test_to_trend_config_allows_only_weighting_scheme_override(tmp_path: Path) -> None:

--- a/tests/monte_carlo/strategy/test_variant.py
+++ b/tests/monte_carlo/strategy/test_variant.py
@@ -407,6 +407,43 @@ def test_to_trend_config_weighting_scheme_and_name_preserve_defaults(
     assert base_config["portfolio"]["weighting"]["name"] == "score_prop_bayes"
 
 
+def test_to_trend_config_defaults_with_scheme_name_and_params_no_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    defaults_path = Path("config/defaults.yml")
+    base_config = yaml.safe_load(defaults_path.read_text(encoding="utf-8"))
+    base_snapshot = deepcopy(base_config)
+    variant = StrategyVariant(
+        name="DefaultsSchemeNameParams",
+        overrides={
+            "portfolio": {
+                "weighting_scheme": "risk_parity",
+                "weighting": {"name": "score_prop_bayes", "params": {"half_life": 12}},
+            }
+        },
+    )
+
+    captured: dict[str, object] = {}
+    real_validate = validate_trend_config
+
+    def _wrapped(data: dict[str, object], *, base_path: Path) -> object:
+        captured.update(data)
+        return real_validate(data, base_path=base_path)
+
+    monkeypatch.setattr(
+        "trend_analysis.monte_carlo.strategy.variant.validate_trend_config", _wrapped
+    )
+
+    cfg = variant.to_trend_config(base_config, base_path=defaults_path.parent)
+
+    assert cfg.portfolio.rebalance_calendar == base_config["portfolio"]["rebalance_calendar"]
+    assert captured["portfolio"]["weighting_scheme"] == "risk_parity"
+    assert captured["portfolio"]["weighting"]["name"] == "score_prop_bayes"
+    assert captured["portfolio"]["weighting"]["params"]["half_life"] == 12
+    assert captured["portfolio"]["weighting"]["params"]["shrink_tau"] == 0.25
+    assert base_config == base_snapshot
+
+
 def test_to_trend_config_allows_only_weighting_scheme_override(tmp_path: Path) -> None:
     base = _base_config(tmp_path)
     variant = StrategyVariant(

--- a/tests/monte_carlo/strategy/test_variant.py
+++ b/tests/monte_carlo/strategy/test_variant.py
@@ -186,6 +186,40 @@ def test_to_trend_config_merges_weighting_scheme_name_and_params(
     assert base == base_snapshot
 
 
+def test_to_trend_config_uses_scheme_and_name_without_mutating_base(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = _base_config(tmp_path)
+    base_snapshot = deepcopy(base)
+    variant = StrategyVariant(
+        name="SchemeAndName",
+        overrides={
+            "portfolio": {
+                "weighting_scheme": "robust_mv",
+                "weighting": {"name": "score_prop_bayes"},
+            }
+        },
+    )
+
+    captured: dict[str, object] = {}
+    real_validate = validate_trend_config
+
+    def _wrapped(data: dict[str, object], *, base_path: Path) -> object:
+        captured.update(data)
+        return real_validate(data, base_path=base_path)
+
+    monkeypatch.setattr(
+        "trend_analysis.monte_carlo.strategy.variant.validate_trend_config", _wrapped
+    )
+
+    cfg = variant.to_trend_config(base, base_path=tmp_path)
+
+    assert cfg.portfolio.rebalance_calendar == "NYSE"
+    assert captured["portfolio"]["weighting_scheme"] == "robust_mv"
+    assert captured["portfolio"]["weighting"]["name"] == "score_prop_bayes"
+    assert base == base_snapshot
+
+
 def test_to_trend_config_preserves_weighting_params_when_scheme_and_name_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/monte_carlo/strategy/test_variant.py
+++ b/tests/monte_carlo/strategy/test_variant.py
@@ -369,6 +369,44 @@ def test_to_trend_config_uses_defaults_without_mutation_when_weighting_overrides
     assert base_config["portfolio"]["weighting"]["name"] == "score_prop_bayes"
 
 
+def test_to_trend_config_weighting_scheme_and_name_preserve_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    defaults_path = Path("config/defaults.yml")
+    base_config = yaml.safe_load(defaults_path.read_text(encoding="utf-8"))
+    base_snapshot = deepcopy(base_config)
+    variant = StrategyVariant(
+        name="DefaultsSchemeName",
+        overrides={
+            "portfolio": {
+                "weighting_scheme": "risk_parity",
+                "weighting": {"name": "score_prop"},
+            }
+        },
+    )
+
+    captured: dict[str, object] = {}
+    real_validate = validate_trend_config
+
+    def _wrapped(data: dict[str, object], *, base_path: Path) -> object:
+        captured.update(data)
+        return real_validate(data, base_path=base_path)
+
+    monkeypatch.setattr(
+        "trend_analysis.monte_carlo.strategy.variant.validate_trend_config", _wrapped
+    )
+
+    cfg = variant.to_trend_config(base_config, base_path=defaults_path.parent)
+
+    assert cfg.portfolio.rebalance_calendar == base_config["portfolio"]["rebalance_calendar"]
+    assert captured["portfolio"]["weighting_scheme"] == "risk_parity"
+    assert captured["portfolio"]["weighting"]["name"] == "score_prop"
+    assert captured["portfolio"]["weighting"]["params"]["shrink_tau"] == 0.25
+    assert base_config == base_snapshot
+    assert base_config["portfolio"]["weighting_scheme"] == "equal"
+    assert base_config["portfolio"]["weighting"]["name"] == "score_prop_bayes"
+
+
 def test_to_trend_config_allows_only_weighting_scheme_override(tmp_path: Path) -> None:
     base = _base_config(tmp_path)
     variant = StrategyVariant(

--- a/tests/monte_carlo/strategy/test_variant.py
+++ b/tests/monte_carlo/strategy/test_variant.py
@@ -150,6 +150,7 @@ def test_to_trend_config_merges_weighting_scheme_name_and_params(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     base = _base_config(tmp_path)
+    base_snapshot = deepcopy(base)
     variant = StrategyVariant(
         name="WeightedParams",
         overrides={
@@ -182,14 +183,14 @@ def test_to_trend_config_merges_weighting_scheme_name_and_params(
     assert captured["portfolio"]["weighting"]["params"]["column"] == "Return"
     assert captured["portfolio"]["weighting"]["params"]["half_life"] == 12
     assert captured["portfolio"]["weighting"]["params"]["shrink_tau"] == 0.25
-    assert base["portfolio"]["weighting_scheme"] == "equal"
-    assert base["portfolio"]["weighting"]["name"] == "equal"
+    assert base == base_snapshot
 
 
 def test_to_trend_config_preserves_weighting_params_when_scheme_and_name_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     base = _base_config(tmp_path)
+    base_snapshot = deepcopy(base)
     variant = StrategyVariant(
         name="SchemeAndNameNoParams",
         overrides={
@@ -218,8 +219,7 @@ def test_to_trend_config_preserves_weighting_params_when_scheme_and_name_overrid
     assert captured["portfolio"]["weighting"]["name"] == "score_prop"
     assert captured["portfolio"]["weighting"]["params"]["column"] == "Sharpe"
     assert captured["portfolio"]["weighting"]["params"]["shrink_tau"] == 0.25
-    assert base["portfolio"]["weighting_scheme"] == "equal"
-    assert base["portfolio"]["weighting"]["name"] == "equal"
+    assert base == base_snapshot
 
 
 def test_to_trend_config_applies_scheme_and_name_overrides(

--- a/tests/monte_carlo/strategy/test_variant.py
+++ b/tests/monte_carlo/strategy/test_variant.py
@@ -496,6 +496,35 @@ def test_apply_to_allows_weighting_params_extension(tmp_path: Path) -> None:
     assert "obs_sigma" not in base["portfolio"]["weighting"]["params"]
 
 
+def test_apply_to_allows_weighting_params_extension_with_scheme_and_name(
+    tmp_path: Path,
+) -> None:
+    base = _base_config(tmp_path)
+    base_snapshot = deepcopy(base)
+    variant = StrategyVariant(
+        name="SchemeNameParams",
+        overrides={
+            "portfolio": {
+                "weighting_scheme": "risk_parity",
+                "weighting": {
+                    "name": "score_prop_bayes",
+                    "params": {"column": "Return", "half_life": 24, "obs_sigma": 0.2},
+                },
+            }
+        },
+    )
+
+    merged = variant.apply_to(base)
+
+    assert merged["portfolio"]["weighting_scheme"] == "risk_parity"
+    assert merged["portfolio"]["weighting"]["name"] == "score_prop_bayes"
+    assert merged["portfolio"]["weighting"]["params"]["column"] == "Return"
+    assert merged["portfolio"]["weighting"]["params"]["half_life"] == 24
+    assert merged["portfolio"]["weighting"]["params"]["obs_sigma"] == 0.2
+    assert merged["portfolio"]["weighting"]["params"]["shrink_tau"] == 0.25
+    assert base == base_snapshot
+
+
 def test_apply_to_allows_weighting_params_creation_for_curated(tmp_path: Path) -> None:
     base = _base_config(tmp_path)
     base["portfolio"]["weighting"].pop("params")

--- a/tests/monte_carlo/strategy/test_variant.py
+++ b/tests/monte_carlo/strategy/test_variant.py
@@ -342,6 +342,12 @@ def test_to_trend_config_uses_defaults_without_mutation_when_weighting_overrides
         },
     )
 
+    merged = variant.apply_to(base_config)
+    assert merged["portfolio"]["weighting_scheme"] == "risk_parity"
+    assert merged["portfolio"]["weighting"]["name"] == "score_prop"
+    assert merged["portfolio"]["weighting"]["params"]["shrink_tau"] == 0.25
+    assert base_config == base_snapshot
+
     captured: dict[str, object] = {}
     real_validate = validate_trend_config
 

--- a/tests/monte_carlo/test_example_config.py
+++ b/tests/monte_carlo/test_example_config.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from pathlib import Path
 from typing import Mapping
+
+import yaml
 
 from trend_analysis.monte_carlo import (
     MonteCarloSettings,
@@ -66,3 +69,19 @@ def test_example_config_marks_curated_variants() -> None:
     curated = scenario.strategy_set.get("curated")
     assert curated is not None
     assert all(variant.curated for variant in curated)
+
+
+def test_example_config_curated_variants_do_not_mutate_defaults() -> None:
+    base_path = Path("config/defaults.yml")
+    base_config = yaml.safe_load(base_path.read_text(encoding="utf-8"))
+    base_snapshot = deepcopy(base_config)
+
+    scenario = load_scenario("example_scenario")
+
+    assert scenario.strategy_set is not None
+    curated = scenario.strategy_set.get("curated")
+    assert curated is not None
+
+    for variant in curated:
+        _ = variant.to_trend_config(base_config, base_path=base_path.parent)
+        assert base_config == base_snapshot


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #4724

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Not provided._

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Trend_Model_Project#4723](https://github.com/stranske/Trend_Model_Project/issues/4723)
- [#4723](https://github.com/stranske/Trend_Model_Project/issues/4723)
- [#4671](https://github.com/stranske/Trend_Model_Project/issues/4671)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] <!-- Incomplete tasks from original issue -->
- [ ] Write unit tests to load `hf_equity_curated.yml`, validate each strategy against the schema, and confirm that global defaults remain unaffected.
- [x] Write unit tests to load `hf_equity_curated.yml` (verify: tests pass)
- [ ] validate each strategy against the schema (verify: confirm completion in repo)
- [x] (verify: tests pass)
- [ ] confirm that global defaults remain unaffected. (verify: confirm completion in repo)
- [x] Define scope for: Write unit tests to validate each strategy in `hf_equity_curated.yml` against the schema. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Implement focused slice for: Write unit tests to validate each strategy in `hf_equity_curated.yml` against the schema. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Validate focused slice for: Write unit tests to validate each strategy in `hf_equity_curated.yml` against the schema. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Define scope for: Write unit tests to confirm that global defaults remain unaffected when loading `hf_equity_curated.yml`. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Implement focused slice for: Write unit tests to confirm that global defaults remain unaffected when loading `hf_equity_curated.yml`. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Validate focused slice for: Write unit tests to confirm that global defaults remain unaffected when loading `hf_equity_curated.yml`. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided, ensuring no unintended global modifications.
- [x] Define scope for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [x] Implement focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [x] Validate focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] `portfolio.weighting.name` are provided (verify: confirm completion in repo)
- [ ] ensuring no unintended global modifications. (verify: confirm completion in repo)
- [x] Define scope for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Implement focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Validate focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] `portfolio.weighting.name` are provided. (verify: confirm completion in repo)
- [x] Define scope for: Add test cases for `StrategyVariant.to_trend_config` to ensure no unintended global modifications occur. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Implement focused slice for: Add test cases for `StrategyVariant.to_trend_config` to ensure no unintended global modifications occur. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Validate focused slice for: Add test cases for `StrategyVariant.to_trend_config` to ensure no unintended global modifications occur. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] <!-- New tasks to address unmet acceptance criteria -->
- [ ] Unit tests load `hf_equity_curated.yml`, validate each strategy against the schema, and confirm that global defaults remain unaffected.
- [x] Unit tests load `hf_equity_curated.yml` (verify: tests pass)
- [ ] validate each strategy against the schema (verify: confirm completion in repo)
- [x] (verify: tests pass)
- [ ] confirm that global defaults remain unaffected. (verify: confirm completion in repo)
- [x] Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided, and ensure no unintended global modifications.
- [ ] Define scope for: Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [x] Implement focused slice for: Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Validate focused slice for: Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] `portfolio.weighting.name` are provided (verify: confirm completion in repo)
- [ ] (verify: confirm completion in repo)
- [ ] ensure no unintended global modifications. (verify: confirm completion in repo)
- [ ] <!-- Incomplete tasks from original issue -->
- [ ] Write unit tests to load `hf_equity_curated.yml`, validate each strategy against the schema, and confirm that global defaults remain unaffected.
- [x] Write unit tests to load `hf_equity_curated.yml` (verify: tests pass)
- [ ] validate each strategy against the schema (verify: confirm completion in repo)
- [x] (verify: tests pass)
- [ ] confirm that global defaults remain unaffected. (verify: confirm completion in repo)
- [x] Define scope for: Write unit tests to validate each strategy in `hf_equity_curated.yml` against the schema. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Implement focused slice for: Write unit tests to validate each strategy in `hf_equity_curated.yml` against the schema. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Validate focused slice for: Write unit tests to validate each strategy in `hf_equity_curated.yml` against the schema. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Define scope for: Write unit tests to confirm that global defaults remain unaffected when loading `hf_equity_curated.yml`. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Implement focused slice for: Write unit tests to confirm that global defaults remain unaffected when loading `hf_equity_curated.yml`. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Validate focused slice for: Write unit tests to confirm that global defaults remain unaffected when loading `hf_equity_curated.yml`. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided, ensuring no unintended global modifications.
- [x] Define scope for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [x] Implement focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [x] Validate focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] `portfolio.weighting.name` are provided (verify: confirm completion in repo)
- [ ] ensuring no unintended global modifications. (verify: confirm completion in repo)
- [x] Define scope for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Implement focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Validate focused slice for: Add test cases for `StrategyVariant.to_trend_config` to verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] `portfolio.weighting.name` are provided. (verify: confirm completion in repo)
- [x] Define scope for: Add test cases for `StrategyVariant.to_trend_config` to ensure no unintended global modifications occur. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Implement focused slice for: Add test cases for `StrategyVariant.to_trend_config` to ensure no unintended global modifications occur. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [x] Validate focused slice for: Add test cases for `StrategyVariant.to_trend_config` to ensure no unintended global modifications occur. (verify: tests pass)
- [ ] Split into smaller (verify: confirm completion in repo)
- [ ] single-action tasks (verify: confirm completion in repo)
- [ ] <!-- New tasks to address unmet acceptance criteria -->
- [ ] Unit tests load `hf_equity_curated.yml`, validate each strategy against the schema, and confirm that global defaults remain unaffected.
- [x] Unit tests load `hf_equity_curated.yml` (verify: tests pass)
- [ ] validate each strategy against the schema (verify: confirm completion in repo)
- [x] (verify: tests pass)
- [ ] confirm that global defaults remain unaffected. (verify: confirm completion in repo)
- [x] Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided, and ensure no unintended global modifications.
- [ ] Define scope for: Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [x] Implement focused slice for: Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] Validate focused slice for: Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme`
- [ ] `portfolio.weighting.name` are provided (verify: confirm completion in repo)
- [ ] (verify: confirm completion in repo)
- [ ] ensure no unintended global modifications. (verify: confirm completion in repo)

#### Acceptance criteria
- [ ] <!-- Criteria verified as unmet by verifier -->
- [ ] Unit tests load `hf_equity_curated.yml`, validate each strategy against the schema, and confirm that global defaults remain unaffected.
- [x] Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided, and ensure no unintended global modifications.
- [ ] <!-- Criteria verified as unmet by verifier -->
- [ ] Unit tests load `hf_equity_curated.yml`, validate each strategy against the schema, and confirm that global defaults remain unaffected.
- [x] Test cases for `StrategyVariant.to_trend_config` verify the correct application of weighting methods when both `portfolio.weighting_scheme` and `portfolio.weighting.name` are provided, and ensure no unintended global modifications.

<!-- auto-status-summary:end -->