### PR TITLE
Fix silent CASH injection failures and enable fallback in cost scenario

### DIFF
--- a/config/scenarios/monte_carlo/cost_regime_example.yml
+++ b/config/scenarios/monte_carlo/cost_regime_example.yml
@@ -9,6 +9,12 @@ scenario:
 
 base_config: config/defaults.yml
 
+# Override the default to enable CASH column injection when risk_free_column is
+# absent.  Without this the runner silently skips CASH injection because
+# defaults.yml sets allow_risk_free_fallback: false.
+data:
+  allow_risk_free_fallback: true
+
 monte_carlo:
   mode: two_layer
   n_paths: 20

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -1213,24 +1213,47 @@ class MonteCarloRunner:
         try:
             config = Config(**self._base_config)
         except Exception:
+            self._logger.warning(
+                "CASH injection skipped: failed to parse base config"
+            )
             return returns
         data_settings = config.data or {}
         if data_settings.get("risk_free_column"):
             return returns
         if data_settings.get("allow_risk_free_fallback") is not True:
+            self._logger.warning(
+                "CASH injection skipped: data.allow_risk_free_fallback is not "
+                "enabled (set to true in your config to allow CASH column "
+                "injection)"
+            )
             return returns
         try:
             resolution = resolve_risk_free_source(returns, config)
         except Exception as exc:
-            self._logger.debug("Failed to inject CASH returns: %s", exc)
+            self._logger.warning("CASH injection failed: %s", exc)
             return returns
         risk_free = resolution.risk_free
         if not isinstance(risk_free, pd.Series):
+            self._logger.warning(
+                "CASH injection skipped: resolved risk-free source is not a "
+                "Series (source=%s)",
+                getattr(resolution, "source", "unknown"),
+            )
             return returns
         cash_values = pd.to_numeric(risk_free, errors="coerce")
         if len(cash_values) != len(returns):
+            self._logger.warning(
+                "CASH injection skipped: risk-free length (%d) does not match "
+                "returns length (%d)",
+                len(cash_values),
+                len(returns),
+            )
             return returns
         if cash_values.isna().any():
+            self._logger.warning(
+                "CASH injection skipped: resolved risk-free series contains "
+                "NaN values"
+            )
             return returns
         out = returns.copy()
         out["CASH"] = cash_values.to_numpy(dtype=float, copy=False)

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -194,6 +194,7 @@ class MonteCarloRunner:
         self._base_config = self._coerce_base_config(base_config)
         self._price_history = price_history
         self._logger = logger or logging.getLogger("trend_analysis.monte_carlo")
+        self._cash_injection_warned = False
         self._seed_manager: SeedManager | None = None
         self._seed_manager_init = False
         self._cost_process: CostProcess | None = None
@@ -1207,39 +1208,46 @@ class MonteCarloRunner:
             self._logger.debug("Failed to compute score frame: %s", exc)
             return pd.DataFrame()
 
+    def _warn_cash_once(self, msg: str, *args: object) -> None:
+        """Emit a CASH-injection warning at most once per runner lifetime."""
+        if self._cash_injection_warned:
+            return
+        self._cash_injection_warned = True
+        self._logger.warning(msg, *args)
+
     def _inject_cash_returns(self, returns: pd.DataFrame) -> pd.DataFrame:
         if "CASH" in returns.columns:
             return returns
         try:
             config = Config(**self._base_config)
         except Exception:
-            self._logger.warning("CASH injection skipped: failed to parse base config")
+            self._warn_cash_once("CASH injection skipped: failed to parse base config")
             return returns
         data_settings = config.data or {}
         if data_settings.get("risk_free_column"):
             return returns
         if data_settings.get("allow_risk_free_fallback") is not True:
