### PR TITLE
Codex belt for #4851

### DIFF
--- a/.agents/issue-4851-ledger.yml
+++ b/.agents/issue-4851-ledger.yml
@@ -1,0 +1,299 @@
+version: 1
+issue: 4851
+base: phase-3
+branch: codex/issue-4851
+tasks:
+  - id: task-01
+    title: Add test file(s) for visualization smoke tests covering that Plotly figures
+      create successfully and `fig.to_json()` works (e.g., `tests/test_visualization_smoke.py`).
+    status: doing
+    started_at: '2026-02-11T22:26:00Z'
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-02
+    title: 'Create the test file `tests/test_visualization_smoke.py` with basic structure
+      (verify: tests pass)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-03
+    title: 'Create the test file `tests/test_visualization_smoke.py` with imports.
+      (verify: tests pass)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-04
+    title: 'Define scope for: Add a test case verifying that Plotly figures can be
+      created successfully without errors. (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-05
+    title: 'Implement focused slice for: Add a test case verifying that Plotly figures
+      can be created successfully without errors. (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-06
+    title: 'Validate focused slice for: Add a test case verifying that Plotly figures
+      can be created successfully without errors. (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-07
+    title: 'Define scope for: Add a test case verifying that `fig.to_json()` returns
+      valid JSON output for created figures. (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-08
+    title: 'Implement focused slice for: Add a test case verifying that `fig.to_json()`
+      returns valid JSON output for created figures. (verify: confirm completion in
+      repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-09
+    title: 'Validate focused slice for: Add a test case verifying that `fig.to_json()`
+      returns valid JSON output for created figures. (verify: confirm completion in
+      repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-10
+    title: Add test(s) validating the `nav_paths` contract/schema used by the visualization
+      layer (e.g., `tests/test_nav_paths_contract.py`).
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-11
+    title: Add test(s) covering adapter behavior for `nav_paths` inputs/outputs (e.g.,
+      `tests/test_nav_paths_adapters.py`).
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-12
+    title: Add test(s) verifying export behavior works without Kaleido installed (e.g.,
+      `tests/test_export_without_kaleido.py`).
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-13
+    title: Create documentation at `docs/monte_carlo/visualization.md` describing
+      the `nav_paths` schema and chart extension points, including how to trigger
+      agent work post-creation.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-14
+    title: 'Create the documentation file `docs/monte_carlo/visualization.md` with
+      basic structure (verify: docs updated)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-15
+    title: 'Create the documentation file `docs/monte_carlo/visualization.md` with
+      headings. (verify: docs updated)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-16
+    title: 'Document the `nav_paths` schema including field definitions (verify: confirm
+      completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-17
+    title: 'Document the `nav_paths` schema including expected data types. (verify:
+      confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-18
+    title: 'Define scope for: Document the chart extension points with examples of
+      how to extend existing visualizations. (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-19
+    title: 'Implement focused slice for: Document the chart extension points with
+      examples of how to extend existing visualizations. (verify: confirm completion
+      in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-20
+    title: 'Validate focused slice for: Document the chart extension points with examples
+      of how to extend existing visualizations. (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-21
+    title: 'Define scope for: Document the process for triggering agent work after
+      chart creation with concrete examples. (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-22
+    title: 'Implement focused slice for: Document the process for triggering agent
+      work after chart creation with concrete examples. (verify: confirm completion
+      in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-23
+    title: 'Validate focused slice for: Document the process for triggering agent
+      work after chart creation with concrete examples. (verify: confirm completion
+      in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-24
+    title: Update an existing docs index/README to link to `docs/monte_carlo/visualization.md`
+      from an obvious location (e.g., `docs/README.md` or `docs/index.md` if present).
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-25
+    title: Running the test suite succeeds (e.g., `pytest` exits with code 0) and
+      includes smoke coverage that Plotly figures can be created and `fig.to_json()`
+      returns JSON.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-26
+    title: Tests verifying the `nav_paths` contract and adapters exist and pass (relevant
+      `tests/test_*.py` files present and `pytest` passes).
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-27
+    title: Tests verifying export behavior without Kaleido exist and pass (e.g., `pytest
+      -k kaleido` passes on an environment without Kaleido).
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-28
+    title: '`docs/monte_carlo/visualization.md` exists in the repo.'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-29
+    title: At least one docs entry point links to `docs/monte_carlo/visualization.md`
+      (link present in an inspected docs index file).
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-30
+    title: 'Add viz smoke tests:'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-31
+    title: figures create successfully
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-32
+    title: '`fig.to_json()` works'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-33
+    title: 'Add docs:'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-34
+    title: '`docs/monte_carlo/visualization.md` describing schema + extension points'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-35
+    title: Ensure docs are linked from somewhere obvious.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-36
+    title: CI passes.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-37
+    title: Docs exist and are easy to find.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []

--- a/.agents/issue-4851-ledger.yml
+++ b/.agents/issue-4851-ledger.yml
@@ -6,10 +6,10 @@ tasks:
   - id: task-01
     title: Add test file(s) for visualization smoke tests covering that Plotly figures
       create successfully and `fig.to_json()` works (e.g., `tests/test_visualization_smoke.py`).
-    status: doing
+    status: done
     started_at: '2026-02-11T22:26:00Z'
-    finished_at: null
-    commit: ''
+    finished_at: '2026-02-11T22:26:10Z'
+    commit: 120d0016f8bce32ab8de42dd3654166a7e573cb7
     notes: []
   - id: task-02
     title: 'Create the test file `tests/test_visualization_smoke.py` with basic structure

--- a/.agents/issue-4851-ledger.yml
+++ b/.agents/issue-4851-ledger.yml
@@ -14,191 +14,191 @@ tasks:
   - id: task-02
     title: 'Create the test file `tests/test_visualization_smoke.py` with basic structure
       (verify: tests pass)'
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-11T22:39:30Z'
+    finished_at: '2026-02-11T22:39:30Z'
+    commit: 19ab5192ecf1c77f4258631ff0b56d20655c4ae9
     notes: []
   - id: task-03
     title: 'Create the test file `tests/test_visualization_smoke.py` with imports.
       (verify: tests pass)'
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-11T22:39:30Z'
+    finished_at: '2026-02-11T22:39:30Z'
+    commit: 19ab5192ecf1c77f4258631ff0b56d20655c4ae9
     notes: []
   - id: task-04
     title: 'Define scope for: Add a test case verifying that Plotly figures can be
       created successfully without errors. (verify: confirm completion in repo)'
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-11T22:39:30Z'
+    finished_at: '2026-02-11T22:39:30Z'
+    commit: 19ab5192ecf1c77f4258631ff0b56d20655c4ae9
     notes: []
   - id: task-05
     title: 'Implement focused slice for: Add a test case verifying that Plotly figures
       can be created successfully without errors. (verify: confirm completion in repo)'
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-11T22:39:30Z'
+    finished_at: '2026-02-11T22:39:30Z'
+    commit: 19ab5192ecf1c77f4258631ff0b56d20655c4ae9
     notes: []
   - id: task-06
     title: 'Validate focused slice for: Add a test case verifying that Plotly figures
       can be created successfully without errors. (verify: confirm completion in repo)'
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-11T22:39:30Z'
+    finished_at: '2026-02-11T22:39:30Z'
+    commit: 19ab5192ecf1c77f4258631ff0b56d20655c4ae9
     notes: []
   - id: task-07
     title: 'Define scope for: Add a test case verifying that `fig.to_json()` returns
       valid JSON output for created figures. (verify: confirm completion in repo)'
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-11T22:39:30Z'
+    finished_at: '2026-02-11T22:39:30Z'
+    commit: 19ab5192ecf1c77f4258631ff0b56d20655c4ae9
     notes: []
   - id: task-08
     title: 'Implement focused slice for: Add a test case verifying that `fig.to_json()`
       returns valid JSON output for created figures. (verify: confirm completion in
       repo)'
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-11T22:39:30Z'
+    finished_at: '2026-02-11T22:39:30Z'
+    commit: 19ab5192ecf1c77f4258631ff0b56d20655c4ae9
     notes: []
   - id: task-09
     title: 'Validate focused slice for: Add a test case verifying that `fig.to_json()`
       returns valid JSON output for created figures. (verify: confirm completion in
       repo)'
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-11T22:39:30Z'
+    finished_at: '2026-02-11T22:39:30Z'
+    commit: 19ab5192ecf1c77f4258631ff0b56d20655c4ae9
     notes: []
   - id: task-10
     title: Add test(s) validating the `nav_paths` contract/schema used by the visualization
       layer (e.g., `tests/test_nav_paths_contract.py`).
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:40:20Z'
+    finished_at: '2026-02-11T22:42:20Z'
     commit: ''
     notes: []
   - id: task-11
     title: Add test(s) covering adapter behavior for `nav_paths` inputs/outputs (e.g.,
       `tests/test_nav_paths_adapters.py`).
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:44:10Z'
+    finished_at: '2026-02-11T22:45:20Z'
     commit: ''
     notes: []
   - id: task-12
     title: Add test(s) verifying export behavior works without Kaleido installed (e.g.,
       `tests/test_export_without_kaleido.py`).
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:46:20Z'
+    finished_at: '2026-02-11T22:47:00Z'
     commit: ''
     notes: []
   - id: task-13
     title: Create documentation at `docs/monte_carlo/visualization.md` describing
       the `nav_paths` schema and chart extension points, including how to trigger
       agent work post-creation.
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:50:10Z'
+    finished_at: '2026-02-11T22:50:40Z'
     commit: ''
     notes: []
   - id: task-14
     title: 'Create the documentation file `docs/monte_carlo/visualization.md` with
       basic structure (verify: docs updated)'
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:50:10Z'
+    finished_at: '2026-02-11T22:50:40Z'
     commit: ''
     notes: []
   - id: task-15
     title: 'Create the documentation file `docs/monte_carlo/visualization.md` with
       headings. (verify: docs updated)'
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:50:10Z'
+    finished_at: '2026-02-11T22:50:40Z'
     commit: ''
     notes: []
   - id: task-16
     title: 'Document the `nav_paths` schema including field definitions (verify: confirm
       completion in repo)'
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:50:10Z'
+    finished_at: '2026-02-11T22:50:40Z'
     commit: ''
     notes: []
   - id: task-17
     title: 'Document the `nav_paths` schema including expected data types. (verify:
       confirm completion in repo)'
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:50:10Z'
+    finished_at: '2026-02-11T22:50:40Z'
     commit: ''
     notes: []
   - id: task-18
     title: 'Define scope for: Document the chart extension points with examples of
       how to extend existing visualizations. (verify: confirm completion in repo)'
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:50:40Z'
+    finished_at: '2026-02-11T22:51:00Z'
     commit: ''
     notes: []
   - id: task-19
     title: 'Implement focused slice for: Document the chart extension points with
       examples of how to extend existing visualizations. (verify: confirm completion
       in repo)'
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:50:40Z'
+    finished_at: '2026-02-11T22:51:00Z'
     commit: ''
     notes: []
   - id: task-20
     title: 'Validate focused slice for: Document the chart extension points with examples
       of how to extend existing visualizations. (verify: confirm completion in repo)'
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:50:40Z'
+    finished_at: '2026-02-11T22:51:00Z'
     commit: ''
     notes: []
   - id: task-21
     title: 'Define scope for: Document the process for triggering agent work after
       chart creation with concrete examples. (verify: confirm completion in repo)'
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:51:00Z'
+    finished_at: '2026-02-11T22:51:20Z'
     commit: ''
     notes: []
   - id: task-22
     title: 'Implement focused slice for: Document the process for triggering agent
       work after chart creation with concrete examples. (verify: confirm completion
       in repo)'
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:51:00Z'
+    finished_at: '2026-02-11T22:51:20Z'
     commit: ''
     notes: []
   - id: task-23
     title: 'Validate focused slice for: Document the process for triggering agent
       work after chart creation with concrete examples. (verify: confirm completion
       in repo)'
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:51:00Z'
+    finished_at: '2026-02-11T22:51:20Z'
     commit: ''
     notes: []
   - id: task-24
     title: Update an existing docs index/README to link to `docs/monte_carlo/visualization.md`
       from an obvious location (e.g., `docs/README.md` or `docs/index.md` if present).
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:51:20Z'
+    finished_at: '2026-02-11T22:51:40Z'
     commit: ''
     notes: []
   - id: task-25
@@ -213,74 +213,74 @@ tasks:
   - id: task-26
     title: Tests verifying the `nav_paths` contract and adapters exist and pass (relevant
       `tests/test_*.py` files present and `pytest` passes).
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:47:30Z'
+    finished_at: '2026-02-11T22:47:40Z'
     commit: ''
     notes: []
   - id: task-27
     title: Tests verifying export behavior without Kaleido exist and pass (e.g., `pytest
       -k kaleido` passes on an environment without Kaleido).
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:47:50Z'
+    finished_at: '2026-02-11T22:48:10Z'
     commit: ''
     notes: []
   - id: task-28
     title: '`docs/monte_carlo/visualization.md` exists in the repo.'
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:50:10Z'
+    finished_at: '2026-02-11T22:50:40Z'
     commit: ''
     notes: []
   - id: task-29
     title: At least one docs entry point links to `docs/monte_carlo/visualization.md`
       (link present in an inspected docs index file).
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:51:20Z'
+    finished_at: '2026-02-11T22:51:40Z'
     commit: ''
     notes: []
   - id: task-30
     title: 'Add viz smoke tests:'
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-11T22:39:30Z'
+    finished_at: '2026-02-11T22:39:30Z'
+    commit: 19ab5192ecf1c77f4258631ff0b56d20655c4ae9
     notes: []
   - id: task-31
     title: figures create successfully
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-11T22:39:30Z'
+    finished_at: '2026-02-11T22:39:30Z'
+    commit: 19ab5192ecf1c77f4258631ff0b56d20655c4ae9
     notes: []
   - id: task-32
     title: '`fig.to_json()` works'
-    status: todo
-    started_at: null
-    finished_at: null
-    commit: ''
+    status: done
+    started_at: '2026-02-11T22:39:30Z'
+    finished_at: '2026-02-11T22:39:30Z'
+    commit: 19ab5192ecf1c77f4258631ff0b56d20655c4ae9
     notes: []
   - id: task-33
     title: 'Add docs:'
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:50:10Z'
+    finished_at: '2026-02-11T22:50:40Z'
     commit: ''
     notes: []
   - id: task-34
     title: '`docs/monte_carlo/visualization.md` describing schema + extension points'
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:50:10Z'
+    finished_at: '2026-02-11T22:50:40Z'
     commit: ''
     notes: []
   - id: task-35
     title: Ensure docs are linked from somewhere obvious.
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:51:20Z'
+    finished_at: '2026-02-11T22:51:40Z'
     commit: ''
     notes: []
   - id: task-36
@@ -292,8 +292,8 @@ tasks:
     notes: []
   - id: task-37
     title: Docs exist and are easy to find.
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:51:20Z'
+    finished_at: '2026-02-11T22:51:40Z'
     commit: ''
     notes: []

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -253,6 +253,7 @@ Use this index to find the current contributor guides and to understand which ov
 ### Data and app flows
 - `README_DATA.md` for bundled data constraints and validation helpers.
 - `README_APP.md` for Streamlit app packaging and presets.
+- `docs/monte_carlo/visualization.md` for the `nav_paths` visualization schema contract and chart extension workflow.
 
 ### Repository hygiene
 - `docs/repository_housekeeping.md` for archiving rules, quarterly checklists, and folder ownership.

--- a/docs/monte_carlo/visualization.md
+++ b/docs/monte_carlo/visualization.md
@@ -1,0 +1,70 @@
+# Monte Carlo Visualization Contract
+
+This document defines the `nav_paths` data contract used by the visualization layer and the expected extension workflow for new charts.
+
+## `nav_paths` Schema
+
+### Accepted input to `make_paths(nav_paths)`
+
+`nav_paths` must be a `pandas.DataFrame` with:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| index | datetime-like index | yes | Converted with `pd.to_datetime`; non-datetime values raise `ValueError`. |
+| columns | path labels or `MultiIndex` | yes | Plain path labels are accepted. For `MultiIndex`, a `path` level is used; if an `asset` level exists, only `asset == "NAV"` is retained. |
+| values | numeric-like | yes | Coerced via `pd.to_numeric(errors="coerce")`. |
+
+### Canonical output from `make_paths(nav_paths)`
+
+The adapter returns a long-form frame with:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| index level `date` | `datetime64[ns]` | yes | First level of canonical `MultiIndex`. |
+| index level `path` | string/int label | yes | Second level of canonical `MultiIndex`. |
+| `nav` | `float64` | yes | Required value column used by downstream charts. |
+
+Contract constants are defined in `src/trend_analysis/viz/adapters.py`:
+- `PATHS_INDEX_NAMES = ("date", "path")`
+- `PATHS_REQUIRED_COLUMNS = ("nav",)`
+- `PATHS_REQUIRED_DTYPES = {"nav": "float64"}`
+
+## Chart Extension Points
+
+### Adapter layer
+
+Use the adapter layer to keep chart modules stable against upstream shape changes:
+
+- `make_paths(nav_paths)` normalizes raw navigation paths.
+- `terminal_returns(paths)` calculates per-path terminal returns.
+- `rolling_stats(paths)` emits rolling mean/std/Sharpe diagnostics.
+- `path_correlations(paths)` emits a correlation matrix.
+
+### Chart modules
+
+Core chart constructors currently used for MC diagnostics:
+
+- `trend_analysis.viz.fan.make`
+- `trend_analysis.viz.path_dist.make`
+- `trend_analysis.viz.risk_return.make`
+
+When adding a chart:
+
+1. Build from adapter outputs rather than raw bundle objects.
+2. Return a Plotly `go.Figure`.
+3. Add smoke coverage that figure creation succeeds and `fig.to_json()` is valid JSON.
+4. Add focused unit tests for any schema assumptions in the chart.
+
+## Triggering Agent Work After Chart Creation
+
+Use this flow after introducing or changing charts:
+
+1. Run focused tests.
+   - `pytest tests/test_visualization_smoke.py tests/test_nav_paths_contract.py tests/test_nav_paths_adapters.py -m "not slow"`
+2. For export behavior without Kaleido, run:
+   - `pytest tests/test_export_without_kaleido.py -k kaleido -m "not slow"`
+3. Post a keepalive/agent follow-up request in the PR with explicit next tasks and acceptance criteria.
+   - Example task: `- [ ] Add test(s) for <new chart module> input validation.`
+   - Example acceptance: `- [ ] pytest tests/test_<new_chart>.py exits with code 0.`
+
+This keeps future agent rounds aligned to the same schema contract and verification commands.

--- a/tests/test_export_without_kaleido.py
+++ b/tests/test_export_without_kaleido.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import zipfile
+
+import plotly.graph_objects as go
+import pytest
+
+from trend_analysis.monte_carlo import export_bundle
+
+
+def test_export_without_kaleido_skips_png_and_records_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(export_bundle, "kaleido_available", lambda: False)
+
+    def _to_image_should_not_run(*_args, **_kwargs):  # pragma: no cover - guard assertion
+        raise AssertionError("pio.to_image should not be called when Kaleido is unavailable")
+
+    monkeypatch.setattr(export_bundle.pio, "to_image", _to_image_should_not_run)
+
+    charts = {"paths": go.Figure(data=[go.Scatter(x=[1, 2], y=[1.0, 1.1])])}
+    warnings: list[str] = []
+    buffer = export_bundle.save(charts, include_png=True, warnings=warnings)
+
+    with zipfile.ZipFile(buffer) as bundle:
+        names = set(bundle.namelist())
+        assert "paths.png" not in names
+        assert "paths.json" in names
+        assert "paths.html" in names
+
+    assert warnings
+    assert "Kaleido is not installed" in warnings[0]

--- a/tests/test_nav_paths_adapters.py
+++ b/tests/test_nav_paths_adapters.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from trend_analysis.viz.adapters import PATHS_INDEX_NAMES, make_paths
+
+
+def test_nav_paths_adapter_filters_to_nav_asset_level() -> None:
+    index = pd.date_range("2024-01-31", periods=2, freq="ME")
+    columns = pd.MultiIndex.from_tuples(
+        [("path_a", "NAV"), ("path_a", "PX_LAST"), ("path_b", "NAV")],
+        names=["path", "asset"],
+    )
+    nav_paths = pd.DataFrame(
+        [
+            [1.00, 101.0, 1.00],
+            [1.05, 105.0, 1.02],
+        ],
+        index=index,
+        columns=columns,
+    )
+
+    canonical = make_paths(nav_paths)
+
+    assert tuple(canonical.index.names) == PATHS_INDEX_NAMES
+    assert canonical.shape == (4, 1)
+    assert canonical.loc[(pd.Timestamp("2024-02-29"), "path_a"), "nav"] == pytest.approx(1.05)
+    assert canonical.loc[(pd.Timestamp("2024-02-29"), "path_b"), "nav"] == pytest.approx(1.02)
+
+
+def test_nav_paths_adapter_collapses_duplicate_paths_by_mean() -> None:
+    nav_paths = pd.DataFrame(
+        {
+            "path_1": [1.0, 1.1],
+            "path_1_dup": [1.2, 1.5],
+            "path_2": [0.9, 1.0],
+        },
+        index=pd.date_range("2024-01-31", periods=2, freq="ME"),
+    )
+    nav_paths.columns = pd.Index(["path_1", "path_1", "path_2"], name="path")
+
+    canonical = make_paths(nav_paths)
+
+    assert canonical.loc[(pd.Timestamp("2024-01-31"), "path_1"), "nav"] == pytest.approx(1.1)
+    assert canonical.loc[(pd.Timestamp("2024-02-29"), "path_1"), "nav"] == pytest.approx(1.3)
+    assert canonical.loc[(pd.Timestamp("2024-02-29"), "path_2"), "nav"] == pytest.approx(1.0)
+
+
+def test_nav_paths_adapter_empty_input_returns_empty_canonical_frame() -> None:
+    nav_paths = pd.DataFrame(index=pd.DatetimeIndex([], name="date"))
+
+    canonical = make_paths(nav_paths)
+
+    assert canonical.empty
+    assert tuple(canonical.index.names) == PATHS_INDEX_NAMES
+    assert list(canonical.columns) == ["nav"]
+    assert canonical["nav"].dtype == "float64"

--- a/tests/test_nav_paths_contract.py
+++ b/tests/test_nav_paths_contract.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from trend_analysis.viz.adapters import (
+    PATHS_INDEX_NAMES,
+    PATHS_REQUIRED_COLUMNS,
+    PATHS_REQUIRED_DTYPES,
+    make_paths,
+)
+
+
+def _sample_nav_paths() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "path_1": [1.0, 1.02, 1.05],
+            "path_2": [1.0, 0.98, 1.01],
+        },
+        index=pd.date_range("2024-01-31", periods=3, freq="ME"),
+    )
+
+
+def test_nav_paths_contract_make_paths_emits_canonical_schema() -> None:
+    canonical = make_paths(_sample_nav_paths())
+
+    assert isinstance(canonical.index, pd.MultiIndex)
+    assert tuple(canonical.index.names) == PATHS_INDEX_NAMES
+    assert tuple(canonical.columns) == PATHS_REQUIRED_COLUMNS
+    assert canonical["nav"].dtype == PATHS_REQUIRED_DTYPES["nav"]
+
+
+def test_nav_paths_contract_requires_datetime_like_index() -> None:
+    nav_paths = pd.DataFrame(
+        {"path_1": [1.0, 1.01], "path_2": [1.0, 0.99]},
+        index=["not-a-date", "also-not-a-date"],
+    )
+
+    with pytest.raises(ValueError, match="datetime-like"):
+        make_paths(nav_paths)
+
+
+def test_nav_paths_contract_rejects_non_dataframe_input() -> None:
+    with pytest.raises(TypeError, match="pandas DataFrame"):
+        make_paths({"path_1": [1.0, 1.01]})  # type: ignore[arg-type]

--- a/tests/test_visualization_smoke.py
+++ b/tests/test_visualization_smoke.py
@@ -6,6 +6,7 @@ import json
 
 import pandas as pd
 import plotly.graph_objects as go
+import pytest
 
 from trend_analysis.viz import fan, path_dist, risk_return
 
@@ -30,26 +31,34 @@ def _sample_returns() -> pd.DataFrame:
     )
 
 
-def _smoke_figures() -> list[go.Figure]:
+@pytest.mark.parametrize(
+    ("builder", "payload"),
+    [
+        pytest.param(lambda nav, _ret: fan.make(nav, max_paths=None), "nav", id="fan"),
+        pytest.param(lambda nav, _ret: path_dist.make(nav, max_paths=None), "nav", id="path_dist"),
+        pytest.param(lambda _nav, ret: risk_return.make(ret), "returns", id="risk_return"),
+    ],
+)
+def test_plotly_figures_create_successfully(builder, payload: str) -> None:
     nav_paths = _sample_nav_paths()
     returns = _sample_returns()
-    return [
+    figure = builder(nav_paths, returns)
+
+    assert payload in {"nav", "returns"}
+    assert isinstance(figure, go.Figure)
+    assert figure.data
+
+
+def test_plotly_figures_to_json_returns_valid_json() -> None:
+    nav_paths = _sample_nav_paths()
+    returns = _sample_returns()
+    figures = [
         fan.make(nav_paths, max_paths=None),
         path_dist.make(nav_paths, max_paths=None),
         risk_return.make(returns),
     ]
-
-
-def test_plotly_figures_create_successfully() -> None:
-    figures = _smoke_figures()
-    assert figures
     for fig in figures:
-        assert isinstance(fig, go.Figure)
-
-
-def test_plotly_figures_to_json_returns_valid_json() -> None:
-    for fig in _smoke_figures():
         payload = json.loads(fig.to_json())
         assert isinstance(payload, dict)
-        assert "data" in payload
-        assert "layout" in payload
+        assert isinstance(payload.get("data"), list)
+        assert isinstance(payload.get("layout"), dict)

--- a/tests/test_visualization_smoke.py
+++ b/tests/test_visualization_smoke.py
@@ -1,0 +1,55 @@
+"""Visualization smoke tests for Plotly figure construction and JSON serialization."""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from trend_analysis.viz import fan, path_dist, risk_return
+
+
+def _sample_nav_paths() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "path_1": [1.00, 1.03, 1.05, 1.08],
+            "path_2": [1.00, 0.99, 1.02, 1.07],
+        },
+        index=pd.date_range("2020-01-31", periods=4, freq="ME"),
+    )
+
+
+def _sample_returns() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "strategy_a": [0.01, -0.01, 0.015, 0.002],
+            "strategy_b": [0.0, 0.012, -0.004, 0.01],
+        },
+        index=pd.date_range("2020-01-31", periods=4, freq="ME"),
+    )
+
+
+def _smoke_figures() -> list[go.Figure]:
+    nav_paths = _sample_nav_paths()
+    returns = _sample_returns()
+    return [
+        fan.make(nav_paths, max_paths=None),
+        path_dist.make(nav_paths, max_paths=None),
+        risk_return.make(returns),
+    ]
+
+
+def test_plotly_figures_create_successfully() -> None:
+    figures = _smoke_figures()
+    assert figures
+    for fig in figures:
+        assert isinstance(fig, go.Figure)
+
+
+def test_plotly_figures_to_json_returns_valid_json() -> None:
+    for fig in _smoke_figures():
+        payload = json.loads(fig.to_json())
+        assert isinstance(payload, dict)
+        assert "data" in payload
+        assert "layout" in payload


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #4851

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Cross-repo consistency only works if the data contract and rendering stack are stable and tested.

#### Tasks
- [x] Add test file(s) for visualization smoke tests covering that Plotly figures create successfully and `fig.to_json()` works (e.g., `tests/test_visualization_smoke.py`).
  - [ ] Create the test file `tests/test_visualization_smoke.py` with basic structure (verify: tests pass)
  - [ ] Create the test file `tests/test_visualization_smoke.py` with imports. (verify: tests pass)
  - [ ] Define scope for: Add a test case verifying that Plotly figures can be created successfully without errors. (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a test case verifying that Plotly figures can be created successfully without errors. (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a test case verifying that Plotly figures can be created successfully without errors. (verify: confirm completion in repo)
  - [ ] Define scope for: Add a test case verifying that `fig.to_json()` returns valid JSON output for created figures. (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Add a test case verifying that `fig.to_json()` returns valid JSON output for created figures. (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Add a test case verifying that `fig.to_json()` returns valid JSON output for created figures. (verify: confirm completion in repo)
- [x] Add test(s) validating the `nav_paths` contract/schema used by the visualization layer (e.g., `tests/test_nav_paths_contract.py`).
- [x] Add test(s) covering adapter behavior for `nav_paths` inputs/outputs (e.g., `tests/test_nav_paths_adapters.py`).
- [x] Add test(s) verifying export behavior works without Kaleido installed (e.g., `tests/test_export_without_kaleido.py`).
- [x] Create documentation at `docs/monte_carlo/visualization.md` describing the `nav_paths` schema and chart extension points, including how to trigger agent work post-creation.
  - [ ] Create the documentation file `docs/monte_carlo/visualization.md` with basic structure (verify: docs updated)
  - [ ] Create the documentation file `docs/monte_carlo/visualization.md` with headings. (verify: docs updated)
  - [ ] Document the `nav_paths` schema including field definitions (verify: confirm completion in repo)
  - [ ] Document the `nav_paths` schema including expected data types. (verify: confirm completion in repo)
  - [ ] Define scope for: Document the chart extension points with examples of how to extend existing visualizations. (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Document the chart extension points with examples of how to extend existing visualizations. (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Document the chart extension points with examples of how to extend existing visualizations. (verify: confirm completion in repo)
  - [ ] Define scope for: Document the process for triggering agent work after chart creation with concrete examples. (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Document the process for triggering agent work after chart creation with concrete examples. (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Document the process for triggering agent work after chart creation with concrete examples. (verify: confirm completion in repo)
- [x] Update an existing docs index/README to link to `docs/monte_carlo/visualization.md` from an obvious location (e.g., `docs/README.md` or `docs/index.md` if present).

#### Acceptance criteria
- [x] Running the test suite succeeds (e.g., `pytest` exits with code 0) and includes smoke coverage that Plotly figures can be created and `fig.to_json()` returns JSON.
- [x] Tests verifying the `nav_paths` contract and adapters exist and pass (relevant `tests/test_*.py` files present and `pytest` passes).
- [x] Tests verifying export behavior without Kaleido exist and pass (e.g., `pytest -k kaleido` passes on an environment without Kaleido).
- [x] `docs/monte_carlo/visualization.md` exists in the repo.
- [x] At least one docs entry point links to `docs/monte_carlo/visualization.md` (link present in an inspected docs index file).

<!-- auto-status-summary:end -->