### PR TITLE
Codex bootstrap for #4840

### DIFF
--- a/COMPONENTS_TO_REFACTOR.md
+++ b/COMPONENTS_TO_REFACTOR.md
@@ -11,3 +11,12 @@ Components in `streamlit_app/components/` that import LLM modules:
 
 None at this time. The components that perform LLM API calls already rely on the shared
 resolver in `streamlit_app/components/llm_settings.py` for API key resolution.
+
+## Environment Variable Audit
+
+Audit command: `grep -E "os\\.environ|getenv" streamlit_app/components/*.py`
+
+Findings:
+- Only `streamlit_app/components/llm_settings.py` reads Anthropic API key variables.
+- Other components read non-key environment variables (for example, provider name or
+  upload limits) and do not require refactoring for Anthropic key resolution.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ See `config/defaults.yml` for the complete schema and `config/presets/` for read
 
 ## Environment Variables
 
+Anthropic keys resolve in order, with `CLAUDE_API_STRANSKE` as the canonical primary and
+`ANTHROPIC_API_KEY` used only as a fallback when the primary is unset.
+
 - `CLAUDE_API_STRANSKE`: Canonical Anthropic API key (primary).
 - `ANTHROPIC_API_KEY`: Anthropic API key (fallback, used only if CLAUDE_API_STRANSKE is unset).
 

--- a/agents/codex-4840.md
+++ b/agents/codex-4840.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #4840 -->

--- a/archives/agents/ledgers/issue-4840-ledger.yml
+++ b/archives/agents/ledgers/issue-4840-ledger.yml
@@ -14,164 +14,164 @@ tasks:
   - id: task-02
     title: Add fallback resolution in `streamlit_app/components/llm_settings.py` to
       use `ANTHROPIC_API_KEY` only when `CLAUDE_API_STRANSKE` is unset.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-03
     title: 'Add docstring to the Anthropic key resolver function in `streamlit_app/components/llm_settings.py`
       documenting the precedence order: `CLAUDE_API_STRANSKE` (primary), then `ANTHROPIC_API_KEY`
       (fallback).'
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-04
     title: Identify all Python files under `streamlit_app/components/` that perform
       LLM API calls or provider configuration by searching for imports of `anthropic`,
       `openai`, or `llm` modules.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-05
     title: Audit each identified component to find direct environment variable reads
       for API keys using `grep -E 'os\.environ|getenv' streamlit_app/components/*.py`.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T09:37:23Z'
+    finished_at: '2026-02-10T09:37:23Z'
+    commit: eec80a8f
     notes: []
   - id: task-06
     title: Create a list document (e.g., `COMPONENTS_TO_REFACTOR.md`) of components
       that need refactoring to use the shared resolver.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-07
     title: Fix `streamlit_app/pages/2_Model.py` to defer Anthropic key/provider config
       resolution to the shared resolver in `streamlit_app/components/llm_settings.py`
       (remove any one-off env var reads).
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-08
     title: Fix `streamlit_app/components/explain_results.py` to rely on the shared
       resolver in `streamlit_app/components/llm_settings.py` for Anthropic key resolution
       (remove any one-off env var reads).
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-09
     title: Update each component identified in `COMPONENTS_TO_REFACTOR.md` to import
       and use the shared resolver from `llm_settings.py`.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-10
     title: Verify that no component bypasses the shared resolver precedence logic
       by running `grep -r 'os\.environ.*ANTHROPIC_API_KEY\|os\.environ.*CLAUDE_API_STRANSKE'
       streamlit_app/components/ streamlit_app/pages/` and confirming only `llm_settings.py`
       contains direct access.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T09:37:23Z'
+    finished_at: '2026-02-10T09:37:23Z'
+    commit: eec80a8f
     notes: []
   - id: task-11
     title: Create a unit test in `tests/test_llm_settings.py` that sets only `CLAUDE_API_STRANSKE`
       environment variable and verifies the resolver returns the correct API key value.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-12
     title: Create a unit test in `tests/test_llm_settings.py` that verifies the Anthropic
       provider is correctly configured when only `CLAUDE_API_STRANSKE` is set.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-13
     title: Create a unit test in `tests/test_llm_settings.py` that confirms no error
       is raised when only `CLAUDE_API_STRANSKE` is present and provider is `anthropic`.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-14
     title: Create a unit test in `tests/test_llm_settings.py` that sets only `ANTHROPIC_API_KEY`
       environment variable and verifies the resolver returns it as fallback.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T09:30:12Z'