-            self._logger.warning(
+            self._warn_cash_once(
                 "CASH injection skipped: data.allow_risk_free_fallback is not "
-                "enabled (set to true in your config to allow CASH column "
-                "injection)"
+                "enabled (set to true in your scenario or base config to "
+                "allow CASH column injection)"
             )
             return returns
         try:
             resolution = resolve_risk_free_source(returns, config)
         except Exception as exc:
-            self._logger.warning("CASH injection failed: %s", exc)
+            self._warn_cash_once("CASH injection failed: %s", exc)
             return returns
         risk_free = resolution.risk_free
         if not isinstance(risk_free, pd.Series):
-            self._logger.warning(
-                "CASH injection skipped: resolved risk-free source is not a " "Series (source=%s)",
+            self._warn_cash_once(
+                "CASH injection skipped: resolved risk-free source is not a Series (source=%s)",
                 getattr(resolution, "source", "unknown"),
             )
             return returns
         cash_values = pd.to_numeric(risk_free, errors="coerce")
         if len(cash_values) != len(returns):
-            self._logger.warning(
+            self._warn_cash_once(
                 "CASH injection skipped: risk-free length (%d) does not match "
                 "returns length (%d)",
                 len(cash_values),
@@ -1247,8 +1255,8 @@ class MonteCarloRunner:
             )
             return returns
         if cash_values.isna().any():
-            self._logger.warning(
-                "CASH injection skipped: resolved risk-free series contains " "NaN values"
+            self._warn_cash_once(
+                "CASH injection skipped: resolved risk-free series contains NaN values"
             )
             return returns
         out = returns.copy()
@@ -1903,12 +1911,54 @@ class MonteCarloRunner:
             payload = yaml.safe_load(raw)
             if not isinstance(payload, dict):
                 raise ValueError("Base config must be a mapping")
+            payload = self._apply_scenario_overrides(payload)
             return self._ensure_required_sections(payload)
         if hasattr(base_config, "model_dump"):
             payload = base_config.model_dump()
         else:
             payload = dict(base_config)
+        payload = self._apply_scenario_overrides(payload)
         return self._ensure_required_sections(payload)
+
+    def _apply_scenario_overrides(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Merge scenario-level section overrides into the base config.
+
+        Scenario YAML files may contain top-level keys like ``data`` that
+        should override values inherited from ``base_config``.  Without this
+        merge the overrides sit in ``scenario.raw`` but never reach the
+        runtime config dict.
+        """
+        raw = getattr(self.scenario, "raw", None)
+        if not isinstance(raw, Mapping):
+            return config
+        # Only merge keys that correspond to known config sections so we
+        # don't accidentally inject scenario-only keys (e.g. ``costs``,
+        # ``strategy_set``) into the pipeline config.
+        mergeable_sections = (
+            "data",
+            "preprocessing",
+            "vol_adjust",
+            "sample_split",
+            "portfolio",
+            "metrics",
+            "benchmarks",
+            "export",
+            "run",
+            "regime",
+        )
+        updated = dict(config)
+        for section in mergeable_sections:
+            override = raw.get(section)
+            if override is None or not isinstance(override, Mapping):
+                continue
+            existing = updated.get(section)
+            if isinstance(existing, dict):
+                merged = dict(existing)
+                merged.update(override)
+                updated[section] = merged
+            else:
+                updated[section] = dict(override)
+        return updated
 
     def _ensure_required_sections(self, config: dict[str, Any]) -> dict[str, Any]:
         required = [

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -1213,9 +1213,7 @@ class MonteCarloRunner:
         try:
             config = Config(**self._base_config)
         except Exception:
-            self._logger.warning(
-                "CASH injection skipped: failed to parse base config"
-            )
+            self._logger.warning("CASH injection skipped: failed to parse base config")
             return returns
         data_settings = config.data or {}
         if data_settings.get("risk_free_column"):
@@ -1235,8 +1233,7 @@ class MonteCarloRunner:
         risk_free = resolution.risk_free
         if not isinstance(risk_free, pd.Series):
             self._logger.warning(
-                "CASH injection skipped: resolved risk-free source is not a "
-                "Series (source=%s)",
+                "CASH injection skipped: resolved risk-free source is not a " "Series (source=%s)",
                 getattr(resolution, "source", "unknown"),
             )
             return returns
@@ -1251,8 +1248,7 @@ class MonteCarloRunner:
             return returns
         if cash_values.isna().any():
             self._logger.warning(
-                "CASH injection skipped: resolved risk-free series contains "
-                "NaN values"
+                "CASH injection skipped: resolved risk-free series contains " "NaN values"
             )
             return returns
         out = returns.copy()

--- a/tests/monte_carlo/test_costs.py
+++ b/tests/monte_carlo/test_costs.py
@@ -238,9 +238,7 @@ def test_runner_injects_cash_series_when_risk_free_column_absent(monkeypatch: An
         assert np.isfinite(cash_series.to_numpy(dtype=float, copy=False)).all()
 
 
-def test_inject_cash_warns_when_fallback_disabled(
-    monkeypatch: Any, caplog: Any
-) -> None:
+def test_inject_cash_warns_when_fallback_disabled(monkeypatch: Any, caplog: Any) -> None:
     """When allow_risk_free_fallback is False the runner should log a warning
     explaining why CASH injection was skipped."""
     scenario = load_scenario("cost_regime_example")
@@ -271,11 +269,11 @@ def test_inject_cash_warns_when_fallback_disabled(
 
     assert captured_returns
     for returns in captured_returns:
-        assert "CASH" not in returns.columns, (
-            "CASH should not be injected when allow_risk_free_fallback is False"
-        )
+        assert (
+            "CASH" not in returns.columns
+        ), "CASH should not be injected when allow_risk_free_fallback is False"
 
     warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
-    assert any("allow_risk_free_fallback" in msg for msg in warning_messages), (
-        f"Expected a warning about allow_risk_free_fallback, got: {warning_messages}"
-    )
+    assert any(
+        "allow_risk_free_fallback" in msg for msg in warning_messages
+    ), f"Expected a warning about allow_risk_free_fallback, got: {warning_messages}"

--- a/tests/monte_carlo/test_costs.py
+++ b/tests/monte_carlo/test_costs.py
@@ -278,13 +278,13 @@ def test_inject_cash_warns_when_fallback_disabled(monkeypatch: Any, caplog: Any)
 
     warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
     fallback_warnings = [m for m in warning_messages if "allow_risk_free_fallback" in m]
-    assert fallback_warnings, (
-        f"Expected a warning about allow_risk_free_fallback, got: {warning_messages}"
-    )
+    assert (
+        fallback_warnings
+    ), f"Expected a warning about allow_risk_free_fallback, got: {warning_messages}"
     # P2 fix: The warning should be emitted only once, not per path.
-    assert len(fallback_warnings) == 1, (
-        f"Expected exactly 1 fallback warning but got {len(fallback_warnings)}"
-    )
+    assert (
+        len(fallback_warnings) == 1
+    ), f"Expected exactly 1 fallback warning but got {len(fallback_warnings)}"
 
 
 def test_scenario_data_override_merges_into_base_config(
@@ -307,6 +307,6 @@ def test_scenario_data_override_merges_into_base_config(
     )
 
     # The merged base config should now have the override applied.
-    assert runner.base_config["data"]["allow_risk_free_fallback"] is True, (
-        "Scenario-level data.allow_risk_free_fallback should override defaults"
-    )
+    assert (
+        runner.base_config["data"]["allow_risk_free_fallback"] is True
+    ), "Scenario-level data.allow_risk_free_fallback should override defaults"

--- a/tests/monte_carlo/test_costs.py
+++ b/tests/monte_carlo/test_costs.py
@@ -245,6 +245,9 @@ def test_inject_cash_warns_when_fallback_disabled(monkeypatch: Any, caplog: Any)
     scenario.monte_carlo.n_paths = 10
     scenario.strategy_set = {"curated": [StrategyVariant(name="StrategyA")]}
     scenario.costs = None
+    # Remove the scenario-level data override so the base_config value wins.
+    if isinstance(scenario.raw, dict):
+        scenario.raw.pop("data", None)
 
     base_cfg = _base_config()
     base_cfg["data"]["allow_risk_free_fallback"] = False
@@ -274,6 +277,36 @@ def test_inject_cash_warns_when_fallback_disabled(monkeypatch: Any, caplog: Any)
         ), "CASH should not be injected when allow_risk_free_fallback is False"
 
     warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
-    assert any(
-        "allow_risk_free_fallback" in msg for msg in warning_messages
-    ), f"Expected a warning about allow_risk_free_fallback, got: {warning_messages}"
+    fallback_warnings = [m for m in warning_messages if "allow_risk_free_fallback" in m]
+    assert fallback_warnings, (
+        f"Expected a warning about allow_risk_free_fallback, got: {warning_messages}"
+    )
+    # P2 fix: The warning should be emitted only once, not per path.
+    assert len(fallback_warnings) == 1, (
+        f"Expected exactly 1 fallback warning but got {len(fallback_warnings)}"
+    )
+
+
+def test_scenario_data_override_merges_into_base_config(
+    monkeypatch: Any,
+) -> None:
+    """Scenario-level data overrides (e.g. allow_risk_free_fallback) should be
+    merged into the runner's base config even when the base config file sets
+    a different value."""
+    scenario = load_scenario("cost_regime_example")
+    scenario.monte_carlo.n_paths = 10
+    scenario.strategy_set = {"curated": [StrategyVariant(name="StrategyA")]}
+    scenario.costs = None
+
+    # Do NOT pass base_config — let the runner load it from the scenario's
+    # base_config path.  The scenario YAML sets data.allow_risk_free_fallback:
+    # true which should override defaults.yml's false.
+    runner = MonteCarloRunner(
+        scenario,
+        price_history=_price_history(),
+    )
+
+    # The merged base config should now have the override applied.
+    assert runner.base_config["data"]["allow_risk_free_fallback"] is True, (
+        "Scenario-level data.allow_risk_free_fallback should override defaults"
+    )

--- a/tests/monte_carlo/test_costs.py
+++ b/tests/monte_carlo/test_costs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import numpy as np
@@ -235,3 +236,46 @@ def test_runner_injects_cash_series_when_risk_free_column_absent(monkeypatch: An
         cash_series = returns["CASH"]
         assert pd.api.types.is_numeric_dtype(cash_series)
         assert np.isfinite(cash_series.to_numpy(dtype=float, copy=False)).all()
+
+
+def test_inject_cash_warns_when_fallback_disabled(
+    monkeypatch: Any, caplog: Any
+) -> None:
+    """When allow_risk_free_fallback is False the runner should log a warning
+    explaining why CASH injection was skipped."""
+    scenario = load_scenario("cost_regime_example")
+    scenario.monte_carlo.n_paths = 10
+    scenario.strategy_set = {"curated": [StrategyVariant(name="StrategyA")]}
+    scenario.costs = None
+
+    base_cfg = _base_config()
+    base_cfg["data"]["allow_risk_free_fallback"] = False
+
+    runner = MonteCarloRunner(
+        scenario,
+        base_config=base_cfg,
+        price_history=_price_history(),
+    )
+
+    captured_returns: list[pd.DataFrame] = []
+
+    def fake_run_simulation(config: Any, returns: pd.DataFrame) -> RunResult:
+        captured_returns.append(returns.copy())
+        metrics = pd.DataFrame({"annual_return": [0.1]}, index=["user_weight"])
+        return RunResult(metrics=metrics, details={}, seed=0, environment={})
+
+    monkeypatch.setattr(runner_module, "run_simulation", fake_run_simulation)
+
+    with caplog.at_level(logging.WARNING, logger="trend_analysis.monte_carlo"):
+        _ = runner.run(jobs=1)
+
+    assert captured_returns
+    for returns in captured_returns:
+        assert "CASH" not in returns.columns, (
+            "CASH should not be injected when allow_risk_free_fallback is False"
+        )
+
+    warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("allow_risk_free_fallback" in msg for msg in warning_messages), (
+        f"Expected a warning about allow_risk_free_fallback, got: {warning_messages}"
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #4882

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
We need one "known good" scenario that exercises:
- cost regime switching (calm vs stress)
- slippage multipliers
- explicit risk-free/CASH series injection in simulated returns

This ensures future regressions in cost modeling are caught quickly through automated testing.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#4881](https://github.com/stranske/Trend_Model_Project/issues/4881)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
### Scenario Configuration
- [x] Create a new scenario YAML file in `config/scenarios/monte_carlo/` with a descriptive name like `cost_regime_example.yml`
- [x] Configure the costs section with `kind` set to `regime_stochastic` in the new scenario file
- [x] Define `trade_cost_bps` parameter values for both calm and stress regimes in the scenario
- [x] Define `slippage_multiplier` parameter values for both calm and stress regimes in the scenario
- [x] Add inline comments to the scenario YAML explaining each cost parameter's purpose
- [x] Update `config/scenarios/monte_carlo/index.yml` to register the new scenario with tags including `example` and `costs`

### Test Implementation - Cost Drag Verification
- [x] Decide whether to add the cost regime test to existing `tests/monte_carlo/test_runner.py` or create a new `tests/monte_carlo/test_costs.py` file
- [x] Create a test function that loads the new cost regime scenario using the scenario registry
- [x] Configure the test to run Monte Carlo simulation with a small `n_paths` value like 10 or 20
- [x] Add assertion to verify that `total_cost_drag` column exists in the `results_frame` DataFrame
- [x] Add assertion to verify that `total_cost_drag` contains non-zero numeric values when costs are enabled

### Test Implementation - CASH Column Verification
- [x] Create a test function that configures a scenario without specifying `risk_free_column` parameter
- [x] Run Monte Carlo simulation with the risk-free-absent configuration using small `n_paths`
- [x] Add assertion to verify that `CASH` column exists in the returns DataFrame output
- [x] Add assertion to verify that `CASH` column contains valid numeric values representing risk-free returns

### Documentation
- [ ] Decide whether to document CLI usage in the scenario YAML comments or in `docs/phase-3/MonteCarlo.md`
- [x] Write a comment block at the top of the scenario YAML explaining its purpose and features
- [x] Add a CLI usage example showing how to run the scenario with `trend mc run` command
- [x] Document the expected outputs and cost-related columns that will appear in results

#### Acceptance criteria
- [x] Running `trend mc list` shows the scenario registered from `config/scenarios/monte_carlo/index.yml`
- [x] The scenario is filterable by tags `example` and `costs` via `trend mc list`
- [x] The scenario passes validation when running `trend mc validate <scenario_name>`
- [x] The scenario loads successfully in the added unit/integration test without raising validation errors
- [x] The cost drag verification test passes and confirms `total_cost_drag` appears in `results_frame`
- [x] The cost drag verification test confirms `total_cost_drag` contains non-zero numeric values
- [x] The CASH column verification test passes and confirms `CASH` column exists in returns when `risk_free_column` is absent
- [x] The CASH column verification test confirms `CASH` column contains valid numeric values

**Head SHA:** b82926c07bbc83290f3e3dc6ba3c8d8517163267
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/agents-80-pr-event-hub.yml | ❌ failure | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/21903676843) |
| .github/workflows/dependabot-auto-lock.yml | ❌ failure | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/21903677093) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/21903945209) |
| Autofix | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/21903678661) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/21903677905) |
| Gate | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/21903678675) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Trend_Model_Project/actions/runs/21903678485) |
<!-- auto-status-summary:end -->