### PR TITLE
feat: implement regime-conditional turnover caps in Monte Carlo simulation

### DIFF
--- a/src/trend_analysis/pipeline.py
+++ b/src/trend_analysis/pipeline.py
@@ -246,7 +246,7 @@ def run_analysis(
     periods_per_year: float | None = None,
     previous_weights: Mapping[str, float] | None = None,
     lambda_tc: float | None = None,
-    max_turnover: float | None = None,
+    max_turnover: float | Mapping[str, float] | None = None,
     signal_spec: TrendSpec | None = None,
     regime_cfg: Mapping[str, Any] | None = None,
     calendar_frequency: str | None = None,

--- a/src/trend_analysis/pipeline_helpers.py
+++ b/src/trend_analysis/pipeline_helpers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, Mapping
+from typing import Any, Mapping, cast
 
 import numpy as np
 import pandas as pd
@@ -154,13 +154,16 @@ def _resolve_regime_turnover_cap(
     regime_label: str | None,
     settings: Any,
 ) -> float | None:
+    def _coerce_optional_float(value: object) -> float | None:
+        try:
+            return float(cast(Any, value))
+        except (TypeError, ValueError):
+            return None
+
     if max_turnover is None:
         return None
     if not isinstance(max_turnover, Mapping):
-        try:
-            return float(max_turnover)
-        except (TypeError, ValueError):
-            return None
+        return _coerce_optional_float(max_turnover)
 
     normalized: dict[str, object] = {}
     for key, value in max_turnover.items():
@@ -174,25 +177,16 @@ def _resolve_regime_turnover_cap(
     if regime_label:
         label_key = _normalize_regime_key(regime_label)
         if label_key and label_key in normalized:
-            try:
-                return float(normalized[label_key])
-            except (TypeError, ValueError):
-                return None
+            return _coerce_optional_float(normalized[label_key])
 
     default_label = getattr(settings, "default_label", None)
     default_key = _normalize_regime_key(default_label)
     if default_key and default_key in normalized:
-        try:
-            return float(normalized[default_key])
-        except (TypeError, ValueError):
-            return None
+        return _coerce_optional_float(normalized[default_key])
 
     for fallback in ("default", "all", "any"):
         if fallback in normalized:
-            try:
-                return float(normalized[fallback])
-            except (TypeError, ValueError):
-                return None
+            return _coerce_optional_float(normalized[fallback])
     return None
 
 

--- a/src/trend_analysis/pipeline_helpers.py
+++ b/src/trend_analysis/pipeline_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, Mapping
 
 import numpy as np
@@ -27,6 +28,7 @@ __all__ = [
     "_empty_run_full_result",
     "_format_period",
     "_policy_from_config",
+    "_resolve_regime_turnover_cap",
     "_resolve_regime_label",
     "_resolve_sample_split",
     "_resolve_target_vol",
@@ -136,6 +138,62 @@ def _resolve_regime_label(
     if aligned.empty:
         return None, settings
     return str(aligned.iloc[-1]), settings
+
+
+def _normalize_regime_key(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return re.sub(r"[^a-z0-9]+", "", text.casefold())
+
+
+def _resolve_regime_turnover_cap(
+    max_turnover: object | None,
+    regime_label: str | None,
+    settings: Any,
+) -> float | None:
+    if max_turnover is None:
+        return None
+    if not isinstance(max_turnover, Mapping):
+        try:
+            return float(max_turnover)
+        except (TypeError, ValueError):
+            return None
+
+    normalized: dict[str, object] = {}
+    for key, value in max_turnover.items():
+        normalized_key = _normalize_regime_key(key)
+        if not normalized_key:
+            continue
+        normalized[normalized_key] = value
+    if not normalized:
+        return None
+
+    if regime_label:
+        label_key = _normalize_regime_key(regime_label)
+        if label_key and label_key in normalized:
+            try:
+                return float(normalized[label_key])
+            except (TypeError, ValueError):
+                return None
+
+    default_label = getattr(settings, "default_label", None)
+    default_key = _normalize_regime_key(default_label)
+    if default_key and default_key in normalized:
+        try:
+            return float(normalized[default_key])
+        except (TypeError, ValueError):
+            return None
+
+    for fallback in ("default", "all", "any"):
+        if fallback in normalized:
+            try:
+                return float(normalized[fallback])
+            except (TypeError, ValueError):
+                return None
+    return None
 
 
 def _apply_regime_overrides(

--- a/src/trend_analysis/pipeline_runner.py
+++ b/src/trend_analysis/pipeline_runner.py
@@ -10,6 +10,7 @@ from .pipeline_helpers import (
     _apply_regime_overrides,
     _apply_regime_weight_overrides,
     _resolve_regime_label,
+    _resolve_regime_turnover_cap,
 )
 from .signals import TrendSpec
 from .stages import portfolio as portfolio_stage
@@ -47,7 +48,7 @@ def _run_analysis_with_diagnostics(
     periods_per_year_override: float | None = None,
     previous_weights: Mapping[str, float] | None = None,
     lambda_tc: float | None = None,
-    max_turnover: float | None = None,
+    max_turnover: float | Mapping[str, float] | None = None,
     signal_spec: TrendSpec | None = None,
     regime_cfg: Mapping[str, Any] | None = None,
     weight_policy: Mapping[str, Any] | None = None,
@@ -99,6 +100,11 @@ def _run_analysis_with_diagnostics(
         settings=regime_settings,
         regime_cfg=regime_cfg,
     )
+    resolved_max_turnover = _resolve_regime_turnover_cap(
+        max_turnover,
+        regime_label,
+        regime_settings,
+    )
 
     selection_stage_result = selection_stage._select_universe(
         preprocess_stage,
@@ -133,7 +139,7 @@ def _run_analysis_with_diagnostics(
         risk_window=risk_window,
         previous_weights=previous_weights,
         lambda_tc=lambda_tc,
-        max_turnover=max_turnover,
+        max_turnover=resolved_max_turnover,
         signal_spec=signal_spec,
         weight_policy=weight_policy,
         warmup=preprocess_stage.warmup,
@@ -184,7 +190,7 @@ def _run_analysis(
     periods_per_year_override: float | None = None,
     previous_weights: Mapping[str, float] | None = None,
     lambda_tc: float | None = None,
-    max_turnover: float | None = None,
+    max_turnover: float | Mapping[str, float] | None = None,
     signal_spec: TrendSpec | None = None,
     regime_cfg: Mapping[str, Any] | None = None,
     weight_policy: Mapping[str, Any] | None = None,

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -1114,7 +1114,6 @@ def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
     resource_signature = _chain_resource_signature(cache_key, llm_cache_key)
     previous_signature = cache_state.get("last_signature")
     previous_resource_signature = cache_state.get("last_resource_signature")
-    settings_changed = bool(previous_signature and previous_signature != signature)
     previous_cache_key = cache_state.get("last_cache_key")
     previous_llm_cache_key = cache_state.get("last_llm_cache_key")
     changed_fields = _cache_key_changes(previous_cache_key, cache_key, _CONFIG_CHAIN_CORE_FIELDS)
@@ -1127,6 +1126,11 @@ def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
         previous_cache_key,
         cache_key,
         _CONFIG_CHAIN_REBUILD_FIELDS,
+    )
+    settings_changed = bool(
+        (previous_signature and previous_signature != signature)
+        or invalidation_fields
+        or reset_fields
     )
     resource_changed = bool(
         previous_resource_signature and previous_resource_signature != resource_signature

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -74,7 +74,12 @@ _DEFAULT_CONFIG_CHAT_MODEL = "gpt-4o-mini"
 _CONFIG_CHAIN_CACHE_VERSION = "v1"
 _CONFIG_CHAIN_METRICS_KEY = "config_chat_chain_metrics"
 _CONFIG_CHAIN_STATS_KEY = "config_chat_chain_stats"
-_CONFIG_CHAIN_CORE_FIELDS = (
+_CONFIG_CHAIN_KEY_FIELDS = (
+    "provider",
+    "model",
+    "temperature",
+)
+_CONFIG_CHAIN_INVALIDATION_FIELDS = (
     "provider",
     "model",
     "base_url",
@@ -88,7 +93,7 @@ _CONFIG_CHAIN_LLM_FIELDS = (
     "api_key_fingerprint",
 )
 _LOGGER = logging.getLogger(__name__)
-_CONFIG_CHAIN_INVALIDATION_FIELDS = _CONFIG_CHAIN_CORE_FIELDS
+_CONFIG_CHAIN_CORE_FIELDS = _CONFIG_CHAIN_KEY_FIELDS
 _CONFIG_CHAIN_REBUILD_FIELDS = _CONFIG_CHAIN_INVALIDATION_FIELDS
 _CONFIG_CHAIN_RESET_FIELDS = _CONFIG_CHAIN_INVALIDATION_FIELDS
 _LLM_PROVIDER_OVERRIDE_KEY = "llm_provider_override"
@@ -135,12 +140,18 @@ def _chain_resource_signature(
     return _chain_cache_signature({"chain": dict(chain_cache_key), "llm": dict(llm_cache_key)})
 
 
-def _chain_cache_summary(cache_key: Mapping[str, Any]) -> str:
+def _chain_cache_summary(
+    cache_key: Mapping[str, Any],
+    llm_cache_key: Mapping[str, Any] | None = None,
+) -> str:
     provider = cache_key.get("provider") or "default"
     model = cache_key.get("model") or "default"
     temperature = cache_key.get("temperature")
-    base_url = cache_key.get("base_url")
-    organization = cache_key.get("organization")
+    base_url = None
+    organization = None
+    if isinstance(llm_cache_key, Mapping):
+        base_url = llm_cache_key.get("base_url")
+        organization = llm_cache_key.get("organization")
     summary = f"{provider}:{model}@{_format_value(temperature)}"
     if base_url:
         summary = f"{summary} | base_url={base_url}"
@@ -153,16 +164,12 @@ def _build_chain_cache_key(
     *,
     provider: str,
     model: str,
-    base_url: str | None,
-    organization: str | None,
     temperature: float,
 ) -> dict[str, Any]:
     return {
         "cache_version": _CONFIG_CHAIN_CACHE_VERSION,
         "provider": provider,
         "model": model,
-        "base_url": base_url,
-        "organization": organization,
         "temperature": temperature,
     }
 
@@ -1079,8 +1086,6 @@ def _build_chain_cache_context(
     cache_key = _build_chain_cache_key(
         provider=provider,
         model=resolved_model,
-        base_url=base_url,
-        organization=organization,
         temperature=temperature,
     )
     return {
@@ -1190,7 +1195,7 @@ def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
         "chain_cache_key": cache_key,
         "chain_cache_signature": signature,
         "chain_resource_signature": resource_signature,
-        "chain_cache_summary": _chain_cache_summary(cache_key),
+        "chain_cache_summary": _chain_cache_summary(cache_key, llm_cache_key),
         "chain_cache_miss_reason": cache_miss_reason,
         "chain_cache_invalidation_fields": invalidation_fields,
         "chain_settings_changed": settings_changed,
@@ -1643,7 +1648,12 @@ def _render_config_chat_contents(model_state: Mapping[str, Any] | None) -> None:
         st.caption(f"Cache key unavailable: {exc}")
     else:
         cache_key = cache_context.get("cache_key")
-        cache_summary = _chain_cache_summary(cache_key) if isinstance(cache_key, Mapping) else "—"
+        llm_cache_key = cache_context.get("llm_cache_key")
+        cache_summary = (
+            _chain_cache_summary(cache_key, llm_cache_key)
+            if isinstance(cache_key, Mapping)
+            else "—"
+        )
         cache_signature = (
             _chain_cache_signature(cache_key)[:8] if isinstance(cache_key, Mapping) else "—"
         )

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -358,6 +358,24 @@ def _format_seconds(value: Any) -> str:
     return f"{numeric:.2f}s"
 
 
+def _preview_timing_summary(
+    timings: Mapping[str, Any] | None,
+    total_seconds: float | None = None,
+) -> str:
+    if not isinstance(timings, Mapping):
+        return "Preview timing unavailable."
+    cache_hit = "hit" if timings.get("chain_reused") else "miss"
+    build = _format_seconds(timings.get("chain_build_seconds"))
+    lookup = _format_seconds(timings.get("chain_lookup_seconds"))
+    run = _format_seconds(timings.get("run_seconds"))
+    total_value = total_seconds if total_seconds is not None else timings.get("total_seconds")
+    total = _format_seconds(total_value)
+    return (
+        "Preview timing: "
+        f"cache {cache_hit} | build {build} | lookup {lookup} | run {run} | total {total}"
+    )
+
+
 def _render_preview_timing_history() -> None:
     st.markdown("**Preview timings**")
     history = st.session_state.get(_CONFIG_PREVIEW_TIMINGS_KEY)
@@ -1259,6 +1277,10 @@ def _generate_preview_with_progress(
     if isinstance(timings, Mapping):
         timings["total_seconds"] = duration
     _record_preview_timing(result, duration)
+    st.session_state["config_chat_last_preview_summary"] = _preview_timing_summary(
+        timings if isinstance(timings, Mapping) else None,
+        total_seconds=duration,
+    )
     return result
 
 
@@ -1608,6 +1630,9 @@ def _render_config_change_history() -> None:
 def _render_config_chat_contents(model_state: Mapping[str, Any] | None) -> None:
     st.caption("Describe the configuration change you want to try.")
     _render_last_preview_metrics()
+    last_summary = st.session_state.get("config_chat_last_preview_summary")
+    if isinstance(last_summary, str) and last_summary:
+        st.caption(last_summary)
     try:
         cache_context = _build_chain_cache_context()
     except Exception as exc:

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -825,26 +825,33 @@ def _resolve_llm_session_overrides() -> dict[str, str | None]:
     }
 
 
-def _current_chain_settings_snapshot() -> dict[str, Any]:
-    config = _resolve_llm_provider_config()
+def _current_chain_settings_snapshot(
+    config: LLMProviderConfig | None = None,
+    temperature: float | None = None,
+) -> dict[str, Any]:
+    if config is None:
+        config = _resolve_llm_provider_config()
+    if temperature is None:
+        temperature = _resolve_llm_temperature()
     return {
         "provider": _normalize_cache_str(config.provider),
         "model": _normalize_cache_str(config.model),
         "base_url": _normalize_cache_str(config.base_url),
         "organization": _normalize_cache_str(config.organization),
-        "temperature": _normalize_temperature(_resolve_llm_temperature()),
+        "temperature": _normalize_temperature(temperature),
     }
 
 
-def _maybe_reset_config_chat_cache(snapshot: Mapping[str, Any]) -> None:
+def _maybe_reset_config_chat_cache(snapshot: Mapping[str, Any]) -> list[str]:
     previous = st.session_state.get(_LLM_OVERRIDE_SNAPSHOT_KEY)
     normalized = dict(snapshot)
     if not isinstance(previous, Mapping):
         st.session_state[_LLM_OVERRIDE_SNAPSHOT_KEY] = normalized
-        return
+        return []
     previous_normalized = {key: previous.get(key) for key in normalized}
     if previous_normalized == normalized:
-        return
+        return []
+    changed = [key for key in normalized if previous_normalized.get(key) != normalized.get(key)]
     st.session_state[_LLM_OVERRIDE_SNAPSHOT_KEY] = normalized
     st.session_state.pop("config_chat_preview", None)
     st.session_state.pop("config_chat_last_instruction", None)
@@ -857,6 +864,7 @@ def _maybe_reset_config_chat_cache(snapshot: Mapping[str, Any]) -> None:
         previous_normalized,
         normalized,
     )
+    return changed
 
 
 def _llm_env_var_hints(provider: str) -> list[str]:
@@ -1023,10 +1031,16 @@ def _cached_config_patch_chain(
     )
 
 
-def _build_chain_cache_context() -> dict[str, Any]:
-    config = _resolve_llm_provider_config()
+def _build_chain_cache_context(
+    config: LLMProviderConfig | None = None,
+    temperature: float | None = None,
+) -> dict[str, Any]:
+    if config is None:
+        config = _resolve_llm_provider_config()
+    if temperature is None:
+        temperature = _resolve_llm_temperature()
     provider = _normalize_cache_str(config.provider) or "openai"
-    temperature = _normalize_temperature(_resolve_llm_temperature())
+    temperature = _normalize_temperature(temperature)
     base_url = _normalize_cache_str(config.base_url)
     organization = _normalize_cache_str(config.organization)
     normalized_model = _normalize_cache_str(config.model)
@@ -1066,8 +1080,12 @@ def _build_chain_cache_context() -> dict[str, Any]:
 
 
 def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
-    _maybe_reset_config_chat_cache(_current_chain_settings_snapshot())
-    context = _build_chain_cache_context()
+    config = _resolve_llm_provider_config()
+    temperature = _resolve_llm_temperature()
+    reset_fields = _maybe_reset_config_chat_cache(
+        _current_chain_settings_snapshot(config, temperature)
+    )
+    context = _build_chain_cache_context(config, temperature)
     api_key = context["api_key"]
     api_key_fingerprint = context["api_key_fingerprint"]
     extra_payload = context["extra_payload"]
@@ -1101,9 +1119,14 @@ def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
         st.session_state.pop("config_chat_last_instruction", None)
         cache_state["last_invalidation_fields"] = list(invalidation_fields)
         session_reset = True
-    session_cache_key = (
-        _reset_config_chat_session_id() if session_reset else _get_config_chat_session_id()
-    )
+    elif reset_fields:
+        invalidation_fields = list(reset_fields)
+        cache_state["last_invalidation_fields"] = list(invalidation_fields)
+        session_reset = True
+    if session_reset and not reset_fields:
+        session_cache_key = _reset_config_chat_session_id()
+    else:
+        session_cache_key = _get_config_chat_session_id()
     api_key_secret = _ApiKeySecret(api_key, api_key_fingerprint)
     lookup_start = monotonic()
     chain = _cached_config_patch_chain(

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -1029,10 +1029,11 @@ def _build_chain_cache_context() -> dict[str, Any]:
     temperature = _normalize_temperature(_resolve_llm_temperature())
     base_url = _normalize_cache_str(config.base_url)
     organization = _normalize_cache_str(config.organization)
+    normalized_model = _normalize_cache_str(config.model)
     api_key_fingerprint = _hash_api_key(config.api_key)
     extra_payload = _serialize_extra(config.extra)
     extra_payload_hash = _hash_text(extra_payload)
-    resolved_model = _normalize_cache_str(config.model) or _DEFAULT_CONFIG_CHAT_MODEL
+    resolved_model = normalized_model or _DEFAULT_CONFIG_CHAT_MODEL
     llm_cache_key = _build_llm_cache_key(
         provider=provider,
         model=resolved_model,
@@ -1065,6 +1066,7 @@ def _build_chain_cache_context() -> dict[str, Any]:
 
 
 def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
+    _maybe_reset_config_chat_cache(_current_chain_settings_snapshot())
     context = _build_chain_cache_context()
     api_key = context["api_key"]
     api_key_fingerprint = context["api_key_fingerprint"]

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from time import monotonic, sleep
 from typing import Any, Mapping
-from uuid import uuid4
 
 import streamlit as st
 import yaml
@@ -69,7 +68,6 @@ _MAX_CONFIG_HISTORY = 20
 _CONFIG_PREVIEW_TIMINGS_KEY = "config_chat_preview_timings"
 _MAX_CONFIG_PREVIEW_TIMINGS = 20
 _CONFIG_CHAIN_STATE_KEY = "config_chat_chain_state"
-_CONFIG_CHAT_SESSION_KEY = "config_chat_session_id"
 _DEFAULT_CONFIG_CHAT_MODEL = "gpt-4o-mini"
 _CONFIG_CHAIN_CACHE_VERSION = "v1"
 _CONFIG_CHAIN_METRICS_KEY = "config_chat_chain_metrics"
@@ -113,20 +111,6 @@ def _get_chain_cache_state() -> dict[str, Any]:
     if not isinstance(entries, dict):
         state["entries"] = {}
     return state
-
-
-def _get_config_chat_session_id() -> str:
-    session_id = st.session_state.get(_CONFIG_CHAT_SESSION_KEY)
-    if not session_id:
-        session_id = uuid4().hex
-        st.session_state[_CONFIG_CHAT_SESSION_KEY] = session_id
-    return session_id
-
-
-def _reset_config_chat_session_id() -> str:
-    session_id = uuid4().hex
-    st.session_state[_CONFIG_CHAT_SESSION_KEY] = session_id
-    return session_id
 
 
 def _chain_cache_signature(cache_key: Mapping[str, Any]) -> str:
@@ -895,7 +879,6 @@ def _maybe_reset_config_chat_cache(snapshot: Mapping[str, Any]) -> list[str]:
     st.session_state.pop(_CONFIG_CHAIN_STATE_KEY, None)
     st.session_state.pop(_CONFIG_CHAIN_METRICS_KEY, None)
     st.session_state.pop(_CONFIG_CHAIN_STATS_KEY, None)
-    _reset_config_chat_session_id()
     _LOGGER.info(
         "Config chat cache reset due to settings change: %s -> %s",
         previous_normalized,
@@ -1021,12 +1004,10 @@ def _cached_compact_schema() -> dict[str, Any]:
     hash_funcs={dict: _hash_cache_key, _ApiKeySecret: _hash_api_key_secret},
 )
 def _cached_llm_client(
-    session_cache_key: str,
     cache_key: Mapping[str, Any],
     api_key_secret: _ApiKeySecret | None,
     extra_payload: str,
 ) -> Any:
-    del session_cache_key
     api_key = api_key_secret.value if api_key_secret is not None else None
     config = LLMProviderConfig(
         provider=str(cache_key.get("provider")),
@@ -1046,14 +1027,12 @@ def _cached_llm_client(
     hash_funcs={dict: _hash_cache_key, _ApiKeySecret: _hash_api_key_secret},
 )
 def _cached_config_patch_chain(
-    session_cache_key: str,
     chain_cache_key: Mapping[str, Any],
     llm_cache_key: Mapping[str, Any],
     api_key_secret: _ApiKeySecret | None,
     extra_payload: str,
 ) -> ConfigPatchChain:
     llm = _cached_llm_client(
-        session_cache_key,
         llm_cache_key,
         api_key_secret,
         extra_payload,
@@ -1166,14 +1145,9 @@ def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
         invalidation_fields = list(reset_fields)
         cache_state["last_invalidation_fields"] = list(invalidation_fields)
         session_reset = True
-    if session_reset and not reset_fields:
-        session_cache_key = _reset_config_chat_session_id()
-    else:
-        session_cache_key = _get_config_chat_session_id()
     api_key_secret = _ApiKeySecret(api_key, api_key_fingerprint)
     lookup_start = monotonic()
     chain = _cached_config_patch_chain(
-        session_cache_key,
         cache_key,
         llm_cache_key,
         api_key_secret,

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -212,6 +212,18 @@ def _cache_key_changes(
     return changed
 
 
+def _merge_cache_keys(
+    cache_key: Mapping[str, Any] | None,
+    llm_cache_key: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    merged: dict[str, Any] = {}
+    if isinstance(cache_key, Mapping):
+        merged.update(cache_key)
+    if isinstance(llm_cache_key, Mapping):
+        merged.update(llm_cache_key)
+    return merged
+
+
 def _get_config_change_history() -> list[dict[str, Any]]:
     history = st.session_state.get(_CONFIG_HISTORY_KEY)
     if not isinstance(history, list):
@@ -1121,6 +1133,10 @@ def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
     previous_resource_signature = cache_state.get("last_resource_signature")
     previous_cache_key = cache_state.get("last_cache_key")
     previous_llm_cache_key = cache_state.get("last_llm_cache_key")
+    previous_invalidation_key = None
+    if isinstance(previous_cache_key, Mapping) or isinstance(previous_llm_cache_key, Mapping):
+        previous_invalidation_key = _merge_cache_keys(previous_cache_key, previous_llm_cache_key)
+    current_invalidation_key = _merge_cache_keys(cache_key, llm_cache_key)
     changed_fields = _cache_key_changes(previous_cache_key, cache_key, _CONFIG_CHAIN_CORE_FIELDS)
     llm_changed_fields = _cache_key_changes(
         previous_llm_cache_key,
@@ -1128,8 +1144,8 @@ def _build_nl_chain() -> tuple[ConfigPatchChain, dict[str, Any]]:
         _CONFIG_CHAIN_LLM_FIELDS,
     )
     invalidation_fields = _cache_key_changes(
-        previous_cache_key,
-        cache_key,
+        previous_invalidation_key,
+        current_invalidation_key,
         _CONFIG_CHAIN_REBUILD_FIELDS,
     )
     settings_changed = bool(

--- a/tests/app/test_model_page_helpers.py
+++ b/tests/app/test_model_page_helpers.py
@@ -1176,6 +1176,59 @@ def test_build_nl_chain_invalidation_on_model_change(
     assert "config_chat_last_instruction" not in stub.session_state
 
 
+def test_build_nl_chain_invalidation_on_base_url_change(
+    monkeypatch: pytest.MonkeyPatch, model_module: ModuleType
+) -> None:
+    stub = model_module.st
+    stub.session_state.clear()
+    stub.session_state["config_chat_preview"] = {"after": {"lookback_periods": 6}}
+    stub.session_state["config_chat_last_instruction"] = "Increase lookback"
+
+    configs = iter(
+        [
+            model_module.LLMProviderConfig(
+                provider="openai",
+                model="gpt-4o-mini",
+                api_key="sk-test",
+                base_url="https://one.example.com",
+            ),
+            model_module.LLMProviderConfig(
+                provider="openai",
+                model="gpt-4o-mini",
+                api_key="sk-test",
+                base_url="https://two.example.com",
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(model_module, "_resolve_llm_provider_config", lambda: next(configs))
+    monkeypatch.setattr(model_module, "_resolve_llm_temperature", lambda: 0.0)
+
+    chain_one = object()
+    chain_two = object()
+    call_count = {"value": 0}
+
+    def fake_cached_config_patch_chain(
+        session_cache_key: str,
+        chain_cache_key: dict[str, object],
+        llm_cache_key: dict[str, object],
+        api_key: str | None,
+        extra_payload: str,
+    ) -> object:
+        call_count["value"] += 1
+        return chain_one if call_count["value"] == 1 else chain_two
+
+    monkeypatch.setattr(model_module, "_cached_config_patch_chain", fake_cached_config_patch_chain)
+
+    _, meta_first = model_module._build_nl_chain()
+    _, meta_second = model_module._build_nl_chain()
+
+    assert meta_first["chain_reused"] is False
+    assert "base_url" in (meta_second["chain_cache_invalidation_fields"] or [])
+    assert "config_chat_preview" not in stub.session_state
+    assert "config_chat_last_instruction" not in stub.session_state
+
+
 def test_llm_session_overrides_win_over_env(
     monkeypatch: pytest.MonkeyPatch, model_module: ModuleType
 ) -> None:

--- a/tests/app/test_model_page_helpers.py
+++ b/tests/app/test_model_page_helpers.py
@@ -560,6 +560,21 @@ def test_record_preview_timing_tracks_chain_reuse(model_module: ModuleType) -> N
     assert metrics["chain_reused"] is True
 
 
+def test_preview_timing_summary_reports_cache_hit(model_module: ModuleType) -> None:
+    summary = model_module._preview_timing_summary(
+        {
+            "chain_reused": True,
+            "chain_build_seconds": 0.4,
+            "chain_lookup_seconds": 0.05,
+            "run_seconds": 1.2,
+        },
+        total_seconds=1.7,
+    )
+
+    assert "cache hit" in summary
+    assert "total 1.70s" in summary
+
+
 def test_side_by_side_diff_renders_yaml(model_module: ModuleType) -> None:
     stub = model_module.st
     languages: list[str | None] = []

--- a/tests/app/test_model_page_helpers.py
+++ b/tests/app/test_model_page_helpers.py
@@ -214,7 +214,6 @@ def test_build_nl_chain_reuses_cached_chain_with_provider_config(
     cache: dict[str, object] = {}
 
     def fake_cached_config_patch_chain(
-        _session_cache_key,
         chain_cache_key,
         _llm_cache_key,
         _api_key,
@@ -244,7 +243,6 @@ def test_build_nl_chain_invalidates_on_model_change(
     cache: dict[str, object] = {}
 
     def fake_cached_config_patch_chain(
-        _session_cache_key,
         chain_cache_key,
         _llm_cache_key,
         _api_key,
@@ -263,13 +261,10 @@ def test_build_nl_chain_invalidates_on_model_change(
     stub.session_state["config_chat_last_instruction"] = "old"
 
     _chain, _meta = model_module._build_nl_chain()
-    session_id_before = stub.session_state.get(model_module._CONFIG_CHAT_SESSION_KEY)
 
     stub.session_state[model_module._LLM_MODEL_OVERRIDE_KEY] = "gpt-4.1-mini"
     _chain, meta = model_module._build_nl_chain()
 
-    session_id_after = stub.session_state.get(model_module._CONFIG_CHAT_SESSION_KEY)
-    assert session_id_before != session_id_after
     assert meta["chain_cache_invalidation_fields"] == ["model"]
     assert meta["chain_cache_session_reset"] is True
     assert "config_chat_preview" not in stub.session_state
@@ -284,7 +279,6 @@ def test_build_nl_chain_invalidates_on_provider_change(
     cache: dict[str, object] = {}
 
     def fake_cached_config_patch_chain(
-        _session_cache_key,
         chain_cache_key,
         _llm_cache_key,
         _api_key,
@@ -303,13 +297,10 @@ def test_build_nl_chain_invalidates_on_provider_change(
     stub.session_state["config_chat_last_instruction"] = "old"
 
     _chain, _meta = model_module._build_nl_chain()
-    session_id_before = stub.session_state.get(model_module._CONFIG_CHAT_SESSION_KEY)
 
     stub.session_state[model_module._LLM_PROVIDER_OVERRIDE_KEY] = "anthropic"
     _chain, meta = model_module._build_nl_chain()
 
-    session_id_after = stub.session_state.get(model_module._CONFIG_CHAT_SESSION_KEY)
-    assert session_id_before != session_id_after
     assert meta["chain_cache_invalidation_fields"] == ["provider"]
     assert meta["chain_cache_session_reset"] is True
     assert "config_chat_preview" not in stub.session_state
@@ -324,7 +315,6 @@ def test_build_nl_chain_invalidates_on_temperature_env_change(
     cache: dict[str, object] = {}
 
     def fake_cached_config_patch_chain(
-        _session_cache_key,
         chain_cache_key,
         _llm_cache_key,
         _api_key,
@@ -342,13 +332,10 @@ def test_build_nl_chain_invalidates_on_temperature_env_change(
     stub.session_state["config_chat_last_instruction"] = "old"
 
     _chain, _meta = model_module._build_nl_chain()
-    session_id_before = stub.session_state.get(model_module._CONFIG_CHAT_SESSION_KEY)
 
     stub.session_state[model_module._LLM_TEMPERATURE_OVERRIDE_KEY] = "0.7"
     _chain, meta = model_module._build_nl_chain()
 
-    session_id_after = stub.session_state.get(model_module._CONFIG_CHAT_SESSION_KEY)
-    assert session_id_before != session_id_after
     assert meta["chain_cache_invalidation_fields"] == ["temperature"]
     assert meta["chain_cache_session_reset"] is True
     assert "config_chat_preview" not in stub.session_state
@@ -363,7 +350,6 @@ def test_build_nl_chain_passes_api_key_to_cache(
     captured: dict[str, object] = {}
 
     def fake_cached_config_patch_chain(
-        _session_cache_key,
         _chain_cache_key,
         _llm_cache_key,
         api_key_secret,
@@ -391,7 +377,6 @@ def test_build_nl_chain_invalidates_on_base_url_change(
     cache: dict[str, object] = {}
 
     def fake_cached_config_patch_chain(
-        _session_cache_key,
         chain_cache_key,
         _llm_cache_key,
         _api_key,
@@ -411,13 +396,10 @@ def test_build_nl_chain_invalidates_on_base_url_change(
     stub.session_state["config_chat_last_instruction"] = "old"
 
     _chain, _meta = model_module._build_nl_chain()
-    session_id_before = stub.session_state.get(model_module._CONFIG_CHAT_SESSION_KEY)
 
     stub.session_state[model_module._LLM_BASE_URL_OVERRIDE_KEY] = "https://api.two"
     _chain, meta = model_module._build_nl_chain()
 
-    session_id_after = stub.session_state.get(model_module._CONFIG_CHAT_SESSION_KEY)
-    assert session_id_before != session_id_after
     assert meta["chain_cache_invalidation_fields"] == ["base_url"]
     assert meta["chain_cache_session_reset"] is True
     assert "config_chat_preview" not in stub.session_state
@@ -432,7 +414,6 @@ def test_build_nl_chain_invalidates_on_org_change(
     cache: dict[str, object] = {}
 
     def fake_cached_config_patch_chain(
-        _session_cache_key,
         chain_cache_key,
         _llm_cache_key,
         _api_key,
@@ -452,13 +433,10 @@ def test_build_nl_chain_invalidates_on_org_change(
     stub.session_state["config_chat_last_instruction"] = "old"
 
     _chain, _meta = model_module._build_nl_chain()
-    session_id_before = stub.session_state.get(model_module._CONFIG_CHAT_SESSION_KEY)
 
     stub.session_state[model_module._LLM_ORG_OVERRIDE_KEY] = "org-two"
     _chain, meta = model_module._build_nl_chain()
 
-    session_id_after = stub.session_state.get(model_module._CONFIG_CHAT_SESSION_KEY)
-    assert session_id_before != session_id_after
     assert meta["chain_cache_invalidation_fields"] == ["organization"]
     assert meta["chain_cache_session_reset"] is True
     assert "config_chat_preview" not in stub.session_state
@@ -473,7 +451,6 @@ def test_build_nl_chain_invalidates_on_temperature_change(
     cache: dict[str, object] = {}
 
     def fake_cached_config_patch_chain(
-        _session_cache_key,
         chain_cache_key,
         _llm_cache_key,
         _api_key,
@@ -488,15 +465,12 @@ def test_build_nl_chain_invalidates_on_temperature_change(
 
     monkeypatch.setenv("TREND_LLM_TEMPERATURE", "0.1")
     _chain, _meta = model_module._build_nl_chain()
-    session_id_before = stub.session_state.get(model_module._CONFIG_CHAT_SESSION_KEY)
 
     stub.session_state["config_chat_preview"] = {"before": {}, "after": {}}
     stub.session_state["config_chat_last_instruction"] = "old"
     monkeypatch.setenv("TREND_LLM_TEMPERATURE", "0.7")
     _chain, meta = model_module._build_nl_chain()
 
-    session_id_after = stub.session_state.get(model_module._CONFIG_CHAT_SESSION_KEY)
-    assert session_id_before != session_id_after
     assert meta["chain_cache_invalidation_fields"] == ["temperature"]
     assert meta["chain_cache_session_reset"] is True
     assert "config_chat_preview" not in stub.session_state
@@ -1084,7 +1058,6 @@ def test_build_nl_chain_reuses_cached_chain(
     calls: list[dict[str, object]] = []
 
     def fake_cached_config_patch_chain(
-        session_cache_key: str,
         chain_cache_key: dict[str, object],
         llm_cache_key: dict[str, object],
         api_key: object,
@@ -1156,7 +1129,6 @@ def test_build_nl_chain_invalidation_on_model_change(
     call_count = {"value": 0}
 
     def fake_cached_config_patch_chain(
-        session_cache_key: str,
         chain_cache_key: dict[str, object],
         llm_cache_key: dict[str, object],
         api_key: str | None,
@@ -1209,7 +1181,6 @@ def test_build_nl_chain_invalidation_on_base_url_change(
     call_count = {"value": 0}
 
     def fake_cached_config_patch_chain(
-        session_cache_key: str,
         chain_cache_key: dict[str, object],
         llm_cache_key: dict[str, object],
         api_key: str | None,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -169,6 +169,31 @@ def test_run_propagates_max_turnover_to_risk(tmp_path, monkeypatch):
     assert captured["max_turnover"] == pytest.approx(0.33)
 
 
+def test_run_resolves_regime_max_turnover_mapping(tmp_path, monkeypatch):
+    df = make_df()
+    cfg = make_cfg(tmp_path, df)
+    cfg.regime = {
+        "enabled": True,
+        "proxy": "A",
+        "lookback": 1,
+        "smoothing": 1,
+        "threshold": 0.0,
+    }
+    cfg.portfolio["max_turnover"] = {"risk_on": 0.12, "risk_off": 0.05}
+    captured = {}
+
+    def _stub_enforce(target, prev, max_turnover):
+        captured["max_turnover"] = max_turnover
+        turnover = float(target.abs().sum())
+        return target, turnover
+
+    monkeypatch.setattr(risk, "_enforce_turnover_cap", _stub_enforce)
+
+    result = pipeline.run(cfg)
+    assert not result.empty
+    assert captured["max_turnover"] == pytest.approx(0.12)
+
+
 def test_run_file_missing(tmp_path, monkeypatch):
     cfg = make_cfg(tmp_path, make_df())
     cfg.data["csv_path"] = str(tmp_path / "missing.csv")

--- a/tests/unit/test_streamlit_model_cache_keys.py
+++ b/tests/unit/test_streamlit_model_cache_keys.py
@@ -18,14 +18,10 @@ def test_chain_cache_key_includes_core_fields():
     key = module._build_chain_cache_key(
         provider="openai",
         model="gpt-4o-mini",
-        base_url="https://example.test",
-        organization="org",
         temperature=0.2,
     )
     assert key["provider"] == "openai"
     assert key["model"] == "gpt-4o-mini"
-    assert key["base_url"] == "https://example.test"
-    assert key["organization"] == "org"
     assert key["temperature"] == 0.2
 
 
@@ -34,15 +30,11 @@ def test_cache_key_changes_detects_core_fields():
     previous = module._build_chain_cache_key(
         provider="openai",
         model="gpt-4o-mini",
-        base_url=None,
-        organization=None,
         temperature=0.0,
     )
     current = module._build_chain_cache_key(
         provider="anthropic",
         model="claude-3-5-sonnet",
-        base_url="https://example.test",
-        organization="org",
         temperature=0.4,
     )
     changed = module._cache_key_changes(
@@ -52,8 +44,6 @@ def test_cache_key_changes_detects_core_fields():
     )
     assert "provider" in changed
     assert "model" in changed
-    assert "base_url" in changed
-    assert "organization" in changed
     assert "temperature" in changed
 
 
@@ -77,3 +67,9 @@ def test_llm_cache_key_tracks_connection_fields():
     assert key["max_retries"] == 3
     assert key["extra_payload_hash"] == "hash"
     assert key["api_key_fingerprint"] == "fingerprint"
+
+
+def test_invalidation_fields_include_connection_overrides():
+    module = _load_model_page()
+    assert "base_url" in module._CONFIG_CHAIN_INVALIDATION_FIELDS
+    assert "organization" in module._CONFIG_CHAIN_INVALIDATION_FIELDS


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #4735

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #4729 aimed to resolve issue #4704 but failed verification due to incomplete implementation of regime-conditional turnover caps. This follow-up addresses the gaps by refining the task structure to ensure the Monte Carlo simulation correctly applies turnover caps based on the current regime.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#4729](https://github.com/stranske/Trend_Model_Project/issues/4729)
- [#4704](https://github.com/stranske/Trend_Model_Project/issues/4704)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Modify the simulation module to parse the scenario config for regime-conditional turnover cap syntax and apply the correct turnover cap based on the current regime
- [ ] Update the runner module to record and persist the realized turnover for each period and simulation path
- [ ] Enhance the simulation output to include an indicator for when turnover caps were binding during the simulation
- [ ] Develop unit tests to validate the parsing of regime-specific turnover cap configurations, application of turnover caps in simulation logic, recording of turnover values, and presence of the cap-binding indicator in the output

#### Acceptance criteria
- [ ] The simulation module correctly parses the scenario config for regime-conditional turnover caps using the syntax `max_turnover: {calm: 0.15, stress: 0.08}` and applies the correct turnover cap based on the current regime during the Monte Carlo simulations
- [ ] The runner module records and persists the actual turnover applied for every period and for each Monte Carlo simulation path, and this data is accessible for post-simulation diagnostics
- [ ] The simulation output includes a specific flag or diagnostic field indicating whether the turnover cap was binding in any given period during the simulation
- [ ] Unit tests verify that regime-conditional turnover caps are correctly interpreted and applied in the simulation logic, that the runner correctly records the realized turnover per period and strategy path, and that the simulation output includes an accurate indicator for when turnover caps are binding

<!-- auto-status-summary:end -->