+    finished_at: '2026-02-10T09:30:12Z'
+    commit: 9c249fe8
     notes: []
   - id: task-15
     title: Create a unit test in `tests/test_llm_settings.py` that verifies `CLAUDE_API_STRANSKE`
       takes precedence when both `CLAUDE_API_STRANSKE` and `ANTHROPIC_API_KEY` environment
       variables are set.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-16
     title: Create a unit test in `tests/test_llm_settings.py` that confirms an appropriate
       error or None is returned when neither `CLAUDE_API_STRANSKE` nor `ANTHROPIC_API_KEY`
       is set.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-17
     title: Update `README.md` to add or modify an "Environment Variables" or "Configuration"
       section that lists `CLAUDE_API_STRANSKE` with description "Canonical Anthropic
       API key (primary)".
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-18
     title: Update `README.md` to add `ANTHROPIC_API_KEY` with description "Anthropic
       API key (fallback, used only if CLAUDE_API_STRANSKE is unset)".
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-19
     title: 'Add inline code comments in `streamlit_app/components/llm_settings.py`
       explaining the precedence order: `CLAUDE_API_STRANSKE` checked first, then `ANTHROPIC_API_KEY`
       as fallback.'
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-20
     title: Create or update `docs/environment_variables.md` (if it exists) to document
       the precedence rules for Anthropic API key resolution.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-21
     title: With `CLAUDE_API_STRANSKE` set and `ANTHROPIC_API_KEY` unset, selecting
@@ -201,34 +201,34 @@ tasks:
     title: Running `grep -r 'os\.environ.*ANTHROPIC_API_KEY\|os\.environ.*CLAUDE_API_STRANSKE'
       streamlit_app/` returns matches only in `streamlit_app/components/llm_settings.py`
       (excluding comments and import statements).
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T09:37:23Z'
+    finished_at: '2026-02-10T09:37:23Z'
+    commit: eec80a8f
     notes: []
   - id: task-25
     title: All unit tests in `tests/test_llm_settings.py` pass with exit code 0.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T09:37:23Z'
+    finished_at: '2026-02-10T09:37:23Z'
+    commit: eec80a8f
     notes: []
   - id: task-26
     title: '`README.md` contains a section titled "Environment Variables" or "Configuration"
       that lists `CLAUDE_API_STRANSKE` with description "Canonical Anthropic API key
       (primary)" and `ANTHROPIC_API_KEY` with description "Anthropic API key (fallback,
       used only if CLAUDE_API_STRANSKE is unset)".'
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []
   - id: task-27
     title: The docstring or inline comments in the Anthropic key resolver function
       in `streamlit_app/components/llm_settings.py` explicitly document the precedence
       order.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T08:48:47Z'
+    finished_at: '2026-02-10T08:48:47Z'
+    commit: 9bc9a4c0b
     notes: []

--- a/archives/agents/ledgers/issue-4840-ledger.yml
+++ b/archives/agents/ledgers/issue-4840-ledger.yml
@@ -176,26 +176,26 @@ tasks:
   - id: task-21
     title: With `CLAUDE_API_STRANSKE` set and `ANTHROPIC_API_KEY` unset, selecting
       provider `anthropic` in the Streamlit UI works without "Missing API key" errors.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T10:19:48Z'
+    finished_at: '2026-02-10T10:19:48Z'
+    commit: 197ad5a9
     notes: []
   - id: task-22
     title: With `ANTHROPIC_API_KEY` set and `CLAUDE_API_STRANSKE` unset, selecting
       provider `anthropic` in the Streamlit UI works without "Missing API key" errors.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T10:19:48Z'
