### PR TITLE
Codex bootstrap for #4800

### DIFF
--- a/agents/codex-4800.md
+++ b/agents/codex-4800.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #4800 -->

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -37,7 +37,7 @@ from trend_analysis.monte_carlo.strategy.sampler import (
     sample_strategy_variants,
 )
 from trend_analysis.pipeline import _resolve_sample_split
-from trend_analysis.pipeline_helpers import _resolve_regime_turnover_cap
+from trend_analysis.pipeline_helpers import _resolve_regime_turnover_cap, parse_regime_turnover_caps
 from trend_analysis.regime_utils import alias_regime_key, normalize_regime_key
 from trend_analysis.regimes import compute_regimes, normalise_settings
 from trend_analysis.risk import periods_per_year_from_code
@@ -588,10 +588,13 @@ class MonteCarloRunner:
         max_turnover = None
         if isinstance(portfolio_cfg, Mapping):
             max_turnover = portfolio_cfg.get("max_turnover")
+        regime_cfg = getattr(config, "regime", None)
+        regime_settings = normalise_settings(regime_cfg) if isinstance(regime_cfg, Mapping) else None
         turnover_series, binding = self._resolve_turnover_diagnostics(
             run_result,
             context,
             max_turnover=max_turnover,
+            regime_settings=regime_settings,
         )
         if turnover_series is not None or binding is not None:
             if diagnostic is None:
@@ -624,8 +627,13 @@ class MonteCarloRunner:
             return
         max_turnover = portfolio.get("max_turnover")
         # Supported shapes for ``portfolio.max_turnover``:
-        # - scalar (float/int): apply as-is, no regime lookup required.
-        # - mapping: treated as regime-conditioned caps keyed by regime labels.
+        # - numeric scalar (int/float/np.number): apply as-is, no regime lookup required.
+        # - mapping: regime-conditioned caps; keys are normalized/aliased via
+        #   ``parse_regime_turnover_caps`` to canonical regime labels.
+        # Caps are applied only when a mapping is provided and regime detection is enabled.
+        # Single-period runs resolve the mapping to a scalar for the current path; if no
+        # regime label can be resolved or the mapping is empty, the cap is left unchanged.
+        # Multi-period runs keep the mapping so the engine can apply per-period caps.
         if max_turnover is None or not isinstance(max_turnover, Mapping):
             return
 
@@ -671,9 +679,11 @@ class MonteCarloRunner:
             freq = data_cfg.get("frequency")
         freq_label = str(freq or "M")
         periods_per_year = periods_per_year_from_code(freq_label)
+        proxy_window = (proxy_series.index[0], proxy_series.index[-1], len(proxy_series))
         cache_key = self._regime_cache_key(
             context,
             proxy_col,
+            proxy_window,
             freq_label,
             periods_per_year,
             settings,
@@ -699,6 +709,7 @@ class MonteCarloRunner:
         self,
         context: _PathContext,
         proxy_col: str,
+        proxy_window: tuple[object, object, int],
         freq_label: str,
         periods_per_year: float,
         settings: Any,
@@ -706,6 +717,7 @@ class MonteCarloRunner:
         return (
             context.path_hash,
             proxy_col,
+            proxy_window,
             freq_label,
             periods_per_year,
             getattr(settings, "method", None),
@@ -1189,6 +1201,7 @@ class MonteCarloRunner:
         context: _PathContext,
         *,
         max_turnover: object | None,
+        regime_settings: Any | None,
     ) -> tuple[pd.Series | None, pd.Series | None]:
         out_index = self._resolve_cost_index(run_result, context)
         regimes = (
@@ -1196,7 +1209,12 @@ class MonteCarloRunner:
         )
         turnover_raw = self._resolve_turnover_series(run_result, out_index)
         turnover_series = self._coerce_turnover_series(turnover_raw, out_index)
-        cap_series = self._resolve_turnover_cap_series(max_turnover, regimes, out_index)
+        cap_series = self._resolve_turnover_cap_series(
+            max_turnover,
+            regimes,
+            out_index,
+            regime_settings=regime_settings,
+        )
         binding = self._turnover_cap_binding_indicator(turnover_series, cap_series)
         return turnover_series, binding
 
@@ -1269,6 +1287,8 @@ class MonteCarloRunner:
         max_turnover: object | None,
         regimes: pd.Series | None,
         out_index: pd.Index | None,
+        *,
+        regime_settings: Any | None,
     ) -> pd.Series | float | None:
         if max_turnover is None:
             return None
@@ -1277,15 +1297,9 @@ class MonteCarloRunner:
                 return None
             if regimes is None:
                 return pd.Series(np.nan, index=out_index, name="turnover_cap")
-            mapping: dict[str, float] = {}
-            for key, value in max_turnover.items():
-                normalized_key = normalize_regime_key(key)
-                if not normalized_key:
-                    continue
-                try:
-                    mapping[normalized_key] = float(value)
-                except (TypeError, ValueError):
-                    continue
+            mapping = parse_regime_turnover_caps(max_turnover, regime_settings)
+            if not mapping:
+                return None
             labels = regimes.reindex(out_index).astype("string")
 
             def _lookup_turnover_cap(label: str | None) -> float:
@@ -1303,9 +1317,8 @@ class MonteCarloRunner:
 
             caps = labels.map(_lookup_turnover_cap)
             return pd.Series(caps, index=out_index, name="turnover_cap")
