### PR TITLE
Codex belt for #4856

### DIFF
--- a/.agents/issue-4856-ledger.yml
+++ b/.agents/issue-4856-ledger.yml
@@ -1,0 +1,235 @@
+version: 1
+issue: 4856
+base: phase-3
+branch: codex/issue-4856
+tasks:
+  - id: task-01
+    title: Create `src/trend_analysis/viz/__init__.py` with a minimal initializer
+      that does not import `streamlit` and does not import viz implementation modules
+      (`fan`, `path_dist`, `risk_return`) at import time
+    status: doing
+    started_at: '2026-02-10T20:52:06Z'
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-02
+    title: Add `tests/test_viz_package_import.py` to import `trend_analysis.viz` and
+      assert `"streamlit" not in sys.modules` after import
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-03
+    title: Add `tests/viz/test_fan_make.py` to call `trend_analysis.viz.fan.make(...)`
+      with minimal valid input and assert `isinstance(fig, plotly.graph_objects.Figure)`
+      and `json.loads(fig.to_json())` succeeds
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-04
+    title: Add `tests/viz/test_path_dist_make.py` to call `trend_analysis.viz.path_dist.make(...)`
+      with minimal valid input and assert `isinstance(fig, plotly.graph_objects.Figure)`
+      and `json.loads(fig.to_json())` succeeds
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-05
+    title: Add `tests/viz/test_risk_return_make.py` to call `trend_analysis.viz.risk_return.make(...)`
+      with minimal valid input and assert `isinstance(fig, plotly.graph_objects.Figure)`
+      and `json.loads(fig.to_json())` succeeds
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-06
+    title: Update `trend_analysis.viz.utils.quantile_bands(...)` to remove usage of
+      `zip(..., strict=False)` by implementing equivalent pairing logic compatible
+      with Python < 3.10
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-07
+    title: Add `tests/viz/test_utils_quantile_bands.py` to exercise `quantile_bands(...)`
+      pairing behavior, including at least one expected pairing case and at least
+      one mismatched/odd-length quantile inputs case (assert output pairing or a well-defined
+      exception)
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-08
+    title: Add tests for `_select_nav_paths` with empty DataFrame input asserting
+      specific exception type and message substring
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-09
+    title: Add tests for `_select_nav_paths` with unsorted quantile labels asserting
+      correct DataFrame shape and index order
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-10
+    title: Add tests for `_select_nav_paths` with duplicate quantile labels asserting
+      specific exception type and message substring
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-11
+    title: Add tests for `_select_terminal_values` with MultiIndex having unexpected
+      level names asserting specific exception type and message substring
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-12
+    title: Add tests for `_select_terminal_values` with MultiIndex having unexpected
+      level order asserting correct numeric output values
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-13
+    title: Add tests for `_select_terminal_values` with numeric values provided as
+      strings asserting correct dtype coercion to numeric types
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-14
+    title: '`src/trend_analysis/viz/__init__.py` exists, and `import trend_analysis.viz`
+      does not raise when `streamlit` is not installed'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-15
+    title: After `import trend_analysis.viz`, `"streamlit"` is not present in `sys.modules`
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-16
+    title: '`src/trend_analysis/viz/__init__.py` contains no `import streamlit` statement
+      and does not import `fan`, `path_dist`, or `risk_return` at import time'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-17
+    title: Calling `trend_analysis.viz.fan.make(...)` with minimal valid input returns
+      an instance of `plotly.graph_objects.Figure`
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-18
+    title: 'The Figure from `trend_analysis.viz.fan.make(...)` is JSON-serializable:
+      `fig.to_json()` completes without raising and `json.loads(...)` parses the returned
+      string'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-19
+    title: Calling `trend_analysis.viz.path_dist.make(...)` with minimal valid input
+      returns an instance of `plotly.graph_objects.Figure`
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-20
+    title: 'The Figure from `trend_analysis.viz.path_dist.make(...)` is JSON-serializable:
+      `fig.to_json()` completes without raising and `json.loads(...)` parses the returned
+      string'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-21
+    title: Calling `trend_analysis.viz.risk_return.make(...)` with minimal valid input
+      returns an instance of `plotly.graph_objects.Figure`
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-22
+    title: 'The Figure from `trend_analysis.viz.risk_return.make(...)` is JSON-serializable:
+      `fig.to_json()` completes without raising and `json.loads(...)` parses the returned
+      string'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-23
+    title: '`trend_analysis.viz.utils.quantile_bands(...)` contains no usage of `zip(...,
+      strict=...)` and executes without requiring Python 3.10+ language features'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-24
+    title: '`tests/viz/test_utils_quantile_bands.py` exists and passes, including
+      coverage for mismatched/odd-length quantile inputs per intended behavior'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-25
+    title: '`_select_nav_paths` has automated tests covering: (1) empty input, (2)
+      unsorted quantile labels, (3) duplicate quantile labels; each asserts a specific
+      returned DataFrame shape/index or a specific exception type and message substring'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-26
+    title: '`_select_terminal_values` has automated tests covering: (1) MultiIndex
+      quirks (unexpected level names/order), and (2) dtype coercion (numeric values
+      provided as strings); each asserts correct numeric output values/dtypes or a
+      specific exception type and message substring'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-27
+    title: 'Pytest collects the new test files: `tests/test_viz_package_import.py`,
+      `tests/viz/test_fan_make.py`, `tests/viz/test_path_dist_make.py`, `tests/viz/test_risk_return_make.py`,
+      `tests/viz/test_utils_quantile_bands.py`, and tests for `_select_nav_paths`
+      and `_select_terminal_values` edge cases'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []

--- a/.agents/issue-4856-ledger.yml
+++ b/.agents/issue-4856-ledger.yml
@@ -7,10 +7,10 @@ tasks:
     title: Create `src/trend_analysis/viz/__init__.py` with a minimal initializer
       that does not import `streamlit` and does not import viz implementation modules
       (`fan`, `path_dist`, `risk_return`) at import time
-    status: doing
+    status: done
     started_at: '2026-02-10T20:52:06Z'
-    finished_at: null
-    commit: ''
+    finished_at: '2026-02-10T20:52:15Z'
+    commit: df7feff33f76dc7577afd4aafb9e358afdae0262
     notes: []
   - id: task-02
     title: Add `tests/test_viz_package_import.py` to import `trend_analysis.viz` and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ dev = [
     "flake8==7.3.0",
     "pytest==9.0.2",
     "pytest-cov==7.0.0",
-    "coverage>=7.13.4",
+    "coverage==7.13.4",
     "pytest-rerunfailures==16.1",
     "pytest-xdist==3.8.0",
     "packaging==25.0",

--- a/src/trend_analysis/viz/__init__.py
+++ b/src/trend_analysis/viz/__init__.py
@@ -1,19 +1,8 @@
 """Chart helpers for Trend Analysis results pages.
 
-This module exposes small utilities that transform simulation outputs
-into dataframes ready for visualisation.  The helpers are intentionally
-lightweight so they can be reused outside of Streamlit and make it easy
-to export the underlying data.
+Keep imports lightweight so `trend_analysis.viz` can be imported without
+pulling in optional UI dependencies.
 """
-
-from .charts import (
-    drawdown_curve,
-    equity_curve,
-    rolling_information_ratio,
-    turnover_series,
-    weights_heatmap,
-    weights_heatmap_data,
-)
 
 __all__ = [
     "equity_curve",
@@ -23,3 +12,15 @@ __all__ = [
     "weights_heatmap",
     "weights_heatmap_data",
 ]
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        from . import charts
+
+        return getattr(charts, name)
+    raise AttributeError(f"module 'trend_analysis.viz' has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(__all__)

--- a/src/trend_analysis/viz/__init__.py
+++ b/src/trend_analysis/viz/__init__.py
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> object:
     if name in __all__:
         from . import charts
 
@@ -22,5 +22,5 @@ def __getattr__(name: str):
     raise AttributeError(f"module 'trend_analysis.viz' has no attribute {name!r}")
 
 
-def __dir__():
+def __dir__() -> list[str]:
     return sorted(__all__)

--- a/src/trend_analysis/viz/fan.py
+++ b/src/trend_analysis/viz/fan.py
@@ -49,6 +49,9 @@ def _select_nav_paths(
         else:
             frame.columns = ["_".join(map(str, col)) for col in frame.columns]
 
+    if frame.columns.has_duplicates:
+        raise ValueError("nav_paths has duplicate path labels")
+
     if max_paths is not None and frame.shape[1] > max_paths:
         frame = frame.iloc[:, :max_paths]
 

--- a/src/trend_analysis/viz/path_dist.py
+++ b/src/trend_analysis/viz/path_dist.py
@@ -31,9 +31,7 @@ def _select_terminal_values(
         names = [name or "" for name in frame.columns.names]
         unexpected = [name for name in names if name not in {"", "asset", "path"}]
         if unexpected:
-            raise ValueError(
-                "nav_paths MultiIndex levels must be named 'asset' and/or 'path'"
-            )
+            raise ValueError("nav_paths MultiIndex levels must be named 'asset' and/or 'path'")
         if "asset" in names:
             asset_level = names.index("asset")
             assets = frame.columns.get_level_values(asset_level)
@@ -116,9 +114,7 @@ def make(
                 y0=0,
                 y1=1,
                 yref="paper",
-                line=dict(
-                    color=DEFAULT_COLORS[(idx + 1) % len(DEFAULT_COLORS)], dash="dash"
-                ),
+                line=dict(color=DEFAULT_COLORS[(idx + 1) % len(DEFAULT_COLORS)], dash="dash"),
             )
             fig.add_annotation(
                 x=q_value,

--- a/src/trend_analysis/viz/path_dist.py
+++ b/src/trend_analysis/viz/path_dist.py
@@ -29,6 +29,11 @@ def _select_terminal_values(
 
     if isinstance(frame.columns, pd.MultiIndex):
         names = [name or "" for name in frame.columns.names]
+        unexpected = [name for name in names if name not in {"", "asset", "path"}]
+        if unexpected:
+            raise ValueError(
+                "nav_paths MultiIndex levels must be named 'asset' and/or 'path'"
+            )
         if "asset" in names:
             asset_level = names.index("asset")
             assets = frame.columns.get_level_values(asset_level)

--- a/src/trend_analysis/viz/path_dist.py
+++ b/src/trend_analysis/viz/path_dist.py
@@ -31,9 +31,7 @@ def _select_terminal_values(
         names = [name or "" for name in frame.columns.names]
         unexpected = [name for name in names if name not in {"", "asset", "path"}]
         if unexpected:
-            raise ValueError(
-                "nav_paths MultiIndex levels must be named 'asset' and/or 'path'"
-            )
+            raise ValueError("nav_paths MultiIndex levels must be named 'asset' and/or 'path'")
         if "asset" in names:
             asset_level = names.index("asset")
             assets = frame.columns.get_level_values(asset_level)

--- a/src/trend_analysis/viz/path_dist.py
+++ b/src/trend_analysis/viz/path_dist.py
@@ -31,7 +31,9 @@ def _select_terminal_values(
         names = [name or "" for name in frame.columns.names]
         unexpected = [name for name in names if name not in {"", "asset", "path"}]
         if unexpected:
-            raise ValueError("nav_paths MultiIndex levels must be named 'asset' and/or 'path'")
+            raise ValueError(
+                "nav_paths MultiIndex levels must be named 'asset' and/or 'path'"
+            )
         if "asset" in names:
             asset_level = names.index("asset")
             assets = frame.columns.get_level_values(asset_level)
@@ -114,7 +116,9 @@ def make(
                 y0=0,
                 y1=1,
                 yref="paper",
-                line=dict(color=DEFAULT_COLORS[(idx + 1) % len(DEFAULT_COLORS)], dash="dash"),
+                line=dict(
+                    color=DEFAULT_COLORS[(idx + 1) % len(DEFAULT_COLORS)], dash="dash"
+                ),
             )
             fig.add_annotation(
                 x=q_value,

--- a/src/trend_analysis/viz/utils.py
+++ b/src/trend_analysis/viz/utils.py
@@ -104,9 +104,10 @@ def quantile_bands(
 
     q_values = sorted(validate_quantiles(quantiles))
     bands: list[QuantileBand] = []
-    for lower, upper in zip(q_values, reversed(q_values), strict=False):
+    for idx, lower in enumerate(q_values):
+        upper = q_values[-(idx + 1)]
         if lower >= upper:
-            continue
+            break
         bands.append(QuantileBand(lower=lower, upper=upper))
     return tuple(bands)
 

--- a/tests/test_viz_package_import.py
+++ b/tests/test_viz_package_import.py
@@ -1,0 +1,9 @@
+"""Tests for viz package import behavior."""
+
+import sys
+
+
+def test_viz_import_does_not_load_streamlit():
+    import trend_analysis.viz  # noqa: F401
+
+    assert "streamlit" not in sys.modules

--- a/tests/viz/test_fan_helpers.py
+++ b/tests/viz/test_fan_helpers.py
@@ -1,0 +1,41 @@
+"""Tests for fan helper utilities."""
+
+import pandas as pd
+import pytest
+
+from trend_analysis.viz.fan import _select_nav_paths
+
+
+def test_select_nav_paths_empty_frame_raises():
+    empty = pd.DataFrame()
+
+    with pytest.raises(ValueError, match="nav_paths cannot be empty"):
+        _select_nav_paths(empty, max_paths=None)
+
+
+def test_select_nav_paths_unsorted_labels_sorts_index():
+    dates = pd.to_datetime(["2020-03-31", "2020-01-31", "2020-02-29"])
+    frame = pd.DataFrame(
+        {
+            0.9: [1.2, 1.0, 1.1],
+            0.1: [0.8, 0.9, 0.95],
+        },
+        index=dates,
+    )
+
+    selected = _select_nav_paths(frame, max_paths=None)
+
+    assert selected.shape == (3, 2)
+    assert list(selected.index) == sorted(dates)
+
+
+def test_select_nav_paths_duplicate_labels_raise():
+    dates = pd.date_range("2020-01-31", periods=3, freq="ME")
+    frame = pd.DataFrame(
+        [[1.0, 1.0], [1.1, 1.1], [1.2, 1.2]],
+        index=dates,
+        columns=["path_1", "path_1"],
+    )
+
+    with pytest.raises(ValueError, match="duplicate path labels"):
+        _select_nav_paths(frame, max_paths=None)

--- a/tests/viz/test_fan_make.py
+++ b/tests/viz/test_fan_make.py
@@ -1,0 +1,23 @@
+"""Tests for fan chart make helper."""
+
+import json
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from trend_analysis.viz import fan
+
+
+def test_fan_make_minimal_input():
+    dates = pd.date_range("2020-01-31", periods=3, freq="ME")
+    nav_paths = {
+        "path_1": [1.0, 1.1, 1.2],
+        "path_2": [1.0, 0.9, 1.05],
+    }
+    frame = pd.DataFrame(nav_paths, index=dates)
+
+    fig = fan.make(frame, max_paths=None, show_paths=True)
+
+    assert isinstance(fig, go.Figure)
+    payload = fig.to_json()
+    assert json.loads(payload)

--- a/tests/viz/test_path_dist_helpers.py
+++ b/tests/viz/test_path_dist_helpers.py
@@ -1,0 +1,61 @@
+"""Tests for path distribution helper utilities."""
+
+import pandas as pd
+import pytest
+
+from trend_analysis.viz.path_dist import _select_terminal_values
+
+
+def test_select_terminal_values_unexpected_level_names_raise():
+    dates = pd.date_range("2020-01-31", periods=2, freq="ME")
+    columns = pd.MultiIndex.from_product(
+        [["scenario_a", "scenario_b"], ["path_1", "path_2"]],
+        names=["scenario", "path"],
+    )
+    frame = pd.DataFrame(
+        [[1.0, 1.1, 0.9, 1.05], [1.2, 1.3, 1.0, 1.1]],
+        index=dates,
+        columns=columns,
+    )
+
+    with pytest.raises(ValueError, match="MultiIndex levels must be named"):
+        _select_terminal_values(frame, max_paths=None)
+
+
+def test_select_terminal_values_unexpected_level_order():
+    dates = pd.date_range("2020-01-31", periods=3, freq="ME")
+    columns = pd.MultiIndex.from_product(
+        [["path_1", "path_2"], ["NAV"]],
+        names=["path", "asset"],
+    )
+    frame = pd.DataFrame(
+        [
+            [1.0, 1.0],
+            [1.1, 0.9],
+            [1.2, 1.05],
+        ],
+        index=dates,
+        columns=columns,
+    )
+
+    terminal = _select_terminal_values(frame, max_paths=None)
+
+    assert terminal.loc["path_1"] == 1.2
+    assert terminal.loc["path_2"] == 1.05
+
+
+def test_select_terminal_values_coerces_numeric_strings():
+    dates = pd.date_range("2020-01-31", periods=2, freq="ME")
+    frame = pd.DataFrame(
+        {
+            "path_1": ["1.0", "1.2"],
+            "path_2": ["0.9", "1.1"],
+        },
+        index=dates,
+    )
+
+    terminal = _select_terminal_values(frame, max_paths=None)
+
+    assert pd.api.types.is_numeric_dtype(terminal)
+    assert terminal.loc["path_1"] == 1.2
+    assert terminal.loc["path_2"] == 1.1

--- a/tests/viz/test_path_dist_make.py
+++ b/tests/viz/test_path_dist_make.py
@@ -1,0 +1,23 @@
+"""Tests for path distribution make helper."""
+
+import json
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from trend_analysis.viz import path_dist
+
+
+def test_path_dist_make_minimal_input():
+    dates = pd.date_range("2020-01-31", periods=4, freq="ME")
+    nav_paths = {
+        "path_1": [1.0, 1.05, 1.1, 1.2],
+        "path_2": [1.0, 0.98, 1.02, 1.08],
+    }
+    frame = pd.DataFrame(nav_paths, index=dates)
+
+    fig = path_dist.make(frame, bins=5, max_paths=None)
+
+    assert isinstance(fig, go.Figure)
+    payload = fig.to_json()
+    assert json.loads(payload)

--- a/tests/viz/test_risk_return_make.py
+++ b/tests/viz/test_risk_return_make.py
@@ -1,0 +1,24 @@
+"""Tests for risk/return make helper."""
+
+import json
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from trend_analysis.viz import risk_return
+
+
+def test_risk_return_make_minimal_input():
+    returns = pd.DataFrame(
+        {
+            "strategy_a": [0.01, -0.02, 0.015, 0.005],
+            "strategy_b": [0.0, 0.01, -0.005, 0.02],
+        },
+        index=pd.date_range("2020-01-31", periods=4, freq="ME"),
+    )
+
+    fig = risk_return.make(returns, periods_per_year=12.0)
+
+    assert isinstance(fig, go.Figure)
+    payload = fig.to_json()
+    assert json.loads(payload)

--- a/tests/viz/test_utils_quantile_bands.py
+++ b/tests/viz/test_utils_quantile_bands.py
@@ -1,0 +1,18 @@
+"""Tests for quantile band pairing behavior."""
+
+from trend_analysis.viz.utils import quantile_bands
+
+
+def test_quantile_bands_even_pairing():
+    bands = quantile_bands([0.1, 0.25, 0.75, 0.9])
+
+    assert [(band.lower, band.upper) for band in bands] == [
+        (0.1, 0.9),
+        (0.25, 0.75),
+    ]
+
+
+def test_quantile_bands_odd_length():
+    bands = quantile_bands([0.05, 0.5, 0.95])
+
+    assert [(band.lower, band.upper) for band in bands] == [(0.05, 0.95)]


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #4856

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #4855 addressed issue #4846, but verification still failed due to missing package initialization, insufficient test coverage for the viz modules, and a Python-version compatibility risk in `utils.quantile_bands()`. This follow-up closes those gaps by adding a minimal `viz` package initializer (that does not pull in Streamlit), adding targeted unit tests for imports and `make(...)` functions (including Plotly JSON serialization), improving compatibility for Python < 3.10, and adding edge-case tests for fan-chart DataFrame selection helpers.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#4855](https://github.com/stranske/Trend_Model_Project/issues/4855)
- [#4846](https://github.com/stranske/Trend_Model_Project/issues/4846)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Create `src/trend_analysis/viz/__init__.py` with a minimal initializer that does not import `streamlit` and does not import viz implementation modules (`fan`, `path_dist`, `risk_return`) at import time
- [x] Add `tests/test_viz_package_import.py` to import `trend_analysis.viz` and assert `"streamlit" not in sys.modules` after import
- [x] Add `tests/viz/test_fan_make.py` to call `trend_analysis.viz.fan.make(...)` with minimal valid input and assert `isinstance(fig, plotly.graph_objects.Figure)` and `json.loads(fig.to_json())` succeeds
- [x] Add `tests/viz/test_path_dist_make.py` to call `trend_analysis.viz.path_dist.make(...)` with minimal valid input and assert `isinstance(fig, plotly.graph_objects.Figure)` and `json.loads(fig.to_json())` succeeds
- [x] Add `tests/viz/test_risk_return_make.py` to call `trend_analysis.viz.risk_return.make(...)` with minimal valid input and assert `isinstance(fig, plotly.graph_objects.Figure)` and `json.loads(fig.to_json())` succeeds
- [x] Update `trend_analysis.viz.utils.quantile_bands(...)` to remove usage of `zip(..., strict=False)` by implementing equivalent pairing logic compatible with Python < 3.10
- [x] Add `tests/viz/test_utils_quantile_bands.py` to exercise `quantile_bands(...)` pairing behavior, including at least one expected pairing case and at least one mismatched/odd-length quantile inputs case (assert output pairing or a well-defined exception)
- [x] Add tests for `_select_nav_paths` with empty DataFrame input asserting specific exception type and message substring
- [x] Add tests for `_select_nav_paths` with unsorted quantile labels asserting correct DataFrame shape and index order
- [x] Add tests for `_select_nav_paths` with duplicate quantile labels asserting specific exception type and message substring
- [x] Add tests for `_select_terminal_values` with MultiIndex having unexpected level names asserting specific exception type and message substring
- [x] Add tests for `_select_terminal_values` with MultiIndex having unexpected level order asserting correct numeric output values
- [x] Add tests for `_select_terminal_values` with numeric values provided as strings asserting correct dtype coercion to numeric types

#### Acceptance criteria
- [x] `src/trend_analysis/viz/__init__.py` exists, and `import trend_analysis.viz` does not raise when `streamlit` is not installed
- [x] After `import trend_analysis.viz`, `"streamlit"` is not present in `sys.modules`
- [x] `src/trend_analysis/viz/__init__.py` contains no `import streamlit` statement and does not import `fan`, `path_dist`, or `risk_return` at import time
- [x] Calling `trend_analysis.viz.fan.make(...)` with minimal valid input returns an instance of `plotly.graph_objects.Figure`
- [x] The Figure from `trend_analysis.viz.fan.make(...)` is JSON-serializable: `fig.to_json()` completes without raising and `json.loads(...)` parses the returned string
- [x] Calling `trend_analysis.viz.path_dist.make(...)` with minimal valid input returns an instance of `plotly.graph_objects.Figure`
- [x] The Figure from `trend_analysis.viz.path_dist.make(...)` is JSON-serializable: `fig.to_json()` completes without raising and `json.loads(...)` parses the returned string
- [x] Calling `trend_analysis.viz.risk_return.make(...)` with minimal valid input returns an instance of `plotly.graph_objects.Figure`
- [x] The Figure from `trend_analysis.viz.risk_return.make(...)` is JSON-serializable: `fig.to_json()` completes without raising and `json.loads(...)` parses the returned string
- [x] `trend_analysis.viz.utils.quantile_bands(...)` contains no usage of `zip(..., strict=...)` and executes without requiring Python 3.10+ language features
- [x] `tests/viz/test_utils_quantile_bands.py` exists and passes, including coverage for mismatched/odd-length quantile inputs per intended behavior
- [x] `_select_nav_paths` has automated tests covering: (1) empty input, (2) unsorted quantile labels, (3) duplicate quantile labels; each asserts a specific returned DataFrame shape/index or a specific exception type and message substring
- [x] `_select_terminal_values` has automated tests covering: (1) MultiIndex quirks (unexpected level names/order), and (2) dtype coercion (numeric values provided as strings); each asserts correct numeric output values/dtypes or a specific exception type and message substring
- [x] Pytest collects the new test files: `tests/test_viz_package_import.py`, `tests/viz/test_fan_make.py`, `tests/viz/test_path_dist_make.py`, `tests/viz/test_risk_return_make.py`, `tests/viz/test_utils_quantile_bands.py`, and tests for `_select_nav_paths` and `_select_terminal_values` edge cases

<!-- auto-status-summary:end -->