### PR TITLE
Codex belt for #4868

### DIFF
--- a/.agents/issue-4868-ledger.yml
+++ b/.agents/issue-4868-ledger.yml
@@ -1,0 +1,118 @@
+version: 1
+issue: 4868
+base: phase-3
+branch: codex/issue-4868
+tasks:
+  - id: task-01
+    title: "Add a \u201CMixture mode seeding\u201D section to `docs/phase-3/MonteCarlo.md`\
+      \ describing mixture-mode determinism and the two execution modes."
+    status: doing
+    started_at: '2026-02-11T12:01:00Z'
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-02
+    title: 'Update `docs/phase-3/MonteCarlo.md` to document the exact condition under
+      which shared-path bulk generation vs per-path generation occurs (explicitly:
+      when per-path seeds match the base `SeedManager` vs when seeds diverge).'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-03
+    title: "Add a troubleshooting note to `docs/phase-3/MonteCarlo.md` titled \u201C\
+      why is my mixture run slower?\u201D explaining the performance tradeoff when\
+      \ per-path generation is selected."
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-04
+    title: Add a debug log line in `src/trend_analysis/monte_carlo/runner.py` that
+      logs when mixture-mode chooses per-path generation (optional).
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-05
+    title: "`docs/phase-3/MonteCarlo.md` contains a \u201CMixture mode seeding\u201D\
+      \ section that states mixture-mode determinism rules and distinguishes shared-path\
+      \ bulk vs per-path generation."
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-06
+    title: '`docs/phase-3/MonteCarlo.md` explicitly states the condition that determines
+      whether a run uses shared-path bulk generation or per-path generation (matching
+      base `SeedManager` seeds vs diverging per-path seeds).'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-07
+    title: "`docs/phase-3/MonteCarlo.md` includes a \u201Cwhy is my mixture run slower?\u201D\
+      \ troubleshooting note describing that per-path generation can be slower than\
+      \ shared-path bulk generation."
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-08
+    title: If `src/trend_analysis/monte_carlo/runner.py` is modified, it emits a debug
+      log message when mixture-mode selects per-path generation.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-09
+    title: "Add a \u201CMixture mode seeding\u201D section to `docs/phase-3/MonteCarlo.md`"
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-10
+    title: Document the exact condition under which bulk vs per-path generation occurs
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-11
+    title: "Add a short troubleshooting note (\u201Cwhy is my mixture run slower?\u201D\
+      )"
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-12
+    title: (Optional) Add a debug log line when mixture chooses per-path mode
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-13
+    title: Documentation explains mixture mode determinism and performance at a glance
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-14
+    title: Users can predict whether a run will use shared-path or per-path generation
+      from config
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []

--- a/.agents/issue-4868-ledger.yml
+++ b/.agents/issue-4868-ledger.yml
@@ -6,10 +6,10 @@ tasks:
   - id: task-01
     title: "Add a \u201CMixture mode seeding\u201D section to `docs/phase-3/MonteCarlo.md`\
       \ describing mixture-mode determinism and the two execution modes."
-    status: doing
+    status: done
     started_at: '2026-02-11T12:01:00Z'
-    finished_at: null
-    commit: ''
+    finished_at: '2026-02-11T12:01:09Z'
+    commit: 9ce393393a707343fbf82353e7544d557b51f24c
     notes: []
   - id: task-02
     title: 'Update `docs/phase-3/MonteCarlo.md` to document the exact condition under

