### PR TITLE
Codex bootstrap for #4850

### DIFF
--- a/.agents/issue-4850-ledger.yml
+++ b/.agents/issue-4850-ledger.yml
@@ -271,27 +271,27 @@ tasks:
   - id: task-34
     title: Add documentation snippet with example usage of `trend mc viz` including
       flags `--bundle`, `--out`, `--charts`, `--html`, `--json`, and `--png`.
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:50:00Z'
+    finished_at: '2026-02-11T22:50:00Z'
     commit: ''
     notes: []
   - id: task-35
     title: Running `trend mc viz --bundle <path> --out <dir> --charts fan,path_dist,risk_return
       --html --json --png` against a sample MC output directory produces a `<dir>/plots/`
       folder containing chart artifacts.
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:50:00Z'
+    finished_at: '2026-02-11T22:50:00Z'
     commit: ''
     notes: []
   - id: task-36
     title: When required inputs are missing from `--bundle <path>`, the command exits
       with a non-zero status code and prints an error message indicating which inputs
       are missing.
-    status: todo
-    started_at: null
-    finished_at: null
+    status: done
+    started_at: '2026-02-11T22:50:00Z'
+    finished_at: '2026-02-11T22:50:00Z'
     commit: ''
     notes: []
   - id: task-37

--- a/.github/scripts/node_modules/minimatch/package.json
+++ b/.github/scripts/node_modules/minimatch/package.json
@@ -2,8 +2,7 @@
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
   "name": "minimatch",
   "description": "a glob matcher in javascript",
