### PR TITLE
Codex bootstrap for #4783

### DIFF
--- a/agents/codex-4783.md
+++ b/agents/codex-4783.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #4783 -->

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import math
 import random
-import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -39,6 +38,7 @@ from trend_analysis.monte_carlo.strategy.sampler import (
 )
 from trend_analysis.pipeline import _resolve_sample_split
 from trend_analysis.pipeline_helpers import _resolve_regime_turnover_cap
+from trend_analysis.regime_utils import alias_regime_key, normalize_regime_key
 from trend_analysis.regimes import compute_regimes, normalise_settings
 from trend_analysis.risk import periods_per_year_from_code
 from trend_analysis.stages.selection import single_period_run
@@ -87,25 +87,6 @@ def _coerce_turnover_guard(value: Any) -> float:
         raise ValueError(
             f"{_TURNOVER_GUARD_PATH} must be numeric or a distribution mapping"
         ) from exc
-
-
-def _normalize_regime_key(value: Any) -> str | None:
-    if value is None:
-        return None
-    text = str(value).strip()
-    if not text:
-        return None
-    return re.sub(r"[^a-z0-9]+", "", text.casefold())
-
-
-def _alias_regime_key(value: str) -> str | None:
-    aliases = {
-        "riskon": "calm",
-        "riskoff": "stress",
-        "calm": "riskon",
-        "stress": "riskoff",
-    }
-    return aliases.get(value)
 
 
 def _is_distribution_mapping(value: Mapping[str, Any]) -> bool:
@@ -1253,7 +1234,7 @@ class MonteCarloRunner:
                 return pd.Series(np.nan, index=out_index, name="turnover_cap")
             mapping: dict[str, float] = {}
             for key, value in max_turnover.items():
-                normalized_key = _normalize_regime_key(key)
+                normalized_key = normalize_regime_key(key)
                 if not normalized_key:
                     continue
                 try:
@@ -1265,12 +1246,12 @@ class MonteCarloRunner:
             def _lookup_turnover_cap(label: str | None) -> float:
                 if not label:
                     return float("nan")
-                normalized = _normalize_regime_key(label)
+                normalized = normalize_regime_key(label)
                 if not normalized:
                     return float("nan")
                 if normalized in mapping:
                     return mapping[normalized]
-                alias_key = _alias_regime_key(normalized)
+                alias_key = alias_regime_key(normalized)
                 if alias_key and alias_key in mapping:
                     return mapping[alias_key]
                 return float("nan")

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -619,19 +619,25 @@ class MonteCarloRunner:
 
     def _apply_regime_turnover_caps(self, config: ConfigType, context: _PathContext) -> None:
         multi_period_cfg = getattr(config, "multi_period", None)
-        if isinstance(multi_period_cfg, Mapping):
-            return
+        multi_period_enabled = isinstance(multi_period_cfg, Mapping)
         portfolio = getattr(config, "portfolio", None)
         if not isinstance(portfolio, Mapping):
             return
         max_turnover = portfolio.get("max_turnover")
+        # Supported shapes:
+        # - scalar max_turnover (float/int): apply as-is, no regime lookup required.
+        # - mapping max_turnover: interpreted as regime-conditioned caps.
         if not isinstance(max_turnover, Mapping):
             return