+    finished_at: '2026-02-10T10:19:48Z'
+    commit: 197ad5a9
     notes: []
   - id: task-23
     title: With both `CLAUDE_API_STRANSKE` and `ANTHROPIC_API_KEY` set to different
       values, the Anthropic client uses the value from `CLAUDE_API_STRANSKE`.
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-10T10:19:48Z'
+    finished_at: '2026-02-10T10:19:48Z'
+    commit: 197ad5a9
     notes: []
   - id: task-24
     title: Running `grep -r 'os\.environ.*ANTHROPIC_API_KEY\|os\.environ.*CLAUDE_API_STRANSKE'

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -7,4 +7,6 @@ When the provider is set to `anthropic`, the API key resolver checks variables i
 1. `CLAUDE_API_STRANSKE` (primary)
 2. `ANTHROPIC_API_KEY` (fallback, used only if `CLAUDE_API_STRANSKE` is unset)
 
+`CLAUDE_API_STRANSKE` is the canonical key to configure for Anthropic access.
+
 If neither is set, the Anthropic client will raise a missing API key error.

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -9,4 +9,5 @@ When the provider is set to `anthropic`, the API key resolver checks variables i
 
 `CLAUDE_API_STRANSKE` is the canonical key to configure for Anthropic access.
 
-If neither is set, the Anthropic client will raise a missing API key error.
+If neither is set, `resolve_llm_provider_config()` raises a `ValueError`
+indicating which variables to set.

--- a/streamlit_app/components/llm_settings.py
+++ b/streamlit_app/components/llm_settings.py
@@ -186,7 +186,7 @@ def resolve_llm_provider_config(
         env_hint = (
             "OPENAI_API_KEY"
             if provider_name == "openai"
-            else "CLAUDE_API_STRANSKE or ANTHROPIC_API_KEY"
+            else "CLAUDE_API_STRANSKE (preferred) or ANTHROPIC_API_KEY"
         )
         raise ValueError(
             f"Missing API key for {provider_name}. "

--- a/streamlit_app/components/llm_settings.py
+++ b/streamlit_app/components/llm_settings.py
@@ -95,6 +95,26 @@ def resolve_anthropic_api_key(
     return None
 
 
+def anthropic_api_key_status(
+    *,
+    include_secrets: bool = True,
+    include_env: bool = True,
+) -> dict[str, bool]:
+    """Report which Anthropic API key sources are present."""
+    status = {"CLAUDE_API_STRANSKE": False, "ANTHROPIC_API_KEY": False}
+    if include_secrets:
+        if sanitize_api_key(read_secret("CLAUDE_API_STRANSKE")):
+            status["CLAUDE_API_STRANSKE"] = True
+        if sanitize_api_key(read_secret("ANTHROPIC_API_KEY")):
+            status["ANTHROPIC_API_KEY"] = True
+    if include_env:
+        if sanitize_api_key(os.environ.get("CLAUDE_API_STRANSKE")):
+            status["CLAUDE_API_STRANSKE"] = True
+        if sanitize_api_key(os.environ.get("ANTHROPIC_API_KEY")):
+            status["ANTHROPIC_API_KEY"] = True
+    return status
+
+
 def default_api_key(provider_name: str) -> str | None:
     proxy_url = os.environ.get("TS_LLM_PROXY_URL")
     if proxy_url:
@@ -188,6 +208,7 @@ def resolve_llm_provider_config(
 
 
 __all__ = [
+    "anthropic_api_key_status",
     "default_api_key",
     "read_secret",
     "resolve_api_key_input",

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -24,6 +24,8 @@ from streamlit_app import state as app_state
 from streamlit_app.components import analysis_runner, nl_operation_viewer
 from streamlit_app.components.llm_settings import (
     anthropic_api_key_status as _anthropic_api_key_status,
+)
+from streamlit_app.components.llm_settings import (
     resolve_llm_provider_config as _resolve_llm_provider_config_shared,
 )
 from streamlit_app.components.llm_settings import (

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -972,8 +972,9 @@ def _llm_required_env_vars(provider: str) -> list[str] | None:
     if provider == "openai":
         required.append("OPENAI_API_KEY")
     elif provider == "anthropic":
+        # Only the canonical key is listed; the resolver accepts
+        # ANTHROPIC_API_KEY as a fallback so either satisfies the check.
         required.append("CLAUDE_API_STRANSKE")
-        required.append("ANTHROPIC_API_KEY")
     elif provider == "ollama":
         pass
     else:
@@ -983,7 +984,12 @@ def _llm_required_env_vars(provider: str) -> list[str] | None:
 
 
 def _llm_env_var_present(name: str) -> bool:
-    if name in {"CLAUDE_API_STRANSKE", "ANTHROPIC_API_KEY"}:
+    if name == "CLAUDE_API_STRANSKE":
+        # The resolver accepts either key, so treat both as satisfying
+        # the canonical variable requirement.
+        status = _anthropic_api_key_status()
+        return any(status.values())
+    if name == "ANTHROPIC_API_KEY":
         status = _anthropic_api_key_status()
         return bool(status.get(name))
     value = os.environ.get(name)

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -898,12 +898,38 @@ def _resolve_llm_session_overrides() -> dict[str, str | None]:
     }
 
 
+def _fallback_llm_provider_config() -> LLMProviderConfig:
+    overrides = _resolve_llm_session_overrides()
+    provider = overrides.get("provider") or os.environ.get("TREND_LLM_PROVIDER")
+    provider = (provider or _DEFAULT_CONFIG_CHAT_PROVIDER).lower()
+    if provider not in {"openai", "anthropic", "ollama"}:
+        provider = _DEFAULT_CONFIG_CHAT_PROVIDER
+    model = overrides.get("model") or os.environ.get("TREND_LLM_MODEL") or _DEFAULT_CONFIG_CHAT_MODEL
+    base_url = overrides.get("base_url") or os.environ.get("TREND_LLM_BASE_URL")
+    organization = overrides.get("organization") or os.environ.get("TREND_LLM_ORG")
+    kwargs: dict[str, object] = {"provider": provider}
+    if model:
+        kwargs["model"] = model
+    if base_url:
+        kwargs["base_url"] = base_url
+    if organization:
+        kwargs["organization"] = organization
+    return LLMProviderConfig(**kwargs)
+
+
 def _current_chain_settings_snapshot(
     config: LLMProviderConfig | None = None,
     temperature: float | None = None,
+    *,
+    allow_missing_api_key: bool = False,
 ) -> dict[str, Any]:
     if config is None:
-        config = _resolve_llm_provider_config()
+        try:
+            config = _resolve_llm_provider_config()
+        except ValueError:
+            if not allow_missing_api_key:
+                raise
+            config = _fallback_llm_provider_config()
     if temperature is None:
         temperature = _resolve_llm_temperature()
     return {
@@ -1074,7 +1100,9 @@ def _render_llm_session_overrides_panel() -> None:
             except (TypeError, ValueError):
                 st.warning("Temperature override must be a number; using env default.")
         _sync_llm_selection_from_overrides()
-        _maybe_reset_config_chat_cache(_current_chain_settings_snapshot())
+        _maybe_reset_config_chat_cache(
+            _current_chain_settings_snapshot(allow_missing_api_key=True)
+        )
 
 
 def _normalize_temperature(value: float) -> float:
@@ -1306,7 +1334,7 @@ def _build_nl_chain(
         _hash_api_key(config.api_key),
     )
     reset_fields = _maybe_reset_config_chat_cache(
-        _current_chain_settings_snapshot(temperature=resolved_temp)
+        _current_chain_settings_snapshot(config=config, temperature=resolved_temp)
     )
     llm_cache_key = _build_llm_cache_key(
         provider=resolved_provider,

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -23,6 +23,7 @@ import yaml
 from streamlit_app import state as app_state
 from streamlit_app.components import analysis_runner, nl_operation_viewer
 from streamlit_app.components.llm_settings import (
+    anthropic_api_key_status as _anthropic_api_key_status,
     resolve_llm_provider_config as _resolve_llm_provider_config_shared,
 )
 from streamlit_app.components.llm_settings import (
@@ -952,13 +953,14 @@ def _llm_required_env_vars(provider: str) -> list[str] | None:
 
 
 def _llm_env_var_present(name: str) -> bool:
+    if name in {"CLAUDE_API_STRANSKE", "ANTHROPIC_API_KEY"}:
+        status = _anthropic_api_key_status()
+        return bool(status.get(name))
     value = os.environ.get(name)
     if name in {
         "TS_STREAMLIT_API_KEY",
         "TREND_LLM_API_KEY",
         "OPENAI_API_KEY",
-        "ANTHROPIC_API_KEY",
-        "CLAUDE_API_STRANSKE",
     }:
         return bool(_sanitize_api_key(value))
     return bool(value)

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -904,7 +904,9 @@ def _fallback_llm_provider_config() -> LLMProviderConfig:
     provider = (provider or _DEFAULT_CONFIG_CHAT_PROVIDER).lower()
     if provider not in {"openai", "anthropic", "ollama"}:
         provider = _DEFAULT_CONFIG_CHAT_PROVIDER
-    model = overrides.get("model") or os.environ.get("TREND_LLM_MODEL") or _DEFAULT_CONFIG_CHAT_MODEL
+    model = (
+        overrides.get("model") or os.environ.get("TREND_LLM_MODEL") or _DEFAULT_CONFIG_CHAT_MODEL
+    )
     base_url = overrides.get("base_url") or os.environ.get("TREND_LLM_BASE_URL")
     organization = overrides.get("organization") or os.environ.get("TREND_LLM_ORG")
     kwargs: dict[str, object] = {"provider": provider}
@@ -1100,9 +1102,7 @@ def _render_llm_session_overrides_panel() -> None:
             except (TypeError, ValueError):
                 st.warning("Temperature override must be a number; using env default.")
         _sync_llm_selection_from_overrides()
-        _maybe_reset_config_chat_cache(
-            _current_chain_settings_snapshot(allow_missing_api_key=True)
-        )
+        _maybe_reset_config_chat_cache(_current_chain_settings_snapshot(allow_missing_api_key=True))
 
 
 def _normalize_temperature(value: float) -> float:

--- a/tests/app/test_model_page_helpers.py
+++ b/tests/app/test_model_page_helpers.py
@@ -47,6 +47,10 @@ def _capture_streamlit_calls(
 
 @pytest.fixture()
 def model_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    # Ensure provider config resolution has a key in tests that don't set env explicitly.
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+
     def _noop(*_args, **_kwargs):
         return None
 
@@ -1609,7 +1613,7 @@ def test_build_nl_chain_invalidation_on_model_change(
         model="gpt-4o",
         api_key="sk-test",
     )
-    configs = iter([config_first, config_first, config_second, config_second])
+    configs = iter([config_first, config_second])
 
     monkeypatch.setattr(model_module, "_resolve_llm_provider_config", lambda: next(configs))
     monkeypatch.setattr(model_module, "_resolve_llm_temperature", lambda: 0.0)
@@ -1658,7 +1662,7 @@ def test_build_nl_chain_invalidation_on_base_url_change(
         api_key="sk-test",
         base_url="https://two.example.com",
     )
-    configs = iter([config_first, config_first, config_second, config_second])
+    configs = iter([config_first, config_second])
 
     monkeypatch.setattr(model_module, "_resolve_llm_provider_config", lambda: next(configs))
     monkeypatch.setattr(model_module, "_resolve_llm_temperature", lambda: 0.0)
@@ -1752,7 +1756,7 @@ def test_build_nl_chain_invalidation_on_org_change(
         api_key="sk-test",
         organization="org-two",
     )
-    configs = iter([config_first, config_first, config_second, config_second])
+    configs = iter([config_first, config_second])
 
     monkeypatch.setattr(model_module, "_resolve_llm_provider_config", lambda: next(configs))
     monkeypatch.setattr(model_module, "_resolve_llm_temperature", lambda: 0.0)

--- a/tests/test_llm_settings.py
+++ b/tests/test_llm_settings.py
@@ -67,6 +67,14 @@ def test_anthropic_key_precedence_primary_over_fallback() -> None:
         assert resolve_anthropic_api_key() == "claude-primary"
 
 
+def test_anthropic_provider_config_prefers_primary_over_fallback() -> None:
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("CLAUDE_API_STRANSKE", "claude-primary")
+        mp.setenv("ANTHROPIC_API_KEY", "anthropic-fallback")
+        config = resolve_llm_provider_config("anthropic")
+        assert config.api_key == "claude-primary"
+
+
 def test_anthropic_key_missing_returns_none_and_config_errors() -> None:
     assert resolve_anthropic_api_key() is None
     with pytest.raises(ValueError):

--- a/tests/test_llm_settings.py
+++ b/tests/test_llm_settings.py
@@ -61,6 +61,12 @@ def test_anthropic_provider_config_from_fallback_env() -> None:
         assert config.api_key == "anthropic-fallback"
 
 
+def test_anthropic_provider_config_no_error_with_fallback_env() -> None:
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("ANTHROPIC_API_KEY", "anthropic-fallback")
+        resolve_llm_provider_config("anthropic")
+
+
 def test_anthropic_key_precedence_primary_over_fallback() -> None:
     with pytest.MonkeyPatch.context() as mp:
         mp.setenv("CLAUDE_API_STRANSKE", "claude-primary")

--- a/tests/test_llm_settings.py
+++ b/tests/test_llm_settings.py
@@ -93,3 +93,53 @@ def test_anthropic_key_status_reports_primary_env() -> None:
         mp.setenv("CLAUDE_API_STRANSKE", "claude-primary")
         status = anthropic_api_key_status(include_secrets=False, include_env=True)
         assert status == {"CLAUDE_API_STRANSKE": True, "ANTHROPIC_API_KEY": False}
+
+
+# --- Secrets-based resolution path tests ---
+
+
+def test_resolve_anthropic_key_secret_primary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Secrets path: CLAUDE_API_STRANSKE secret is preferred over env fallback."""
+    import streamlit as st
+
+    fake_secrets = {"CLAUDE_API_STRANSKE": "secret-primary"}
+    monkeypatch.setattr(st, "secrets", fake_secrets)
+    result = resolve_anthropic_api_key(include_secrets=True, include_env=True)
+    assert result == "secret-primary"
+
+
+def test_resolve_anthropic_key_secret_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Secrets path: ANTHROPIC_API_KEY secret used when CLAUDE_API_STRANSKE absent."""
+    import streamlit as st
+
+    fake_secrets = {"ANTHROPIC_API_KEY": "secret-fallback"}
+    monkeypatch.setattr(st, "secrets", fake_secrets)
+    result = resolve_anthropic_api_key(include_secrets=True, include_env=True)
+    assert result == "secret-fallback"
+
+
+def test_resolve_anthropic_key_secret_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Secrets path: CLAUDE_API_STRANSKE secret wins even when ANTHROPIC_API_KEY env is set."""
+    import streamlit as st
+
+    fake_secrets = {"CLAUDE_API_STRANSKE": "secret-primary"}
+    monkeypatch.setattr(st, "secrets", fake_secrets)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "env-fallback")
+    result = resolve_anthropic_api_key(include_secrets=True, include_env=True)
+    assert result == "secret-primary"
+
+
+def test_anthropic_status_secrets_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """anthropic_api_key_status reflects secrets presence."""
+    import streamlit as st
+
+    fake_secrets = {"CLAUDE_API_STRANSKE": "secret-val"}
+    monkeypatch.setattr(st, "secrets", fake_secrets)
+    status = anthropic_api_key_status(include_secrets=True, include_env=True)
+    assert status["CLAUDE_API_STRANSKE"] is True
+
+
+def test_config_error_message_mentions_precedence() -> None:
+    """Error message on missing key mentions CLAUDE_API_STRANSKE as preferred."""
+    with pytest.raises(ValueError, match=r"CLAUDE_API_STRANSKE \(preferred\)"):
+        resolve_llm_provider_config("anthropic")

--- a/tests/test_llm_settings.py
+++ b/tests/test_llm_settings.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from streamlit_app.components.llm_settings import (
+    anthropic_api_key_status,
     resolve_anthropic_api_key,
     resolve_llm_provider_config,
 )
@@ -79,3 +80,10 @@ def test_anthropic_key_missing_returns_none_and_config_errors() -> None:
     assert resolve_anthropic_api_key() is None
     with pytest.raises(ValueError):
         resolve_llm_provider_config("anthropic")
+
+
+def test_anthropic_key_status_reports_primary_env() -> None:
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("CLAUDE_API_STRANSKE", "claude-primary")
+        status = anthropic_api_key_status(include_secrets=False, include_env=True)
+        assert status == {"CLAUDE_API_STRANSKE": True, "ANTHROPIC_API_KEY": False}

--- a/tests/test_llm_settings.py
+++ b/tests/test_llm_settings.py
@@ -52,6 +52,14 @@ def test_resolve_anthropic_key_fallback_env() -> None:
         assert resolve_anthropic_api_key() == "anthropic-fallback"
 
 
+def test_anthropic_provider_config_from_fallback_env() -> None:
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("ANTHROPIC_API_KEY", "anthropic-fallback")
+        config = resolve_llm_provider_config("anthropic")
+        assert config.provider == "anthropic"
+        assert config.api_key == "anthropic-fallback"
+
+
 def test_anthropic_key_precedence_primary_over_fallback() -> None:
     with pytest.MonkeyPatch.context() as mp:
         mp.setenv("CLAUDE_API_STRANSKE", "claude-primary")


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The Workflows automation system standardizes on `CLAUDE_API_STRANSKE` for Anthropic credentials. Trend Model Project should align on the same canonical variable to avoid duplicated secrets and inconsistent environment setups across repos.

#### Tasks
### Core Resolver Implementation
- [x] Update `streamlit_app/components/llm_settings.py` to resolve the Anthropic API key from `CLAUDE_API_STRANSKE` as the primary env var when provider is `anthropic`.
- [x] Add fallback resolution in `streamlit_app/components/llm_settings.py` to use `ANTHROPIC_API_KEY` only when `CLAUDE_API_STRANSKE` is unset.
- [x] Add docstring to the Anthropic key resolver function in `streamlit_app/components/llm_settings.py` documenting the precedence order: `CLAUDE_API_STRANSKE` (primary), then `ANTHROPIC_API_KEY` (fallback).

### Component Refactoring - Discovery
- [x] Identify all Python files under `streamlit_app/components/` that perform LLM API calls or provider configuration by searching for imports of `anthropic`, `openai`, or `llm` modules.
- [x] Audit each identified component to find direct environment variable reads for API keys using `grep -E 'os\.environ|getenv' streamlit_app/components/*.py`.
- [x] Create a list document (e.g., `COMPONENTS_TO_REFACTOR.md`) of components that need refactoring to use the shared resolver.

### Component Refactoring - Implementation
- [x] Fix `streamlit_app/pages/2_Model.py` to defer Anthropic key/provider config resolution to the shared resolver in `streamlit_app/components/llm_settings.py` (remove any one-off env var reads).
- [x] Fix `streamlit_app/components/explain_results.py` to rely on the shared resolver in `streamlit_app/components/llm_settings.py` for Anthropic key resolution (remove any one-off env var reads).
- [x] Update each component identified in `COMPONENTS_TO_REFACTOR.md` to import and use the shared resolver from `llm_settings.py`.
- [x] Verify that no component bypasses the shared resolver precedence logic by running `grep -r 'os\.environ.*ANTHROPIC_API_KEY\|os\.environ.*CLAUDE_API_STRANSKE' streamlit_app/components/ streamlit_app/pages/` and confirming only `llm_settings.py` contains direct access.

### Testing - Primary Variable
- [x] Create a unit test in `tests/test_llm_settings.py` that sets only `CLAUDE_API_STRANSKE` environment variable and verifies the resolver returns the correct API key value.
- [x] Create a unit test in `tests/test_llm_settings.py` that verifies the Anthropic provider is correctly configured when only `CLAUDE_API_STRANSKE` is set.
- [x] Create a unit test in `tests/test_llm_settings.py` that confirms no error is raised when only `CLAUDE_API_STRANSKE` is present and provider is `anthropic`.

### Testing - Fallback Behavior
- [x] Create a unit test in `tests/test_llm_settings.py` that sets only `ANTHROPIC_API_KEY` environment variable and verifies the resolver returns it as fallback.
- [x] Create a unit test in `tests/test_llm_settings.py` that verifies `CLAUDE_API_STRANSKE` takes precedence when both `CLAUDE_API_STRANSKE` and `ANTHROPIC_API_KEY` environment variables are set.
- [x] Create a unit test in `tests/test_llm_settings.py` that confirms an appropriate error or None is returned when neither `CLAUDE_API_STRANSKE` nor `ANTHROPIC_API_KEY` is set.

### Documentation
- [x] Update `README.md` to add or modify an "Environment Variables" or "Configuration" section that lists `CLAUDE_API_STRANSKE` with description "Canonical Anthropic API key (primary)".
- [x] Update `README.md` to add `ANTHROPIC_API_KEY` with description "Anthropic API key (fallback, used only if CLAUDE_API_STRANSKE is unset)".
- [x] Add inline code comments in `streamlit_app/components/llm_settings.py` explaining the precedence order: `CLAUDE_API_STRANSKE` checked first, then `ANTHROPIC_API_KEY` as fallback.
- [x] Create or update `docs/environment_variables.md` (if it exists) to document the precedence rules for Anthropic API key resolution.

#### Acceptance criteria
- [x] With `CLAUDE_API_STRANSKE` set and `ANTHROPIC_API_KEY` unset, selecting provider `anthropic` in the Streamlit UI works without "Missing API key" errors.
- [x] With `ANTHROPIC_API_KEY` set and `CLAUDE_API_STRANSKE` unset, selecting provider `anthropic` in the Streamlit UI works without "Missing API key" errors.
- [x] With both `CLAUDE_API_STRANSKE` and `ANTHROPIC_API_KEY` set to different values, the Anthropic client uses the value from `CLAUDE_API_STRANSKE`.
- [x] Running `grep -r 'os\.environ.*ANTHROPIC_API_KEY\|os\.environ.*CLAUDE_API_STRANSKE' streamlit_app/` returns matches only in `streamlit_app/components/llm_settings.py` (excluding comments and import statements).
- [x] All unit tests in `tests/test_llm_settings.py` pass with exit code 0.
- [x] `README.md` contains a section titled "Environment Variables" or "Configuration" that lists `CLAUDE_API_STRANSKE` with description "Canonical Anthropic API key (primary)" and `ANTHROPIC_API_KEY` with description "Anthropic API key (fallback, used only if CLAUDE_API_STRANSKE is unset)".
- [x] The docstring or inline comments in the Anthropic key resolver function in `streamlit_app/components/llm_settings.py` explicitly document the precedence order.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



# Standardize Anthropic API Key Environment Variable

## Why
The Workflows automation system standardizes on `CLAUDE_API_STRANSKE` for Anthropic credentials. Trend Model Project should align on the same canonical variable to avoid duplicated secrets and inconsistent environment setups across repos.

## Scope
Make `CLAUDE_API_STRANSKE` the canonical Anthropic API key input for Trend's LLM configuration (Streamlit + supporting helpers). Allow `ANTHROPIC_API_KEY` as a backward-compatible fallback.

## Non-Goals
- This does not change which providers are supported (still OpenAI / Anthropic / Ollama).
- This does not store or display secret values in the UI.
- This does not introduce new secret-management mechanisms.

## Tasks

### Core Resolver Implementation
- [x] Update `streamlit_app/components/llm_settings.py` to resolve the Anthropic API key from `CLAUDE_API_STRANSKE` as the primary env var when provider is `anthropic`.
- [ ] Add fallback resolution in `streamlit_app/components/llm_settings.py` to use `ANTHROPIC_API_KEY` only when `CLAUDE_API_STRANSKE` is unset.
- [x] Add docstring to the Anthropic key resolver function in `streamlit_app/components/llm_settings.py` documenting the precedence order: `CLAUDE_API_STRANSKE` (primary), then `ANTHROPIC_API_KEY` (fallback).

### Component Refactoring - Discovery
- [ ] Identify all Python files under `streamlit_app/components/` that perform LLM API calls or provider configuration by searching for imports of `anthropic`, `openai`, or `llm` modules.
- [ ] Audit each identified component to find direct environment variable reads for API keys using `grep -E 'os\.environ|getenv' streamlit_app/components/*.py`.
- [ ] Create a list document (e.g., `COMPONENTS_TO_REFACTOR.md`) of components that need refactoring to use the shared resolver.

### Component Refactoring - Implementation
- [ ] Fix `streamlit_app/pages/2_Model.py` to defer Anthropic key/provider config resolution to the shared resolver in `streamlit_app/components/llm_settings.py` (remove any one-off env var reads).
- [ ] Fix `streamlit_app/components/explain_results.py` to rely on the shared resolver in `streamlit_app/components/llm_settings.py` for Anthropic key resolution (remove any one-off env var reads).
- [ ] Update each component identified in `COMPONENTS_TO_REFACTOR.md` to import and use the shared resolver from `llm_settings.py`.
- [ ] Verify that no component bypasses the shared resolver precedence logic by running `grep -r 'os\.environ.*ANTHROPIC_API_KEY\|os\.environ.*CLAUDE_API_STRANSKE' streamlit_app/components/ streamlit_app/pages/` and confirming only `llm_settings.py` contains direct access.

### Testing - Primary Variable
- [x] Create a unit test in `tests/test_llm_settings.py` that sets only `CLAUDE_API_STRANSKE` environment variable and verifies the resolver returns the correct API key value.
- [x] Create a unit test in `tests/test_llm_settings.py` that verifies the Anthropic provider is correctly configured when only `CLAUDE_API_STRANSKE` is set.
- [x] Create a unit test in `tests/test_llm_settings.py` that confirms no error is raised when only `CLAUDE_API_STRANSKE` is present and provider is `anthropic`.

### Testing - Fallback Behavior
- [x] Create a unit test in `tests/test_llm_settings.py` that sets only `ANTHROPIC_API_KEY` environment variable and verifies the resolver returns it as fallback.
- [x] Create a unit test in `tests/test_llm_settings.py` that verifies `CLAUDE_API_STRANSKE` takes precedence when both `CLAUDE_API_STRANSKE` and `ANTHROPIC_API_KEY` environment variables are set.
- [x] Create a unit test in `tests/test_llm_settings.py` that confirms an appropriate error or None is returned when neither `CLAUDE_API_STRANSKE` nor `ANTHROPIC_API_KEY` is set.

### Documentation
- [x] Update `README.md` to add or modify an "Environment Variables" or "Configuration" section that lists `CLAUDE_API_STRANSKE` with description "Canonical Anthropic API key (primary)".
- [x] Update `README.md` to add `ANTHROPIC_API_KEY` with description "Anthropic API key (fallback, used only if CLAUDE_API_STRANSKE is unset)".
- [x] Add inline code comments in `streamlit_app/components/llm_settings.py` explaining the precedence order: `CLAUDE_API_STRANSKE` checked first, then `ANTHROPIC_API_KEY` as fallback.
- [x] Create or update `docs/environment_variables.md` (if it exists) to document the precedence rules for Anthropic API key resolution.

## Acceptance Criteria
- [ ] With `CLAUDE_API_STRANSKE` set and `ANTHROPIC_API_KEY` unset, selecting provider `anthropic` in the Streamlit UI works without "Missing API key" errors.
- [ ] With `ANTHROPIC_API_KEY` set and `CLAUDE_API_STRANSKE` unset, selecting provider `anthropic` in the Streamlit UI works without "Missing API key" errors.
- [ ] With both `CLAUDE_API_STRANSKE` and `ANTHROPIC_API_KEY` set to different values, the Anthropic client uses the value from `CLAUDE_API_STRANSKE`.
- [ ] Running `grep -r 'os\.environ.*ANTHROPIC_API_KEY\|os\.environ.*CLAUDE_API_STRANSKE' streamlit_app/` returns matches only in `streamlit_app/components/llm_settings.py` (excluding comments and import statements).
- [x] All unit tests in `tests/test_llm_settings.py` pass with exit code 0.
- [ ] `README.md` contains a section titled "Environment Variables" or "Configuration" that lists `CLAUDE_API_STRANSKE` with description "Canonical Anthropic API key (primary)" and `ANTHROPIC_API_KEY` with description "Anthropic API key (fallback, used only if CLAUDE_API_STRANSKE is unset)".
- [x] The docstring or inline comments in the Anthropic key resolver function in `streamlit_app/components/llm_settings.py` explicitly document the precedence order.

## Implementation Notes

### Primary files to check/update:
- `streamlit_app/components/llm_settings.py` - Canonicalize Anthropic key resolution with precedence logic
- `streamlit_app/pages/2_Model.py` - Provider config resolution should defer to shared resolver
- `streamlit_app/components/explain_results.py` - Ensure it relies on shared resolver behavior
- Any other LLM-enabled components under `streamlit_app/components/` - Identified during discovery phase

### Proposed precedence for Anthropic API key resolution:
1. `CLAUDE_API_STRANSKE` (primary, canonical)
2. `ANTHROPIC_API_KEY` (fallback for backward compatibility)
3. Return `None` or raise appropriate error if neither is set

### Testing strategy:
- Use `unittest.mock.patch.dict` to control environment variables in unit tests
- Test all three scenarios: primary only, fallback only, both set
- Verify precedence order is respected when both variables are present

---

## Deferred Tasks (Requires Human)
None - all tasks are actionable by an automated agent.

---

Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/21857465866).



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #4840

<!-- pr-preamble:end -->