### PR TITLE
Codex belt for #4872

### DIFF
--- a/.agents/issue-4872-ledger.yml
+++ b/.agents/issue-4872-ledger.yml
@@ -7,10 +7,10 @@ tasks:
     title: 'Update `src/trend_analysis/monte_carlo/registry.py` scenario parsing to
       treat `strategy_set: null`, `outputs: null`, and `costs: null` as `None` (instead
       of attempting to coerce as mappings)'
-    status: doing
+    status: done
     started_at: '2026-02-11T12:43:51Z'
-    finished_at: null
-    commit: ''
+    finished_at: '2026-02-11T12:43:59Z'
+    commit: 3789d1760c0116339ff9dc6e28afc699a0247e68
     notes: []
   - id: task-02
     title: 'Add a unit test in `tests/monte_carlo/test_registry.py` that loads a scenario

--- a/.agents/issue-4872-ledger.yml
+++ b/.agents/issue-4872-ledger.yml
@@ -1,0 +1,68 @@
+version: 1
+issue: 4872
+base: phase-3
+branch: codex/issue-4872
+tasks:
+  - id: task-01
+    title: 'Update `src/trend_analysis/monte_carlo/registry.py` scenario parsing to
+      treat `strategy_set: null`, `outputs: null`, and `costs: null` as `None` (instead
+      of attempting to coerce as mappings)'
+    status: doing
+    started_at: '2026-02-11T12:43:51Z'
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-02
+    title: 'Add a unit test in `tests/monte_carlo/test_registry.py` that loads a scenario
+      with `strategy_set: null`, `outputs: null`, and `costs: null` and asserts it
+      parses successfully'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-03
+    title: 'A scenario definition containing `strategy_set: null`, `outputs: null`,
+      and `costs: null` loads without raising an exception in tests'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-04
+    title: Running the existing test suite (including `tests/monte_carlo/test_registry.py`)
+      passes without changes to expected validation for non-null mappings
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-05
+    title: 'Update scenario parsing to treat `strategy_set: null`, `outputs: null`,
+      `costs: null` as `None`'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-06
+    title: Add a unit test scenario confirming null optional sections load cleanly
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-07
+    title: Scenario with null optional sections loads successfully
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-08
+    title: Existing scenarios continue to validate as before
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []

--- a/src/trend_analysis/monte_carlo/registry.py
+++ b/src/trend_analysis/monte_carlo/registry.py
@@ -375,7 +375,7 @@ def _parse_scenario(
     monte_carlo_map = _ensure_mapping(monte_carlo, label="Scenario config 'monte_carlo'")
 
     strategy_set = None
-    if "strategy_set" in raw:
+    if "strategy_set" in raw and raw.get("strategy_set") is not None:
         strategy_set = _ensure_mapping(
             raw.get("strategy_set"), label="Scenario config 'strategy_set'"
         )
@@ -399,11 +399,11 @@ def _parse_scenario(
             strategy_set = merged
 
     outputs = None
-    if "outputs" in raw:
+    if "outputs" in raw and raw.get("outputs") is not None:
         outputs = _ensure_mapping(raw.get("outputs"), label="Scenario config 'outputs'")
 
     costs = None
-    if "costs" in raw:
+    if "costs" in raw and raw.get("costs") is not None:
         costs = _ensure_mapping(raw.get("costs"), label="Scenario config 'costs'")
 
     enable_fold_runs = raw.get("enable_fold_runs", _MISSING)

--- a/tests/monte_carlo/test_registry.py
+++ b/tests/monte_carlo/test_registry.py
@@ -672,6 +672,37 @@ def test_load_scenario_accepts_return_model_mapping(tmp_path: Path) -> None:
     }
 
 
+def test_load_scenario_accepts_null_optional_mappings(tmp_path: Path) -> None:
+    base_config = tmp_path / "base.yml"
+    base_config.write_text("{}", encoding="utf-8")
+    scenario_path = tmp_path / "null_optional.yml"
+    scenario_path.write_text(
+        "scenario:\n"
+        "  name: null_optional\n"
+        "  version: '1'\n"
+        "base_config: base.yml\n"
+        "monte_carlo:\n"
+        "  mode: mixture\n"
+        "  n_paths: 10\n"
+        "  horizon_years: 1\n"
+        "  frequency: M\n"
+        "strategy_set: null\n"
+        "outputs: null\n"
+        "costs: null\n",
+        encoding="utf-8",
+    )
+    registry = tmp_path / "index.yml"
+    registry.write_text(
+        "scenarios:\n" "  - name: null_optional\n" "    path: null_optional.yml\n",
+        encoding="utf-8",
+    )
+
+    scenario = load_scenario("null_optional", registry_path=registry)
+    assert scenario.strategy_set is None
+    assert scenario.outputs is None
+    assert scenario.costs is None
+
+
 def test_load_scenario_rejects_null_folds_mapping(tmp_path: Path) -> None:
     base_config = tmp_path / "base.yml"
     base_config.write_text("{}", encoding="utf-8")


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #4872

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Some scenario authors use `strategy_set: null` (or `outputs: null`, `costs: null`) to indicate intentional absence. Today this can error depending on strict mapping coercion.

#### Tasks
- [x] Update `src/trend_analysis/monte_carlo/registry.py` scenario parsing to treat `strategy_set: null`, `outputs: null`, and `costs: null` as `None` (instead of attempting to coerce as mappings)
- [x] Add a unit test in `tests/monte_carlo/test_registry.py` that loads a scenario with `strategy_set: null`, `outputs: null`, and `costs: null` and asserts it parses successfully

#### Acceptance criteria
- [x] A scenario definition containing `strategy_set: null`, `outputs: null`, and `costs: null` loads without raising an exception in tests
- [x] Running the existing test suite (including `tests/monte_carlo/test_registry.py`) passes without changes to expected validation for non-null mappings

<!-- auto-status-summary:end -->