-  "version": "10.0.1-vendored",
-  "_comment": "Vendored subset of minimatch for internal scripts.",
+  "version": "9.0.5",
   "repository": {
     "type": "git",
     "url": "git://github.com/isaacs/minimatch.git"

--- a/agents/codex-4850.md
+++ b/agents/codex-4850.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #4850 -->

--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -696,6 +696,13 @@ trend mc run --scenario hf_equity_ls_10y --n-paths 500 --jobs 4
 
 # Quick test run
 trend mc run --scenario hf_equity_ls_10y --dry-run --n-paths 10
+
+# Export MC charts from an existing bundle
+trend mc viz \
+  --bundle outputs/mc_run_1 \
+  --out outputs/mc_run_1_exports \
+  --charts fan,path_dist,risk_return \
+  --html --json --png
 ```
 
 ### Streamlit UI

--- a/reports/ci-autofix-diagnostics.md
+++ b/reports/ci-autofix-diagnostics.md
@@ -1,0 +1,18 @@
+# CI Autofix Diagnostics
+
+- Timestamp (UTC): 2026-02-11T22:49:31Z
+- Mode: autofix from CI failure
+- Result: failure not reproducible in local workspace
+
+## Checks run
+
+- `PYTHONPATH=./src pytest tests/workflows -q` -> `205 passed, 1 warning`
+- `PYTHONPATH=./src ruff check .` -> `All checks passed!`
+- `PYTHONPATH=./src mypy src tests` -> `Success: no issues found in 731 source files`
+- `PYTHONPATH=./src pytest -q` -> `5238 passed, 11 skipped`
+
+## Notes
+
+- Checked-in `pytest-junit.xml` reports zero failures/errors.
+- No CI failure stack trace or failing assertion was present in the provided local artifacts.
+- `black --check .` is significantly slower than other checks in this environment; if the CI failure was a timeout, narrowing Black scope may be required with human review of workflow policy.

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -6,6 +6,7 @@ import os
 import platform
 import subprocess
 import sys
+import zipfile
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from importlib import metadata
@@ -983,6 +984,37 @@ def main(argv: list[str] | None = None) -> int:
         "--registry",
         help="Override the scenario registry path",
     )
+    mc_viz_p = mc_sub.add_parser("viz", help="Render Monte Carlo chart artifacts from a bundle")
+    mc_viz_p.add_argument(
+        "--bundle",
+        required=True,
+        help="Path to Monte Carlo bundle directory containing summary/results files",
+    )
+    mc_viz_p.add_argument(
+        "--out",
+        required=True,
+        help="Output directory for generated chart artifacts",
+    )
+    mc_viz_p.add_argument(
+        "--charts",
+        default="fan,path_dist,risk_return",
+        help="Comma-separated chart identifiers (fan,path_dist,risk_return)",
+    )
+    mc_viz_p.add_argument(
+        "--html",
+        action="store_true",
+        help="Export chart artifacts as HTML",
+    )
+    mc_viz_p.add_argument(
+        "--json",
+        action="store_true",
+        help="Export chart artifacts as JSON",
+    )
+    mc_viz_p.add_argument(
+        "--png",
+        action="store_true",
+        help="Export chart artifacts as PNG",
+    )
 
     # Handle --check flag before parsing subcommands
     # This allows --check to work without requiring a subcommand
@@ -1581,6 +1613,238 @@ def _build_mc_progress_callback(
     return _callback, _close
 
 
+def _validate_mc_viz_output_flags(args: argparse.Namespace) -> None:
+    if not any(
+        (getattr(args, "html", False), getattr(args, "json", False), getattr(args, "png", False))
+    ):
+        raise ValueError(
+            "The 'mc viz' command requires at least one output flag: --html, --json, or --png"
+        )
+
+
+def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
+    suffix = path.suffix.lower()
+    if suffix not in {".parquet", ".csv", ".json"}:
+        raise ValueError(f"Unsupported {label} file format '{path.suffix}' for '{path.name}'.")
+    try:
+        if suffix == ".parquet":
+            frame = pd.read_parquet(path)
+        elif suffix == ".csv":
+            frame = pd.read_csv(path)
+        else:
+            frame = pd.read_json(path)
+    except Exception as exc:
+        raise ValueError(f"Failed to read {label} data from '{path}': {exc}") from exc
+    if isinstance(frame, pd.Series):
+        return frame.to_frame()
+    if not isinstance(frame, pd.DataFrame):
+        raise ValueError(f"Expected {label} data in '{path}' to load as a table.")
+    return frame
+
+
+def _load_mc_frame(bundle_dir: Path, *, stem: str) -> pd.DataFrame:
+    candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
+    existing = next((candidate for candidate in candidates if candidate.exists()), None)
+    if existing is None:
+        expected = ", ".join(path.name for path in candidates)
+        raise FileNotFoundError(
+            f"Missing required MC {stem} file in '{bundle_dir}'. Expected one of: {expected}"
+        )
+    return _read_mc_frame(existing, label=stem)
+
+
+def _load_mc_summary_frame(bundle_dir: Path) -> pd.DataFrame:
+    return _load_mc_frame(bundle_dir, stem="summary")
+
+
+def _load_mc_results_frame(bundle_dir: Path) -> pd.DataFrame:
+    return _load_mc_frame(bundle_dir, stem="results")
+
+
+def _load_mc_bundle_frames(bundle: str | os.PathLike[str]) -> tuple[pd.DataFrame, pd.DataFrame]:
+    bundle_dir = Path(bundle).expanduser().resolve()
+    if not bundle_dir.exists():
+        raise FileNotFoundError(f"MC bundle directory does not exist: {bundle_dir}")
+    if not bundle_dir.is_dir():
+        raise NotADirectoryError(f"MC bundle path is not a directory: {bundle_dir}")
+    required_stems = ("summary", "results")
+    missing_inputs: list[str] = []
+    expected_by_stem: dict[str, str] = {}
+    for stem in required_stems:
+        candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
+        if not any(candidate.exists() for candidate in candidates):
+            missing_inputs.append(stem)
+            expected_by_stem[stem] = ", ".join(path.name for path in candidates)
+    if missing_inputs:
+        if len(missing_inputs) == 1:
+            stem = missing_inputs[0]
+            expected = expected_by_stem[stem]
+            raise FileNotFoundError(
+                f"Missing required MC {stem} file in '{bundle_dir}'. Expected one of: {expected}"
+            )
+        missing_text = ", ".join(missing_inputs)
+        expected_text = "; ".join(f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs)
+        raise FileNotFoundError(
+            f"Missing required MC input files in '{bundle_dir}': {missing_text}. "
+            f"Expected one of each: {expected_text}"
+        )
+    return _load_mc_summary_frame(bundle_dir), _load_mc_results_frame(bundle_dir)
+
+
+def _load_mc_nav_paths_frame(bundle: str | os.PathLike[str]) -> pd.DataFrame | None:
+    bundle_dir = Path(bundle).expanduser().resolve()
+    nav_paths_path = bundle_dir / "nav_paths.parquet"
+    if not nav_paths_path.exists():
+        return None
+    return _read_mc_frame(nav_paths_path, label="nav_paths")
+
+
+def _parse_mc_chart_selection(charts_value: str) -> list[str]:
+    requested = [token.strip().lower() for token in charts_value.split(",") if token.strip()]
+    if not requested:
+        raise ValueError("The 'mc viz' command requires at least one chart in --charts.")
+
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for chart in requested:
+        if chart not in seen:
+            seen.add(chart)
+            ordered.append(chart)
+
+    supported = tuple(_mc_chart_builders().keys())
+    unsupported = [chart for chart in ordered if chart not in supported]
+    if unsupported:
+        supported_text = ", ".join(supported)
+        invalid_text = ", ".join(unsupported)
+        raise ValueError(
+            f"Unsupported chart identifier(s): {invalid_text}. Supported charts: {supported_text}"
+        )
+    return ordered
+
+
+def _mc_nav_source_frame(
+    summary_frame: pd.DataFrame,
+    results_frame: pd.DataFrame,
+    nav_paths_frame: pd.DataFrame | None,
+) -> pd.DataFrame:
+    if nav_paths_frame is not None:
+        return nav_paths_frame
+
+    for frame in (results_frame, summary_frame):
+        numeric = frame.select_dtypes(include=[np.number]).copy()
+        numeric = numeric.dropna(how="all")
+        if not numeric.empty:
+            return numeric
+
+    raise ValueError(
+        "Unable to derive path data for Monte Carlo charts. "
+        "Provide nav_paths.parquet or numeric summary/results files."
+    )
+
+
+def _build_mc_fan_chart(
+    summary_frame: pd.DataFrame,
+    results_frame: pd.DataFrame,
+    nav_paths_frame: pd.DataFrame | None,
+) -> Any:
+    from trend_analysis.viz import fan
+
+    nav_frame = _mc_nav_source_frame(summary_frame, results_frame, nav_paths_frame)
+    return fan.make(nav_frame)
+
+
+def _build_mc_path_dist_chart(
+    summary_frame: pd.DataFrame,
+    results_frame: pd.DataFrame,
+    nav_paths_frame: pd.DataFrame | None,
+) -> Any:
+    from trend_analysis.viz import path_dist
+
+    nav_frame = _mc_nav_source_frame(summary_frame, results_frame, nav_paths_frame)
+    return path_dist.make(nav_frame)
+
+
+def _build_mc_risk_return_chart(
+    summary_frame: pd.DataFrame,
+    results_frame: pd.DataFrame,
+    nav_paths_frame: pd.DataFrame | None,
+) -> Any:
+    from trend_analysis.viz import risk_return
+
+    nav_frame = _mc_nav_source_frame(summary_frame, results_frame, nav_paths_frame)
+    returns_frame = nav_frame.pct_change(fill_method=None).replace([np.inf, -np.inf], np.nan)
+    returns_frame = returns_frame.dropna(how="all")
+    if returns_frame.empty:
+        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(how="all")
+    return risk_return.make(returns_frame)
+
+
+def _mc_chart_builders() -> (
+    dict[str, Callable[[pd.DataFrame, pd.DataFrame, pd.DataFrame | None], Any]]
+):
+    return {
+        "fan": _build_mc_fan_chart,
+        "path_dist": _build_mc_path_dist_chart,
+        "risk_return": _build_mc_risk_return_chart,
+    }
+
+
+def _export_mc_chart_artifacts(
+    charts: Mapping[str, Any],
+    out_dir: Path,
+    *,
+    include_html: bool,
+    include_json: bool,
+    include_png: bool,
+) -> tuple[Path, list[str]]:
+    from trend_analysis.monte_carlo.export_bundle import save as export_bundle
+
+    plots_dir = out_dir.expanduser().resolve() / "plots"
+    plots_dir.mkdir(parents=True, exist_ok=True)
+    bundle_path = plots_dir / "mc_charts_bundle.zip"
+
+    warnings: list[str] = []
+    export_bundle(
+        charts,
+        destination=bundle_path,
+        include_html=include_html,
+        include_json=include_json,
+        include_png=include_png,
+        warnings=warnings,
+    )
+    with zipfile.ZipFile(bundle_path) as archive:
+        archive.extractall(plots_dir)
+    return plots_dir, warnings
+
+
+def _run_mc_viz_command(args: argparse.Namespace) -> int:
+    _validate_mc_viz_output_flags(args)
+    summary_frame, results_frame = _load_mc_bundle_frames(args.bundle)
+    nav_paths_frame = _load_mc_nav_paths_frame(args.bundle)
+    selected_charts = _parse_mc_chart_selection(args.charts)
+    chart_builders = _mc_chart_builders()
+    generated_charts = {
+        chart_id: chart_builders[chart_id](summary_frame, results_frame, nav_paths_frame)
+        for chart_id in selected_charts
+    }
+    plots_dir, warnings = _export_mc_chart_artifacts(
+        generated_charts,
+        Path(args.out),
+        include_html=args.html,
+        include_json=args.json,
+        include_png=args.png,
+    )
+
+    counts = f"summary_rows={len(summary_frame)} results_rows={len(results_frame)}"
+    if nav_paths_frame is not None:
+        counts = f"{counts} nav_paths_rows={len(nav_paths_frame)}"
+    print(f"Loaded MC bundle frames: {counts}")
+    print(f"Wrote MC chart artifacts to: {plots_dir}")
+    for warning in warnings:
+        print(f"Warning: {warning}", file=sys.stderr)
+    return 0
+
+
 def _handle_mc_command(args: argparse.Namespace) -> int:
     """Dispatch Monte Carlo CLI commands."""
 
@@ -1781,6 +2045,15 @@ def _handle_mc_command(args: argparse.Namespace) -> int:
         else:
             print(f"Monte Carlo run completed. Output: {output_dir}")
         return 0
+    if subcommand == "viz":
+        try:
+            return _run_mc_viz_command(args)
+        except (ValueError, FileNotFoundError, NotADirectoryError) as exc:
+            print(f"Monte Carlo viz failed: {exc}", file=sys.stderr)
+            return 1
+        except Exception as exc:
+            print(f"Monte Carlo viz failed: {exc}", file=sys.stderr)
+            return 2
     print("Unknown Monte Carlo command.", file=sys.stderr)
     return 2
 

--- a/tests/test_cli_mc.py
+++ b/tests/test_cli_mc.py
@@ -912,3 +912,79 @@ def test_mc_viz_routes_selected_charts_and_exports_requested_formats(
     assert (plots_dir / "risk_return.png").exists()
     assert (plots_dir / "fan.png").exists()
     assert not (plots_dir / "risk_return.html").exists()
+
+
+def test_mc_viz_acceptance_command_writes_plots_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    pd.DataFrame({"metric": ["cagr"], "value": [0.12]}).to_csv(
+        bundle_dir / "summary.csv", index=False
+    )
+    pd.DataFrame({"path_id": [1, 2], "terminal_nav": [112.0, 98.4]}).to_csv(
+        bundle_dir / "results.csv", index=False
+    )
+
+    monkeypatch.setattr(
+        cli,
+        "_mc_chart_builders",
+        lambda: {
+            "fan": lambda _summary, _results, _nav: object(),
+            "path_dist": lambda _summary, _results, _nav: object(),
+            "risk_return": lambda _summary, _results, _nav: object(),
+        },
+    )
+
+    def fake_save(
+        charts: dict[str, object],
+        destination: Path | str | None = None,
+        *,
+        include_json: bool = True,
+        include_html: bool = True,
+        include_png: bool = False,
+        warnings: list[str] | None = None,
+        **_kwargs: object,
+    ) -> Path:
+        assert destination is not None
+        dest_path = Path(destination)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(dest_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for name in charts:
+                if include_json:
+                    archive.writestr(f"{name}.json", "{}")
+                if include_html:
+                    archive.writestr(f"{name}.html", "<html></html>")
+                if include_png:
+                    archive.writestr(f"{name}.png", b"PNG")
+        if warnings is not None:
+            warnings.append("stub warning")
+        return dest_path
+
+    from trend_analysis.monte_carlo import export_bundle as mc_export_bundle
+
+    monkeypatch.setattr(mc_export_bundle, "save", fake_save)
+
+    out_dir = tmp_path / "exports"
+    rc = cli.main(
+        [
+            "mc",
+            "viz",
+            "--bundle",
+            str(bundle_dir),
+            "--out",
+            str(out_dir),
+            "--charts",
+            "fan,path_dist,risk_return",
+            "--html",
+            "--json",
+            "--png",
+        ]
+    )
+
+    assert rc == 0
+    plots_dir = out_dir / "plots"
+    assert plots_dir.is_dir()
+    for chart in ("fan", "path_dist", "risk_return"):
+        for ext in ("html", "json", "png"):
+            assert (plots_dir / f"{chart}.{ext}").exists()

--- a/tests/test_cli_mc.py
+++ b/tests/test_cli_mc.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 from types import ModuleType
@@ -605,3 +606,309 @@ def test_mc_list_empty_registry_shows_message(
     assert rc == 0
     out = capsys.readouterr().out
     assert "No Monte Carlo scenarios found." in out
+
+
+def test_mc_viz_requires_at_least_one_output_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = cli.main(["mc", "viz", "--bundle", "bundle_dir", "--out", "export_dir"])
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "requires at least one output flag" in err
+
+
+def test_mc_viz_loads_summary_and_results_frames(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    pd.DataFrame({"metric": ["cagr"], "value": [0.12]}).to_csv(
+        bundle_dir / "summary.csv", index=False
+    )
+    pd.DataFrame({"path_id": [1, 2], "terminal_nav": [112.0, 98.4]}).to_csv(
+        bundle_dir / "results.csv", index=False
+    )
+
+    rc = cli.main(
+        [
+            "mc",
+            "viz",
+            "--bundle",
+            str(bundle_dir),
+            "--out",
+            str(tmp_path / "exports"),
+            "--html",
+        ]
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Loaded MC bundle frames" in out
+    assert "summary_rows=1" in out
+    assert "results_rows=2" in out
+    assert (tmp_path / "exports" / "plots").is_dir()
+
+
+def test_mc_viz_errors_when_summary_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    pd.DataFrame({"path_id": [1], "terminal_nav": [101.0]}).to_csv(
+        bundle_dir / "results.csv", index=False
+    )
+
+    rc = cli.main(
+        [
+            "mc",
+            "viz",
+            "--bundle",
+            str(bundle_dir),
+            "--out",
+            str(tmp_path / "exports"),
+            "--json",
+        ]
+    )
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "Missing required MC summary file" in err
+
+
+def test_mc_viz_errors_when_results_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    pd.DataFrame({"metric": ["vol"], "value": [0.09]}).to_csv(
+        bundle_dir / "summary.csv", index=False
+    )
+
+    rc = cli.main(
+        [
+            "mc",
+            "viz",
+            "--bundle",
+            str(bundle_dir),
+            "--out",
+            str(tmp_path / "exports"),
+            "--html",
+        ]
+    )
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "Missing required MC results file" in err
+
+
+def test_mc_viz_errors_when_multiple_required_inputs_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+
+    rc = cli.main(
+        [
+            "mc",
+            "viz",
+            "--bundle",
+            str(bundle_dir),
+            "--out",
+            str(tmp_path / "exports"),
+            "--json",
+        ]
+    )
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "Missing required MC input files" in err
+    assert "summary" in err
+    assert "results" in err
+
+
+def test_mc_viz_errors_when_results_file_is_corrupted(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    pd.DataFrame({"metric": ["vol"], "value": [0.09]}).to_csv(
+        bundle_dir / "summary.csv", index=False
+    )
+    (bundle_dir / "results.json").write_text("{bad json", encoding="utf-8")
+
+    rc = cli.main(
+        [
+            "mc",
+            "viz",
+            "--bundle",
+            str(bundle_dir),
+            "--out",
+            str(tmp_path / "exports"),
+            "--png",
+        ]
+    )
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "Failed to read results data" in err
+
+
+def test_mc_viz_loads_optional_nav_paths_frame(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    pd.DataFrame({"metric": ["cagr"], "value": [0.12]}).to_csv(
+        bundle_dir / "summary.csv", index=False
+    )
+    pd.DataFrame({"path_id": [1, 2], "terminal_nav": [112.0, 98.4]}).to_csv(
+        bundle_dir / "results.csv", index=False
+    )
+    (bundle_dir / "nav_paths.parquet").write_text("placeholder", encoding="utf-8")
+
+    monkeypatch.setattr(cli.pd, "read_parquet", lambda _path: pd.DataFrame({"path_id": [1, 2, 3]}))
+
+    rc = cli.main(
+        [
+            "mc",
+            "viz",
+            "--bundle",
+            str(bundle_dir),
+            "--out",
+            str(tmp_path / "exports"),
+            "--png",
+        ]
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "nav_paths_rows=3" in out
+
+
+def test_mc_viz_errors_when_chart_identifier_is_invalid(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    pd.DataFrame({"metric": ["cagr"], "value": [0.12]}).to_csv(
+        bundle_dir / "summary.csv", index=False
+    )
+    pd.DataFrame({"path_id": [1, 2], "terminal_nav": [112.0, 98.4]}).to_csv(
+        bundle_dir / "results.csv", index=False
+    )
+
+    rc = cli.main(
+        [
+            "mc",
+            "viz",
+            "--bundle",
+            str(bundle_dir),
+            "--out",
+            str(tmp_path / "exports"),
+            "--charts",
+            "fan,unknown",
+            "--html",
+        ]
+    )
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "Unsupported chart identifier" in err
+
+
+def test_mc_viz_routes_selected_charts_and_exports_requested_formats(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    pd.DataFrame({"metric": ["cagr"], "value": [0.12]}).to_csv(
+        bundle_dir / "summary.csv", index=False
+    )
+    pd.DataFrame({"path_id": [1, 2], "terminal_nav": [112.0, 98.4]}).to_csv(
+        bundle_dir / "results.csv", index=False
+    )
+
+    call_order: list[str] = []
+
+    def _builder(name: str):
+        def _inner(
+            _summary: pd.DataFrame, _results: pd.DataFrame, _nav: pd.DataFrame | None
+        ) -> object:
+            call_order.append(name)
+            return object()
+
+        return _inner
+
+    monkeypatch.setattr(
+        cli,
+        "_mc_chart_builders",
+        lambda: {
+            "fan": _builder("fan"),
+            "path_dist": _builder("path_dist"),
+            "risk_return": _builder("risk_return"),
+        },
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_save(
+        charts: dict[str, object],
+        destination: Path | str | None = None,
+        *,
+        include_json: bool = True,
+        include_html: bool = True,
+        include_png: bool = False,
+        warnings: list[str] | None = None,
+        **_kwargs: object,
+    ) -> Path:
+        assert destination is not None
+        dest_path = Path(destination)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        captured["charts"] = list(charts.keys())
+        captured["include_json"] = include_json
+        captured["include_html"] = include_html
+        captured["include_png"] = include_png
+        with zipfile.ZipFile(dest_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for name in charts:
+                if include_json:
+                    archive.writestr(f"{name}.json", "{}")
+                if include_html:
+                    archive.writestr(f"{name}.html", "<html></html>")
+                if include_png:
+                    archive.writestr(f"{name}.png", b"PNG")
+        if warnings is not None:
+            warnings.append("stub warning")
+        return dest_path
+
+    from trend_analysis.monte_carlo import export_bundle as mc_export_bundle
+
+    monkeypatch.setattr(mc_export_bundle, "save", fake_save)
+
+    out_dir = tmp_path / "exports"
+    rc = cli.main(
+        [
+            "mc",
+            "viz",
+            "--bundle",
+            str(bundle_dir),
+            "--out",
+            str(out_dir),
+            "--charts",
+            "risk_return,fan",
+            "--json",
+            "--png",
+        ]
+    )
+
+    assert rc == 0
+    assert call_order == ["risk_return", "fan"]
+    assert captured["charts"] == ["risk_return", "fan"]
+    assert captured["include_json"] is True
+    assert captured["include_html"] is False
+    assert captured["include_png"] is True
+    plots_dir = out_dir / "plots"
+    assert plots_dir.is_dir()
+    assert (plots_dir / "risk_return.json").exists()
+    assert (plots_dir / "fan.json").exists()
+    assert (plots_dir / "risk_return.png").exists()
+    assert (plots_dir / "fan.png").exists()
+    assert not (plots_dir / "risk_return.html").exists()


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
A CLI exporter enables automation (scheduled runs, CI artifacts, batch scenario sweeps) and keeps Streamlit UI simpler.

#### Tasks
- [x] Add a CLI subcommand `trend mc viz` that accepts `--bundle <path> --out <dir> --charts fan,path_dist,risk_return --html --json --png`.
  - [ ] Register the `trend mc viz` subcommand in the CLI command hierarchy (verify: confirm completion in repo)
  - [ ] Implement argument parser for `--bundle` flag to accept input directory path (verify: confirm completion in repo)
  - [ ] Implement argument parser for `--out` flag to specify output directory (verify: confirm completion in repo)
  - [ ] Implement argument parser for `--charts` flag accepting comma-separated chart types (verify: confirm completion in repo)
  - [ ] Implement boolean flags `--html`, `--json`, (verify: confirm completion in repo)
  - [ ] `--png` for output format selection (verify: formatter passes)
  - [ ] Define scope for: Add validation logic to ensure at least one output format flag is specified (verify: formatter passes)
  - [ ] Implement focused slice for: Add validation logic to ensure at least one output format flag is specified (verify: formatter passes)
  - [ ] Validate focused slice for: Add validation logic to ensure at least one output format flag is specified (verify: formatter passes)
- [x] Implement loaders to read MC summary/results data frames from the bundle path.
  - [ ] Define scope for: Implement loader function to read MC summary data frame from the bundle directory (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Implement loader function to read MC summary data frame from the bundle directory (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Implement loader function to read MC summary data frame from the bundle directory (verify: confirm completion in repo)
  - [ ] Define scope for: Implement loader function to read MC results data frame from the bundle directory (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Implement loader function to read MC results data frame from the bundle directory (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Implement loader function to read MC results data frame from the bundle directory (verify: confirm completion in repo)
  - [ ] Add error handling for missing or corrupted summary data files (verify: confirm completion in repo)
  - [ ] Add error handling for missing or corrupted results data files (verify: confirm completion in repo)
- [x] Implement loading of `nav_paths.parquet` from the bundle path when present.
- [x] Implement routing from parsed `--charts` selections to `trend_analysis.viz` chart builder functions and call `export_bundle` to write artifacts to the output directory.
  - [ ] Define scope for: Parse the comma-separated `--charts` argument into a list of chart type identifiers (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Parse the comma-separated `--charts` argument into a list of chart type identifiers (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Parse the comma-separated `--charts` argument into a list of chart type identifiers (verify: confirm completion in repo)
  - [ ] Define scope for: Create a mapping dictionary from chart type strings to corresponding viz builder functions (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Create a mapping dictionary from chart type strings to corresponding viz builder functions (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Create a mapping dictionary from chart type strings to corresponding viz builder functions (verify: confirm completion in repo)
  - [ ] Define scope for: Implement routing logic to invoke the appropriate viz builder for each selected chart type (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Implement routing logic to invoke the appropriate viz builder for each selected chart type (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Implement routing logic to invoke the appropriate viz builder for each selected chart type (verify: confirm completion in repo)
  - [ ] Call `export_bundle` function with generated charts (verify: confirm completion in repo)
  - [ ] Call `export_bundle` function with selected output formats (verify: formatter passes)
  - [ ] Ensure output directory structure is created before writing artifacts (verify: confirm completion in repo)
- [x] Add documentation snippet with example usage of `trend mc viz` including flags `--bundle`, `--out`, `--charts`, `--html`, `--json`, and `--png`.

#### Acceptance criteria
- [x] Running `trend mc viz --bundle <path> --out <dir> --charts fan,path_dist,risk_return --html --json --png` against a sample MC output directory produces a `<dir>/plots/` folder containing chart artifacts.
- [x] When required inputs are missing from `--bundle <path>`, the command exits with a non-zero status code and prints an error message indicating which inputs are missing.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

A CLI exporter enables automation (scheduled runs, CI artifacts, batch scenario sweeps) and keeps Streamlit UI simpler.

## Scope

Add a CLI subcommand that reads an MC output directory/bundle and writes chart artifacts using `trend_analysis.viz`.

## Non-Goals

No full report generator; just reproducible chart artifacts.

## Tasks

- [ ] Add a CLI subcommand `trend mc viz` that accepts `--bundle <path> --out <dir> --charts fan,path_dist,risk_return --html --json --png`.
  - [ ] Register the `trend mc viz` subcommand in the CLI command hierarchy (verify: confirm completion in repo)
  - [ ] Implement argument parser for `--bundle` flag to accept input directory path (verify: confirm completion in repo)
  - [ ] Implement argument parser for `--out` flag to specify output directory (verify: confirm completion in repo)
  - [ ] Implement argument parser for `--charts` flag accepting comma-separated chart types (verify: confirm completion in repo)
  - [ ] Implement boolean flags `--html`, `--json`, (verify: confirm completion in repo)
  - [ ] `--png` for output format selection (verify: formatter passes)
  - [ ] Define scope for: Add validation logic to ensure at least one output format flag is specified (verify: formatter passes)
  - [ ] Implement focused slice for: Add validation logic to ensure at least one output format flag is specified (verify: formatter passes)
  - [ ] Validate focused slice for: Add validation logic to ensure at least one output format flag is specified (verify: formatter passes)
- [ ] Implement loaders to read MC summary/results data frames from the bundle path.
  - [ ] Define scope for: Implement loader function to read MC summary data frame from the bundle directory (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Implement loader function to read MC summary data frame from the bundle directory (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Implement loader function to read MC summary data frame from the bundle directory (verify: confirm completion in repo)
  - [ ] Define scope for: Implement loader function to read MC results data frame from the bundle directory (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Implement loader function to read MC results data frame from the bundle directory (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Implement loader function to read MC results data frame from the bundle directory (verify: confirm completion in repo)
  - [ ] Add error handling for missing or corrupted summary data files (verify: confirm completion in repo)
  - [ ] Add error handling for missing or corrupted results data files (verify: confirm completion in repo)
- [ ] Implement loading of `nav_paths.parquet` from the bundle path when present.
- [ ] Implement routing from parsed `--charts` selections to `trend_analysis.viz` chart builder functions and call `export_bundle` to write artifacts to the output directory.
  - [ ] Define scope for: Parse the comma-separated `--charts` argument into a list of chart type identifiers (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Parse the comma-separated `--charts` argument into a list of chart type identifiers (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Parse the comma-separated `--charts` argument into a list of chart type identifiers (verify: confirm completion in repo)
  - [ ] Define scope for: Create a mapping dictionary from chart type strings to corresponding viz builder functions (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Create a mapping dictionary from chart type strings to corresponding viz builder functions (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Create a mapping dictionary from chart type strings to corresponding viz builder functions (verify: confirm completion in repo)
  - [ ] Define scope for: Implement routing logic to invoke the appropriate viz builder for each selected chart type (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Implement routing logic to invoke the appropriate viz builder for each selected chart type (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Implement routing logic to invoke the appropriate viz builder for each selected chart type (verify: confirm completion in repo)
  - [ ] Call `export_bundle` function with generated charts (verify: confirm completion in repo)
  - [ ] Call `export_bundle` function with selected output formats (verify: formatter passes)
  - [ ] Ensure output directory structure is created before writing artifacts (verify: confirm completion in repo)
- [ ] Add documentation snippet with example usage of `trend mc viz` including flags `--bundle`, `--out`, `--charts`, `--html`, `--json`, and `--png`.

## Acceptance Criteria

- [ ] Running `trend mc viz --bundle <path> --out <dir> --charts fan,path_dist,risk_return --html --json --png` against a sample MC output directory produces a `<dir>/plots/` folder containing chart artifacts.
- [ ] When required inputs are missing from `--bundle <path>`, the command exits with a non-zero status code and prints an error message indicating which inputs are missing.

## Implementation Notes

_Not provided._

<details>
<summary>Original Issue</summary>

```text
Topic GUID: 7e3e5b35-5017-56c7-b2ac-fc5e53f88586

## Why
A CLI exporter enables automation (scheduled runs, CI artifacts, batch scenario sweeps) and keeps Streamlit UI simpler.

## Scope
- Add a CLI subcommand that reads an MC output directory/bundle and writes chart artifacts using `trend_analysis.viz`.

## Non-Goals
- No full report generator; just reproducible chart artifacts.

## Tasks
- [ ] Add CLI command (suggested shape):
- [ ] `trend mc viz --bundle <path> --out <dir> --charts fan,path_dist,risk_return --html --json --png`
- [ ] Implement loaders:
- [ ] read summary/results frames
- [ ] read `nav_paths.parquet` when present
- [ ] Route to viz builders + export_bundle.
- [ ] Add docs snippet with example usage.

## Acceptance Criteria
- [ ] Running against a sample MC output directory produces a `plots/` folder with artifacts.
- [ ] Clear non-zero exit and message when required inputs are missing.

## Implementation Notes
_Not provided._

---
Synced by [workflow run](https://github.com/stranske/Trend_Model_Project/actions/runs/21857960567).
```
</details>



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #4850

<!-- pr-preamble:end -->