### PR TITLE
Codex bootstrap for #4898

### DIFF
--- a/.github/scripts/node_modules/minimatch/package.json
+++ b/.github/scripts/node_modules/minimatch/package.json
@@ -2,8 +2,7 @@
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
   "name": "minimatch",
   "description": "a glob matcher in javascript",
-  "version": "10.0.1-vendored",
-  "_comment": "Vendored subset of minimatch for internal scripts.",
+  "version": "9.0.5",
   "repository": {
     "type": "git",
     "url": "git://github.com/isaacs/minimatch.git"

--- a/.github/scripts/node_modules/minimatch/package.json
+++ b/.github/scripts/node_modules/minimatch/package.json
@@ -2,7 +2,8 @@
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
   "name": "minimatch",
   "description": "a glob matcher in javascript",
-  "version": "9.0.5",
+  "version": "9.0.5-vendored",
+  "_comment": "Vendored subset of minimatch@9.0.5 for .github scripts; do not publish to npm.",
   "repository": {
     "type": "git",
     "url": "git://github.com/isaacs/minimatch.git"

--- a/agents/codex-4898.md
+++ b/agents/codex-4898.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #4898 -->

--- a/src/trend_analysis/viz/adapters.py
+++ b/src/trend_analysis/viz/adapters.py
@@ -6,6 +6,7 @@ chart components that expect predictable DataFrame schemas.
 
 from __future__ import annotations
 
+import os
 from collections.abc import Iterable, Sequence
 from typing import Any, Callable, ParamSpec, TypeVar, cast
 
@@ -63,16 +64,27 @@ LOOKBACK_PERIODS_VALIDATION_MESSAGE = (
 NO_VALID_LOOKBACK_PERIODS_MESSAGE = "No valid lookback_periods provided"
 """Controlled validation error when iterable normalization produces no valid lookbacks."""
 
+CACHING_REQUIRED_UNAVAILABLE_MESSAGE = "Caching required but streamlit.cache_data is unavailable"
+"""Error raised when runtime requires caching but streamlit.cache_data cannot be used."""
+
 
 def _cache_data(*args: object, **kwargs: object) -> Callable[[Callable[P, R]], Callable[P, R]]:
     cache_data = getattr(st, "cache_data", None) if st is not None else None
     if callable(cache_data):
         return cast(Callable[[Callable[P, R]], Callable[P, R]], cache_data(*args, **kwargs))
+    if _is_caching_required():
+        raise RuntimeError(CACHING_REQUIRED_UNAVAILABLE_MESSAGE)
 
     def _identity(func: Callable[P, R]) -> Callable[P, R]:
         return func
 
     return _identity
+
+
+def _is_caching_required() -> bool:
+    if os.environ.get("TREND_VIZ_REQUIRE_CACHE", "").strip().lower() in {"1", "true", "yes", "on"}:
+        return True
+    return os.environ.get("TREND_ENV", "").strip().lower() in {"production", "prod"}
 
 
 @_cache_data(show_spinner=False)

--- a/src/trend_analysis/viz/adapters.py
+++ b/src/trend_analysis/viz/adapters.py
@@ -7,7 +7,7 @@ chart components that expect predictable DataFrame schemas.
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from typing import Any, Callable, ParamSpec, TypeGuard, TypeVar, cast
+from typing import Any, Callable, ParamSpec, TypeVar, cast
 
 import numpy as np
 import pandas as pd
@@ -22,8 +22,6 @@ except Exception:  # pragma: no cover - streamlit is optional outside app runtim
 
 P = ParamSpec("P")
 R = TypeVar("R")
-_IntLike = int | np.integer[Any]
-
 SUMMARY_REQUIRED_COLUMNS: tuple[str, ...] = ("fold_id", "fold_label", "strategy", "paths")
 """Required columns for ``make_summary`` outputs."""
 
@@ -61,6 +59,9 @@ LOOKBACK_PERIODS_VALIDATION_MESSAGE = (
     "positive integer"
 )
 """Controlled validation error message for ``terminal_returns`` lookback input."""
+
+NO_VALID_LOOKBACK_PERIODS_MESSAGE = "No valid lookback_periods provided"
+"""Controlled validation error when iterable normalization produces no valid lookbacks."""
 
 
 def _cache_data(*args: object, **kwargs: object) -> Callable[[Callable[P, R]], Callable[P, R]]:
@@ -186,9 +187,12 @@ def terminal_returns(
         Optional trailing window (in rows). If ``None``, uses first to last NAV
         over the full horizon. If provided as an integer, return is computed from
         ``t - lookback_periods`` to final ``t``.
-        If provided as an iterable, invalid entries are filtered out and the first
-        valid positive integer is used. Raises a controlled ``ValueError`` if no
-        valid positive integer remains.
+        If provided as an iterable, invalid entries are filtered out to include
+        only values where ``type(x) is int`` and ``x > 0``.
+        For iterable inputs, the first normalized lookback that fits the available
+        rows is used; if none fit, the maximum available lookback is used.
+        Raises ``ValueError("No valid lookback_periods provided")`` if iterable
+        normalization produces no valid lookbacks.
 
     Returns
     -------
@@ -207,16 +211,19 @@ def terminal_returns(
             }
         )
 
-    normalized_lookback = _normalize_lookback_periods(lookback_periods)
+    normalized_lookbacks = _normalize_lookback_periods(lookback_periods)
 
-    if normalized_lookback is None:
+    if normalized_lookbacks is None:
         base = wide.ffill().iloc[0]
         periods_used = max(len(wide.index) - 1, 0)
     else:
-        if len(wide.index) <= normalized_lookback:
-            raise ValueError("lookback_periods must be smaller than the number of rows")
-        base = wide.ffill().iloc[-(normalized_lookback + 1)]
-        periods_used = normalized_lookback
+        max_lookback = max(len(wide.index) - 1, 0)
+        selected_lookback = next(
+            (value for value in normalized_lookbacks if value <= max_lookback),
+            max_lookback,
+        )
+        base = wide.ffill().iloc[-(selected_lookback + 1)]
+        periods_used = selected_lookback
 
     terminal = wide.ffill().iloc[-1]
     returns = (terminal / base) - 1.0
@@ -228,24 +235,19 @@ def terminal_returns(
 
 def _normalize_lookback_periods(
     lookback_periods: int | Iterable[object] | None,
-) -> int | None:
+) -> list[int] | None:
     if lookback_periods is None:
         return None
-    if _is_valid_lookback_period(lookback_periods):
-        return int(lookback_periods)
+    if type(lookback_periods) is int and lookback_periods > 0:
+        return [lookback_periods]
     if isinstance(lookback_periods, (str, bytes)):
         raise ValueError(LOOKBACK_PERIODS_VALIDATION_MESSAGE)
     if isinstance(lookback_periods, Iterable):
-        valid_periods = [
-            int(value) for value in lookback_periods if _is_valid_lookback_period(value)
-        ]
+        valid_periods = [value for value in lookback_periods if type(value) is int and value > 0]
         if valid_periods:
-            return valid_periods[0]
+            return valid_periods
+        raise ValueError(NO_VALID_LOOKBACK_PERIODS_MESSAGE)
     raise ValueError(LOOKBACK_PERIODS_VALIDATION_MESSAGE)
-
-
-def _is_valid_lookback_period(value: object) -> TypeGuard[_IntLike]:
-    return isinstance(value, (int, np.integer)) and not isinstance(value, bool) and int(value) > 0
 
 
 def rolling_stats(

--- a/tests/test_terminal_returns_helper.py
+++ b/tests/test_terminal_returns_helper.py
@@ -4,7 +4,8 @@ import pandas as pd
 import pytest
 
 from trend_analysis.viz.adapters import (
-    LOOKBACK_PERIODS_VALIDATION_MESSAGE,
+    NO_VALID_LOOKBACK_PERIODS_MESSAGE,
+    _normalize_lookback_periods,
     make_paths,
     terminal_returns,
 )
@@ -24,29 +25,53 @@ def _sample_nav_paths() -> pd.DataFrame:
 def test_terminal_returns_rejects_empty_lookback_iterable() -> None:
     canonical = make_paths(_sample_nav_paths())
 
-    with pytest.raises(ValueError, match=LOOKBACK_PERIODS_VALIDATION_MESSAGE):
+    with pytest.raises(ValueError, match=NO_VALID_LOOKBACK_PERIODS_MESSAGE):
         terminal_returns(canonical, lookback_periods=[])
 
 
 def test_terminal_returns_rejects_non_positive_lookbacks() -> None:
     canonical = make_paths(_sample_nav_paths())
 
-    with pytest.raises(ValueError, match=LOOKBACK_PERIODS_VALIDATION_MESSAGE):
+    with pytest.raises(ValueError, match=NO_VALID_LOOKBACK_PERIODS_MESSAGE):
         terminal_returns(canonical, lookback_periods=[0, -2])
 
 
 def test_terminal_returns_rejects_non_integer_lookbacks() -> None:
     canonical = make_paths(_sample_nav_paths())
 
-    with pytest.raises(ValueError, match=LOOKBACK_PERIODS_VALIDATION_MESSAGE):
+    with pytest.raises(ValueError, match=NO_VALID_LOOKBACK_PERIODS_MESSAGE):
         terminal_returns(canonical, lookback_periods=[1.5, "3", None])
 
 
 def test_terminal_returns_filters_invalid_iterable_entries_and_uses_first_valid() -> None:
     canonical = make_paths(_sample_nav_paths())
 
-    lookback = terminal_returns(canonical, lookback_periods=[0, -1, 2, 1.1])
+    lookback = terminal_returns(canonical, lookback_periods=[0, -1, 2, 1.1, True])
 
     assert lookback.loc[0, "lookback_periods"] == 2
     assert lookback.loc[0, "terminal_return"] == pytest.approx(0.09090909)
     assert lookback.loc[1, "terminal_return"] == pytest.approx(0.12222222)
+
+
+def test_terminal_returns_handles_single_oversized_integer_lookback() -> None:
+    canonical = make_paths(_sample_nav_paths())
+
+    returns = terminal_returns(canonical, lookback_periods=999)
+
+    assert returns.loc[0, "lookback_periods"] == 3
+    assert returns.loc[0, "terminal_return"] == pytest.approx(0.2)
+
+
+def test_terminal_returns_handles_iterable_with_oversized_and_valid_lookbacks() -> None:
+    canonical = make_paths(_sample_nav_paths())
+
+    returns = terminal_returns(canonical, lookback_periods=[999, 2, 1])
+
+    assert returns.loc[0, "lookback_periods"] == 2
+    assert returns.loc[0, "terminal_return"] == pytest.approx(0.09090909)
+
+
+def test_normalize_lookback_periods_returns_positive_ints_in_input_order() -> None:
+    normalized = _normalize_lookback_periods([0, 4, True, -2, 1, False, 3])
+
+    assert normalized == [4, 1, 3]

--- a/tests/test_viz_caching.py
+++ b/tests/test_viz_caching.py
@@ -83,6 +83,46 @@ def test_viz_cache_data_is_decorated_and_invoked(monkeypatch) -> None:
         assert called[name] >= 1
 
 
+def test_viz_cache_data_wraps_functions_when_streamlit_is_available(monkeypatch) -> None:
+    def cache_data(*_args, **_kwargs):
+        def decorator(func):
+            def wrapped(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            wrapped.__wrapped__ = func
+            wrapped._streamlit_cache_wrapped = True
+            return wrapped
+
+        return decorator
+
+    monkeypatch.setitem(sys.modules, "streamlit", SimpleNamespace(cache_data=cache_data))
+
+    adapters = importlib.reload(importlib.import_module("trend_analysis.viz.adapters"))
+    corr_heatmap = importlib.reload(
+        importlib.import_module("trend_analysis.viz.charts.corr_heatmap")
+    )
+    rolling_panel = importlib.reload(
+        importlib.import_module("trend_analysis.viz.charts.rolling_panel")
+    )
+    seasonality_heatmap = importlib.reload(
+        importlib.import_module("trend_analysis.viz.charts.seasonality_heatmap")
+    )
+    sharpe_ladder = importlib.reload(importlib.import_module("trend_analysis.viz.sharpe_ladder"))
+
+    wrapped_functions = [
+        adapters._make_summary_cached,
+        adapters._make_paths_cached,
+        corr_heatmap._prepare_corr_matrix,
+        rolling_panel._prepare_panel_series,
+        seasonality_heatmap._prepare_seasonality_matrix,
+        sharpe_ladder.prepare_sharpe_ladder,
+    ]
+    for fn in wrapped_functions:
+        assert getattr(fn, "_streamlit_cache_wrapped", False) is True
+        assert hasattr(fn, "__wrapped__")
+        assert fn is not fn.__wrapped__
+
+
 def test_viz_cache_guard_raises_when_required_and_cache_data_missing(monkeypatch) -> None:
     monkeypatch.setenv("TREND_VIZ_REQUIRE_CACHE", "1")
     monkeypatch.setitem(sys.modules, "streamlit", SimpleNamespace(cache_data=None))

--- a/tests/test_viz_caching.py
+++ b/tests/test_viz_caching.py
@@ -6,6 +6,7 @@ from collections import Counter
 from types import SimpleNamespace
 
 import pandas as pd
+import pytest
 
 
 def _sample_results_frame() -> pd.DataFrame:
@@ -80,3 +81,13 @@ def test_viz_cache_data_is_decorated_and_invoked(monkeypatch) -> None:
     assert expected.issubset(decorated)
     for name in expected:
         assert called[name] >= 1
+
+
+def test_viz_cache_guard_raises_when_required_and_cache_data_missing(monkeypatch) -> None:
+    monkeypatch.setenv("TREND_VIZ_REQUIRE_CACHE", "1")
+    monkeypatch.setitem(sys.modules, "streamlit", SimpleNamespace(cache_data=None))
+
+    with pytest.raises(
+        RuntimeError, match="Caching required but streamlit.cache_data is unavailable"
+    ):
+        importlib.reload(importlib.import_module("trend_analysis.viz.adapters"))

--- a/tests/viz/test_chart_entrypoints_contract.py
+++ b/tests/viz/test_chart_entrypoints_contract.py
@@ -60,7 +60,9 @@ def _find_streamlit_attribute_violations(func_def: ast.FunctionDef) -> list[int]
     return bad_line_numbers
 
 
-def _load_function_def_from_source(source: str, function_name: str = "build_figure") -> ast.FunctionDef:
+def _load_function_def_from_source(
+    source: str, function_name: str = "build_figure"
+) -> ast.FunctionDef:
     module = ast.parse(source)
     for node in module.body:
         if isinstance(node, ast.FunctionDef) and node.name == function_name:
@@ -98,12 +100,12 @@ def build_figure(data):
             [3],
         ),
         (
-            '''
+            """
 def build_figure(data):
     # st.write(data)
     note = "streamlit.write(data)"
     return data
-''',
+""",
             [],
         ),
         (

--- a/tests/viz/test_chart_entrypoints_contract.py
+++ b/tests/viz/test_chart_entrypoints_contract.py
@@ -6,6 +6,8 @@ import ast
 import inspect
 from pathlib import Path
 
+import pytest
+
 from trend_analysis.viz import sharpe_ladder
 from trend_analysis.viz.charts import corr_heatmap, rolling_panel, seasonality_heatmap
 
@@ -58,6 +60,14 @@ def _find_streamlit_attribute_violations(func_def: ast.FunctionDef) -> list[int]
     return bad_line_numbers
 
 
+def _load_function_def_from_source(source: str, function_name: str = "build_figure") -> ast.FunctionDef:
+    module = ast.parse(source)
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            return node
+    raise AssertionError(f"Unable to locate function definition for {function_name!r}")
+
+
 def test_public_entrypoints_do_not_call_streamlit_api() -> None:
     for entrypoint in ENTRYPOINTS:
         entrypoint_ast = _load_entrypoint_ast(entrypoint)
@@ -66,3 +76,55 @@ def test_public_entrypoints_do_not_call_streamlit_api() -> None:
             f"{entrypoint.__module__}.{entrypoint.__name__} calls Streamlit in executable body "
             f"at lines {violations}"
         )
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_violations"),
+    [
+        (
+            """
+def build_figure(data):
+    st.write(data)
+    return data
+""",
+            [3],
+        ),
+        (
+            """
+def build_figure(data):
+    streamlit.write(data)
+    return data
+""",
+            [3],
+        ),
+        (
+            '''
+def build_figure(data):
+    # st.write(data)
+    note = "streamlit.write(data)"
+    return data
+''',
+            [],
+        ),
+        (
+            """
+@st.cache_data
+def build_figure(data):
+    return data
+""",
+            [],
+        ),
+        (
+            """
+HELPER = st.write
+
+def build_figure(data):
+    return data
+""",
+            [],
+        ),
+    ],
+)
+def test_streamlit_attribute_detection_cases(source: str, expected_violations: list[int]) -> None:
+    function_def = _load_function_def_from_source(source)
+    assert _find_streamlit_attribute_violations(function_def) == expected_violations

--- a/tests/viz/test_chart_entrypoints_contract.py
+++ b/tests/viz/test_chart_entrypoints_contract.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import ast
 import inspect
+from pathlib import Path
 
 from trend_analysis.viz import sharpe_ladder
 from trend_analysis.viz.charts import corr_heatmap, rolling_panel, seasonality_heatmap
@@ -27,7 +29,40 @@ def test_primary_input_parameter_name_is_consistent() -> None:
     assert first_param_names == ["data", "data", "data", "data"]
 
 
+def _load_entrypoint_ast(entrypoint: object) -> ast.FunctionDef:
+    source_path = inspect.getsourcefile(entrypoint)
+    if source_path is None:
+        raise AssertionError(f"Unable to resolve source file for {entrypoint!r}")
+
+    tree = ast.parse(Path(source_path).read_text(encoding="utf-8"), filename=source_path)
+    function_name = getattr(entrypoint, "__name__", None)
+    if not isinstance(function_name, str):
+        raise AssertionError(f"Unable to resolve function name for {entrypoint!r}")
+
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            return node
+    raise AssertionError(f"Unable to locate function definition for {function_name!r}")
+
+
+def _find_streamlit_attribute_violations(func_def: ast.FunctionDef) -> list[int]:
+    bad_line_numbers: list[int] = []
+    for statement in func_def.body:
+        for node in ast.walk(statement):
+            if (
+                isinstance(node, ast.Attribute)
+                and isinstance(node.value, ast.Name)
+                and node.value.id in {"st", "streamlit"}
+            ):
+                bad_line_numbers.append(node.lineno)
+    return bad_line_numbers
+
+
 def test_public_entrypoints_do_not_call_streamlit_api() -> None:
     for entrypoint in ENTRYPOINTS:
-        entrypoint_source = inspect.getsource(entrypoint)
-        assert "st." not in entrypoint_source
+        entrypoint_ast = _load_entrypoint_ast(entrypoint)
+        violations = _find_streamlit_attribute_violations(entrypoint_ast)
+        assert not violations, (
+            f"{entrypoint.__module__}.{entrypoint.__name__} calls Streamlit in executable body "
+            f"at lines {violations}"
+        )


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #4892 addressed issue #4891, and verification passed, but it surfaced a few enforceability and contract-clarity gaps around (1) reliably detecting Streamlit usage inside chart entrypoints, (2) deterministic lookback normalization/terminal-returns behavior for oversized/invalid lookbacks, and (3) ensuring Streamlit caching is actually applied (and loudly fails when required but unavailable). This follow-up converts those concerns into concrete implementation tasks with testable acceptance criteria.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#4892](https://github.com/stranske/Trend_Model_Project/issues/4892)
- [#4891](https://github.com/stranske/Trend_Model_Project/issues/4891)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Update `tests/<contract_test_file_for_chart_entrypoints>.py` to parse chart modules with `ast`, locate each public entrypoint `FunctionDef`, and fail when its executable body contains `Attribute` access on `Name(id="st")` or `Name(id="streamlit")`, excluding decorator lines and ignoring comments/string literals.
- [x] Add or extend tests in `tests/<contract_test_file_for_chart_entrypoints>.py` to cover: in-body `st.*` failure, in-body `streamlit.*` failure, comment/string occurrences that pass, decorator-only occurrences that pass, and module-scope-only occurrences that pass.
- [x] Update `trend_analysis/<path_to_terminal_returns_helper>.py` to normalize iterable `lookback_periods` by filtering to `type(x) is int` (excluding `bool`) and `x > 0`, and to raise `ValueError("No valid lookback_periods provided")` exactly when no valid lookback remains after normalization.
- [x] Add/extend unit tests in `tests/test_terminal_returns_helper.py` to cover oversized `lookback_periods` cases: a single integer greater than the number of DataFrame rows, and an iterable containing oversized values plus at least one valid lookback, asserting no `ValueError`/`IndexError` when at least one valid lookback exists per the defined contract.
- [x] Update `trend_analysis/<module_containing__normalize_lookback_periods>.py` to implement the chosen `_normalize_lookback_periods` contract (either return all valid lookbacks in order, or select exactly one by a documented rule), filter out booleans as invalid, and update the docstring to match.
- [x] Add/update unit tests in `tests/<tests_for_lookback_normalization>.py` to enforce the chosen `_normalize_lookback_periods` behavior, including that `True`/`False` are treated as invalid and filtered out.
- [x] Refactor `trend_analysis/viz/<module_containing__cache_data>.py` so that when Streamlit is importable, `_cache_data` returns/applies `streamlit.cache_data` (not a silent no-op), and add a production-mode caching-required runtime guard that raises `RuntimeError("Caching required but streamlit.cache_data is unavailable")` exactly when required but missing/None.
- [x] Update caching tests in `tests/test_viz_caching.py` and `tests/<any_related_caching_test_files>.py` to (a) verify a function decorated via `_cache_data` is actually wrapped by `streamlit.cache_data` (e.g., using a spy stub) and (b) verify the production-mode guard raises the specified `RuntimeError` when caching is required but `streamlit.cache_data` is absent.

#### Acceptance criteria
- [x] `tests/<contract_test_file_for_chart_entrypoints>.py` inspects each chart module public entrypoint function body (excluding decorator lines) and fails if it finds Streamlit attribute access in executable code via either `st.<name>` or `streamlit.<name>`.
- [x] The Streamlit-usage contract test does not fail when `st.` or `streamlit.` occur only inside comments or string literals.
- [x] The Streamlit-usage contract test does not fail when `st.` or `streamlit.` occur only at module scope (e.g., imports/constants) and not within the public entrypoint function body.
- [x] For the terminal returns helper, when `lookback_periods` is a single integer greater than the number of rows in the input DataFrame, the helper does not raise an exception when at least one valid lookback exists per the function’s defined fallback/selection behavior (as enforced by tests).
- [x] For the terminal returns helper, when `lookback_periods` is an iterable containing some lookbacks greater than the number of DataFrame rows and at least one valid lookback, the helper returns successfully (no `ValueError`/`IndexError`) and uses the valid lookback(s) per the defined contract (as enforced by tests).
- [x] The terminal returns helper filters iterable `lookback_periods` to only `type(x) is int` (booleans excluded) and `x > 0`, and proceeds when at least one valid lookback remains (as enforced by tests).
- [x] The terminal returns helper raises `ValueError` with the exact message `No valid lookback_periods provided` when no valid lookback remains after normalization (as enforced by tests).
- [x] When Streamlit is importable, applying `_cache_data` results in the decorated function being wrapped by `streamlit.cache_data` (verified via an automated test using a spy/stub wrapper).
- [x] When production-mode caching is required and `streamlit.cache_data` is missing/None, a runtime guard raises `RuntimeError` with the exact message `Caching required but streamlit.cache_data is unavailable` (verified by an automated test).
- [x] `_normalize_lookback_periods` behavior is explicitly one of: (A) returns all valid positive integers in original order, OR (B) returns exactly one selected valid positive integer per documented selection rule, and this is enforced by unit tests.
- [x] `_normalize_lookback_periods` treats booleans (`True`/`False`) as invalid and filters them out, as enforced by unit tests.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why
PR #4892 addressed issue #4891, and verification passed, but it surfaced a few enforceability and contract-clarity gaps around (1) reliably detecting Streamlit usage inside chart entrypoints, (2) deterministic lookback normalization/terminal-returns behavior for oversized/invalid lookbacks, and (3) ensuring Streamlit caching is actually applied (and loudly fails when required but unavailable). This follow-up converts those concerns into concrete implementation tasks with testable acceptance criteria.

## Scope
Update contract tests and implementation to:
- Reliably detect Streamlit usage inside each chart module’s public entrypoint function body (supporting both `st.` and `streamlit.` forms) while avoiding false positives from comments/strings/decorators/module scope.
- Define and enforce deterministic lookback normalization and terminal returns behavior for invalid/oversized lookbacks, including controlled error handling.
- Ensure `_cache_data` applies Streamlit caching when available and raises a runtime error when production-mode caching is required but unavailable.
- Add/adjust automated tests covering the above behaviors.

## Non-Goals
- Centralizing chart modules’ `_cache_data` helpers into a shared utility (advisory only).
- General refactors unrelated to Streamlit usage detection, lookback normalization, terminal returns behavior, or caching enforcement.

## Tasks
- [x] Update `tests/<contract_test_file_for_chart_entrypoints>.py` to parse chart modules with `ast`, locate each public entrypoint `FunctionDef`, and fail when its executable body contains `Attribute` access on `Name(id="st")` or `Name(id="streamlit")`, excluding decorator lines and ignoring comments/string literals.
- [ ] Add or extend tests in `tests/<contract_test_file_for_chart_entrypoints>.py` to cover: in-body `st.*` failure, in-body `streamlit.*` failure, comment/string occurrences that pass, decorator-only occurrences that pass, and module-scope-only occurrences that pass.
- [ ] Update `trend_analysis/<path_to_terminal_returns_helper>.py` to normalize iterable `lookback_periods` by filtering to `type(x) is int` (excluding `bool`) and `x > 0`, and to raise `ValueError("No valid lookback_periods provided")` exactly when no valid lookback remains after normalization.
- [ ] Add/extend unit tests in `tests/test_terminal_returns_helper.py` to cover oversized `lookback_periods` cases: a single integer greater than the number of DataFrame rows, and an iterable containing oversized values plus at least one valid lookback, asserting no `ValueError`/`IndexError` when at least one valid lookback exists per the defined contract.
- [ ] Update `trend_analysis/<module_containing__normalize_lookback_periods>.py` to implement the chosen `_normalize_lookback_periods` contract (either return all valid lookbacks in order, or select exactly one by a documented rule), filter out booleans as invalid, and update the docstring to match.
- [ ] Add/update unit tests in `tests/<tests_for_lookback_normalization>.py` to enforce the chosen `_normalize_lookback_periods` behavior, including that `True`/`False` are treated as invalid and filtered out.
- [ ] Refactor `trend_analysis/viz/<module_containing__cache_data>.py` so that when Streamlit is importable, `_cache_data` returns/applies `streamlit.cache_data` (not a silent no-op), and add a production-mode caching-required runtime guard that raises `RuntimeError("Caching required but streamlit.cache_data is unavailable")` exactly when required but missing/None.
- [ ] Update caching tests in `tests/test_viz_caching.py` and `tests/<any_related_caching_test_files>.py` to (a) verify a function decorated via `_cache_data` is actually wrapped by `streamlit.cache_data` (e.g., using a spy stub) and (b) verify the production-mode guard raises the specified `RuntimeError` when caching is required but `streamlit.cache_data` is absent.

## Acceptance Criteria
- [ ] `tests/<contract_test_file_for_chart_entrypoints>.py` inspects each chart module public entrypoint function body (excluding decorator lines) and fails if it finds Streamlit attribute access in executable code via either `st.<name>` or `streamlit.<name>`.
- [ ] The Streamlit-usage contract test does not fail when `st.` or `streamlit.` occur only inside comments or string literals.
- [ ] The Streamlit-usage contract test does not fail when `st.` or `streamlit.` occur only at module scope (e.g., imports/constants) and not within the public entrypoint function body.
- [ ] For the terminal returns helper, when `lookback_periods` is a single integer greater than the number of rows in the input DataFrame, the helper does not raise an exception when at least one valid lookback exists per the function’s defined fallback/selection behavior (as enforced by tests).
- [ ] For the terminal returns helper, when `lookback_periods` is an iterable containing some lookbacks greater than the number of DataFrame rows and at least one valid lookback, the helper returns successfully (no `ValueError`/`IndexError`) and uses the valid lookback(s) per the defined contract (as enforced by tests).
- [ ] The terminal returns helper filters iterable `lookback_periods` to only `type(x) is int` (booleans excluded) and `x > 0`, and proceeds when at least one valid lookback remains (as enforced by tests).
- [ ] The terminal returns helper raises `ValueError` with the exact message `No valid lookback_periods provided` when no valid lookback remains after normalization (as enforced by tests).
- [x] When Streamlit is importable, applying `_cache_data` results in the decorated function being wrapped by `streamlit.cache_data` (verified via an automated test using a spy/stub wrapper).
- [ ] When production-mode caching is required and `streamlit.cache_data` is missing/None, a runtime guard raises `RuntimeError` with the exact message `Caching required but streamlit.cache_data is unavailable` (verified by an automated test).
- [ ] `_normalize_lookback_periods` behavior is explicitly one of: (A) returns all valid positive integers in original order, OR (B) returns exactly one selected valid positive integer per documented selection rule, and this is enforced by unit tests.
- [ ] `_normalize_lookback_periods` treats booleans (`True`/`False`) as invalid and filters them out, as enforced by unit tests.

## Implementation Notes
- Streamlit-usage contract test:
  - Restrict inspection to the public entrypoint function body only (exclude decorator lines and module scope).
  - Prefer an AST-based approach: parse the module, locate the entrypoint `FunctionDef`, and walk its body for `Attribute` access where the base is `Name(id="st")` or `Name(id="streamlit")`. This naturally ignores comments/strings and avoids substring false positives.
  - Add fixtures/cases within `tests/<contract_test_file_for_chart_entrypoints>.py` to cover: in-body `st.*` failure, in-body `streamlit.*` failure, comment/string pass, decorator-only pass, and module-scope-only pass.
- Terminal returns helper and lookback normalization:
  - Normalize iterable inputs by filtering to `type(x) is int` (exclude `bool`) and `x > 0`.
  - Oversized lookbacks (greater than available rows) should not crash if at least one other valid lookback exists per the chosen contract; encode the decision in tests.
  - If, after normalization, no valid lookback remains, raise `ValueError("No valid lookback_periods provided")` exactly.
  - Decide and document `_normalize_lookback_periods` contract (return all valids vs select one) and align both helper behavior and tests accordingly.
- `_cache_data` behavior:
  - When Streamlit is importable, `_cache_data` must apply `streamlit.cache_data` rather than silently doing nothing.
  - Add a configuration/flag-driven runtime guard for “production-mode caching required”; in that mode, if `streamlit.cache_data` is missing/None, raise `RuntimeError("Caching required but streamlit.cache_data is unavailable")` exactly.
  - Tests should use a spy `streamlit.cache_data` stub that returns a wrapper marking the wrapped function, and separately test the guard failure path.

<details>
<summary>Original Issue</summary>

```text
<!-- follow-up-depth: 2 -->
## Why
PR #4892 addressed issue #4891, and verification passed, but it surfaced a few enforceability and contract-clarity gaps around (1) reliably detecting Streamlit usage inside chart entrypoints, (2) deterministic lookback normalization/terminal-returns behavior for oversized/invalid lookbacks, and (3) ensuring Streamlit caching is actually applied (and loudly fails when required but unavailable). This follow-up converts those concerns into concrete implementation tasks with testable acceptance criteria.

## Source
- Original PR: #4892
- Parent issue: #4891

## Tasks
- [ ] Update the Streamlit-usage contract test to detect both `st.` and `streamlit.` within each chart module’s public entrypoint body, ignoring decorators/comments/strings where feasible. (File: `tests/<contract_test_file_for_chart_entrypoints>.py`)
- [ ] Add/extend unit tests for the terminal returns helper to cover `lookback_periods` values that exceed the number of DataFrame rows (both single int and iterable cases), asserting non-crashing behavior when at least one valid lookback exists. (File: `tests/test_terminal_returns_helper.py`)
- [ ] Modify the terminal returns helper to normalize iterable `lookback_periods` by filtering out non-integers and non-positive values, selecting valid lookback(s) per the current function contract, and raising a controlled `ValueError` with a specific message only when no valid lookback remains (or a clearly defined unrecoverable condition occurs). (File: `trend_analysis/<path_to_terminal_returns_helper>.py`)
- [ ] Refactor the `_cache_data` helper so that when Streamlit is importable it must return/apply `streamlit.cache_data` (not a silent no-op), and add a runtime guard that fails loudly if production-mode caching is expected but not active. (File: `trend_analysis/viz/<module_containing__cache_data>.py`)
- [ ] Update caching-related tests to validate that cached functions are actually wrapped by `streamlit.cache_data` when Streamlit is available (e.g., via a spy wrapper) and that the production-mode guard triggers when `cache_data` is unexpectedly absent. (Files: `tests/test_viz_caching.py`, `tests/<any_related_caching_test_files>.py`)
- [ ] Align `_normalize_lookback_periods` implementation and tests with the chosen behavior by either (a) returning all valid lookbacks or (b) explicitly selecting one; update docstring and unit tests accordingly. (Files: `trend_analysis/<module_containing__normalize_lookback_periods>.py`, `tests/<tests_for_lookback_normalization>.py`)

## Acceptance Criteria
- [ ] The Streamlit-usage contract test inspects each chart module public entrypoint function body (excluding decorator lines) and fails if it finds any Streamlit attribute access using either alias form `st.<name>` or full form `streamlit.<name>` in executable code; occurrences inside comments or string literals do not trigger a failure.
- [ ] The Streamlit-usage contract test must not flag `st.` or `streamlit.` when they occur only in the module-level scope (imports, constants) and not within the public entrypoint function body.
- [ ] For terminal returns helper: when `lookback_periods` is a single integer greater than the number of rows in the input DataFrame, the helper does not raise an exception if there exists at least one other valid lookback available via the function’s defined fallback/selection behavior (as codified in tests).
- [ ] For terminal returns helper: when `lookback_periods` is an iterable containing some lookbacks greater than the number of DataFrame rows and at least one valid lookback, the helper returns successfully (no `ValueError`/`IndexError`) and uses the valid lookback(s) per the defined contract (selection or all-valid behavior).
- [ ] The terminal returns helper normalizes iterable `lookback_periods` by filtering out entries that are not instances of `int` (booleans treated as invalid) and entries that are `<= 0`; the helper proceeds when at least one valid lookback remains.
- [ ] The terminal returns helper raises a `ValueError` with the exact message `No valid lookback_periods provided` (case- and whitespace-sensitive) when, after normalization, no valid lookback remains.
- [ ] When Streamlit is importable, `_cache_data` returns a decorator that is `streamlit.cache_data` (or a direct wrapper produced by calling it) and applying `_cache_data` to a function results in the function being wrapped by Streamlit caching (i.e., the wrapper returned by `streamlit.cache_data` is actually invoked).
- [ ] A runtime guard raises a `RuntimeError` with the exact message `Caching required but streamlit.cache_data is unavailable` when the application is in production-mode caching-required configuration and `streamlit.cache_data` is missing/None.
- [ ] Caching-related tests validate both (a) successful wrapping via `streamlit.cache_data` when available and (b) the production-mode guard failure path when caching is required but not active; both scenarios are covered by automated tests.
- [ ] `_normalize_lookback_periods` behavior is explicitly one of the following and is enforced by tests: (A) returns a list/tuple of all valid positive integers from the input iterable in their original order, OR (B) returns exactly one selected valid positive integer per documented selection rule (e.g., first valid). The chosen option is stated in the function docstring and matches unit tests.
- [ ] `_normalize_lookback_periods` treats booleans as invalid (i.e., `True`/`False` are not accepted as integers) and filters them out in the same way as other non-integer values.

## Implementation Notes
- Streamlit-usage contract test:
  - Restrict inspection to the public entrypoint function body only (exclude decorator lines and module scope).
  - Prefer an AST-based approach: parse the module, locate the entrypoint `FunctionDef`, and walk its body for `Attribute` access where the base is `Name(id="st")` or `Name(id="streamlit")`. This naturally ignores comments/strings and avoids substring false positives.
  - Add fixtures/cases within `tests/<contract_test_file_for_chart_entrypoints>.py` to cover: in-body `st.*` failure, in-body `streamlit.*` failure, comment/string pass, decorator-only pass, and module-scope-only pass.
- Terminal returns helper and lookback normalization:
  - Normalize iterable inputs by filtering to `type(x) is int` (exclude `bool`) and `x > 0`.
  - Oversized lookbacks (greater than available rows) should not crash if at least one other valid lookback exists per the chosen contract; encode the decision in tests.
  - If, after normalization, no valid lookback remains, raise `ValueError("No valid lookback_periods provided")` exactly.
  - Decide and document `_normalize_lookback_periods` contract (return all valids vs select one) and align both helper behavior and tests accordingly.
- `_cache_data` behavior:
  - When Streamlit is importable, `_cache_data` must apply `streamlit.cache_data` rather than silently doing nothing.
  - Add a configuration/flag-driven runtime guard for “production-mode caching required”; in that mode, if `streamlit.cache_data` is missing/None, raise `RuntimeError("Caching required but streamlit.cache_data is unavailable")` exactly.
  - Tests should use a spy `streamlit.cache_data` stub that returns a wrapper marking the wrapped function, and separately test the guard failure path.

## Notes
<details>
<summary>Advisory items (non-blocking)</summary>

- Chart modules each implement their own optional-Streamlit `_cache_data` helper; this is fine but slightly repetitive—consider centralizing to reduce drift risk.

</details>

<details>
<summary>Background (previous attempt context)</summary>

- Relying solely on substring `st.` in contract tests for detecting Streamlit usage can miss invocations that use a different alias (e.g., `streamlit.`) and can lead to false negatives/positives; use broader detection (preferably AST-based) for both `st.` and `streamlit.`.
- Using a no-op decorator when Streamlit is unavailable in the `_cache_data` helper can mask cases where caching is expected but not actually applied (especially in production); add a runtime check so production-required caching fails loudly if `streamlit.cache_data` is unavailable.

</details>

## Critical Rules
1. Do NOT include "Remaining Unchecked Items" or "Iteration Details" sections unless they contain specific, useful failure context
2. Tasks should be concrete actions, not verification concerns restated
3. Acceptance criteria must be testable (not "all concerns addressed")
4. Keep the main body focused - hide background/history in the collapsible section
5. Do NOT include the entire analysis object - only include specific failure contexts from `blockers_to_avoid`
6. Omit the Notes section entirely if no advisory notes are provided
```
</details>



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #4898

<!-- pr-preamble:end -->