--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -62,6 +62,24 @@ This implies an **expected variance-reduction factor of ~100x** (independent var
 
 This meets the documented expectation of ~100x reduction for the benchmark configuration.
 
+### Mixture mode seeding
+
+Mixture mode remains deterministic when a scenario seed is set, but it has two valid execution modes:
+
+1. **Shared-path bulk generation**: generate all paths in one bulk call, then evaluate one sampled strategy per path.
+2. **Per-path generation**: generate each path independently with that path's seed, then evaluate one sampled strategy for that path.
+
+The exact mode-selection condition is:
+
+- Use **shared-path bulk generation** when per-path seeds match what the base `SeedManager` would produce for the run seed (or when all per-path seeds are `None`).
+- Use **per-path generation** when per-path seeds diverge from the base `SeedManager` sequence.
+
+Both modes are deterministic for fixed inputs and fixed seeds; they differ in how path generation work is scheduled.
+
+#### why is my mixture run slower?
+
+If mixture mode selects **per-path generation**, the runner performs many small model calls (`n_paths=1`) instead of one bulk call (`n_paths=N`). This can be slower due to repeated setup overhead and reduced vectorization compared with shared-path bulk generation.
+
 ---
 
 ## Goals and Non-Goals

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -505,21 +505,36 @@ class MonteCarloRunner:
         evaluations: list[StrategyEvaluation] = []
         errors: list[MonteCarloPathError] = []
         base_seed = self._settings().seed
-
-        try:
-            path_result = model.sample_prices(
-                n_periods=n_periods,
-                n_paths=total,
-                frequency=self.scenario.simulation_frequency(),
-                seed=base_seed,
+        seed_manager = SeedManager(base_seed) if base_seed is not None else None
+        seeds_match_base = False
+        if seed_manager is not None:
+            seeds_match_base = all(
+                seed == seed_manager.get_path_seed(path_id)
+                for path_id, seed in enumerate(path_seeds)
+                if seed is not None
             )
-        except Exception as exc:
-            for path_id in range(total):
-                self._log_path_error(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
-                errors.append(
-                    self._error_record(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
+        shared_paths = seeds_match_base or all(seed is None for seed in path_seeds)
+
+        path_result = None
+        if shared_paths:
+            try:
+                path_result = model.sample_prices(
+                    n_periods=n_periods,
+                    n_paths=total,
+                    frequency=self.scenario.simulation_frequency(),
+                    seed=base_seed,
                 )
-            return evaluations, errors
+            except Exception as exc:
+                for path_id in range(total):
+                    self._log_path_error(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
+                    errors.append(
+                        self._error_record(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
+                    )
+                return evaluations, errors
+        else:
+            self._logger.debug(
+                "Mixture mode selected per-path generation because path seeds diverge from the base SeedManager"
+            )
 
         def _evaluate_path(
             path_id: int, seed: int | None

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -528,7 +528,9 @@ class MonteCarloRunner:
                 for path_id in range(total):
                     self._log_path_error(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
                     errors.append(
-                        self._error_record(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
+                        self._error_record(
+                            path_id, None, exc, fold_id=fold_id, fold_label=fold_label
+                        )
                     )
                 return evaluations, errors
         else:

--- a/tests/monte_carlo/test_runner.py
+++ b/tests/monte_carlo/test_runner.py
@@ -1315,6 +1315,172 @@ def test_run_mixture_deterministic() -> None:
     pd.testing.assert_frame_equal(frame1, frame2)
 
 
+def test_run_mixture_uses_shared_bulk_generation_when_path_seeds_match_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenario = _scenario("mixture")
+    runner = MonteCarloRunner(
+        scenario,
+        base_config=_base_config(),
+        price_history=_price_history(),
+    )
+    n_periods = runner._compute_n_periods()
+    total = scenario.monte_carlo.n_paths
+    assert total is not None
+    strategies = runner._resolve_strategies()
+    path_seeds, strategy_seeds = runner._build_seeds()
+    call_log: list[dict[str, Any]] = []
+
+    class _RecordingModel:
+        def sample_prices(
+            self,
+            *,
+            n_periods: int,
+            n_paths: int,
+            frequency: str,
+            seed: int | None,
+        ) -> Any:
+            call_log.append(
+                {
+                    "n_periods": n_periods,
+                    "n_paths": n_paths,
+                    "frequency": frequency,
+                    "seed": seed,
+                }
+            )
+            index = pd.date_range("2024-01-31", periods=n_periods, freq="ME")
+            columns = pd.MultiIndex.from_product(
+                [range(n_paths), ["AssetA", "AssetB"]],
+                names=["path", "asset"],
+            )
+            prices = pd.DataFrame(100.0, index=index, columns=columns)
+            log_returns = pd.DataFrame(0.0, index=index, columns=columns)
+            return type("PathResult", (), {"prices": prices, "log_returns": log_returns})()
+
+    monkeypatch.setattr(
+        runner,
+        "_compute_score_frame",
+        lambda _returns: pd.DataFrame({"score": [1.0]}, index=["AssetA"]),
+    )
+
+    def _fake_evaluate_strategy(
+        strategy: StrategyVariant, context: runner_module._PathContext
+    ) -> StrategyEvaluation:
+        return StrategyEvaluation(
+            fold_id=None,
+            path_id=context.path_id,
+            strategy_name=strategy.name,
+            metrics={"metric": 1.0},
+            metric_source="stub",
+            path_hash=context.path_hash,
+            seed=context.seed,
+        )
+
+    monkeypatch.setattr(runner, "_evaluate_strategy", _fake_evaluate_strategy)
+
+    evals, errors = runner._run_mixture(
+        model=_RecordingModel(),
+        n_periods=n_periods,
+        strategies=strategies,
+        path_seeds=path_seeds,
+        strategy_seeds=strategy_seeds,
+        progress_callback=None,
+        jobs=1,
+    )
+
+    assert not errors
+    assert len(evals) == total
+    assert len(call_log) == 1
+    assert call_log[0]["n_paths"] == total
+    assert call_log[0]["seed"] == scenario.monte_carlo.seed
+
+
+def test_run_mixture_uses_per_path_generation_when_path_seeds_diverge(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    scenario = _scenario("mixture")
+    runner = MonteCarloRunner(
+        scenario,
+        base_config=_base_config(),
+        price_history=_price_history(),
+    )
+    n_periods = runner._compute_n_periods()
+    total = scenario.monte_carlo.n_paths
+    assert total is not None
+    strategies = runner._resolve_strategies()
+    path_seeds, strategy_seeds = runner._build_seeds()
+    assert path_seeds[0] is not None
+    divergent_seeds = list(path_seeds)
+    divergent_seeds[0] = int(path_seeds[0]) + 1
+    call_log: list[dict[str, Any]] = []
+
+    class _RecordingModel:
+        def sample_prices(
+            self,
+            *,
+            n_periods: int,
+            n_paths: int,
+            frequency: str,
+            seed: int | None,
+        ) -> Any:
+            call_log.append(
+                {
+                    "n_periods": n_periods,
+                    "n_paths": n_paths,
+                    "frequency": frequency,
+                    "seed": seed,
+                }
+            )
+            index = pd.date_range("2024-01-31", periods=n_periods, freq="ME")
+            columns = pd.MultiIndex.from_product(
+                [range(n_paths), ["AssetA", "AssetB"]],
+                names=["path", "asset"],
+            )
+            prices = pd.DataFrame(100.0, index=index, columns=columns)
+            log_returns = pd.DataFrame(0.0, index=index, columns=columns)
+            return type("PathResult", (), {"prices": prices, "log_returns": log_returns})()
+
+    monkeypatch.setattr(
+        runner,
+        "_compute_score_frame",
+        lambda _returns: pd.DataFrame({"score": [1.0]}, index=["AssetA"]),
+    )
+
+    def _fake_evaluate_strategy(
+        strategy: StrategyVariant, context: runner_module._PathContext
+    ) -> StrategyEvaluation:
+        return StrategyEvaluation(
+            fold_id=None,
+            path_id=context.path_id,
+            strategy_name=strategy.name,
+            metrics={"metric": 1.0},
+            metric_source="stub",
+            path_hash=context.path_hash,
+            seed=context.seed,
+        )
+
+    monkeypatch.setattr(runner, "_evaluate_strategy", _fake_evaluate_strategy)
+
+    with caplog.at_level(logging.DEBUG, logger="trend_analysis.monte_carlo"):
+        evals, errors = runner._run_mixture(
+            model=_RecordingModel(),
+            n_periods=n_periods,
+            strategies=strategies,
+            path_seeds=divergent_seeds,
+            strategy_seeds=strategy_seeds,
+            progress_callback=None,
+            jobs=1,
+        )
+
+    assert not errors
+    assert len(evals) == total
+    assert len(call_log) == total
+    assert all(call["n_paths"] == 1 for call in call_log)
+    assert [call["seed"] for call in call_log] == divergent_seeds
+    assert "Mixture mode selected per-path generation" in caplog.text
+
+
 def test_score_frame_uses_rf_override(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = _base_config()
     cfg["metrics"] = {


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #4868

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Mixture-mode has two legitimate execution modes:
shared-path bulk generation (when per-path seeds match the base SeedManager)
per-path generation (when seeds diverge)
Without a documented contract, users can misinterpret determinism and performance characteristics.

#### Tasks
- [x] Add a “Mixture mode seeding” section to `docs/phase-3/MonteCarlo.md` describing mixture-mode determinism and the two execution modes.
- [x] Update `docs/phase-3/MonteCarlo.md` to document the exact condition under which shared-path bulk generation vs per-path generation occurs (explicitly: when per-path seeds match the base `SeedManager` vs when seeds diverge).
- [x] Add a troubleshooting note to `docs/phase-3/MonteCarlo.md` titled “why is my mixture run slower?” explaining the performance tradeoff when per-path generation is selected.
- [x] Add a debug log line in `src/trend_analysis/monte_carlo/runner.py` that logs when mixture-mode chooses per-path generation (optional).

#### Acceptance criteria
- [x] `docs/phase-3/MonteCarlo.md` contains a “Mixture mode seeding” section that states mixture-mode determinism rules and distinguishes shared-path bulk vs per-path generation.
- [x] `docs/phase-3/MonteCarlo.md` explicitly states the condition that determines whether a run uses shared-path bulk generation or per-path generation (matching base `SeedManager` seeds vs diverging per-path seeds).
- [x] `docs/phase-3/MonteCarlo.md` includes a “why is my mixture run slower?” troubleshooting note describing that per-path generation can be slower than shared-path bulk generation.
- [x] If `src/trend_analysis/monte_carlo/runner.py` is modified, it emits a debug log message when mixture-mode selects per-path generation.

<!-- auto-status-summary:end -->