### PR TITLE
Codex bootstrap for #4832

### DIFF
--- a/agents/codex-4832.md
+++ b/agents/codex-4832.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #4832 -->

--- a/src/trend_analysis/llm/chain.py
+++ b/src/trend_analysis/llm/chain.py
@@ -446,7 +446,6 @@ class ConfigPatchChain(_BaseConfigPatchChain):
         """Invoke the LLM and parse the ConfigPatch response."""
 
         started_at = time.perf_counter()
-        self.structured_repair_retry_count = 0
         timestamp = datetime.now(timezone.utc)
         request_id = request_id or uuid4().hex
         prompt_text = ""

--- a/tests/test_config_patch_chain.py
+++ b/tests/test_config_patch_chain.py
@@ -830,6 +830,37 @@ def test_structured_retry_count_multiple_retries() -> None:
     assert chain.structured_repair_retry_count == 2
 
 
+def test_structured_repair_retry_count_accumulates_across_runs() -> None:
+    llm = _StructuredLLM(
+        structured_responses=[
+            _retry_invalid_payload(),
+            _retry_valid_payload(),
+            _retry_invalid_payload(),
+            _retry_valid_payload(),
+        ],
+    )
+    chain = ConfigPatchChain(
+        llm=llm,
+        prompt_builder=build_config_patch_prompt,
+        schema={"type": "object"},
+        retries=1,
+    )
+
+    chain.run(
+        current_config={"portfolio": {"max_weight": 0.2}},
+        instruction="Set max_weight to 0.4.",
+    )
+
+    assert chain.structured_repair_retry_count == 1
+
+    chain.run(
+        current_config={"portfolio": {"max_weight": 0.2}},
+        instruction="Set max_weight to 0.4.",
+    )
+
+    assert chain.structured_repair_retry_count == 2
+
+
 def test_structured_retry_count_isolated_per_instance() -> None:
     llm_with_retry = _StructuredLLM(
         structured_responses=[_retry_invalid_payload(), _retry_valid_payload()],


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #4823 fixed `ConfigPatchVariantsChain.run()` so it no longer resets `structured_repair_retry_count = 0` at the top of each call, but the **same bug still exists in `ConfigPatchChain.run()`** at line 449 of `src/trend_analysis/llm/chain.py`.

Issue #4822 explicitly requires "no reset at the start of `run()`" — the fix was applied to `ConfigPatchVariantsChain` but missed `ConfigPatchChain`.

**Chain context:** #4680 → #4795 → #4805 → #4822 → PR #4823 → this issue

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#4823](https://github.com/stranske/Trend_Model_Project/issues/4823)
- [#4822](https://github.com/stranske/Trend_Model_Project/issues/4822)
- [#4680](https://github.com/stranske/Trend_Model_Project/issues/4680)
- [#4795](https://github.com/stranske/Trend_Model_Project/issues/4795)
- [#4805](https://github.com/stranske/Trend_Model_Project/issues/4805)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Remove the line `self.structured_repair_retry_count = 0` from `ConfigPatchChain.run()` method at line 449 in `src/trend_analysis/llm/chain.py`
- [x] Add test function `test_structured_repair_retry_count_accumulates_across_runs` in `tests/test_config_patch_chain.py` that calls `run()` twice with retries and asserts `structured_repair_retry_count` accumulates across calls

#### Acceptance criteria
- [x] File `src/trend_analysis/llm/chain.py` line 449 does not contain `self.structured_repair_retry_count = 0` in `ConfigPatchChain.run()` method
- [x] Test `test_structured_repair_retry_count_accumulates_across_runs` exists in `tests/test_config_patch_chain.py`
- [x] Test `test_structured_repair_retry_count_accumulates_across_runs` passes when executed
- [x] All existing tests in `tests/test_config_patch_chain.py` pass
- [x] All existing tests in `tests/test_config_patch_variants_chain.py` pass

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



# Fix ConfigPatchChain.run() to Not Reset structured_repair_retry_count

## Why

PR #4823 fixed `ConfigPatchVariantsChain.run()` so it no longer resets `structured_repair_retry_count = 0` at the top of each call, but the **same bug still exists in `ConfigPatchChain.run()`** at line 449 of `src/trend_analysis/llm/chain.py`.

Issue #4822 explicitly requires "no reset at the start of `run()`" — the fix was applied to `ConfigPatchVariantsChain` but missed `ConfigPatchChain`.

**Chain context:** #4680 → #4795 → #4805 → #4822 → PR #4823 → this issue

## Scope

**In Scope:**
- `src/trend_analysis/llm/chain.py` — `ConfigPatchChain.run()` method
- `tests/test_config_patch_chain.py` — missing cumulative-across-runs test

**Out of Scope (Non-Goals):**
- No changes to `ConfigPatchVariantsChain` (already fixed by PR #4823)
- No changes to `__init__` (correctly initializes to 0 in both classes)
- No refactoring of the retry loop itself

## Tasks

- [ ] Remove the line `self.structured_repair_retry_count = 0` from `ConfigPatchChain.run()` method at line 449 in `src/trend_analysis/llm/chain.py`
- [ ] Add test function `test_structured_repair_retry_count_accumulates_across_runs` in `tests/test_config_patch_chain.py` that calls `run()` twice with retries and asserts `structured_repair_retry_count` accumulates across calls

## Acceptance Criteria

- [ ] File `src/trend_analysis/llm/chain.py` line 449 does not contain `self.structured_repair_retry_count = 0` in `ConfigPatchChain.run()` method
- [ ] Test `test_structured_repair_retry_count_accumulates_across_runs` exists in `tests/test_config_patch_chain.py`
- [ ] Test `test_structured_repair_retry_count_accumulates_across_runs` passes when executed
- [ ] All existing tests in `tests/test_config_patch_chain.py` pass
- [ ] All existing tests in `tests/test_config_patch_variants_chain.py` pass

## Implementation Notes

### Code Change

**Current state (line 449):**
```python
def run(self, ...):
    self.structured_repair_retry_count = 0   # ← DELETE THIS LINE
    ...
```

**After fix:**
```python
def run(self, ...):
    # counter accumulates across calls; initialized in __init__
    ...
```

### Test Pattern

See `tests/test_config_patch_variants_chain.py` for the cumulative test that already exists for the variants chain. The new test should follow the same pattern but target `ConfigPatchChain`:

1. Create a `ConfigPatchChain` instance
2. Call `run()` method with parameters that trigger retries
3. Record the `structured_repair_retry_count` value
4. Call `run()` method again with parameters that trigger retries
5. Assert that `structured_repair_retry_count` is greater than the first recorded value

## Context

- **Related Issues:** #4680, #4795, #4805, #4822
- **Related PRs:** #4823
- **Files Modified:** 
  - `src/trend_analysis/llm/chain.py`
  - `tests/test_config_patch_chain.py`



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #4832

<!-- pr-preamble:end -->