### PR TITLE
Codex bootstrap for #4805

### DIFF
--- a/agents/codex-4805.md
+++ b/agents/codex-4805.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #4805 -->

--- a/src/trend_analysis/llm/chain.py
+++ b/src/trend_analysis/llm/chain.py
@@ -405,11 +405,32 @@ class _BaseConfigPatchChain:
             patch.operations = filtered_ops
 
 
-@dataclass(slots=True)
 class ConfigPatchChain(_BaseConfigPatchChain):
     """Container for the ConfigPatch LangChain pipeline."""
 
-    structured_repair_retry_count: int = 0
+    __slots__ = ("structured_repair_retry_count",)
+
+    def __init__(
+        self,
+        *,
+        llm: Any,
+        prompt_builder: PromptBuilder,
+        schema: dict[str, Any] | None,
+        temperature: float = 0.0,
+        model: str | None = None,
+        max_tokens: int | None = None,
+        retries: int = 1,
+    ) -> None:
+        super().__init__(
+            llm=llm,
+            prompt_builder=prompt_builder,
+            schema=schema,
+            temperature=temperature,
+            model=model,
+            max_tokens=max_tokens,
+            retries=retries,
+        )
+        self.structured_repair_retry_count = 0
 
     def run(
         self,
@@ -475,6 +496,8 @@ class ConfigPatchChain(_BaseConfigPatchChain):
                 total_attempts = 2
                 retry_id = f"configpatch-structured-{id(structured_llm):x}"
                 for attempt in range(total_attempts):
+                    if attempt > 0:
+                        self.structured_repair_retry_count += 1
                     prompt = (
                         prompt_text
                         if attempt == 0
@@ -508,8 +531,6 @@ class ConfigPatchChain(_BaseConfigPatchChain):
                             retry_id,
                             format_retry_error(exc),
                         )
-                        if attempt == 0 and attempt + 1 < total_attempts:
-                            self.structured_repair_retry_count += 1
                         if attempt + 1 >= total_attempts:
                             raise ValueError(
                                 "Failed to parse ConfigPatch after "
@@ -577,9 +598,32 @@ class ConfigPatchChain(_BaseConfigPatchChain):
                 write_nl_log(entry)
 
 
-@dataclass(slots=True)
 class ConfigPatchVariantsChain(_BaseConfigPatchChain):
     """Container for the variant ConfigPatch LangChain pipeline."""
+
+    __slots__ = ("structured_repair_retry_count",)
+
+    def __init__(
+        self,
+        *,
+        llm: Any,
+        prompt_builder: PromptBuilder,
+        schema: dict[str, Any] | None,
+        temperature: float = 0.0,
+        model: str | None = None,
+        max_tokens: int | None = None,
+        retries: int = 1,
+    ) -> None:
+        super().__init__(
+            llm=llm,
+            prompt_builder=prompt_builder,
+            schema=schema,
+            temperature=temperature,
+            model=model,
+            max_tokens=max_tokens,
+            retries=retries,
+        )
+        self.structured_repair_retry_count = 0
 
     def run(
         self,
@@ -595,6 +639,7 @@ class ConfigPatchVariantsChain(_BaseConfigPatchChain):
         """Invoke the LLM and parse the variant ConfigPatch response."""
 
         started_at = time.perf_counter()
+        self.structured_repair_retry_count = 0
         timestamp = datetime.now(timezone.utc)
         request_id = request_id or uuid4().hex
         prompt_text = ""
@@ -644,6 +689,8 @@ class ConfigPatchVariantsChain(_BaseConfigPatchChain):
                 total_attempts = 2
                 retry_id = f"configpatch-variants-structured-{id(structured_llm):x}"
                 for attempt in range(total_attempts):
+                    if attempt > 0:
+                        self.structured_repair_retry_count += 1
                     prompt = (
                         prompt_text
                         if attempt == 0

--- a/tests/app/test_nl_operation_viewer_component.py
+++ b/tests/app/test_nl_operation_viewer_component.py
@@ -330,7 +330,7 @@ def test_redact_text_handles_escaped_quotes_in_assignment_value(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     module = _load_module(monkeypatch)
-    fixture_text = r'SECRET_KEY=\"va\\\"lue\"'
+    fixture_text = r"SECRET_KEY=\"va\\\"lue\""
 
     redacted = module._redact_text(fixture_text)
 

--- a/tests/app/test_nl_operation_viewer_component.py
+++ b/tests/app/test_nl_operation_viewer_component.py
@@ -304,6 +304,61 @@ def test_redact_text_preserves_non_assignment_line(
     assert redacted == fixture_text
 
 
+def test_redact_text_redacts_full_line_assignments_only_in_multiline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module(monkeypatch)
+    fixture_text = (
+        "header line\n"
+        "SECRET_KEY=value123\n"
+        "prefix SECRET_KEY=value123 suffix\n"
+        "  SECRET_KEY=value456  \n"
+        "footer line"
+    )
+
+    redacted = module._redact_text(fixture_text)
+    lines = redacted.splitlines()
+
+    assert lines[0] == "header line"
+    assert lines[1] == "[REDACTED]"
+    assert lines[2] == "prefix SECRET_KEY=value123 suffix"
+    assert lines[3] == "[REDACTED]"
+    assert lines[4] == "footer line"
+
+
+def test_redact_text_handles_escaped_quotes_in_assignment_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module(monkeypatch)
+    fixture_text = r'SECRET_KEY=\"va\\\"lue\"'
+
+    redacted = module._redact_text(fixture_text)
+
+    assert fixture_text not in redacted
+    assert "[REDACTED]" in redacted
+
+
+def test_redact_text_skips_complex_shell_syntax_and_respects_whitespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module(monkeypatch)
+    fixture_text = (
+        "export SECRET_KEY=value123\n"
+        "SECRET_KEY=value123 command\n"
+        "  SECRET_KEY=value456  \n"
+        "SECRET_KEY=value789\n"
+        "echo done"
+    )
+
+    redacted = module._redact_text(fixture_text)
+
+    assert "export SECRET_KEY=value123" in redacted
+    assert "SECRET_KEY=value123 command" in redacted
+    assert "SECRET_KEY=value456" not in redacted
+    assert "SECRET_KEY=value789" not in redacted
+    assert "[REDACTED]" in redacted
+
+
 def test_render_replay_stores_result_and_renders_redacted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_llm_chain.py
+++ b/tests/test_llm_chain.py
@@ -52,15 +52,22 @@ class _NoStructuredOutputLLMRaises(RunnableLambda):
         raise AssertionError("Structured output should not be requested.")
 
 
-class _StructuredOutputLLM:
-    def __init__(self, *, responses: list[object]) -> None:
+class _StructuredOutputLLM(RunnableLambda):
+    def __init__(
+        self,
+        *,
+        responses: list[object],
+        supports_structured_output: bool = True,
+    ) -> None:
         self.invocation_count = 0
         self.structured_requests = 0
         self.structured_invocations = 0
+        self._supports_structured_output = supports_structured_output
         self._responses = iter(responses)
+        super().__init__(self._respond)
 
     def supports_structured_output(self) -> bool:
-        return True
+        return self._supports_structured_output
 
     def with_structured_output(self, _schema) -> RunnableLambda:
         self.structured_requests += 1
@@ -68,8 +75,12 @@ class _StructuredOutputLLM:
 
     def _respond(self, _prompt_value, **_kwargs) -> object:
         self.invocation_count += 1
-        self.structured_invocations += 1
-        return next(self._responses)
+        if self._supports_structured_output:
+            self.structured_invocations += 1
+        response = next(self._responses)
+        if isinstance(response, BaseException):
+            raise response
+        return response
 
 
 def _make_payload() -> dict[str, object]:
@@ -208,3 +219,61 @@ def test_no_structured_request_when_unsupported() -> None:
 
     assert patch.summary == "Update max_weight"
     assert llm.unstructured_calls == 1
+
+
+def test_structured_output_invocation_count_zero_when_prompt_builder_fails() -> None:
+    def _boom_prompt_builder(**_kwargs) -> str:
+        raise ValueError("prompt builder failure")
+
+    llm = _StructuredOutputLLM(responses=[])
+    chain = ConfigPatchChain(
+        llm=llm,
+        prompt_builder=_boom_prompt_builder,
+        schema={"type": "object"},
+    )
+
+    with pytest.raises(ValueError, match="prompt builder failure"):
+        chain.run(
+            current_config={"portfolio": {"max_weight": 0.2}},
+            instruction="Set max_weight to 0.4.",
+        )
+
+    assert llm.invocation_count == 0
+
+
+def test_structured_output_invocation_count_one_when_llm_raises() -> None:
+    llm = _StructuredOutputLLM(responses=[ValueError("structured boom")])
+    chain = ConfigPatchChain(
+        llm=llm,
+        prompt_builder=build_config_patch_prompt,
+        schema={"type": "object"},
+    )
+
+    with pytest.raises(ValueError, match="structured boom"):
+        chain.run(
+            current_config={"portfolio": {"max_weight": 0.2}},
+            instruction="Set max_weight to 0.4.",
+        )
+
+    assert llm.invocation_count == 1
+
+
+def test_structured_output_invocation_count_three_when_fallback_retries() -> None:
+    llm = _StructuredOutputLLM(
+        responses=["not json", "still not json", "nope"],
+        supports_structured_output=False,
+    )
+    chain = ConfigPatchChain(
+        llm=llm,
+        prompt_builder=build_config_patch_prompt,
+        schema={"type": "object"},
+        retries=2,
+    )
+
+    with pytest.raises(ValueError, match="Failed to parse ConfigPatch after 3 attempts"):
+        chain.run(
+            current_config={"portfolio": {"max_weight": 0.2}},
+            instruction="Set max_weight to 0.4.",
+        )
+
+    assert llm.invocation_count == 3

--- a/tests/test_llm_variant_chain.py
+++ b/tests/test_llm_variant_chain.py
@@ -37,22 +37,35 @@ class _NoStructuredOutputLLM(RunnableLambda):
         return RunnableLambda(self._respond)
 
 
-class _StructuredOutputLLM:
-    def __init__(self, *, responses: list[object]) -> None:
+class _StructuredOutputLLM(RunnableLambda):
+    def __init__(
+        self,
+        *,
+        responses: list[object],
+        supports_structured_output: bool = True,
+    ) -> None:
+        self.invocation_count = 0
         self.structured_requests = 0
         self.structured_invocations = 0
+        self._supports_structured_output = supports_structured_output
         self._responses = iter(responses)
+        super().__init__(self._respond)
 
     def supports_structured_output(self) -> bool:
-        return True
+        return self._supports_structured_output
 
     def with_structured_output(self, _schema) -> RunnableLambda:
         self.structured_requests += 1
         return RunnableLambda(self._respond)
 
     def _respond(self, _prompt_value, **_kwargs) -> object:
-        self.structured_invocations += 1
-        return next(self._responses)
+        self.invocation_count += 1
+        if self._supports_structured_output:
+            self.structured_invocations += 1
+        response = next(self._responses)
+        if isinstance(response, BaseException):
+            raise response
+        return response
 
 
 def _make_patch(summary: str, value: float) -> dict[str, object]:
@@ -137,3 +150,64 @@ def test_variant_patch_requires_summary() -> None:
 
     with pytest.raises(ValidationError):
         ConfigPatchVariants.model_validate(payload)
+
+
+def test_variant_invocation_count_zero_when_prompt_builder_fails() -> None:
+    def _boom_prompt_builder(**_kwargs) -> str:
+        raise ValueError("variant prompt failure")
+
+    llm = _StructuredOutputLLM(responses=[])
+    chain = ConfigPatchVariantsChain(
+        llm=llm,
+        prompt_builder=_boom_prompt_builder,
+        schema={"type": "object"},
+    )
+
+    with pytest.raises(ValueError, match="variant prompt failure"):
+        chain.run(
+            current_config={"portfolio": {"max_weight": 0.2}},
+            instruction="Generate variants.",
+        )
+
+    assert llm.invocation_count == 0
+
+
+def test_variant_invocation_count_one_when_llm_raises() -> None:
+    llm = _StructuredOutputLLM(responses=[ValueError("variant boom")])
+    chain = ConfigPatchVariantsChain(
+        llm=llm,
+        prompt_builder=build_variant_patch_prompt,
+        schema={"type": "object"},
+    )
+
+    with pytest.raises(ValueError, match="variant boom"):
+        chain.run(
+            current_config={"portfolio": {"max_weight": 0.2}},
+            instruction="Generate variants.",
+        )
+
+    assert llm.invocation_count == 1
+
+
+def test_variant_invocation_count_three_when_fallback_retries() -> None:
+    llm = _StructuredOutputLLM(
+        responses=["not json", "still not json", "nope"],
+        supports_structured_output=False,
+    )
+    chain = ConfigPatchVariantsChain(
+        llm=llm,
+        prompt_builder=build_variant_patch_prompt,
+        schema={"type": "object"},
+        retries=2,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Failed to parse ConfigPatchVariants after 3 attempts",
+    ):
+        chain.run(
+            current_config={"portfolio": {"max_weight": 0.2}},
+            instruction="Generate variants.",
+        )
+
+    assert llm.invocation_count == 3


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #4799 addressed issue #4795, and verification passed (**PASS**) but identified a few design/test gaps that could still cause correctness or concurrency issues. This follow-up converts retry counters to per-instance state, fixes retry counting to reflect actual retries, and expands tests to cover missing boundary conditions for the structured-output test double and redaction edge cases.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#4799](https://github.com/stranske/Trend_Model_Project/issues/4799)
- [#4795](https://github.com/stranske/Trend_Model_Project/issues/4795)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Change `ConfigPatchChain.structured_repair_retry_count` from a class attribute to an instance attribute initialized to `0` in `__init__` (or the chain’s dataclass/pydantic initializer).
- [x] Update `ConfigPatchChain` retry loop to increment `structured_repair_retry_count` on every retry attempt (once per retry beyond the initial attempt), and adjust any related logic/tests accordingly.
- [x] Change `ConfigPatchVariantsChain.structured_repair_retry_count` from a class attribute (or missing field) to an instance attribute initialized to `0` in `__init__` (or dataclass/pydantic initializer).
- [x] Update `ConfigPatchVariantsChain` retry loop to increment `structured_repair_retry_count` on every retry attempt (once per retry beyond the initial attempt), mirroring `ConfigPatchChain` behavior.
- [x] Extend tests for the `_StructuredOutputLLM` test double to explicitly cover `invocation_count=0` and `invocation_count=1` cases and assert the chain fails with the expected exception/error outcome.
- [x] Add a test case where `_StructuredOutputLLM` `invocation_count > 2` (e.g., `3`) and assert the chain fails with the expected exception/error outcome.
- [x] Add redaction tests covering multiline strings where secret assignments appear on their own line vs embedded within multiline content; assert only full-line `KEY=value` assignments for configured secret keys are redacted.
- [x] Add redaction tests for escaped quotes in values (e.g., `KEY=\"va\\\"lue\"`) and ensure redaction still applies only to the matching full-line assignment.
- [x] Add redaction tests for complex shell syntax on the assignment line (e.g., `export KEY=value`, `KEY=value command`, whitespace variations) and assert behavior matches the current “full-line assignment only” rule.

#### Acceptance criteria
- [x] `ConfigPatchChain` defines `structured_repair_retry_count` as an instance attribute initialized to `0` during instance construction (e.g., in `__init__` or dataclass/pydantic initializer), and it is not present as a class attribute on `ConfigPatchChain`.
- [x] Two separately constructed `ConfigPatchChain` instances maintain independent retry counters: mutating `chain_a.structured_repair_retry_count` does not change `chain_b.structured_repair_retry_count`.
- [x] In `ConfigPatchChain` retry behavior, `structured_repair_retry_count` increments exactly once per retry attempt beyond the initial attempt (0 retries => 0; 1 retry => 1; N retries => N).
- [x] `ConfigPatchVariantsChain` defines `structured_repair_retry_count` as an instance attribute initialized to `0` during instance construction, and it is not present as a class attribute on `ConfigPatchVariantsChain`.
- [x] Two separately constructed `ConfigPatchVariantsChain` instances maintain independent retry counters: mutating `chain_a.structured_repair_retry_count` does not change `chain_b.structured_repair_retry_count`.
- [x] In `ConfigPatchVariantsChain` retry behavior, `structured_repair_retry_count` increments exactly once per retry attempt beyond the initial attempt (0 retries => 0; 1 retry => 1; N retries => N), mirroring `ConfigPatchChain`.
- [x] The `_StructuredOutputLLM` test double exposes an integer attribute `invocation_count` that starts at 0 and increments by 1 per model invocation.
- [x] When `_StructuredOutputLLM.invocation_count` ends at 0 (i.e., the LLM is never invoked), `ConfigPatchChain` fails with the specific expected exception type and/or error message asserted by tests (and the test asserts `llm.invocation_count == 0`).
- [x] When `_StructuredOutputLLM.invocation_count` ends at 1 (exactly one invocation), `ConfigPatchChain` fails with the specific expected exception type and/or error message asserted by tests (and the test asserts `llm.invocation_count == 1`).
- [x] When `_StructuredOutputLLM.invocation_count` ends at 0 (never invoked), `ConfigPatchVariantsChain` fails with the specific expected exception type and/or error message asserted by tests (and the test asserts `llm.invocation_count == 0`).
- [x] When `_StructuredOutputLLM.invocation_count` ends at 1 (exactly one invocation), `ConfigPatchVariantsChain` fails with the specific expected exception type and/or error message asserted by tests (and the test asserts `llm.invocation_count == 1`).
- [x] When `_StructuredOutputLLM.invocation_count` ends greater than 2 (e.g., 3), `ConfigPatchChain` fails with the specific expected exception type and/or error message asserted by tests, and the test asserts `invocation_count == 3`.
- [x] When `_StructuredOutputLLM.invocation_count` ends greater than 2 (e.g., 3), `ConfigPatchVariantsChain` fails with the specific expected exception type and/or error message asserted by tests, and the test asserts `invocation_count == 3`.
- [x] Redaction: in a multiline string, lines that are exactly full-line assignments for configured secret keys (e.g., `SECRET_KEY=value` with optional surrounding whitespace) are redacted, while occurrences of `SECRET_KEY=value` embedded within longer multiline content (not a full-line assignment) are not redacted.
- [x] Redaction: escaped quotes in assignment values on a full-line secret assignment are still redacted (e.g., input line `SECRET_KEY=\"va\\\"lue\"` becomes redacted), and only that full-line assignment is modified.
- [x] Redaction: lines with complex shell syntax are not redacted unless they match the current “full-line assignment only” rule; specifically, `export SECRET_KEY=value` is not redacted, and `SECRET_KEY=value command` is not redacted, while a pure assignment line with whitespace variations (e.g., `  SECRET_KEY=value  `) is redacted if whitespace-only surrounds the assignment.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why
PR #4799 addressed issue #4795, and verification passed (**PASS**) but identified a few design/test gaps that could still cause correctness or concurrency issues. This follow-up converts retry counters to per-instance state, fixes retry counting to reflect actual retries, and expands tests to cover missing boundary conditions for the structured-output test double and redaction edge cases.

## Source
- Original PR: #4799
- Parent issue: #4795

## Tasks
- [ ] Change `ConfigPatchChain.structured_repair_retry_count` from a class attribute to an instance attribute initialized to `0` in `__init__` (or the chain’s dataclass/pydantic initializer).
- [ ] Update `ConfigPatchChain` retry loop to increment `structured_repair_retry_count` on every retry attempt (once per retry beyond the initial attempt), and adjust any related logic/tests accordingly.
- [ ] Change `ConfigPatchVariantsChain.structured_repair_retry_count` from a class attribute (or missing field) to an instance attribute initialized to `0` in `__init__` (or dataclass/pydantic initializer).
- [ ] Update `ConfigPatchVariantsChain` retry loop to increment `structured_repair_retry_count` on every retry attempt (once per retry beyond the initial attempt), mirroring `ConfigPatchChain` behavior.
- [ ] Extend tests for the `_StructuredOutputLLM` test double to explicitly cover `invocation_count=0` and `invocation_count=1` cases and assert the chain fails with the expected exception/error outcome.
- [ ] Add a test case where `_StructuredOutputLLM` `invocation_count > 2` (e.g., `3`) and assert the chain fails with the expected exception/error outcome.
- [ ] Add redaction tests covering multiline strings where secret assignments appear on their own line vs embedded within multiline content; assert only full-line `KEY=value` assignments for configured secret keys are redacted.
- [ ] Add redaction tests for escaped quotes in values (e.g., `KEY=\"va\\\"lue\"`) and ensure redaction still applies only to the matching full-line assignment.
- [ ] Add redaction tests for complex shell syntax on the assignment line (e.g., `export KEY=value`, `KEY=value command`, whitespace variations) and assert behavior matches the current “full-line assignment only” rule.

## Acceptance Criteria
- [ ] `ConfigPatchChain` defines `structured_repair_retry_count` as an instance attribute initialized to `0` during instance construction (e.g., in `__init__` or dataclass/pydantic initializer), and it is not present as a class attribute on `ConfigPatchChain`.
- [ ] Two separately constructed `ConfigPatchChain` instances maintain independent retry counters: mutating `chain_a.structured_repair_retry_count` does not change `chain_b.structured_repair_retry_count`.
- [ ] In `ConfigPatchChain` retry behavior, `structured_repair_retry_count` increments exactly once per retry attempt beyond the initial attempt (0 retries => 0; 1 retry => 1; N retries => N).
- [ ] `ConfigPatchVariantsChain` defines `structured_repair_retry_count` as an instance attribute initialized to `0` during instance construction, and it is not present as a class attribute on `ConfigPatchVariantsChain`.
- [ ] Two separately constructed `ConfigPatchVariantsChain` instances maintain independent retry counters: mutating `chain_a.structured_repair_retry_count` does not change `chain_b.structured_repair_retry_count`.
- [ ] In `ConfigPatchVariantsChain` retry behavior, `structured_repair_retry_count` increments exactly once per retry attempt beyond the initial attempt (0 retries => 0; 1 retry => 1; N retries => N), mirroring `ConfigPatchChain`.
- [ ] The `_StructuredOutputLLM` test double exposes an integer attribute `invocation_count` that starts at 0 and increments by 1 per model invocation.
- [ ] When `_StructuredOutputLLM.invocation_count` ends at 0 (i.e., the LLM is never invoked), `ConfigPatchChain` fails with the specific expected exception type and/or error message asserted by tests (and the test asserts `llm.invocation_count == 0`).
- [ ] When `_StructuredOutputLLM.invocation_count` ends at 1 (exactly one invocation), `ConfigPatchChain` fails with the specific expected exception type and/or error message asserted by tests (and the test asserts `llm.invocation_count == 1`).
- [ ] When `_StructuredOutputLLM.invocation_count` ends at 0 (never invoked), `ConfigPatchVariantsChain` fails with the specific expected exception type and/or error message asserted by tests (and the test asserts `llm.invocation_count == 0`).
- [ ] When `_StructuredOutputLLM.invocation_count` ends at 1 (exactly one invocation), `ConfigPatchVariantsChain` fails with the specific expected exception type and/or error message asserted by tests (and the test asserts `llm.invocation_count == 1`).
- [ ] When `_StructuredOutputLLM.invocation_count` ends greater than 2 (e.g., 3), `ConfigPatchChain` fails with the specific expected exception type and/or error message asserted by tests, and the test asserts `invocation_count == 3`.
- [ ] When `_StructuredOutputLLM.invocation_count` ends greater than 2 (e.g., 3), `ConfigPatchVariantsChain` fails with the specific expected exception type and/or error message asserted by tests, and the test asserts `invocation_count == 3`.
- [ ] Redaction: in a multiline string, lines that are exactly full-line assignments for configured secret keys (e.g., `SECRET_KEY=value` with optional surrounding whitespace) are redacted, while occurrences of `SECRET_KEY=value` embedded within longer multiline content (not a full-line assignment) are not redacted.
- [ ] Redaction: escaped quotes in assignment values on a full-line secret assignment are still redacted (e.g., input line `SECRET_KEY=\"va\\\"lue\"` becomes redacted), and only that full-line assignment is modified.
- [ ] Redaction: lines with complex shell syntax are not redacted unless they match the current “full-line assignment only” rule; specifically, `export SECRET_KEY=value` is not redacted, and `SECRET_KEY=value command` is not redacted, while a pure assignment line with whitespace variations (e.g., `  SECRET_KEY=value  `) is redacted if whitespace-only surrounds the assignment.

## Implementation Notes
- Likely files to update:
  - `src/**/config_patch_chain.py`
  - `src/**/config_patch_variants_chain.py`
  - `tests/**/test_config_patch_chain.py`
  - `tests/**/test_config_patch_variants_chain.py`
  - `tests/**/test_structured_output_llm.py`
  - `tests/**/test_redaction.py`
- Retry counter changes:
  - Remove any class-scope `structured_repair_retry_count = ...`.
  - Initialize on `self` during construction (`__init__`, dataclass field with `default=0`, or pydantic field with default and instance storage).
  - Ensure retry loop increments exactly once per retry beyond the initial attempt (i.e., increment only when starting a subsequent attempt).
- Tests for invocation boundaries should:
  - Assert both exception type (and message substring if stable) and final `llm.invocation_count`.
  - Include explicit scenarios producing `invocation_count` of 0, 1, and 3.
- Redaction tests should reflect the current rule (“full-line `KEY=value` only”):
  - Multiline cases: standalone assignment redacted; embedded occurrences not redacted.
  - Escaped quotes: ensure the full-line assignment still matches/redacts.
  - Shell-like syntax: `export KEY=value` and `KEY=value command` must remain unchanged; whitespace-only wrapping around pure assignment should still redact.

<details>
<summary>Background (previous attempt context)</summary>

- **What failed:** Use of a class attribute for `structured_repair_retry_count` in `ConfigPatchChain`, which could lead to unsafe behavior if instances are reused concurrently.  
  **Why it failed:** Class attributes are shared across instances.  
  **What to try instead:** Initialize `structured_repair_retry_count` as an instance attribute in `__init__` for each chain instance.

- **What failed:** Only partial testing of `invocation_count` (only checking for count == 2) while omission of tests for failure conditions at counts 0, 1, or >2.  
  **Why it failed:** Required failure boundaries were untested.  
  **What to try instead:** Add explicit tests validating failure conditions for `invocation_count` values outside the valid scenario.

</details>

## Critical Rules
1. Do NOT include "Remaining Unchecked Items" or "Iteration Details" sections unless they contain specific, useful failure context
2. Tasks should be concrete actions, not verification concerns restated
3. Acceptance criteria must be testable (not "all concerns addressed")
4. Keep the main body focused - hide background/history in the collapsible section
5. Do NOT include the entire analysis object - only include specific failure contexts from `blockers_to_avoid`



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #4805

<!-- pr-preamble:end -->