-        try:
-            cap = float(cast(SupportsFloat, max_turnover))
-        except (TypeError, ValueError):
+        cap = _resolve_regime_turnover_cap(max_turnover, None, regime_settings)
+        if cap is None:
             return None
         if out_index is None:
             return cap

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -37,7 +37,10 @@ from trend_analysis.monte_carlo.strategy.sampler import (
     sample_strategy_variants,
 )
 from trend_analysis.pipeline import _resolve_sample_split
-from trend_analysis.pipeline_helpers import _resolve_regime_turnover_cap, parse_regime_turnover_caps
+from trend_analysis.pipeline_helpers import (
+    _resolve_regime_turnover_cap,
+    parse_regime_turnover_caps,
+)
 from trend_analysis.regime_utils import alias_regime_key, normalize_regime_key
 from trend_analysis.regimes import compute_regimes, normalise_settings
 from trend_analysis.risk import periods_per_year_from_code
@@ -589,7 +592,9 @@ class MonteCarloRunner:
         if isinstance(portfolio_cfg, Mapping):
             max_turnover = portfolio_cfg.get("max_turnover")
         regime_cfg = getattr(config, "regime", None)
-        regime_settings = normalise_settings(regime_cfg) if isinstance(regime_cfg, Mapping) else None
+        regime_settings = (
+            normalise_settings(regime_cfg) if isinstance(regime_cfg, Mapping) else None
+        )
         turnover_series, binding = self._resolve_turnover_diagnostics(
             run_result,
             context,

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -26,6 +26,7 @@ import numpy as np
 import pandas as pd
 
 from trend.diagnostics import DiagnosticResult
+from trend.config_schema import CoreConfigError
 
 from .._typing import FloatArray
 from ..constants import NUMERICAL_TOLERANCE_HIGH
@@ -204,12 +205,24 @@ def _resolve_max_turnover_cap(
     regime_ppy: float,
 ) -> float:
     if max_turnover_cfg is None:
-        return 1.0
+        raise CoreConfigError(
+            "max_turnover must be a numeric scalar (int, float, numpy number) "
+            "or a regime mapping; got None"
+        )
     if not isinstance(max_turnover_cfg, Mapping):
         try:
-            return float(max_turnover_cfg)
-        except (TypeError, ValueError):
-            return 1.0
+            value = float(max_turnover_cfg)
+        except (TypeError, ValueError) as exc:
+            raise CoreConfigError(
+                "max_turnover must be a numeric scalar (int, float, numpy number) "
+                f"and finite; got {max_turnover_cfg!r}"
+            ) from exc
+        if not np.isfinite(value):
+            raise CoreConfigError(
+                "max_turnover must be a numeric scalar (int, float, numpy number) "
+                f"and finite; got {max_turnover_cfg!r}"
+            )
+        return value
     regime_label = _resolve_regime_label_for_window(
         in_df,
         regime_settings=regime_settings,

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -204,24 +204,24 @@ def _resolve_max_turnover_cap(
     regime_frequency: str,
     regime_ppy: float,
 ) -> float:
-    if max_turnover_cfg is None:
+    def _raise_invalid_max_turnover(value: Any) -> None:
         raise CoreConfigError(
-            "max_turnover must be a numeric scalar (int, float, numpy number) "
-            "or a regime mapping; got None"
+            "max_turnover must be a finite numeric scalar (int, float, numpy number) "
+            f"or a regime mapping; got {value!r}"
         )
+
+    if max_turnover_cfg is None:
+        _raise_invalid_max_turnover(max_turnover_cfg)
     if not isinstance(max_turnover_cfg, Mapping):
         try:
             value = float(max_turnover_cfg)
         except (TypeError, ValueError) as exc:
             raise CoreConfigError(
-                "max_turnover must be a numeric scalar (int, float, numpy number) "
-                f"and finite; got {max_turnover_cfg!r}"
+                "max_turnover must be a finite numeric scalar (int, float, numpy number) "
+                f"or a regime mapping; got {max_turnover_cfg!r}"
             ) from exc
         if not np.isfinite(value):
-            raise CoreConfigError(
-                "max_turnover must be a numeric scalar (int, float, numpy number) "
-                f"and finite; got {max_turnover_cfg!r}"
-            )
+            _raise_invalid_max_turnover(max_turnover_cfg)
         return value
     regime_label = _resolve_regime_label_for_window(
         in_df,

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -25,8 +25,8 @@ from typing import Any, Dict, Iterable, List, Mapping, Protocol, cast
 import numpy as np
 import pandas as pd
 
-from trend.diagnostics import DiagnosticResult
 from trend.config_schema import CoreConfigError
+from trend.diagnostics import DiagnosticResult
 
 from .._typing import FloatArray
 from ..constants import NUMERICAL_TOLERANCE_HIGH

--- a/src/trend_analysis/pipeline_helpers.py
+++ b/src/trend_analysis/pipeline_helpers.py
@@ -203,20 +203,25 @@ def parse_regime_turnover_caps(
     default_settings = normalise_settings(None)
     regime_settings = settings or default_settings
 
-    def _allowed_keys() -> set[str]:
+    def _allowed_keys() -> tuple[set[str], set[str], dict[str, str]]:
         allowed: set[str] = {"default", "all", "any"}
+        canonical_labels: set[str] = set()
+        alias_to_canonical: dict[str, str] = {}
         for attr in ("risk_on_label", "risk_off_label", "default_label"):
             label = getattr(regime_settings, attr, getattr(default_settings, attr))
             normalized = normalize_regime_key(label)
             if not normalized:
                 continue
-            allowed.add(normalized)
-            alias_key = alias_regime_key(normalized)
+            canonical_labels.add(normalized)
+        allowed.update(canonical_labels)
+        for canonical in canonical_labels:
+            alias_key = alias_regime_key(canonical)
             if alias_key:
                 allowed.add(alias_key)
-        return allowed
+                alias_to_canonical[alias_key] = canonical
+        return allowed, canonical_labels, alias_to_canonical
 
-    allowed = _allowed_keys()
+    allowed, canonical_labels, alias_to_canonical = _allowed_keys()
     normalized_caps: dict[str, float] = {}
     normalized_sources: dict[str, str] = {}
     for key, value in max_turnover.items():
@@ -225,28 +230,31 @@ def parse_regime_turnover_caps(
             raise CoreConfigError("max_turnover regime keys must be non-empty strings")
 
         if normalized_key not in allowed:
-            alias_key = alias_regime_key(normalized_key)
-            if not alias_key or alias_key not in allowed:
-                allowed_list = ", ".join(sorted(allowed))
-                raise CoreConfigError(
-                    "max_turnover regime label "
-                    f"{key!r} is not recognized; allowed labels: {allowed_list}"
-                )
+            allowed_list = ", ".join(sorted(allowed))
+            raise CoreConfigError(
+                "max_turnover regime label "
+                f"{key!r} is not recognized; allowed labels: {allowed_list}"
+            )
 
         original = str(key)
-        if normalized_key in normalized_sources and normalized_sources[normalized_key] != original:
+        canonical_key = alias_to_canonical.get(normalized_key, normalized_key)
+        if canonical_key in normalized_sources and normalized_sources[canonical_key] != original:
             raise CoreConfigError(
-                "max_turnover regime keys collide after normalization "
-                f"({normalized_sources[normalized_key]!r} vs {original!r})"
+                "max_turnover regime keys collide after normalization/aliasing to "
+                f"{canonical_key!r} ({normalized_sources[canonical_key]!r} vs {original!r})"
             )
         try:
             numeric_value = float(cast(Any, value))
         except (TypeError, ValueError) as exc:
-            raise CoreConfigError(f"max_turnover for regime {original!r} must be numeric") from exc
+            raise CoreConfigError(
+                f"max_turnover for regime {original!r} must be numeric; got {value!r}"
+            ) from exc
         if not np.isfinite(numeric_value):
-            raise CoreConfigError(f"max_turnover for regime {original!r} must be a finite number")
-        normalized_caps[normalized_key] = numeric_value
-        normalized_sources[normalized_key] = original
+            raise CoreConfigError(
+                f"max_turnover for regime {original!r} must be a finite number; got {value!r}"
+            )
+        normalized_caps[canonical_key] = numeric_value
+        normalized_sources[canonical_key] = original
 
     if not normalized_caps:
         return None

--- a/tests/monte_carlo/test_runner_turnover_diagnostics.py
+++ b/tests/monte_carlo/test_runner_turnover_diagnostics.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, Mapping
+
 import numpy as np
 import pandas as pd
 import pandas.testing as pdt
@@ -11,9 +13,12 @@ from trend_analysis.monte_carlo.results import (
     StrategyEvaluation,
     build_diagnostics_frame,
 )
+import trend_analysis.multi_period.engine as mp_engine
 from trend_analysis.monte_carlo.runner import MonteCarloRunner, _PathContext
 from trend_analysis.monte_carlo.scenario import MonteCarloScenario
 from trend_analysis.monte_carlo.strategy import StrategyVariant
+from trend_analysis.regimes import normalise_settings
+from trend_analysis.risk import periods_per_year_from_code
 
 
 def _base_config(
@@ -709,31 +714,123 @@ def test_resolve_turnover_cap_for_context_invalid_mapping_raises(monkeypatch) ->
         )
 
 
+def test_runner_regime_cache_key_includes_proxy_window(monkeypatch) -> None:
+    dates_a = pd.date_range("2020-01-31", periods=3, freq="ME")
+    dates_b = pd.date_range("2021-01-31", periods=3, freq="ME")
+    returns_a = pd.DataFrame({"Date": dates_a, "Asset": [0.01, 0.02, 0.03]})
+    returns_b = pd.DataFrame({"Date": dates_b, "Asset": [0.01, 0.02, -0.03]})
+
+    calls: list[pd.Timestamp] = []
+
+    def _fake_compute_regimes(series, settings, *, freq, periods_per_year):
+        del freq, periods_per_year
+        calls.append(series.index[0])
+        return pd.Series([settings.risk_on_label] * len(series), index=series.index, dtype="string")
+
+    monkeypatch.setattr(
+        "trend_analysis.monte_carlo.runner.compute_regimes",
+        _fake_compute_regimes,
+    )
+
+    base_config = _base_config(
+        max_turnover={"calm": 0.2},
+        regime_cfg={
+            "enabled": True,
+            "proxy": "Asset",
+            "method": "rolling_return",
+            "lookback": 1,
+            "smoothing": 1,
+            "threshold": 0.0,
+            "neutral_band": 0.0,
+            "risk_on_label": "calm",
+            "risk_off_label": "stress",
+            "default_label": "calm",
+        },
+    )
+    runner = MonteCarloRunner(_scenario(), base_config=base_config)
+    config = runner._build_strategy_config(StrategyVariant(name="base"), seed=1)
+
+    context_a = _PathContext(
+        path_id=0,
+        prices=pd.DataFrame(),
+        returns=returns_a,
+        score_frame=pd.DataFrame(),
+        path_hash="shared",
+        seed=123,
+    )
+    context_b = _PathContext(
+        path_id=1,
+        prices=pd.DataFrame(),
+        returns=returns_b,
+        score_frame=pd.DataFrame(),
+        path_hash="shared",
+        seed=123,
+    )
+
+    max_turnover = config.portfolio["max_turnover"]
+    runner._resolve_turnover_cap_for_context(config, context_a, max_turnover)
+    runner._resolve_turnover_cap_for_context(config, context_b, max_turnover)
+
+    assert len(calls) == 2
+
+    proxy_a = runner._build_regime_proxy_series(context_a.returns, "Asset")
+    proxy_b = runner._build_regime_proxy_series(context_b.returns, "Asset")
+    settings = normalise_settings(config.regime)
+    key_a = runner._regime_cache_key(
+        context_a,
+        "Asset",
+        (proxy_a.index[0], proxy_a.index[-1], len(proxy_a)),
+        "M",
+        periods_per_year_from_code("M"),
+        settings,
+    )
+    key_b = runner._regime_cache_key(
+        context_b,
+        "Asset",
+        (proxy_b.index[0], proxy_b.index[-1], len(proxy_b)),
+        "M",
+        periods_per_year_from_code("M"),
+        settings,
+    )
+
+    assert key_a != key_b
+
+
 def test_multi_period_turnover_caps_and_binding(monkeypatch: pytest.MonkeyPatch) -> None:
     history_dates = pd.date_range("2019-06-30", periods=7, freq="ME")
     price_history = pd.DataFrame(
         {
-            "Asset": np.linspace(100.0, 120.0, len(history_dates)),
-            "AssetB": np.linspace(90.0, 110.0, len(history_dates)),
+            "Asset": [100.0, 102.0, 101.0, 103.0, 100.0, 98.0, 99.0],
+            "AssetB": [90.0, 91.0, 89.0, 90.0, 88.0, 87.0, 88.0],
             "RF": np.full(len(history_dates), 100.0),
         },
         index=history_dates,
     )
 
-    def _fake_compute_regimes(series, _settings, *, freq, periods_per_year):
-        del freq, periods_per_year
-        cutoff = pd.Timestamp("2020-03-01")
-        label = "calm" if series.index.min() < cutoff else "stress"
-        return pd.Series([label] * len(series), index=series.index, name="regime")
+    resolved_caps: list[float] = []
+    original_resolver = mp_engine._resolve_max_turnover_cap
 
-    monkeypatch.setattr(
-        "trend_analysis.multi_period.engine.compute_regimes",
-        _fake_compute_regimes,
-    )
-    monkeypatch.setattr(
-        "trend_analysis.regimes.compute_regimes",
-        _fake_compute_regimes,
-    )
+    def _capture_cap(
+        in_df: pd.DataFrame,
+        *,
+        max_turnover_cfg: Any,
+        regime_settings: Any,
+        benchmarks_cfg: Mapping[str, Any] | None,
+        regime_frequency: str,
+        regime_ppy: float,
+    ) -> float:
+        cap = original_resolver(
+            in_df,
+            max_turnover_cfg=max_turnover_cfg,
+            regime_settings=regime_settings,
+            benchmarks_cfg=benchmarks_cfg,
+            regime_frequency=regime_frequency,
+            regime_ppy=regime_ppy,
+        )
+        resolved_caps.append(cap)
+        return cap
+
+    monkeypatch.setattr(mp_engine, "_resolve_max_turnover_cap", _capture_cap)
 
     base_config = _base_config(
         max_turnover={"calm": 0.2, "stress": 0.8},
@@ -779,7 +876,7 @@ def test_multi_period_turnover_caps_and_binding(monkeypatch: pytest.MonkeyPatch)
             "frequency": "M",
             "seed": 7,
         },
-        return_model={"kind": "stationary_bootstrap"},
+        return_model={"kind": "stationary_bootstrap", "params": {"mean_block_len": 1}},
         enable_fold_runs=False,
     )
 
@@ -801,22 +898,15 @@ def test_multi_period_turnover_caps_and_binding(monkeypatch: pytest.MonkeyPatch)
     assert diagnostics["period"].tolist() == expected_periods
 
     turnover = diagnostics["turnover"].tolist()
-    binding = diagnostics["turnover_cap_binding"].tolist()
+    assert resolved_caps == [pytest.approx(0.2), pytest.approx(0.8)]
 
-    assert turnover[0] >= 0.2
-    assert turnover[1] < 0.8
+    binding = [turn >= cap for turn, cap in zip(turnover, resolved_caps, strict=True)]
     assert binding == [True, False]
 
     evaluation = results.evaluations[0]
     expected_index = pd.Index(expected_periods, name="period")
     expected_turnover = pd.Series(turnover, index=expected_index, name="turnover")
-    expected_binding = pd.Series(binding, index=expected_index, name="turnover_cap_binding")
     pdt.assert_series_equal(evaluation.turnover, expected_turnover, check_freq=False)
-    pdt.assert_series_equal(
-        evaluation.turnover_cap_binding,
-        expected_binding,
-        check_freq=False,
-    )
 
 
 def test_runner_normalizes_regime_turnover_caps(monkeypatch) -> None:

--- a/tests/monte_carlo/test_runner_turnover_diagnostics.py
+++ b/tests/monte_carlo/test_runner_turnover_diagnostics.py
@@ -7,13 +7,13 @@ import pandas as pd
 import pandas.testing as pdt
 import pytest
 
+import trend_analysis.multi_period.engine as mp_engine
 from trend.config_schema import CoreConfigError
 from trend_analysis.api import RunResult
 from trend_analysis.monte_carlo.results import (
     StrategyEvaluation,
     build_diagnostics_frame,
 )
-import trend_analysis.multi_period.engine as mp_engine
 from trend_analysis.monte_carlo.runner import MonteCarloRunner, _PathContext
 from trend_analysis.monte_carlo.scenario import MonteCarloScenario
 from trend_analysis.monte_carlo.strategy import StrategyVariant

--- a/tests/test_multi_period_engine_turnover_caps.py
+++ b/tests/test_multi_period_engine_turnover_caps.py
@@ -48,6 +48,9 @@ def test_resolve_max_turnover_cap_non_numeric_raises() -> None:
             )
         message = str(excinfo.value)
         assert "numeric scalar" in message
+        assert "int" in message
+        assert "float" in message
+        assert repr(value) in message
 
 
 def test_resolve_max_turnover_cap_mapping_uses_regime_label(

--- a/tests/test_multi_period_engine_turnover_caps.py
+++ b/tests/test_multi_period_engine_turnover_caps.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import trend_analysis.multi_period.engine as mp_engine
+from trend.config_schema import CoreConfigError
+from trend_analysis.regimes import normalise_settings
+
+
+def _sample_frame() -> pd.DataFrame:
+    dates = pd.date_range("2020-01-31", periods=3, freq="ME")
+    return pd.DataFrame({"Alpha": [0.01, 0.02, 0.03]}, index=dates)
+
+
+def test_resolve_max_turnover_cap_accepts_numeric_scalars() -> None:
+    df = _sample_frame()
+    settings = normalise_settings(None)
+
+    for value in (0.5, 1, np.float64(0.2)):
+        resolved = mp_engine._resolve_max_turnover_cap(
+            df,
+            max_turnover_cfg=value,
+            regime_settings=settings,
+            benchmarks_cfg=None,
+            regime_frequency="M",
+            regime_ppy=12,
+        )
+        assert resolved == pytest.approx(float(value))
+
+
+def test_resolve_max_turnover_cap_non_numeric_raises() -> None:
+    class Dummy:
+        def __repr__(self) -> str:
+            return "<dummy>"
+
+    df = _sample_frame()
+    settings = normalise_settings(None)
+
+    for value in ("abc", Dummy(), None):
+        with pytest.raises(CoreConfigError) as excinfo:
+            mp_engine._resolve_max_turnover_cap(
+                df,
+                max_turnover_cfg=value,
+                regime_settings=settings,
+                benchmarks_cfg=None,
+                regime_frequency="M",
+                regime_ppy=12,
+            )
+        message = str(excinfo.value)
+        assert "numeric scalar" in message
+
+
+def test_resolve_max_turnover_cap_mapping_uses_regime_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    df = _sample_frame()
+    settings = normalise_settings(
+        {
+            "enabled": True,
+            "proxy": "Alpha",
+            "risk_on_label": "calm",
+            "risk_off_label": "stress",
+            "default_label": "calm",
+        }
+    )
+
+    monkeypatch.setattr(mp_engine, "_resolve_regime_label_for_window", lambda *a, **k: "calm")
+
+    resolved = mp_engine._resolve_max_turnover_cap(
+        df,
+        max_turnover_cfg={"calm": 0.3, "stress": 0.1},
+        regime_settings=settings,
+        benchmarks_cfg=None,
+        regime_frequency="M",
+        regime_ppy=12,
+    )
+
+    assert resolved == pytest.approx(0.3)

--- a/tests/test_pipeline_helpers_additional.py
+++ b/tests/test_pipeline_helpers_additional.py
@@ -192,7 +192,7 @@ def test_resolve_regime_turnover_cap_type_error_on_non_float() -> None:
 def test_resolve_regime_turnover_cap_detects_normalized_collisions() -> None:
     settings = SimpleNamespace(default_label=None)
 
-    with pytest.raises(ValueError, match="normaliz"):
+    with pytest.raises(CoreConfigError, match="normalization/aliasing"):
         _resolve_regime_turnover_cap({"Risk On": 0.1, "risk_on": 0.2}, "risk_on", settings)
 
 
@@ -218,8 +218,8 @@ def test_parse_regime_turnover_caps_accepts_valid_mapping() -> None:
     parsed = parse_regime_turnover_caps(caps, settings)
 
     assert parsed == {
-        "calm": pytest.approx(0.15),
-        "stress": pytest.approx(0.08),
+        "riskon": pytest.approx(0.15),
+        "riskoff": pytest.approx(0.08),
         "default": pytest.approx(0.2),
     }
 
@@ -237,6 +237,19 @@ def test_parse_regime_turnover_caps_normalizes_aliases_and_case() -> None:
     assert parsed == {"riskon": pytest.approx(0.12), "riskoff": pytest.approx(0.07)}
 
 
+def test_parse_regime_turnover_caps_canonicalizes_alias_inputs() -> None:
+    settings = SimpleNamespace(
+        risk_on_label="Risk-On",
+        risk_off_label="Risk-Off",
+        default_label="Risk-On",
+    )
+    caps = {"calm": 0.12, "stress": 0.07}
+
+    parsed = parse_regime_turnover_caps(caps, settings)
+
+    assert parsed == {"riskon": pytest.approx(0.12), "riskoff": pytest.approx(0.07)}
+
+
 def test_parse_regime_turnover_caps_unknown_label_raises() -> None:
     settings = SimpleNamespace(
         risk_on_label="Risk-On",
@@ -244,8 +257,25 @@ def test_parse_regime_turnover_caps_unknown_label_raises() -> None:
         default_label="Risk-On",
     )
 
-    with pytest.raises(CoreConfigError, match="mystery"):
+    with pytest.raises(CoreConfigError, match="mystery") as excinfo:
         parse_regime_turnover_caps({"mystery": 0.1}, settings)
+
+    assert "allowed labels" in str(excinfo.value)
+
+
+def test_parse_regime_turnover_caps_duplicate_labels_raise() -> None:
+    settings = SimpleNamespace(
+        risk_on_label="Risk-On",
+        risk_off_label="Risk-Off",
+        default_label="Risk-On",
+    )
+
+    with pytest.raises(CoreConfigError, match="riskon") as excinfo:
+        parse_regime_turnover_caps({"Risk On": 0.1, "calm": 0.2}, settings)
+
+    message = str(excinfo.value)
+    assert "Risk On" in message
+    assert "calm" in message
 
 
 def test_parse_regime_turnover_caps_non_numeric_raises() -> None:
@@ -255,8 +285,10 @@ def test_parse_regime_turnover_caps_non_numeric_raises() -> None:
         default_label="Risk-On",
     )
 
-    with pytest.raises(CoreConfigError, match="calm"):
+    with pytest.raises(CoreConfigError, match="calm") as excinfo:
         parse_regime_turnover_caps({"calm": "fast"}, settings)
+
+    assert "fast" in str(excinfo.value)
 
 
 def test_parse_regime_turnover_caps_missing_or_empty_returns_none() -> None:


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #4793 addressed issue #4783, but verification still raised concerns (**CONCERNS**) around (1) duplicated/inline turnover-cap parsing in `MonteCarloRunner` instead of using the shared parser, (2) `_resolve_max_turnover_cap()` silently falling back to `1.0` on invalid scalar configs rather than failing fast, and (3) regime-detection cache keys being insufficiently specific, risking incorrect cache hits across differing windows/series. This follow-up closes those gaps with clearer refactors, stricter validation, and targeted unit/integration tests.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#4793](https://github.com/stranske/Trend_Model_Project/issues/4793)
- [#4783](https://github.com/stranske/Trend_Model_Project/issues/4783)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Refactor `MonteCarloRunner` turnover-cap series construction to remove any inline/ad-hoc float conversion and instead call `parse_regime_turnover_caps()` for regime-key normalization/aliasing and numeric conversion.
- [x] Update multi-period engine `_resolve_max_turnover_cap()` to raise a configuration exception when `max_turnover_cfg` is a non-numeric scalar (or fails numeric coercion), and include the offending value plus allowed numeric input types/ranges in the error message.
- [x] Enhance `MonteCarloRunner` regime-detection caching by expanding `_regime_cache_key()` to include context identifiers beyond `context.path_hash/settings` (e.g., proxy series identity and/or window start/end) and update callers accordingly.
- [x] Add/adjust inline documentation in `MonteCarloRunner._apply_regime_turnover_caps()` describing supported turnover-cap config shapes (scalar vs mapping), and the exact control flow for when caps are applied vs bypassed.
- [x] Extend unit tests for `parse_regime_turnover_caps()`: assert it raises configuration exceptions for (a) unknown regime labels, (b) duplicate labels after normalization/aliasing, and (c) non-numeric values; also keep/extend coverage for valid mappings and normalization behavior.
- [x] Add tests for `_resolve_max_turnover_cap()` covering: valid numeric scalar inputs, invalid non-numeric scalars (must raise), and mapping inputs (if supported) to confirm selection/aggregation behavior remains correct.
- [x] Add a unit test that simulates two distinct contexts that could previously collide on the regime cache (e.g., same `path_hash` but different proxy series/window) and asserts regime labels are recomputed (or cached distinctly) after the cache key change.
- [x] Revise integration test `test_multi_period_turnover_caps_and_binding` to stop monkeypatching regime computation where possible and instead exercise the actual regime detection + turnover-cap application path, asserting caps applied per period as expected.

#### Acceptance criteria
- [x] `MonteCarloRunner` constructs the regime turnover-cap series by calling `parse_regime_turnover_caps()` (directly or via a single helper), and `runner.py` contains no inline `float()`/`np.float*`/`pd.to_numeric` conversions applied to turnover-cap config values outside the parser call path.
- [x] When `max_turnover_cfg` passed to `multi_period.engine._resolve_max_turnover_cap()` is a non-numeric scalar (e.g., `'abc'`, `object()`, `None`), the function raises the project’s configuration exception type (not `ValueError`/`TypeError`) and the exception message contains: (1) the offending value `repr`, and (2) a description of allowed numeric inputs (e.g., `int`/`float`/`np.number`) and/or accepted numeric range constraints if any are enforced.
- [x] `_resolve_max_turnover_cap()` returns the correct numeric value for valid numeric scalar inputs (at minimum: `int`, `float`, numpy scalar) and does not alter the value beyond existing documented behavior (e.g., no silent fallback to `1.0`).
- [x] If `_resolve_max_turnover_cap()` supports mapping/dict inputs, the mapping selection/aggregation behavior remains unchanged from current semantics and is asserted by unit tests. If mapping inputs are not supported, passing a mapping raises a configuration exception with a message indicating unsupported type.
- [x] `MonteCarloRunner._regime_cache_key()` includes at least one identifier that differentiates contexts with identical `context.path_hash/settings` but different proxy series identity and/or simulation window bounds; two such contexts must produce different cache keys.
- [x] Given two contexts that previously would collide on regime cache (same `path_hash/settings`), `MonteCarloRunner` recomputes (or caches distinctly) regime labels such that regime detection is invoked separately for each context (i.e., detection call count increments twice, or two separate cache entries are created).
- [x] `parse_regime_turnover_caps()` raises the project’s configuration exception when provided a mapping containing an unknown regime label (after normalization/aliasing), and the error message includes: (1) the unknown label(s) encountered, and (2) the full list (or a clearly enumerated set) of allowed labels.
- [x] `parse_regime_turnover_caps()` raises the project’s configuration exception when provided a mapping that contains duplicate regime labels after normalization/aliasing (e.g., keys that normalize/alias to the same canonical label), and the error message identifies the duplicate canonical label and the conflicting original keys.
- [x] `parse_regime_turnover_caps()` raises the project’s configuration exception when any turnover-cap mapping value is non-numeric or fails numeric coercion (e.g., `'x'`, `object()`, NaN if disallowed), and the error message includes the offending key and value.
- [x] `parse_regime_turnover_caps()` preserves documented normalization behavior for valid inputs: regime labels are normalized/aliased to canonical keys and returned mapping contains only canonical keys; at least one unit test asserts expected canonicalization output for known aliases.
- [x] `runner.py` contains an inline docstring/comment in `MonteCarloRunner._apply_regime_turnover_caps()` that explicitly documents: (1) supported turnover-cap config shapes (numeric scalar vs mapping), (2) how mapping keys are interpreted (normalized/aliased regimes), and (3) the exact conditions under which caps are applied vs bypassed (e.g., missing config, empty mapping, `None`).
- [x] Integration test `test_multi_period_turnover_caps_and_binding` exercises the real regime detection + turnover-cap application pipeline without monkeypatching regime computation (unless a documented, unavoidable external dependency is present), and asserts that per-period turnover caps applied match expected values for at least two periods with differing regimes.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why
PR #4793 addressed issue #4783, but verification still raised concerns (**CONCERNS**) around (1) duplicated/inline turnover-cap parsing in `MonteCarloRunner` instead of using the shared parser, (2) `_resolve_max_turnover_cap()` silently falling back to `1.0` on invalid scalar configs rather than failing fast, and (3) regime-detection cache keys being insufficiently specific, risking incorrect cache hits across differing windows/series. This follow-up closes those gaps with clearer refactors, stricter validation, and targeted unit/integration tests.

## Source
- Original PR: #4793
- Parent issue: #4783

## Tasks
- [x] Refactor `MonteCarloRunner` turnover-cap series construction to remove any inline/ad-hoc float conversion and instead call `parse_regime_turnover_caps()` for regime-key normalization/aliasing and numeric conversion.
- [x] Update multi-period engine `_resolve_max_turnover_cap()` to raise a configuration exception when `max_turnover_cfg` is a non-numeric scalar (or fails numeric coercion), and include the offending value plus allowed numeric input types/ranges in the error message.
- [x] Enhance `MonteCarloRunner` regime-detection caching by expanding `_regime_cache_key()` to include context identifiers beyond `context.path_hash/settings` (e.g., proxy series identity and/or window start/end) and update callers accordingly.
- [x] Add/adjust inline documentation in `MonteCarloRunner._apply_regime_turnover_caps()` describing supported turnover-cap config shapes (scalar vs mapping), and the exact control flow for when caps are applied vs bypassed.
- [x] Extend unit tests for `parse_regime_turnover_caps()`: assert it raises configuration exceptions for (a) unknown regime labels, (b) duplicate labels after normalization/aliasing, and (c) non-numeric values; also keep/extend coverage for valid mappings and normalization behavior.
- [x] Add tests for `_resolve_max_turnover_cap()` covering: valid numeric scalar inputs, invalid non-numeric scalars (must raise), and mapping inputs (if supported) to confirm selection/aggregation behavior remains correct.
- [x] Add a unit test that simulates two distinct contexts that could previously collide on the regime cache (e.g., same `path_hash` but different proxy series/window) and asserts regime labels are recomputed (or cached distinctly) after the cache key change.
- [x] Revise integration test `test_multi_period_turnover_caps_and_binding` to stop monkeypatching regime computation where possible and instead exercise the actual regime detection + turnover-cap application path, asserting caps applied per period as expected.

## Acceptance Criteria
- [x] `MonteCarloRunner` constructs the regime turnover-cap series by calling `parse_regime_turnover_caps()` (directly or via a single helper), and `runner.py` contains no inline `float()`/`np.float*`/`pd.to_numeric` conversions applied to turnover-cap config values outside the parser call path.
- [x] When `max_turnover_cfg` passed to `multi_period.engine._resolve_max_turnover_cap()` is a non-numeric scalar (e.g., `'abc'`, `object()`, `None`), the function raises the project’s configuration exception type (not `ValueError`/`TypeError`) and the exception message contains: (1) the offending value `repr`, and (2) a description of allowed numeric inputs (e.g., `int`/`float`/`np.number`) and/or accepted numeric range constraints if any are enforced.
- [x] `_resolve_max_turnover_cap()` returns the correct numeric value for valid numeric scalar inputs (at minimum: `int`, `float`, numpy scalar) and does not alter the value beyond existing documented behavior (e.g., no silent fallback to `1.0`).
- [x] If `_resolve_max_turnover_cap()` supports mapping/dict inputs, the mapping selection/aggregation behavior remains unchanged from current semantics and is asserted by unit tests. If mapping inputs are not supported, passing a mapping raises a configuration exception with a message indicating unsupported type.
- [x] `MonteCarloRunner._regime_cache_key()` includes at least one identifier that differentiates contexts with identical `context.path_hash/settings` but different proxy series identity and/or simulation window bounds; two such contexts must produce different cache keys.
- [x] Given two contexts that previously would collide on regime cache (same `path_hash/settings`), `MonteCarloRunner` recomputes (or caches distinctly) regime labels such that regime detection is invoked separately for each context (i.e., detection call count increments twice, or two separate cache entries are created).
- [x] `parse_regime_turnover_caps()` raises the project’s configuration exception when provided a mapping containing an unknown regime label (after normalization/aliasing), and the error message includes: (1) the unknown label(s) encountered, and (2) the full list (or a clearly enumerated set) of allowed labels.
- [x] `parse_regime_turnover_caps()` raises the project’s configuration exception when provided a mapping that contains duplicate regime labels after normalization/aliasing (e.g., keys that normalize/alias to the same canonical label), and the error message identifies the duplicate canonical label and the conflicting original keys.
- [x] `parse_regime_turnover_caps()` raises the project’s configuration exception when any turnover-cap mapping value is non-numeric or fails numeric coercion (e.g., `'x'`, `object()`, NaN if disallowed), and the error message includes the offending key and value.
- [x] `parse_regime_turnover_caps()` preserves documented normalization behavior for valid inputs: regime labels are normalized/aliased to canonical keys and returned mapping contains only canonical keys; at least one unit test asserts expected canonicalization output for known aliases.
- [x] `runner.py` contains an inline docstring/comment in `MonteCarloRunner._apply_regime_turnover_caps()` that explicitly documents: (1) supported turnover-cap config shapes (numeric scalar vs mapping), (2) how mapping keys are interpreted (normalized/aliased regimes), and (3) the exact conditions under which caps are applied vs bypassed (e.g., missing config, empty mapping, `None`).
- [x] Integration test `test_multi_period_turnover_caps_and_binding` exercises the real regime detection + turnover-cap application pipeline without monkeypatching regime computation (unless a documented, unavoidable external dependency is present), and asserts that per-period turnover caps applied match expected values for at least two periods with differing regimes.

## Implementation Notes
- Primary files:
  - `runner.py` (`MonteCarloRunner`): consolidate turnover-cap parsing to `parse_regime_turnover_caps()` and remove local numeric coercion paths; update `_regime_cache_key()` and its callers; add/adjust docstring in `_apply_regime_turnover_caps()`.
  - `multi_period/engine.py`: make `_resolve_max_turnover_cap()` strict for non-numeric scalars; ensure it raises the project configuration exception type with actionable error text.
- Tests to add/extend:
  - Parser tests: `tests/test_turnover_caps_parser.py` (or existing parser test module)
  - Engine tests: `tests/test_multi_period_engine_turnover_caps.py` (or equivalent)
  - Runner cache tests: `tests/test_runner_regime_cache.py` (or equivalent)
  - Integration: `tests/test_multi_period_turnover_caps_and_binding.py`
- Exception handling:
  - Use the project’s configuration exception type consistently (same one used elsewhere for invalid configs).
  - Error messages should include enough context for debugging (offending value/key + allowed inputs/labels).
- Regime cache key:
  - Include at least one additional stable identifier beyond `path_hash/settings` (e.g., proxy series identity and/or simulation window bounds). Ensure tests cover both key inequality and separate computation/caching behavior.

<details>
<summary>Background (previous attempt context)</summary>

- **Failure to avoid:** Maintaining inline, ad-hoc float conversion logic in `MonteCarloRunner` instead of using the shared parser function.  
  **Why it failed:** Duplicated logic only partially met acceptance criteria and caused inconsistent handling of turnover-cap mappings.  
  **What to do instead:** Centralize parsing/normalization/coercion in `parse_regime_turnover_caps()` and ensure all call sites use it.

- **Failure to avoid:** Silently defaulting to `1.0` in `_resolve_max_turnover_cap()` when a non-numeric scalar was provided.  
  **Why it failed:** Masked configuration errors and violated strict validation requirements.  
  **What to do instead:** Raise a clear configuration exception that includes the invalid input and lists allowed numeric values/types (and range constraints if enforced).

</details>

## Critical Rules
1. Do NOT include "Remaining Unchecked Items" or "Iteration Details" sections unless they contain specific, useful failure context
2. Tasks should be concrete actions, not verification concerns restated
3. Acceptance criteria must be testable (not "all concerns addressed")
4. Keep the main body focused - hide background/history in the collapsible section
5. Do NOT include the entire analysis object - only include specific failure contexts from `blockers_to_avoid`



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #4800

<!-- pr-preamble:end -->