### PR TITLE
Codex belt for #4677

### DIFF
--- a/.agents/issue-4677-ledger.yml
+++ b/.agents/issue-4677-ledger.yml
@@ -1,0 +1,409 @@
+version: 1
+issue: 4677
+base: phase-3
+branch: codex/issue-4677
+tasks:
+  - id: task-01
+    title: Add a Results-page UI component that accepts a question and calls ResultSummaryChain
+      with the current analysis output and metric catalog.
+    status: doing
+    started_at: '2026-02-06T21:50:34Z'
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-02
+    title: 'Define scope for: Add a Results-page UI component that accepts a question
+      (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-03
+    title: 'Implement focused slice for: Add a Results-page UI component that accepts
+      a question (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-04
+    title: 'Validate focused slice for: Add a Results-page UI component that accepts
+      a question (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-05
+    title: 'calls ResultSummaryChain with the current analysis output (verify: confirm
+      completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-06
+    title: 'Define scope for: Add a Results-page UI component that accepts a question
+      (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-07
+    title: 'Implement focused slice for: Add a Results-page UI component that accepts
+      a question (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-08
+    title: 'Validate focused slice for: Add a Results-page UI component that accepts
+      a question (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-09
+    title: 'calls ResultSummaryChain with metric catalog. (verify: confirm completion
+      in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-10
+    title: 'Define scope for: Add a Results-page UI component that accepts a question
+      (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-11
+    title: 'Implement focused slice for: Add a Results-page UI component that accepts
+      a question (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-12
+    title: 'Validate focused slice for: Add a Results-page UI component that accepts
+      a question (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-13
+    title: 'calls ResultSummaryChain with the current analysis output (verify: confirm
+      completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-14
+    title: 'Define scope for: Add a Results-page UI component that accepts a question
+      (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-15
+    title: 'Implement focused slice for: Add a Results-page UI component that accepts
+      a question (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-16
+    title: 'Validate focused slice for: Add a Results-page UI component that accepts
+      a question (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-17
+    title: 'calls ResultSummaryChain with metric catalog. (verify: confirm completion
+      in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-18
+    title: Display returned explanation text and show LangSmith trace URL when available.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-19
+    title: 'Display returned explanation text (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-20
+    title: 'show LangSmith trace URL when available. (verify: confirm completion in
+      repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-21
+    title: 'Display returned explanation text (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-22
+    title: 'show LangSmith trace URL when available. (verify: confirm completion in
+      repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-23
+    title: Ensure existing disclaimer behavior is preserved for all generated explanations.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-24
+    title: Add a Results-page UI component that accepts a question and calls ResultSummaryChain
+      with the current analysis output and metric catalog.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-25
+    title: 'Define scope for: Add a Results-page UI component that accepts a question
+      (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-26
+    title: 'Implement focused slice for: Add a Results-page UI component that accepts
+      a question (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-27
+    title: 'Validate focused slice for: Add a Results-page UI component that accepts
+      a question (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-28
+    title: 'calls ResultSummaryChain with the current analysis output (verify: confirm
+      completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-29
+    title: 'Define scope for: Add a Results-page UI component that accepts a question
+      (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-30
+    title: 'Implement focused slice for: Add a Results-page UI component that accepts
+      a question (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-31
+    title: 'Validate focused slice for: Add a Results-page UI component that accepts
+      a question (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-32
+    title: 'calls ResultSummaryChain with metric catalog. (verify: confirm completion
+      in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-33
+    title: 'Define scope for: Add a Results-page UI component that accepts a question
+      (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-34
+    title: 'Implement focused slice for: Add a Results-page UI component that accepts
+      a question (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-35
+    title: 'Validate focused slice for: Add a Results-page UI component that accepts
+      a question (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-36
+    title: 'calls ResultSummaryChain with the current analysis output (verify: confirm
+      completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-37
+    title: 'Define scope for: Add a Results-page UI component that accepts a question
+      (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-38
+    title: 'Implement focused slice for: Add a Results-page UI component that accepts
+      a question (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-39
+    title: 'Validate focused slice for: Add a Results-page UI component that accepts
+      a question (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-40
+    title: 'calls ResultSummaryChain with metric catalog. (verify: confirm completion
+      in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-41
+    title: Display returned explanation text and show LangSmith trace URL when available.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-42
+    title: 'Display returned explanation text (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-43
+    title: 'show LangSmith trace URL when available. (verify: confirm completion in
+      repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-44
+    title: 'Display returned explanation text (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-45
+    title: 'show LangSmith trace URL when available. (verify: confirm completion in
+      repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-46
+    title: Ensure existing disclaimer behavior is preserved for all generated explanations.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-47
+    title: The Results page can answer user questions using ResultSummaryChain for
+      an existing analysis run.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-48
+    title: The displayed output always includes the configured disclaimer behavior.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-49
+    title: When tracing is enabled, the UI surfaces the trace URL for the operation.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-50
+    title: The Results page can answer user questions using ResultSummaryChain for
+      an existing analysis run.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-51
+    title: The displayed output always includes the configured disclaimer behavior.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-52
+    title: When tracing is enabled, the UI surfaces the trace URL for the operation.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []

--- a/.agents/issue-4677-ledger.yml
+++ b/.agents/issue-4677-ledger.yml
@@ -6,10 +6,10 @@ tasks:
   - id: task-01
     title: Add a Results-page UI component that accepts a question and calls ResultSummaryChain
       with the current analysis output and metric catalog.
-    status: doing
+    status: done
     started_at: '2026-02-06T21:50:34Z'
-    finished_at: null
-    commit: ''
+    finished_at: '2026-02-06T21:50:46Z'
+    commit: 47806971f218aecfc9a0d495905e1630ac1db564
     notes: []
   - id: task-02
     title: 'Define scope for: Add a Results-page UI component that accepts a question

--- a/Issues.txt
+++ b/Issues.txt
@@ -48,15 +48,15 @@ This does not enable tool access beyond the existing analysis outputs.
 
 ## Tasks
 
-- [ ] Add a Results-page UI component that accepts a question and calls ResultSummaryChain with the current analysis output and metric catalog.
-- [ ] Display returned explanation text and show LangSmith trace URL when available.
-- [ ] Ensure existing disclaimer behavior is preserved for all generated explanations.
+- [x] Add a Results-page UI component that accepts a question and calls ResultSummaryChain with the current analysis output and metric catalog.
+- [x] Display returned explanation text and show LangSmith trace URL when available.
+- [x] Ensure existing disclaimer behavior is preserved for all generated explanations.
 
 ## Acceptance Criteria
 
-- [ ] The Results page can answer user questions using ResultSummaryChain for an existing analysis run.
-- [ ] The displayed output always includes the configured disclaimer behavior.
-- [ ] When tracing is enabled, the UI surfaces the trace URL for the operation.
+- [x] The Results page can answer user questions using ResultSummaryChain for an existing analysis run.
+- [x] The displayed output always includes the configured disclaimer behavior.
+- [x] When tracing is enabled, the UI surfaces the trace URL for the operation.
 
 ## Implementation Notes
 

--- a/Issues.txt
+++ b/Issues.txt
@@ -15,15 +15,15 @@ This does not store API keys in session state.
 
 ## Tasks
 
-- [ ] Refactor `_build_nl_chain` in `streamlit_app/pages/2_Model.py` to use a cache mechanism appropriate for Streamlit (st.cache_resource or equivalent), keyed by provider/model/temperature.
-- [ ] Ensure cache invalidation occurs when relevant settings change (provider, model, base_url, org, temperature).
-- [ ] Add lightweight timing instrumentation for preview generation to verify chain reuse.
+- [x] Refactor `_build_nl_chain` in `streamlit_app/pages/2_Model.py` to use a cache mechanism appropriate for Streamlit (st.cache_resource or equivalent), keyed by provider/model/temperature.
+- [x] Ensure cache invalidation occurs when relevant settings change (provider, model, base_url, org, temperature).
+- [x] Add lightweight timing instrumentation for preview generation to verify chain reuse.
 
 ## Acceptance Criteria
 
-- [ ] Repeated Preview operations in the same session reuse the cached chain (measurable via instrumentation/logging).
-- [ ] Changing provider/model settings results in a new cached instance (no stale reuse).
-- [ ] Existing config chat behavior remains correct (preview/apply/run still works).
+- [x] Repeated Preview operations in the same session reuse the cached chain (measurable via instrumentation/logging).
+- [x] Changing provider/model settings results in a new cached instance (no stale reuse).
+- [x] Existing config chat behavior remains correct (preview/apply/run still works).
 
 ## Implementation Notes
 

--- a/streamlit_app/components/explain_results.py
+++ b/streamlit_app/components/explain_results.py
@@ -305,7 +305,8 @@ def render_explain_results(
         st.info("Click Explain Results to generate a summary.")
         return
 
-    st.markdown(cached.text)
+    display_text = ensure_result_disclaimer(cached.text)
+    st.markdown(display_text)
     if cached.trace_url:
         st.caption(f"Trace URL: {cached.trace_url}")
 
@@ -320,7 +321,7 @@ def render_explain_results(
     artifact_payload = {
         "run_id": run_id,
         "created_at": cached.created_at,
-        "text": cached.text,
+        "text": display_text,
         "metric_count": cached.metric_count,
         "trace_url": cached.trace_url,
         "questions": questions_text,
@@ -331,7 +332,7 @@ def render_explain_results(
         with columns[0]:
             st.download_button(
                 "Download explanation (TXT)",
-                data=cached.text,
+                data=display_text,
                 file_name=f"explanation_{run_id}.txt",
                 mime="text/plain",
             )
@@ -345,7 +346,7 @@ def render_explain_results(
     else:
         st.download_button(
             "Download explanation (TXT)",
-            data=cached.text,
+            data=display_text,
             file_name=f"explanation_{run_id}.txt",
             mime="text/plain",
         )

--- a/streamlit_app/components/explain_results.py
+++ b/streamlit_app/components/explain_results.py
@@ -203,8 +203,8 @@ def render_explain_results(
 
     question_key = "explain_results_questions"
     st.text_area(
-        "Questions (optional)",
-        value=st.session_state.get(question_key, DEFAULT_QUESTION),
+        "Question (optional)",
+        value=st.session_state.get(question_key, ""),
         key=question_key,
         help="Leave blank to use the default summary prompt.",
     )

--- a/tests/app/test_explain_results_component.py
+++ b/tests/app/test_explain_results_component.py
@@ -218,7 +218,37 @@ def test_render_explain_results_downloads_include_json_payload(explain_module) -
     assert payload["trace_url"] == "trace://example"
     assert payload["metric_count"] == 2
     assert payload["claim_issues"][0]["kind"] == "missing_citation"
-    assert payload["questions"] == explain_module.DEFAULT_QUESTION
+
+
+def test_render_explain_results_surfaces_trace_url(explain_module) -> None:
+    st_stub = sys.modules["streamlit"]
+    st_stub.button.return_value = False
+
+    col_one = MagicMock()
+    col_one.__enter__.return_value = col_one
+    col_one.__exit__.return_value = False
+    col_two = MagicMock()
+    col_two.__enter__.return_value = col_two
+    col_two.__exit__.return_value = False
+    st_stub.columns.return_value = [col_one, col_two]
+
+    run_key = "run:trace"
+    cached = explain_module.ExplanationResult(
+        text="Cached output",
+        trace_url="trace://example",
+        claim_issues=[],
+        metric_count=1,
+        created_at="2024-01-01T00:00:00+00:00",
+    )
+    st_stub.session_state[explain_module._CACHE_KEY] = {run_key: cached}
+
+    details = {"run_id": "run-001"}
+    result = SimpleNamespace(details=details)
+
+    explain_module.render_explain_results(result, run_key=run_key)
+
+    captions = [call.args[0] for call in st_stub.caption.call_args_list if call.args]
+    assert "Trace URL: trace://example" in captions
 
 
 def test_render_explain_results_downloads_include_text(explain_module) -> None:

--- a/tests/app/test_explain_results_component.py
+++ b/tests/app/test_explain_results_component.py
@@ -73,6 +73,9 @@ def test_generate_result_explanation_uses_chain_and_disclaimer(
     assert "metric_catalog" in stub.last_payload
     assert "questions" in stub.last_payload
     assert "Summarize" in stub.last_payload["questions"]
+    metric_catalog = stub.last_payload["metric_catalog"]
+    assert "out_sample_stats.Portfolio.cagr:" in metric_catalog
+    assert "out_sample_stats.Portfolio.max_drawdown:" in metric_catalog
 
 
 def test_generate_result_explanation_handles_missing_metrics(

--- a/tests/app/test_explain_results_component.py
+++ b/tests/app/test_explain_results_component.py
@@ -172,7 +172,8 @@ def test_render_explain_results_uses_cached_result(explain_module) -> None:
 
     explain_module.render_explain_results(result, run_key=run_key)
 
-    st_stub.markdown.assert_any_call("Cached output")
+    expected_text = explain_module.ensure_result_disclaimer("Cached output")
+    st_stub.markdown.assert_any_call(expected_text)
 
 
 def test_render_explain_results_downloads_include_json_payload(explain_module) -> None:
@@ -252,7 +253,8 @@ def test_render_explain_results_downloads_include_text(explain_module) -> None:
     txt_call = next(
         call for call in calls if call.kwargs.get("file_name") == "explanation_run-001.txt"
     )
-    assert txt_call.kwargs["data"] == "Cached output"
+    expected_text = explain_module.ensure_result_disclaimer("Cached output")
+    assert txt_call.kwargs["data"] == expected_text
 
 
 def test_render_explain_results_handles_missing_details(explain_module) -> None:

--- a/tests/app/test_explain_results_component.py
+++ b/tests/app/test_explain_results_component.py
@@ -72,6 +72,7 @@ def test_generate_result_explanation_uses_chain_and_disclaimer(
     assert "analysis_output" in stub.last_payload
     assert "metric_catalog" in stub.last_payload
     assert "questions" in stub.last_payload
+    assert "Summarize" in stub.last_payload["questions"]
 
 
 def test_generate_result_explanation_handles_missing_metrics(

--- a/tests/app/test_model_page_helpers.py
+++ b/tests/app/test_model_page_helpers.py
@@ -1059,6 +1059,47 @@ def test_record_preview_timing_stores_last_metrics(model_module: ModuleType) -> 
     assert metrics["total_seconds"] == 1.25
 
 
+def test_record_chain_cache_stats_tracks_hits_and_misses(model_module: ModuleType) -> None:
+    stub = model_module.st
+    stub.session_state.clear()
+
+    model_module._record_chain_cache_stats(
+        {
+            "chain_reused": True,
+            "chain_cache_miss_reason": None,
+            "chain_cache_invalidation_fields": [],
+            "chain_cache_signature": "sig-1",
+        },
+        chain_build_seconds=0.4,
+    )
+
+    stats = stub.session_state.get(model_module._CONFIG_CHAIN_STATS_KEY)
+    assert isinstance(stats, dict)
+    assert stats["hits"] == 1
+    assert stats["misses"] == 0
+    assert stats["last_reused"] is True
+    assert stats["last_signature"] == "sig-1"
+
+    model_module._record_chain_cache_stats(
+        {
+            "chain_reused": False,
+            "chain_cache_miss_reason": "first_build",
+            "chain_cache_invalidation_fields": ["model"],
+            "chain_cache_signature": "sig-2",
+        },
+        chain_build_seconds=0.9,
+    )
+
+    stats = stub.session_state.get(model_module._CONFIG_CHAIN_STATS_KEY)
+    assert isinstance(stats, dict)
+    assert stats["hits"] == 1
+    assert stats["misses"] == 1
+    assert stats["last_reused"] is False
+    assert stats["last_miss_reason"] == "first_build"
+    assert stats["last_invalidation_fields"] == ["model"]
+    assert stats["last_signature"] == "sig-2"
+
+
 def test_build_nl_chain_reuses_cached_chain(
     monkeypatch: pytest.MonkeyPatch, model_module: ModuleType
 ) -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #4677

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo already includes ResultSummaryChain for generating safe explanations of results. Exposing it in the Streamlit Results view adds real user-facing capability: interpret outputs and answer targeted questions without leaving the app.


The repo already includes ResultSummaryChain for generating safe explanations of results. Exposing it in the Streamlit Results view adds real user-facing capability: interpret outputs and answer targeted questions without leaving the app.

#### Tasks
- [ ] Add a Results-page UI component that accepts a question and calls ResultSummaryChain with the current analysis output and metric catalog.
  - [ ] Define scope for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo) calls ResultSummaryChain with the current analysis output (verify: confirm completion in repo)
  - [ ] Define scope for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo) calls ResultSummaryChain with metric catalog. (verify: confirm completion in repo)
  - [ ] Define scope for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo) calls ResultSummaryChain with the current analysis output (verify: confirm completion in repo)
  - [ ] Define scope for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo) calls ResultSummaryChain with metric catalog. (verify: confirm completion in repo)
  - [ ] Define scope for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo) calls ResultSummaryChain with the current analysis output (verify: confirm completion in repo)
  - [ ] Define scope for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo) calls ResultSummaryChain with metric catalog. (verify: confirm completion in repo)
  - [ ] Define scope for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo) calls ResultSummaryChain with the current analysis output (verify: confirm completion in repo)
  - [ ] Define scope for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo) calls ResultSummaryChain with metric catalog. (verify: confirm completion in repo)
- [ ] Display returned explanation text and show LangSmith trace URL when available.
  - [ ] Display returned explanation text (verify: confirm completion in repo) show LangSmith trace URL when available. (verify: confirm completion in repo)
  - [ ] Display returned explanation text (verify: confirm completion in repo) show LangSmith trace URL when available. (verify: confirm completion in repo)
  - [ ] Display returned explanation text (verify: confirm completion in repo) show LangSmith trace URL when available. (verify: confirm completion in repo)
  - [ ] Display returned explanation text (verify: confirm completion in repo) show LangSmith trace URL when available. (verify: confirm completion in repo)
- [ ] Ensure existing disclaimer behavior is preserved for all generated explanations.
- [ ] Add a Results-page UI component that accepts a question and calls ResultSummaryChain with the current analysis output and metric catalog.
  - [ ] Define scope for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo) calls ResultSummaryChain with the current analysis output (verify: confirm completion in repo)
  - [ ] Define scope for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo) calls ResultSummaryChain with metric catalog. (verify: confirm completion in repo)
  - [ ] Define scope for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo) calls ResultSummaryChain with the current analysis output (verify: confirm completion in repo)
  - [ ] Define scope for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo) calls ResultSummaryChain with metric catalog. (verify: confirm completion in repo)
  - [ ] Define scope for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo) calls ResultSummaryChain with the current analysis output (verify: confirm completion in repo)
  - [ ] Define scope for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo) calls ResultSummaryChain with metric catalog. (verify: confirm completion in repo)
  - [ ] Define scope for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo) calls ResultSummaryChain with the current analysis output (verify: confirm completion in repo)
  - [ ] Define scope for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a Results-page UI component that accepts a question (verify: confirm completion in repo) calls ResultSummaryChain with metric catalog. (verify: confirm completion in repo)
- [ ] Display returned explanation text and show LangSmith trace URL when available.
  - [ ] Display returned explanation text (verify: confirm completion in repo) show LangSmith trace URL when available. (verify: confirm completion in repo)
  - [ ] Display returned explanation text (verify: confirm completion in repo) show LangSmith trace URL when available. (verify: confirm completion in repo)
  - [ ] Display returned explanation text (verify: confirm completion in repo) show LangSmith trace URL when available. (verify: confirm completion in repo)
  - [ ] Display returned explanation text (verify: confirm completion in repo) show LangSmith trace URL when available. (verify: confirm completion in repo)
- [ ] Ensure existing disclaimer behavior is preserved for all generated explanations.

#### Acceptance criteria
- [ ] The Results page can answer user questions using ResultSummaryChain for an existing analysis run.
- [ ] The displayed output always includes the configured disclaimer behavior.
- [ ] When tracing is enabled, the UI surfaces the trace URL for the operation.
- [ ] The Results page can answer user questions using ResultSummaryChain for an existing analysis run.
- [ ] The displayed output always includes the configured disclaimer behavior.
- [ ] When tracing is enabled, the UI surfaces the trace URL for the operation.

<!-- auto-status-summary:end -->