-        resolved = self._resolve_turnover_cap_for_context(config, context, max_turnover)
-        if resolved is None or resolved is max_turnover:
-            return
-        if isinstance(portfolio, dict):
-            portfolio["max_turnover"] = resolved
+        # In single-period runs we can resolve a regime-conditioned mapping to a
+        # scalar for the current path; multi-period runs keep the mapping so the
+        # engine can apply per-window regime caps.
+        if not multi_period_enabled:
+            resolved = self._resolve_turnover_cap_for_context(config, context, max_turnover)
+            if resolved is None or resolved is max_turnover:
+                return
+            if isinstance(portfolio, dict):
+                portfolio["max_turnover"] = resolved
 
     def _resolve_turnover_cap_for_context(
         self,

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -168,6 +168,7 @@ class MonteCarloRunner:
         self._seed_manager_init = False
         self._cost_process: CostProcess | None = None
         self._cost_process_init = False
+        self._regime_cache: dict[tuple[object, ...], pd.Series] = {}
 
     def run(
         self,
@@ -670,12 +671,22 @@ class MonteCarloRunner:
             freq = data_cfg.get("frequency")
         freq_label = str(freq or "M")
         periods_per_year = periods_per_year_from_code(freq_label)
-        regimes = compute_regimes(
-            proxy_series,
+        cache_key = self._regime_cache_key(
+            context,
+            proxy_col,
+            freq_label,
+            periods_per_year,
             settings,
-            freq=freq_label,
-            periods_per_year=periods_per_year,
         )
+        regimes = self._regime_cache.get(cache_key)
+        if regimes is None:
+            regimes = compute_regimes(
+                proxy_series,
+                settings,
+                freq=freq_label,
+                periods_per_year=periods_per_year,
+            )
+            self._regime_cache[cache_key] = regimes
         if regimes.empty:
             return max_turnover
         regime_label = str(regimes.iloc[-1])
@@ -683,6 +694,31 @@ class MonteCarloRunner:
         if resolved is None:
             return max_turnover
         return resolved
+
+    def _regime_cache_key(
+        self,
+        context: _PathContext,
+        proxy_col: str,
+        freq_label: str,
+        periods_per_year: float,
+        settings: Any,
+    ) -> tuple[object, ...]:
+        return (
+            context.path_hash,
+            proxy_col,
+            freq_label,
+            periods_per_year,
+            getattr(settings, "method", None),
+            getattr(settings, "lookback", None),
+            getattr(settings, "smoothing", None),
+            getattr(settings, "threshold", None),
+            getattr(settings, "neutral_band", None),
+            getattr(settings, "min_obs", None),
+            getattr(settings, "risk_on_label", None),
+            getattr(settings, "risk_off_label", None),
+            getattr(settings, "default_label", None),
+            getattr(settings, "annualise_volatility", None),
+        )
 
     def _resolve_regime_proxy_column(
         self,

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -618,26 +618,29 @@ class MonteCarloRunner:
         )
 
     def _apply_regime_turnover_caps(self, config: ConfigType, context: _PathContext) -> None:
-        multi_period_cfg = getattr(config, "multi_period", None)
-        multi_period_enabled = isinstance(multi_period_cfg, Mapping)
         portfolio = getattr(config, "portfolio", None)
         if not isinstance(portfolio, Mapping):
             return
         max_turnover = portfolio.get("max_turnover")
-        # Supported shapes:
-        # - scalar max_turnover (float/int): apply as-is, no regime lookup required.
-        # - mapping max_turnover: interpreted as regime-conditioned caps.
-        if not isinstance(max_turnover, Mapping):
+        # Supported shapes for ``portfolio.max_turnover``:
+        # - scalar (float/int): apply as-is, no regime lookup required.
+        # - mapping: treated as regime-conditioned caps keyed by regime labels.
+        if max_turnover is None or not isinstance(max_turnover, Mapping):
             return
-        # In single-period runs we can resolve a regime-conditioned mapping to a
-        # scalar for the current path; multi-period runs keep the mapping so the
-        # engine can apply per-window regime caps.
-        if not multi_period_enabled:
+
+        multi_period_cfg = getattr(config, "multi_period", None)
+        multi_period_enabled = isinstance(multi_period_cfg, Mapping)
+        # Control flow:
+        # - Single-period runs resolve the mapping to a scalar for the current path.
+        # - Multi-period runs keep the mapping so the engine can apply per-period caps.
+        if multi_period_enabled:
+            resolved: float | Mapping[str, Any] | None = max_turnover
+        else:
             resolved = self._resolve_turnover_cap_for_context(config, context, max_turnover)
-            if resolved is None or resolved is max_turnover:
-                return
-            if isinstance(portfolio, dict):
-                portfolio["max_turnover"] = resolved
+        if resolved is None or resolved is max_turnover:
+            return
+        if isinstance(portfolio, dict):
+            portfolio["max_turnover"] = resolved
 
     def _resolve_turnover_cap_for_context(
         self,

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -143,6 +143,86 @@ def _prepare_returns_frame(df: pd.DataFrame) -> pd.DataFrame:
     return prepared
 
 
+def _resolve_regime_proxy_column(
+    proxy_value: str,
+    columns: Iterable[str],
+    benchmarks_cfg: Mapping[str, Any] | None,
+) -> str | None:
+    if proxy_value in columns:
+        return proxy_value
+    proxy_lower = proxy_value.lower()
+    if isinstance(benchmarks_cfg, Mapping):
+        for key, value in benchmarks_cfg.items():
+            if proxy_lower == str(key).lower() and value in columns:
+                return str(value)
+            if proxy_lower == str(value).lower() and value in columns:
+                return str(value)
+    for col in columns:
+        if proxy_lower == str(col).lower():
+            return str(col)
+    return None
+
+
+def _resolve_regime_label_for_window(
+    in_df: pd.DataFrame,
+    *,
+    regime_settings: Any,
+    benchmarks_cfg: Mapping[str, Any] | None,
+    regime_frequency: str,
+    regime_ppy: float,
+) -> str | None:
+    if not regime_settings.enabled or not regime_settings.proxy:
+        return None
+    proxy_col = _resolve_regime_proxy_column(
+        regime_settings.proxy,
+        in_df.columns,
+        benchmarks_cfg,
+    )
+    if proxy_col is None:
+        return None
+    proxy_series = pd.Series(in_df[proxy_col].to_numpy(), index=in_df.index).dropna()
+    if proxy_series.empty:
+        return None
+    labels = compute_regimes(
+        proxy_series,
+        regime_settings,
+        freq=regime_frequency,
+        periods_per_year=regime_ppy,
+    )
+    if labels.empty:
+        return None
+    return str(labels.iloc[-1])
+
+
+def _resolve_max_turnover_cap(
+    in_df: pd.DataFrame,
+    *,
+    max_turnover_cfg: Any,
+    regime_settings: Any,
+    benchmarks_cfg: Mapping[str, Any] | None,
+    regime_frequency: str,
+    regime_ppy: float,
+) -> float:
+    if max_turnover_cfg is None:
+        return 1.0
+    if not isinstance(max_turnover_cfg, Mapping):
+        try:
+            return float(max_turnover_cfg)
+        except (TypeError, ValueError):
+            return 1.0
+    regime_label = _resolve_regime_label_for_window(
+        in_df,
+        regime_settings=regime_settings,
+        benchmarks_cfg=benchmarks_cfg,
+        regime_frequency=regime_frequency,
+        regime_ppy=regime_ppy,
+    )
+    resolved = _resolve_regime_turnover_cap(max_turnover_cfg, regime_label, regime_settings)
+    if resolved is None:
+        return 1.0
+    return float(resolved)
+
+
 def _membership_table_from_frame(frame: pd.DataFrame) -> MembershipTable:
     """Convert a membership ledger DataFrame into ``MembershipTable``."""
 
@@ -1221,54 +1301,6 @@ def run(
     regime_frequency = str(data_settings.get("frequency") or "M")
     regime_ppy = float(periods_per_year_from_code(regime_frequency))
     max_turnover_cfg = cfg.portfolio.get("max_turnover", 1.0)
-
-    def _resolve_regime_proxy_column(proxy_value: str, columns: Iterable[str]) -> str | None:
-        if proxy_value in columns:
-            return proxy_value
-        proxy_lower = proxy_value.lower()
-        if isinstance(benchmarks_cfg, dict):
-            for key, value in benchmarks_cfg.items():
-                if proxy_lower == str(key).lower() and value in columns:
-                    return str(value)
-                if proxy_lower == str(value).lower() and value in columns:
-                    return str(value)
-        for col in columns:
-            if proxy_lower == str(col).lower():
-                return str(col)
-        return None
-
-    def _resolve_regime_label_for_window(in_df: pd.DataFrame) -> str | None:
-        if not regime_settings.enabled or not regime_settings.proxy:
-            return None
-        proxy_col = _resolve_regime_proxy_column(regime_settings.proxy, in_df.columns)
-        if proxy_col is None:
-            return None
-        proxy_series = pd.Series(in_df[proxy_col].to_numpy(), index=in_df.index).dropna()
-        if proxy_series.empty:
-            return None
-        labels = compute_regimes(
-            proxy_series,
-            regime_settings,
-            freq=regime_frequency,
-            periods_per_year=regime_ppy,
-        )
-        if labels.empty:
-            return None
-        return str(labels.iloc[-1])
-
-    def _resolve_max_turnover_cap(in_df: pd.DataFrame) -> float:
-        if max_turnover_cfg is None:
-            return 1.0
-        if not isinstance(max_turnover_cfg, Mapping):
-            try:
-                return float(max_turnover_cfg)
-            except (TypeError, ValueError):
-                return 1.0
-        regime_label = _resolve_regime_label_for_window(in_df)
-        resolved = _resolve_regime_turnover_cap(max_turnover_cfg, regime_label, regime_settings)
-        if resolved is None:
-            return 1.0
-        return float(resolved)
 
     def _valid_universe(
         full: pd.DataFrame,
@@ -3360,7 +3392,14 @@ def run(
                 and abs(last_aligned.loc[ix]) <= NUMERICAL_TOLERANCE_HIGH
                 and abs(target_w.loc[ix]) > NUMERICAL_TOLERANCE_HIGH
             }
-        max_turnover_cap = _resolve_max_turnover_cap(in_df)
+        max_turnover_cap = _resolve_max_turnover_cap(
+            in_df,
+            max_turnover_cfg=max_turnover_cfg,
+            regime_settings=regime_settings,
+            benchmarks_cfg=benchmarks_cfg,
+            regime_frequency=regime_frequency,
+            regime_ppy=regime_ppy,
+        )
         if (
             max_turnover_cap < 1.0 - NUMERICAL_TOLERANCE_HIGH
             and desired_turnover > max_turnover_cap + NUMERICAL_TOLERANCE_HIGH

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -1238,6 +1238,9 @@ def run(
     # Exclude their columns from the candidate universe even if they are
     # numeric and present in the returns frame.
     benchmarks_cfg = cast(object, getattr(cfg, "benchmarks", None))
+    benchmarks_cfg_mapping: Mapping[str, Any] | None = (
+        benchmarks_cfg if isinstance(benchmarks_cfg, Mapping) else None
+    )
     benchmark_cols: list[str] = []
     if benchmarks_cfg:
         # Config models define `benchmarks` as `dict[str, str]` (label -> column).
@@ -3396,7 +3399,7 @@ def run(
             in_df,
             max_turnover_cfg=max_turnover_cfg,
             regime_settings=regime_settings,
-            benchmarks_cfg=benchmarks_cfg,
+            benchmarks_cfg=benchmarks_cfg_mapping,
             regime_frequency=regime_frequency,
             regime_ppy=regime_ppy,
         )

--- a/src/trend_analysis/pipeline_helpers.py
+++ b/src/trend_analysis/pipeline_helpers.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import logging
-import re
 from typing import Any, Mapping, cast
 
 import numpy as np
 import pandas as pd
 
 from .regimes import compute_regimes, normalise_settings
+from .regime_utils import alias_regime_key, normalize_regime_key
 from .signals import TrendSpec
 from .stages.preprocessing import _PreprocessStage, _WindowStage
 
@@ -140,25 +140,6 @@ def _resolve_regime_label(
     return str(aligned.iloc[-1]), settings
 
 
-def _normalize_regime_key(value: Any) -> str | None:
-    if value is None:
-        return None
-    text = str(value).strip()
-    if not text:
-        return None
-    return re.sub(r"[^a-z0-9]+", "", text.casefold())
-
-
-def _alias_regime_key(value: str) -> str | None:
-    aliases = {
-        "riskon": "calm",
-        "riskoff": "stress",
-        "calm": "riskon",
-        "stress": "riskoff",
-    }
-    return aliases.get(value)
-
-
 def _resolve_regime_turnover_cap(
     max_turnover: object | None,
     regime_label: str | None,
@@ -184,7 +165,7 @@ def _resolve_regime_turnover_cap(
     normalized: dict[str, float] = {}
     normalized_sources: dict[str, str] = {}
     for key, value in max_turnover.items():
-        normalized_key = _normalize_regime_key(key)
+        normalized_key = normalize_regime_key(key)
         if not normalized_key:
             continue
         original = str(key)
@@ -199,12 +180,12 @@ def _resolve_regime_turnover_cap(
         return None
 
     def _lookup(label: str | None) -> float | None:
-        label_key = _normalize_regime_key(label)
+        label_key = normalize_regime_key(label)
         if not label_key:
             return None
         if label_key in normalized:
             return _coerce_optional_float(normalized[label_key])
-        alias_key = _alias_regime_key(label_key)
+        alias_key = alias_regime_key(label_key)
         if alias_key and alias_key in normalized:
             return _coerce_optional_float(normalized[alias_key])
         return None
@@ -223,7 +204,7 @@ def _resolve_regime_turnover_cap(
         if fallback in normalized:
             return normalized[fallback]
 
-    if regime_label and _normalize_regime_key(regime_label):
+    if regime_label and normalize_regime_key(regime_label):
         raise KeyError(f"max_turnover missing regime '{regime_label}' and no default specified")
     return None
 

--- a/src/trend_analysis/pipeline_helpers.py
+++ b/src/trend_analysis/pipeline_helpers.py
@@ -6,9 +6,10 @@ from typing import Any, Mapping, cast
 import numpy as np
 import pandas as pd
 
+from trend.config_schema import CoreConfigError
+
 from .regime_utils import alias_regime_key, normalize_regime_key
 from .regimes import compute_regimes, normalise_settings
-from trend.config_schema import CoreConfigError
 from .signals import TrendSpec
 from .stages.preprocessing import _PreprocessStage, _WindowStage
 
@@ -241,13 +242,9 @@ def parse_regime_turnover_caps(
         try:
             numeric_value = float(cast(Any, value))
         except (TypeError, ValueError) as exc:
-            raise CoreConfigError(
-                f"max_turnover for regime {original!r} must be numeric"
-            ) from exc
+            raise CoreConfigError(f"max_turnover for regime {original!r} must be numeric") from exc
         if not np.isfinite(numeric_value):
-            raise CoreConfigError(
-                f"max_turnover for regime {original!r} must be a finite number"
-            )
+            raise CoreConfigError(f"max_turnover for regime {original!r} must be a finite number")
         normalized_caps[normalized_key] = numeric_value
         normalized_sources[normalized_key] = original
 

--- a/src/trend_analysis/pipeline_helpers.py
+++ b/src/trend_analysis/pipeline_helpers.py
@@ -6,8 +6,8 @@ from typing import Any, Mapping, cast
 import numpy as np
 import pandas as pd
 
-from .regimes import compute_regimes, normalise_settings
 from .regime_utils import alias_regime_key, normalize_regime_key
+from .regimes import compute_regimes, normalise_settings
 from .signals import TrendSpec
 from .stages.preprocessing import _PreprocessStage, _WindowStage
 

--- a/src/trend_analysis/pipeline_helpers.py
+++ b/src/trend_analysis/pipeline_helpers.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from .regime_utils import alias_regime_key, normalize_regime_key
 from .regimes import compute_regimes, normalise_settings
+from trend.config_schema import CoreConfigError
 from .signals import TrendSpec
 from .stages.preprocessing import _PreprocessStage, _WindowStage
 
@@ -28,6 +29,7 @@ __all__ = [
     "_empty_run_full_result",
     "_format_period",
     "_policy_from_config",
+    "parse_regime_turnover_caps",
     "_resolve_regime_turnover_cap",
     "_resolve_regime_label",
     "_resolve_sample_split",
@@ -151,31 +153,12 @@ def _resolve_regime_turnover_cap(
         except (TypeError, ValueError):
             return None
 
-    def _coerce_required_float(value: object) -> float:
-        try:
-            return float(cast(Any, value))
-        except (TypeError, ValueError) as exc:
-            raise TypeError("max_turnover values must be numeric") from exc
-
     if max_turnover is None:
         return None
     if not isinstance(max_turnover, Mapping):
         return _coerce_optional_float(max_turnover)
 
-    normalized: dict[str, float] = {}
-    normalized_sources: dict[str, str] = {}
-    for key, value in max_turnover.items():
-        normalized_key = normalize_regime_key(key)
-        if not normalized_key:
-            continue
-        original = str(key)
-        if normalized_key in normalized_sources and normalized_sources[normalized_key] != original:
-            raise ValueError(
-                "max_turnover regime keys collide after normalization "
-                f"({normalized_sources[normalized_key]!r} vs {original!r})"
-            )
-        normalized[normalized_key] = _coerce_required_float(value)
-        normalized_sources[normalized_key] = original
+    normalized = parse_regime_turnover_caps(max_turnover, settings)
     if not normalized:
         return None
 
@@ -207,6 +190,70 @@ def _resolve_regime_turnover_cap(
     if regime_label and normalize_regime_key(regime_label):
         raise KeyError(f"max_turnover missing regime '{regime_label}' and no default specified")
     return None
+
+
+def parse_regime_turnover_caps(
+    max_turnover: Mapping[str, Any] | None,
+    settings: Any,
+) -> dict[str, float] | None:
+    if not max_turnover:
+        return None
+
+    default_settings = normalise_settings(None)
+    regime_settings = settings or default_settings
+
+    def _allowed_keys() -> set[str]:
+        allowed: set[str] = {"default", "all", "any"}
+        for attr in ("risk_on_label", "risk_off_label", "default_label"):
+            label = getattr(regime_settings, attr, getattr(default_settings, attr))
+            normalized = normalize_regime_key(label)
+            if not normalized:
+                continue
+            allowed.add(normalized)
+            alias_key = alias_regime_key(normalized)
+            if alias_key:
+                allowed.add(alias_key)
+        return allowed
+
+    allowed = _allowed_keys()
+    normalized_caps: dict[str, float] = {}
+    normalized_sources: dict[str, str] = {}
+    for key, value in max_turnover.items():
+        normalized_key = normalize_regime_key(key)
+        if not normalized_key:
+            raise CoreConfigError("max_turnover regime keys must be non-empty strings")
+
+        if normalized_key not in allowed:
+            alias_key = alias_regime_key(normalized_key)
+            if not alias_key or alias_key not in allowed:
+                allowed_list = ", ".join(sorted(allowed))
+                raise CoreConfigError(
+                    "max_turnover regime label "
+                    f"{key!r} is not recognized; allowed labels: {allowed_list}"
+                )
+
+        original = str(key)
+        if normalized_key in normalized_sources and normalized_sources[normalized_key] != original:
+            raise CoreConfigError(
+                "max_turnover regime keys collide after normalization "
+                f"({normalized_sources[normalized_key]!r} vs {original!r})"
+            )
+        try:
+            numeric_value = float(cast(Any, value))
+        except (TypeError, ValueError) as exc:
+            raise CoreConfigError(
+                f"max_turnover for regime {original!r} must be numeric"
+            ) from exc
+        if not np.isfinite(numeric_value):
+            raise CoreConfigError(
+                f"max_turnover for regime {original!r} must be a finite number"
+            )
+        normalized_caps[normalized_key] = numeric_value
+        normalized_sources[normalized_key] = original
+
+    if not normalized_caps:
+        return None
+    return normalized_caps
 
 
 def _apply_regime_overrides(

--- a/src/trend_analysis/regime_utils.py
+++ b/src/trend_analysis/regime_utils.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+__all__ = ["normalize_regime_key", "alias_regime_key"]
+
+
+def normalize_regime_key(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return re.sub(r"[^a-z0-9]+", "", text.casefold())
+
+
+def alias_regime_key(value: str) -> str | None:
+    aliases = {
+        "riskon": "calm",
+        "riskoff": "stress",
+        "calm": "riskon",
+        "stress": "riskoff",
+    }
+    return aliases.get(value)

--- a/tests/monte_carlo/test_runner_turnover_diagnostics.py
+++ b/tests/monte_carlo/test_runner_turnover_diagnostics.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pandas.testing as pdt
 import pytest
 
+from trend.config_schema import CoreConfigError
 from trend_analysis.api import RunResult
 from trend_analysis.monte_carlo.results import (
     StrategyEvaluation,
@@ -608,6 +609,214 @@ def test_runner_caches_regime_labels(monkeypatch) -> None:
     assert call_count["count"] == 1
     assert config_a.portfolio["max_turnover"] == pytest.approx(0.1)
     assert config_b.portfolio["max_turnover"] == pytest.approx(0.1)
+
+
+def test_resolve_turnover_cap_for_context_selects_regime(monkeypatch) -> None:
+    dates = pd.date_range("2021-01-31", periods=2, freq="ME")
+    returns = pd.DataFrame({"Date": dates, "Asset": [0.01, -0.02]})
+
+    def _fake_compute_regimes(series, _settings, *, freq, periods_per_year):
+        del series, freq, periods_per_year
+        return pd.Series(["calm", "stress"], index=dates, name="regime")
+
+    monkeypatch.setattr(
+        "trend_analysis.monte_carlo.runner.compute_regimes",
+        _fake_compute_regimes,
+    )
+
+    runner = MonteCarloRunner(
+        _scenario(),
+        base_config=_base_config(
+            max_turnover={"calm": 0.25, "stress": 0.1},
+            regime_cfg={
+                "enabled": True,
+                "proxy": "Asset",
+                "method": "rolling_return",
+                "lookback": 1,
+                "smoothing": 1,
+                "threshold": 0.0,
+                "neutral_band": 0.0,
+                "risk_on_label": "calm",
+                "risk_off_label": "stress",
+                "default_label": "calm",
+            },
+        ),
+    )
+    context = _PathContext(
+        path_id=0,
+        prices=pd.DataFrame(),
+        returns=returns,
+        score_frame=pd.DataFrame(),
+        path_hash="hash",
+        seed=123,
+    )
+    config = runner._build_strategy_config(StrategyVariant(name="base"), seed=1)
+
+    resolved = runner._resolve_turnover_cap_for_context(
+        config,
+        context,
+        config.portfolio["max_turnover"],
+    )
+    assert resolved == pytest.approx(0.1)
+
+
+def test_resolve_turnover_cap_for_context_invalid_mapping_raises(monkeypatch) -> None:
+    dates = pd.date_range("2021-01-31", periods=2, freq="ME")
+    returns = pd.DataFrame({"Date": dates, "Asset": [0.01, -0.02]})
+
+    def _fake_compute_regimes(series, _settings, *, freq, periods_per_year):
+        del series, freq, periods_per_year
+        return pd.Series(["calm", "calm"], index=dates, name="regime")
+
+    monkeypatch.setattr(
+        "trend_analysis.monte_carlo.runner.compute_regimes",
+        _fake_compute_regimes,
+    )
+
+    runner = MonteCarloRunner(
+        _scenario(),
+        base_config=_base_config(
+            max_turnover={"mystery": 0.2},
+            regime_cfg={
+                "enabled": True,
+                "proxy": "Asset",
+                "method": "rolling_return",
+                "lookback": 1,
+                "smoothing": 1,
+                "threshold": 0.0,
+                "neutral_band": 0.0,
+                "risk_on_label": "calm",
+                "risk_off_label": "stress",
+                "default_label": "calm",
+            },
+        ),
+    )
+    context = _PathContext(
+        path_id=0,
+        prices=pd.DataFrame(),
+        returns=returns,
+        score_frame=pd.DataFrame(),
+        path_hash="hash",
+        seed=123,
+    )
+    config = runner._build_strategy_config(StrategyVariant(name="base"), seed=1)
+
+    with pytest.raises(CoreConfigError):
+        runner._resolve_turnover_cap_for_context(
+            config,
+            context,
+            config.portfolio["max_turnover"],
+        )
+
+
+def test_multi_period_turnover_caps_and_binding(monkeypatch: pytest.MonkeyPatch) -> None:
+    history_dates = pd.date_range("2019-06-30", periods=7, freq="ME")
+    price_history = pd.DataFrame(
+        {
+            "Asset": np.linspace(100.0, 120.0, len(history_dates)),
+            "AssetB": np.linspace(90.0, 110.0, len(history_dates)),
+            "RF": np.full(len(history_dates), 100.0),
+        },
+        index=history_dates,
+    )
+
+    def _fake_compute_regimes(series, _settings, *, freq, periods_per_year):
+        del freq, periods_per_year
+        cutoff = pd.Timestamp("2020-03-01")
+        label = "calm" if series.index.min() < cutoff else "stress"
+        return pd.Series([label] * len(series), index=series.index, name="regime")
+
+    monkeypatch.setattr(
+        "trend_analysis.multi_period.engine.compute_regimes",
+        _fake_compute_regimes,
+    )
+    monkeypatch.setattr(
+        "trend_analysis.regimes.compute_regimes",
+        _fake_compute_regimes,
+    )
+
+    base_config = _base_config(
+        max_turnover={"calm": 0.2, "stress": 0.8},
+        regime_cfg={
+            "enabled": True,
+            "proxy": "Asset",
+            "method": "rolling_return",
+            "lookback": 1,
+            "smoothing": 1,
+            "threshold": 0.0,
+            "neutral_band": 0.0,
+            "risk_on_label": "calm",
+            "risk_off_label": "stress",
+            "default_label": "calm",
+        },
+    )
+    base_config["portfolio"].update(
+        {
+            "policy": "threshold_hold",
+            "selection_mode": "all",
+            "weighting_scheme": "equal",
+        }
+    )
+    base_config["data"]["allow_risk_free_fallback"] = False
+    base_config["data"]["risk_free_column"] = "RF"
+    base_config["multi_period"] = {
+        "frequency": "M",
+        "in_sample_len": 2,
+        "out_sample_len": 2,
+        "start": "2020-01",
+        "end": "2020-06",
+        "min_funds": 0,
+        "max_funds": 2,
+    }
+
+    scenario = MonteCarloScenario(
+        name="multi_period_regime_caps",
+        base_config="base.yml",
+        monte_carlo={
+            "mode": "two_layer",
+            "n_paths": 1,
+            "horizon_years": 0.5,
+            "frequency": "M",
+            "seed": 7,
+        },
+        return_model={"kind": "stationary_bootstrap"},
+        enable_fold_runs=False,
+    )
+
+    runner = MonteCarloRunner(
+        scenario,
+        base_config=base_config,
+        price_history=price_history,
+    )
+
+    results = runner.run(jobs=1)
+
+    assert results.diagnostics_frame is not None
+    diagnostics = results.diagnostics_frame
+    diagnostics = diagnostics[
+        (diagnostics["path_id"] == 0) & (diagnostics["strategy"] == "base")
+    ].sort_values("period")
+
+    expected_periods = ["2020-03-31", "2020-05-31"]
+    assert diagnostics["period"].tolist() == expected_periods
+
+    turnover = diagnostics["turnover"].tolist()
+    binding = diagnostics["turnover_cap_binding"].tolist()
+
+    assert turnover[0] >= 0.2
+    assert turnover[1] < 0.8
+    assert binding == [True, False]
+
+    evaluation = results.evaluations[0]
+    expected_index = pd.Index(expected_periods, name="period")
+    expected_turnover = pd.Series(turnover, index=expected_index, name="turnover")
+    expected_binding = pd.Series(binding, index=expected_index, name="turnover_cap_binding")
+    pdt.assert_series_equal(evaluation.turnover, expected_turnover, check_freq=False)
+    pdt.assert_series_equal(
+        evaluation.turnover_cap_binding,
+        expected_binding,
+        check_freq=False,
+    )
 
 
 def test_runner_normalizes_regime_turnover_caps(monkeypatch) -> None:

--- a/tests/monte_carlo/test_runner_turnover_diagnostics.py
+++ b/tests/monte_carlo/test_runner_turnover_diagnostics.py
@@ -554,6 +554,62 @@ def test_runner_resolves_regime_turnover_caps(monkeypatch) -> None:
     pdt.assert_series_equal(diagnostic["turnover_cap_binding"], expected_binding)
 
 
+def test_runner_caches_regime_labels(monkeypatch) -> None:
+    dates = pd.date_range("2023-01-31", periods=3, freq="ME")
+    returns = pd.DataFrame({"Date": dates, "Asset": [0.01, -0.02, 0.03]})
+    call_count = {"count": 0}
+
+    def _fake_compute_regimes(series, settings, *, freq, periods_per_year):
+        call_count["count"] += 1
+        return pd.Series(
+            ["calm", "stress", "stress"],
+            index=series.index,
+            name="regime",
+        )
+
+    monkeypatch.setattr(
+        "trend_analysis.monte_carlo.runner.compute_regimes",
+        _fake_compute_regimes,
+    )
+
+    runner = MonteCarloRunner(
+        _scenario(),
+        base_config=_base_config(
+            max_turnover={"calm": 0.2, "stress": 0.1},
+            regime_cfg={
+                "enabled": True,
+                "proxy": "Asset",
+                "method": "rolling_return",
+                "lookback": 1,
+                "smoothing": 1,
+                "threshold": 0.0,
+                "neutral_band": 0.0,
+                "risk_on_label": "calm",
+                "risk_off_label": "stress",
+                "default_label": "calm",
+            },
+        ),
+    )
+    context = _PathContext(
+        path_id=0,
+        prices=pd.DataFrame(),
+        returns=returns,
+        score_frame=pd.DataFrame(),
+        path_hash="hash",
+        seed=123,
+    )
+
+    config_a = runner._build_strategy_config(StrategyVariant(name="a"), seed=1)
+    config_b = runner._build_strategy_config(StrategyVariant(name="b"), seed=2)
+
+    runner._apply_regime_turnover_caps(config_a, context)
+    runner._apply_regime_turnover_caps(config_b, context)
+
+    assert call_count["count"] == 1
+    assert config_a.portfolio["max_turnover"] == pytest.approx(0.1)
+    assert config_b.portfolio["max_turnover"] == pytest.approx(0.1)
+
+
 def test_runner_normalizes_regime_turnover_caps(monkeypatch) -> None:
     dates = pd.date_range("2022-01-31", periods=2, freq="ME")
     returns = pd.DataFrame({"Date": dates, "Asset": [0.01, 0.02]})

--- a/tests/test_pipeline_helpers_additional.py
+++ b/tests/test_pipeline_helpers_additional.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 
 import trend_analysis.pipeline as pipeline
+from trend.config_schema import CoreConfigError
 from trend_analysis.pipeline import (
     _build_trend_spec,
     _cfg_section,
@@ -181,7 +182,7 @@ def test_resolve_regime_turnover_cap_missing_default_raises() -> None:
 def test_resolve_regime_turnover_cap_type_error_on_non_float() -> None:
     settings = SimpleNamespace(default_label=None)
 
-    with pytest.raises(TypeError, match="max_turnover"):
+    with pytest.raises(CoreConfigError, match="max_turnover"):
         _resolve_regime_turnover_cap({"calm": "fast"}, "calm", settings)
 
 

--- a/tests/test_pipeline_helpers_additional.py
+++ b/tests/test_pipeline_helpers_additional.py
@@ -28,7 +28,10 @@ from trend_analysis.pipeline import (
     compute_signal,
     single_period_run,
 )
-from trend_analysis.pipeline_helpers import _resolve_regime_turnover_cap, parse_regime_turnover_caps
+from trend_analysis.pipeline_helpers import (
+    _resolve_regime_turnover_cap,
+    parse_regime_turnover_caps,
+)
 from trend_analysis.signals import TrendSpec
 from trend_analysis.util.frequency import FrequencySummary
 from trend_analysis.util.missing import MissingPolicyResult

--- a/tests/test_pipeline_helpers_additional.py
+++ b/tests/test_pipeline_helpers_additional.py
@@ -28,7 +28,7 @@ from trend_analysis.pipeline import (
     compute_signal,
     single_period_run,
 )
-from trend_analysis.pipeline_helpers import _resolve_regime_turnover_cap
+from trend_analysis.pipeline_helpers import _resolve_regime_turnover_cap, parse_regime_turnover_caps
 from trend_analysis.signals import TrendSpec
 from trend_analysis.util.frequency import FrequencySummary
 from trend_analysis.util.missing import MissingPolicyResult
@@ -202,6 +202,69 @@ def test_resolve_regime_turnover_cap_resolves_per_period() -> None:
     ]
 
     assert resolved == [pytest.approx(0.15), pytest.approx(0.08), pytest.approx(0.15)]
+
+
+def test_parse_regime_turnover_caps_accepts_valid_mapping() -> None:
+    settings = SimpleNamespace(
+        risk_on_label="Risk-On",
+        risk_off_label="Risk-Off",
+        default_label="Risk-On",
+    )
+    caps = {"calm": 0.15, "stress": 0.08, "default": 0.2}
+
+    parsed = parse_regime_turnover_caps(caps, settings)
+
+    assert parsed == {
+        "calm": pytest.approx(0.15),
+        "stress": pytest.approx(0.08),
+        "default": pytest.approx(0.2),
+    }
+
+
+def test_parse_regime_turnover_caps_normalizes_aliases_and_case() -> None:
+    settings = SimpleNamespace(
+        risk_on_label="Risk-On",
+        risk_off_label="Risk-Off",
+        default_label="Risk-On",
+    )
+    caps = {"Risk On": 0.12, "RISK OFF": 0.07}
+
+    parsed = parse_regime_turnover_caps(caps, settings)
+
+    assert parsed == {"riskon": pytest.approx(0.12), "riskoff": pytest.approx(0.07)}
+
+
+def test_parse_regime_turnover_caps_unknown_label_raises() -> None:
+    settings = SimpleNamespace(
+        risk_on_label="Risk-On",
+        risk_off_label="Risk-Off",
+        default_label="Risk-On",
+    )
+
+    with pytest.raises(CoreConfigError, match="mystery"):
+        parse_regime_turnover_caps({"mystery": 0.1}, settings)
+
+
+def test_parse_regime_turnover_caps_non_numeric_raises() -> None:
+    settings = SimpleNamespace(
+        risk_on_label="Risk-On",
+        risk_off_label="Risk-Off",
+        default_label="Risk-On",
+    )
+
+    with pytest.raises(CoreConfigError, match="calm"):
+        parse_regime_turnover_caps({"calm": "fast"}, settings)
+
+
+def test_parse_regime_turnover_caps_missing_or_empty_returns_none() -> None:
+    settings = SimpleNamespace(
+        risk_on_label="Risk-On",
+        risk_off_label="Risk-Off",
+        default_label="Risk-On",
+    )
+
+    assert parse_regime_turnover_caps(None, settings) is None
+    assert parse_regime_turnover_caps({}, settings) is None
 
 
 def test_policy_from_config_constructs_composites() -> None:


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #4743 addressed issue #4735, and verification passed (**PASS**) but identified maintainability, correctness, performance, and diagnostics gaps around regime-key handling and regime-conditional turnover caps. This follow-up closes those gaps by centralizing regime utilities and parsing, clarifying runner control flow, adding caching, persisting/standardizing diagnostics (including `turnover_cap_binding`), refactoring complex engine helpers, and adding targeted unit/integration tests to lock in behavior.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#4743](https://github.com/stranske/Trend_Model_Project/issues/4743)
- [#4735](https://github.com/stranske/Trend_Model_Project/issues/4735)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Create a shared utility module for regime-key handling and replace duplicated implementations in MonteCarloRunner and pipeline_helpers.py.
- [x] Implement a dedicated parser function for regime-conditional turnover caps (e.g., `{calm: 0.15, stress: 0.08}`) with strict validation of regime labels and value types; raise a clear configuration error on invalid inputs.
- [x] Refactor `MonteCarloRunner._apply_regime_turnover_caps()` to remove/replace the non-obvious early-return when `config.multi_period` is a `Mapping`, and add inline comments that document the supported config shapes and control flow.
- [x] Add caching for regime detection in MonteCarloRunner so regime labels are computed once per unique context/time-period and reused across strategies/paths that share that context.
- [x] Update the runner to persist realized turnover per period per simulation path and include a boolean flag indicating whether the turnover cap was binding; expose this in the persisted diagnostics structure.
- [x] Add the per-period boolean diagnostic field named `turnover_cap_binding` to the simulation outputs and ensure it is populated from the same logic that applies the cap.
- [x] Refactor `multi_period.engine.run()` by extracting any inline helper closures related to turnover-cap/regime handling into named private functions (only those exceeding a small complexity threshold).
- [x] Add unit tests for turnover-cap parsing/validation covering: valid mappings, regime aliases/case normalization, unknown regime labels (must raise), non-numeric values (must raise), and missing/empty mappings (expected behavior).
- [x] Add unit tests for `runner.py` `_resolve_turnover_cap_for_context()` covering typical and edge cases, including improper config inputs and ensuring the correct cap is selected for each regime.
- [x] Add an integration-style unit test that runs a small multi-period Monte Carlo simulation with two regimes and verifies: (1) correct cap applied by period, (2) realized turnover is persisted per path/period, and (3) `turnover_cap_binding` toggles correctly when the cap binds.

#### Acceptance criteria
- [x] A new module `regime_utils.py` exists under `src/` and exports `normalize_regime_key()` and `alias_regime_key()` (or identically named equivalents) that are used by both `MonteCarloRunner` and `pipeline_helpers.py` for regime-key normalization.
- [x] There is exactly one implementation of regime-key normalization/aliasing logic in the codebase (the shared utility), and no duplicated private helpers remain in `runner.py` or `pipeline_helpers.py`.
- [x] A dedicated parser function exists for regime-conditional turnover caps (e.g., `parse_regime_turnover_caps(...)`) that accepts a mapping like `{calm: 0.15, stress: 0.08}` and returns a normalized mapping keyed by normalized regime labels (case-insensitive) with float values.
- [x] If the turnover-cap mapping contains an unknown regime label (after normalization/aliasing), the parser raises a configuration exception (not a warning and not a NaN fallback), and the error message includes the unknown label and the list of allowed labels.
- [x] If any value in the turnover-cap mapping is non-numeric (e.g., string, object, list) or NaN/inf, the parser raises a configuration exception and identifies the offending regime key in the error message.
- [x] If the turnover-cap mapping is empty or missing, behavior is explicit and test-locked: either (A) it returns `None`/empty meaning “no caps applied” OR (B) it raises a configuration exception. The chosen behavior is asserted by tests.
- [x] `MonteCarloRunner` uses the dedicated turnover-cap parser (directly or via config parsing layer) and does not implement ad-hoc parsing/normalization at the call site.
- [x] `MonteCarloRunner._apply_regime_turnover_caps()` applies caps for supported config shapes and does not contain an early-return that skips cap application solely because `config.multi_period` is a `Mapping`.
- [x] `MonteCarloRunner._apply_regime_turnover_caps()` contains inline comments documenting (1) the supported turnover-cap config shapes (scalar vs regime-mapping) and (2) when caps are applied vs not applied.
- [x] A runner function (e.g., `_resolve_turnover_cap_for_context(context, config)`) exists that selects the correct turnover cap for a given context/regime, and unit tests cover at least: calm selection, stress selection, alias/case normalization, and improper config inputs raising configuration errors.
- [x] Regime detection is cached within `MonteCarloRunner` such that repeated requests for the same unique (context, period) reuse a stored regime label rather than recomputing it.
- [x] The runner persists realized turnover per period per simulation path in the diagnostics/results structure, and the stored value matches the realized turnover used by the engine after applying turnover caps.
- [x] The runner persists, per period per simulation path, a boolean flag indicating cap binding (true iff the unconstrained turnover would exceed the cap and the applied turnover equals the cap within a defined tolerance).
- [x] Simulation outputs include a per-period boolean diagnostic field named exactly `turnover_cap_binding`, and it is populated for every produced period in the output (no missing keys for any period).
- [x] `turnover_cap_binding` in the output matches the persisted runner diagnostic binding flag for the same path/period (no divergence between persistence and output).
- [x] Any inline helper closure(s) inside `multi_period.engine.run()` related to turnover-cap/regime handling that exceed the project’s complexity threshold are extracted into named private functions, and `engine.run()` no longer defines those closures.
- [x] Unit tests exist and cover turnover-cap parsing scenarios: valid mappings, regime aliases/case normalization, unknown labels raising, non-numeric values raising, and missing/empty mappings behavior (explicitly asserted).
- [x] Unit tests exist and cover runner turnover-cap resolution for typical and edge cases, including improper config inputs raising and correct cap chosen per regime.
- [x] An integration-style unit test runs a small multi-period Monte Carlo simulation with two regimes and verifies: (1) correct cap applied by period, (2) realized turnover persisted per path/period, and (3) `turnover_cap_binding` toggles correctly when the cap binds.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why
PR #4743 addressed issue #4735, and verification passed (**PASS**) but identified maintainability, correctness, performance, and diagnostics gaps around regime-key handling and regime-conditional turnover caps. This follow-up closes those gaps by centralizing regime utilities and parsing, clarifying runner control flow, adding caching, persisting/standardizing diagnostics (including `turnover_cap_binding`), refactoring complex engine helpers, and adding targeted unit/integration tests to lock in behavior.

## Source
- Original PR: #4743
- Parent issue: #4735

## Tasks
- [ ] Create a shared utility module for regime-key handling and replace duplicated implementations in MonteCarloRunner and pipeline_helpers.py.
- [ ] Implement a dedicated parser function for regime-conditional turnover caps (e.g., `{calm: 0.15, stress: 0.08}`) with strict validation of regime labels and value types; raise a clear configuration error on invalid inputs.
- [ ] Refactor `MonteCarloRunner._apply_regime_turnover_caps()` to remove/replace the non-obvious early-return when `config.multi_period` is a `Mapping`, and add inline comments that document the supported config shapes and control flow.
- [x] Add caching for regime detection in MonteCarloRunner so regime labels are computed once per unique context/time-period and reused across strategies/paths that share that context.
- [x] Update the runner to persist realized turnover per period per simulation path and include a boolean flag indicating whether the turnover cap was binding; expose this in the persisted diagnostics structure.
- [x] Add the per-period boolean diagnostic field named `turnover_cap_binding` to the simulation outputs and ensure it is populated from the same logic that applies the cap.
- [x] Refactor `multi_period.engine.run()` by extracting any inline helper closures related to turnover-cap/regime handling into named private functions (only those exceeding a small complexity threshold).
- [ ] Add unit tests for turnover-cap parsing/validation covering: valid mappings, regime aliases/case normalization, unknown regime labels (must raise), non-numeric values (must raise), and missing/empty mappings (expected behavior).
- [ ] Add unit tests for `runner.py` `_resolve_turnover_cap_for_context()` covering typical and edge cases, including improper config inputs and ensuring the correct cap is selected for each regime.
- [x] Add an integration-style unit test that runs a small multi-period Monte Carlo simulation with two regimes and verifies: (1) correct cap applied by period, (2) realized turnover is persisted per path/period, and (3) `turnover_cap_binding` toggles correctly when the cap binds.

## Acceptance Criteria
- [ ] A new module `regime_utils.py` exists under `src/` and exports `normalize_regime_key()` and `alias_regime_key()` (or identically named equivalents) that are used by both `MonteCarloRunner` and `pipeline_helpers.py` for regime-key normalization.
- [ ] There is exactly one implementation of regime-key normalization/aliasing logic in the codebase (the shared utility), and no duplicated private helpers remain in `runner.py` or `pipeline_helpers.py`.
- [ ] A dedicated parser function exists for regime-conditional turnover caps (e.g., `parse_regime_turnover_caps(...)`) that accepts a mapping like `{calm: 0.15, stress: 0.08}` and returns a normalized mapping keyed by normalized regime labels (case-insensitive) with float values.
- [ ] If the turnover-cap mapping contains an unknown regime label (after normalization/aliasing), the parser raises a configuration exception (not a warning and not a NaN fallback), and the error message includes the unknown label and the list of allowed labels.
- [ ] If any value in the turnover-cap mapping is non-numeric (e.g., string, object, list) or NaN/inf, the parser raises a configuration exception and identifies the offending regime key in the error message.
- [x] If the turnover-cap mapping is empty or missing, behavior is explicit and test-locked: either (A) it returns `None`/empty meaning “no caps applied” OR (B) it raises a configuration exception. The chosen behavior is asserted by tests.
- [ ] `MonteCarloRunner` uses the dedicated turnover-cap parser (directly or via config parsing layer) and does not implement ad-hoc parsing/normalization at the call site.
- [ ] `MonteCarloRunner._apply_regime_turnover_caps()` applies caps for supported config shapes and does not contain an early-return that skips cap application solely because `config.multi_period` is a `Mapping`.
- [ ] `MonteCarloRunner._apply_regime_turnover_caps()` contains inline comments documenting (1) the supported turnover-cap config shapes (scalar vs regime-mapping) and (2) when caps are applied vs not applied.
- [ ] A runner function (e.g., `_resolve_turnover_cap_for_context(context, config)`) exists that selects the correct turnover cap for a given context/regime, and unit tests cover at least: calm selection, stress selection, alias/case normalization, and improper config inputs raising configuration errors.
- [ ] Regime detection is cached within `MonteCarloRunner` such that repeated requests for the same unique (context, period) reuse a stored regime label rather than recomputing it.
- [ ] The runner persists realized turnover per period per simulation path in the diagnostics/results structure, and the stored value matches the realized turnover used by the engine after applying turnover caps.
- [ ] The runner persists, per period per simulation path, a boolean flag indicating cap binding (true iff the unconstrained turnover would exceed the cap and the applied turnover equals the cap within a defined tolerance).
- [x] Simulation outputs include a per-period boolean diagnostic field named exactly `turnover_cap_binding`, and it is populated for every produced period in the output (no missing keys for any period).
- [ ] `turnover_cap_binding` in the output matches the persisted runner diagnostic binding flag for the same path/period (no divergence between persistence and output).
- [x] Any inline helper closure(s) inside `multi_period.engine.run()` related to turnover-cap/regime handling that exceed the project’s complexity threshold are extracted into named private functions, and `engine.run()` no longer defines those closures.
- [ ] Unit tests exist and cover turnover-cap parsing scenarios: valid mappings, regime aliases/case normalization, unknown labels raising, non-numeric values raising, and missing/empty mappings behavior (explicitly asserted).
- [x] Unit tests exist and cover runner turnover-cap resolution for typical and edge cases, including improper config inputs raising and correct cap chosen per regime.
- [ ] An integration-style unit test runs a small multi-period Monte Carlo simulation with two regimes and verifies: (1) correct cap applied by period, (2) realized turnover persisted per path/period, and (3) `turnover_cap_binding` toggles correctly when the cap binds.

## Implementation Notes
- New shared utility module:
  - Add `src/**/regime_utils.py` (exact final location/path may need small adjustment to match repo conventions) and move regime-key normalization/aliasing there.
  - Remove duplicated `_normalize_regime_key()` / `_alias_regime_key()` definitions from:
    - `src/**/runner.py` (`MonteCarloRunner`)
    - `src/**/pipeline_helpers.py`
  - Update imports and call sites accordingly.

- Turnover-cap parsing & config errors:
  - Implement `parse_regime_turnover_caps(...)` in `regime_utils.py` (or a tightly related module) and ensure it:
    - Normalizes keys via the shared regime-key functions
    - Validates allowed labels (post-aliasing)
    - Validates values are finite numeric floats (reject NaN/inf)
    - Raises a clear configuration exception type used elsewhere in the codebase (e.g., the project’s config error class)
  - Integrate parser through `src/**/config_parsing.py` (or the existing config loader/parser module) if that’s where config normalization belongs; runner should not re-implement parsing.

- Runner refactors:
  - In `src/**/runner.py`:
    - Refactor `_apply_regime_turnover_caps()` to eliminate the surprising early-return based only on `isinstance(config.multi_period, Mapping)`; document supported config shapes inline.
    - Add `_resolve_turnover_cap_for_context(...)` (or equivalent) and ensure cap application calls it.
    - Add caching for regime detection keyed by a stable identifier (e.g., context id + period index/date). Ensure cache is scoped appropriately (per run) and does not leak across runs.
    - Compute and store, per period and per path:
      - realized turnover (post-cap)
      - `turnover_cap_binding` flag derived from the same unconstrained vs applied turnover used in the cap logic (use a defined tolerance for float comparisons).

- Persistence & outputs:
  - Update persistence/results serialization (`src/**/persistence.py` or equivalent) and any schema module (`src/**/output_schema.py`, `src/**/simulation_output.py`, etc.) to include:
    - per-period realized turnover values
    - per-period `turnover_cap_binding` boolean named exactly `turnover_cap_binding`
  - Ensure output builder pulls from the same stored runner diagnostics to avoid divergence.

- Engine refactor:
  - In `src/**/multi_period/engine.py`, extract complex inline helper closures inside `run()` related to turnover-cap/regime handling into named private functions (`def _...`) when they exceed the project’s complexity threshold. Keep `run()` readable and linear.

- Tests:
  - Add/extend tests:
    - `tests/**/test_regime_turnover_cap_parsing.py`
    - `tests/**/test_runner_turnover_cap_resolution.py`
    - `tests/**/test_mc_turnover_caps_end_to_end.py`
  - Integration-style test should run a minimal two-regime, multi-period Monte Carlo simulation and assert:
    1) correct cap applied by period,
    2) realized turnover persisted per path/period,
    3) `turnover_cap_binding` toggles correctly for at least one binding and one non-binding scenario.

<details>
<summary>Background (previous attempt context)</summary>

- Avoid bundling unrelated operational/documentation changes (e.g., API diagnostics, workflow patches, LLM provider tweaks) into this turnover-cap follow-up. Keep the PR focused on regime-conditional turnover caps, regime utilities, runner/engine behavior, and tests to reduce review surface area and maintenance burden.
- Avoid recomputing regime labels separately for each strategy evaluation; this can become a performance bottleneck in large Monte Carlo runs. Implement caching so regime is computed once per unique (context, period) and reused.

</details>

## Critical Rules
1. Do NOT include "Remaining Unchecked Items" or "Iteration Details" sections unless they contain specific, useful failure context
2. Tasks should be concrete actions, not verification concerns restated
3. Acceptance criteria must be testable (not "all concerns addressed")
4. Keep the main body focused - hide background/history in the collapsible section
5. Do NOT include the entire analysis object - only include specific failure contexts from `blockers_to_avoid`



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #4783

<!-- pr-preamble:end -->