### PR TITLE
fix: support fold nav_paths in mc viz

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.1.0
-RUFF_VERSION=0.15.1
+RUFF_VERSION=0.15.0
 ISORT_VERSION=7.0.0
 DOCFORMATTER_VERSION=1.7.7
 MYPY_VERSION=1.19.1

--- a/README.md
+++ b/README.md
@@ -151,6 +151,11 @@ trend mc viz --bundle <path> --out <dir> --charts fan,path_dist,risk_return --ht
 - `--json`: Write JSON chart files to `<out>/plots/*.json`.
 - `--png`: Write PNG chart files to `<out>/plots/*.png`.
 
+NAV-path selection options:
+
+- `--fold <id>`: Use fold-exported `nav_paths_fold_<id>.parquet` when the bundle comes from a fold run.
+- `--nav-paths <file>`: Use an explicit `*.parquet` NAV-path file instead of `<bundle>/nav_paths.parquet`.
+
 ### NAV-Path Utilities and `mc viz` Contracts
 
 Use the NAV-path helpers from `trend.mc.io` instead of re-implementing loading/validation logic:
@@ -165,9 +170,19 @@ from trend.mc.io import (
 nav_paths = load_nav_paths(
     "tests/fixtures/mc_bundle",
     missing_parquet=MISSING_NAV_PATHS_RAISE,
-    required_columns=("date", "path_id", "nav"),
 )
-validated = validate_nav_paths_df(nav_paths, required_columns=("date", "path_id", "nav"))
+validated = validate_nav_paths_df(nav_paths)
+
+# Canonical `nav_paths` shape:
+# - Wide DataFrame
+# - Datetime-like index
+# - One column per simulated path (optionally MultiIndex columns with levels like (path, asset="NAV"))
+# - Values normalized so each path starts at 1.0
+
+# Optional: convert wide NAV paths to long form for downstream charts/diagnostics.
+from trend_analysis.viz.adapters import make_paths
+
+paths_long = make_paths(validated)
 ```
 
 Missing `nav_paths.parquet` contract:

--- a/scripts/langchain/issue_optimizer.py
+++ b/scripts/langchain/issue_optimizer.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
+
 from scripts.langchain.structured_output import (
     DEFAULT_REPAIR_PROMPT,
     build_repair_callback,

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Literal
 
 from pydantic import BaseModel, Field
+
 from scripts import api_client
 from scripts.langchain.structured_output import (
     build_repair_callback,

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -91,9 +91,7 @@ LegacyExtractCacheStats = Callable[[object], dict[str, int] | None]
 
 
 class LegacyMaybeLogStep(Protocol):
-    def __call__(
-        self, enabled: bool, run_id: str, event: str, message: str, **fields: Any
-    ) -> None:
+    def __call__(self, enabled: bool, run_id: str, event: str, message: str, **fields: Any) -> None:
         # Protocol method intentionally empty; implementors provide behaviour.
         ...
 
@@ -162,9 +160,7 @@ def _apply_trend_spec_preset(cfg: Any, preset: TrendSpecPreset) -> None:
         object.__setattr__(cfg, "trend_spec_preset", preset.name)
 
 
-def _apply_universe_mask(
-    df: pd.DataFrame, mask: pd.DataFrame, *, date_column: str
-) -> pd.DataFrame:
+def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: str) -> pd.DataFrame:
     """Apply a time-varying membership mask to returns data."""
 
     if mask.empty:
@@ -174,9 +170,7 @@ def _apply_universe_mask(
     try:
         date_col = lookup[date_column.lower()]
     except KeyError as exc:  # pragma: no cover - defensive guard
-        raise KeyError(
-            f"Date column '{date_column}' is missing from the returns data"
-        ) from exc
+        raise KeyError(f"Date column '{date_column}' is missing from the returns data") from exc
 
     working[date_col] = pd.to_datetime(working[date_col])
     working = working.set_index(date_col)
@@ -191,16 +185,12 @@ def _apply_universe_mask(
         )
 
     masked = working.copy()
-    masked.loc[:, aligned_mask.columns] = masked.loc[:, aligned_mask.columns].where(
-        aligned_mask
-    )
+    masked.loc[:, aligned_mask.columns] = masked.loc[:, aligned_mask.columns].where(aligned_mask)
     masked.reset_index(inplace=True)
     return masked
 
 
-def _attach_universe_paths(
-    cfg: Any, spec: NamedUniverse, *, csv_path: str | None
-) -> None:
+def _attach_universe_paths(cfg: Any, spec: NamedUniverse, *, csv_path: str | None) -> None:
     """Persist the selected universe paths onto ``cfg.data`` when possible."""
 
     membership_value = str(spec.membership_path)
@@ -231,9 +221,7 @@ def _attach_universe_paths(
         setattr(data_section, "universe_membership_path", membership_value)
     except Exception:
         try:
-            object.__setattr__(
-                data_section, "universe_membership_path", membership_value
-            )
+            object.__setattr__(data_section, "universe_membership_path", membership_value)
         except Exception:
             data_section = None
 
@@ -442,9 +430,7 @@ def build_parser(
         help="Report which config keys were validated vs read",
     )
 
-    report_p = sub.add_parser(
-        "report", help="Generate summary artefacts for a configuration"
-    )
+    report_p = sub.add_parser("report", help="Generate summary artefacts for a configuration")
     report_p.add_argument("-c", "--config", help="Path to YAML config")
     report_p.add_argument(
         "-i",
@@ -478,9 +464,7 @@ def build_parser(
         help="Report which config keys were validated vs read",
     )
 
-    stress_p = sub.add_parser(
-        "stress", help="Run the pipeline against a canned stress scenario"
-    )
+    stress_p = sub.add_parser("stress", help="Run the pipeline against a canned stress scenario")
     stress_p.add_argument("-c", "--config", help="Path to YAML config")
     stress_p.add_argument(
         "--scenario",
@@ -500,9 +484,7 @@ def build_parser(
 
     mc_p = sub.add_parser("mc", help="Monte Carlo visualization workflows")
     mc_sub = mc_p.add_subparsers(dest="mc_command", required=True)
-    mc_viz_p = mc_sub.add_parser(
-        "viz", help="Render Monte Carlo chart artifacts from a bundle"
-    )
+    mc_viz_p = mc_sub.add_parser("viz", help="Render Monte Carlo chart artifacts from a bundle")
     mc_viz_p.add_argument(
         "--bundle",
         required=True,
@@ -555,12 +537,8 @@ def build_parser(
     if include_gui_alias:
         sub.add_parser("gui", help="Launch the app (legacy alias for app)")
 
-    quick_p = sub.add_parser(
-        "quick-report", help="Build a compact HTML report from run artefacts"
-    )
-    quick_p.add_argument(
-        "--run-id", help="Run identifier (defaults to artefact inference)"
-    )
+    quick_p = sub.add_parser("quick-report", help="Build a compact HTML report from run artefacts")
+    quick_p.add_argument("--run-id", help="Run identifier (defaults to artefact inference)")
     quick_p.add_argument(
         "--artifacts",
         type=Path,
@@ -790,9 +768,7 @@ def _determine_seed(cfg: Any, override: int | None) -> int:
     return seed
 
 
-def _prepare_export_config(
-    cfg: Any, directory: Path | None, formats: Iterable[str] | None
-) -> None:
+def _prepare_export_config(cfg: Any, directory: Path | None, formats: Iterable[str] | None) -> None:
     if directory is None and formats is None:
         return
     export_cfg = dict(getattr(cfg, "export", {}) or {})
@@ -829,9 +805,7 @@ def _run_pipeline(
     if structured_log:
         log_path = log_file or run_logging.get_default_log_path(run_id)
         run_logging.init_run_logger(run_id, log_path)
-    _legacy_maybe_log_step(
-        structured_log, run_id, "start", "trend CLI execution started"
-    )
+    _legacy_maybe_log_step(structured_log, run_id, "start", "trend CLI execution started")
 
     result = run_simulation(cfg, returns_df)
     diagnostic = getattr(result, "diagnostic", None)
@@ -880,9 +854,7 @@ def _run_pipeline(
 _register_fallback("_run_pipeline", _run_pipeline)
 
 
-def _handle_exports(
-    cfg: Any, result: RunResult, structured_log: bool, run_id: str
-) -> None:
+def _handle_exports(cfg: Any, result: RunResult, structured_log: bool, run_id: str) -> None:
     export_cfg = getattr(cfg, "export", {}) or {}
     out_dir = export_cfg.get("directory")
     out_formats = export_cfg.get("formats")
@@ -977,9 +949,7 @@ def _print_summary(cfg: Any, result: RunResult) -> None:
 _register_fallback("_print_summary", _print_summary)
 
 
-def _write_report_files(
-    out_dir: Path, cfg: Any, result: RunResult, *, run_id: str
-) -> None:
+def _write_report_files(out_dir: Path, cfg: Any, result: RunResult, *, run_id: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     metrics_path = out_dir / f"metrics_{run_id}.csv"
     result.metrics.to_csv(metrics_path)
@@ -996,9 +966,7 @@ def _write_report_files(
     details_path = out_dir / f"details_{run_id}.json"
     with details_path.open("w", encoding="utf-8") as fh:
         json.dump(result.details, fh, default=_json_default, indent=2)
-    turnover_csv_result = _maybe_write_turnover_csv(
-        out_dir, getattr(result, "details", {})
-    )
+    turnover_csv_result = _maybe_write_turnover_csv(out_dir, getattr(result, "details", {}))
     if turnover_csv_result.diagnostic:
         logger.info(turnover_csv_result.diagnostic.message)
     print(f"Report artefacts written to {out_dir}")
@@ -1007,9 +975,7 @@ def _write_report_files(
 _register_fallback("_write_report_files", _write_report_files)
 
 
-def _resolve_report_output_path(
-    output: str | None, export_dir: Path | None, run_id: str
-) -> Path:
+def _resolve_report_output_path(output: str | None, export_dir: Path | None, run_id: str) -> Path:
     if output:
         base = Path(output).expanduser()
         if base.exists() and base.is_dir():
@@ -1116,13 +1082,9 @@ def _require_transaction_cost_controls(cfg: Any) -> None:
             try:
                 slip_value = float(slippage)
             except (TypeError, ValueError) as exc:
-                raise TrendCLIError(
-                    "portfolio.cost_model.slippage_bps must be numeric"
-                ) from exc
+                raise TrendCLIError("portfolio.cost_model.slippage_bps must be numeric") from exc
             if slip_value < 0:
-                raise TrendCLIError(
-                    "portfolio.cost_model.slippage_bps cannot be negative"
-                )
+                raise TrendCLIError("portfolio.cost_model.slippage_bps cannot be negative")
     if cost_value is None:
         raise TrendCLIError(
             "Configuration must define portfolio.transaction_cost_bps for honest costs."
@@ -1225,9 +1187,7 @@ def _load_configuration(path: str) -> Any:
         load_core_config(cfg_path)
     except CoreConfigError as exc:
         raise TrendCLIError(str(exc)) from exc
-    validation = validate_config(
-        payload, base_path=cfg_path.parent, skip_required_fields=True
-    )
+    validation = validate_config(payload, base_path=cfg_path.parent, skip_required_fields=True)
     if not validation.valid:
         details = "\n".join(format_validation_messages(validation))
         raise TrendCLIError(f"Config validation failed:\n{details}")
@@ -1396,9 +1356,7 @@ def _resolve_llm_provider_config(
     *,
     model: str | None = None,
 ) -> LLMProviderConfig:
-    provider_name = (
-        provider or os.environ.get("TREND_LLM_PROVIDER") or "openai"
-    ).lower()
+    provider_name = (provider or os.environ.get("TREND_LLM_PROVIDER") or "openai").lower()
     supported = {"openai", "anthropic", "ollama"}
     if provider_name not in supported:
         raise TrendCLIError(
@@ -1493,9 +1451,7 @@ def _replay_nl_entry(
 ) -> ReplayResult:
     from trend_analysis.llm.replay import replay_nl_entry
 
-    return replay_nl_entry(
-        entry, provider=provider, model=model, temperature=temperature
-    )
+    return replay_nl_entry(entry, provider=provider, model=model, temperature=temperature)
 
 
 def _build_nl_replay_parser() -> argparse.ArgumentParser:
@@ -1503,18 +1459,12 @@ def _build_nl_replay_parser() -> argparse.ArgumentParser:
         prog="trend nl replay",
         description="Replay a logged NL operation entry.",
     )
-    parser.add_argument(
-        "log_file", type=Path, help="Path to nl_ops_<date>.jsonl log file"
-    )
+    parser.add_argument("log_file", type=Path, help="Path to nl_ops_<date>.jsonl log file")
     parser.add_argument("--entry", type=int, required=True, help="1-based entry index")
     parser.add_argument("--provider", help="Override the logged LLM provider")
     parser.add_argument("--model", help="Override the logged LLM model")
-    parser.add_argument(
-        "--temperature", type=float, help="Override the logged temperature"
-    )
-    parser.add_argument(
-        "--show-prompt", action="store_true", help="Print the prompt text"
-    )
+    parser.add_argument("--temperature", type=float, help="Override the logged temperature")
+    parser.add_argument("--show-prompt", action="store_true", help="Print the prompt text")
     return parser
 
 
@@ -1634,9 +1584,7 @@ def _apply_nl_instruction(
 ) -> tuple[ConfigPatch, dict[str, Any], str, str, float]:
     chain = _build_nl_chain(provider, model=model, temperature=temperature)
     try:
-        patch = chain.run(
-            current_config=config, instruction=instruction, request_id=request_id
-        )
+        patch = chain.run(current_config=config, instruction=instruction, request_id=request_id)
     except Exception as exc:
         raise TrendCLIError(str(exc)) from exc
     apply_started = time.perf_counter()
@@ -1746,9 +1694,7 @@ def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
     except TrendCLIError:
         raise
     except Exception as exc:
-        raise TrendCLIError(
-            f"Failed to read {label} data from '{path}': {exc}"
-        ) from exc
+        raise TrendCLIError(f"Failed to read {label} data from '{path}': {exc}") from exc
     if isinstance(frame, pd.Series):
         return frame.to_frame()
     if not isinstance(frame, pd.DataFrame):
@@ -1757,9 +1703,7 @@ def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
 
 
 def _load_mc_frame(bundle_dir: Path, *, stem: str) -> pd.DataFrame:
-    candidates = tuple(
-        bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json")
-    )
+    candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
     existing = next((candidate for candidate in candidates if candidate.exists()), None)
     if existing is None:
         expected = ", ".join(path.name for path in candidates)
@@ -1789,9 +1733,7 @@ def _load_mc_bundle_frames(
     missing_inputs: list[str] = []
     expected_by_stem: dict[str, str] = {}
     for stem in required_stems:
-        candidates = tuple(
-            bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json")
-        )
+        candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
         if not any(candidate.exists() for candidate in candidates):
             missing_inputs.append(stem)
             expected_by_stem[stem] = ", ".join(path.name for path in candidates)
@@ -1803,9 +1745,7 @@ def _load_mc_bundle_frames(
                 f"Missing required MC {stem} file in '{bundle_dir}'. Expected one of: {expected}"
             )
         missing_text = ", ".join(missing_inputs)
-        expected_text = "; ".join(
-            f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs
-        )
+        expected_text = "; ".join(f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs)
         raise TrendCLIError(
             f"Missing required MC input files in '{bundle_dir}': {missing_text}. "
             f"Expected one of each: {expected_text}"
@@ -1814,13 +1754,9 @@ def _load_mc_bundle_frames(
 
 
 def _parse_mc_chart_selection(charts_value: str) -> list[str]:
-    requested = [
-        token.strip().lower() for token in charts_value.split(",") if token.strip()
-    ]
+    requested = [token.strip().lower() for token in charts_value.split(",") if token.strip()]
     if not requested:
-        raise TrendCLIError(
-            "The 'mc viz' command requires at least one chart in --charts."
-        )
+        raise TrendCLIError("The 'mc viz' command requires at least one chart in --charts.")
 
     seen: set[str] = set()
     ordered: list[str] = []
@@ -1890,14 +1826,10 @@ def _build_mc_risk_return_chart(
     from trend_analysis.viz import risk_return
 
     nav_frame = _mc_nav_source_frame(summary_frame, results_frame, nav_paths_frame)
-    returns_frame = nav_frame.pct_change(fill_method=None).replace(
-        [np.inf, -np.inf], np.nan
-    )
+    returns_frame = nav_frame.pct_change(fill_method=None).replace([np.inf, -np.inf], np.nan)
     returns_frame = returns_frame.dropna(how="all")
     if returns_frame.empty:
-        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(
-            how="all"
-        )
+        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(how="all")
     return risk_return.make(returns_frame)
 
 
@@ -1955,17 +1887,13 @@ def _inject_mc_html_chart_markers(
                 continue
             body_token = "<body>"
             if body_token in html_text:
-                updated_html = html_text.replace(
-                    body_token, f"{body_token}\n{marker}", 1
-                )
+                updated_html = html_text.replace(body_token, f"{body_token}\n{marker}", 1)
             else:
                 updated_html = f"{marker}\n{html_text}"
             html_path.parent.mkdir(parents=True, exist_ok=True)
             html_path.write_text(updated_html, encoding="utf-8")
         except Exception as exc:
-            warnings.append(
-                f"Unable to inject HTML chart marker for '{chart_id}': {exc}."
-            )
+            warnings.append(f"Unable to inject HTML chart marker for '{chart_id}': {exc}.")
 
 
 def _run_mc_viz_command(args: argparse.Namespace) -> int:
@@ -2100,9 +2028,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                 fallback = _fallback_explanation(metric_catalog)
                 fallback = append_discrepancy_log(fallback, claim_issues)
                 explanation_text = fallback
-            explanation_text = _finalize_explanation_text(
-                explanation_text, claim_issues
-            )
+            explanation_text = _finalize_explanation_text(explanation_text, claim_issues)
             if args.output:
                 payload = _build_explain_artifact_payload(
                     run_id=run_id,
@@ -2151,9 +2077,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     print("No changes.")
                 return 0
             if args.dry_run:
-                sys.stdout.write(
-                    yaml.safe_dump(updated, sort_keys=False, default_flow_style=False)
-                )
+                sys.stdout.write(yaml.safe_dump(updated, sort_keys=False, default_flow_style=False))
                 return 0
             if args.run:
                 validate_started = time.perf_counter()
@@ -2183,9 +2107,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     )
                     raise TrendCLIError(str(exc)) from exc
                 if not validation.valid:
-                    validation_details = "\n".join(
-                        format_validation_messages(validation)
-                    )
+                    validation_details = "\n".join(format_validation_messages(validation))
                     validation_error = f"validation failed: {validation_details}"
                 _log_nl_operation(
                     request_id=request_id,
@@ -2200,9 +2122,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     timestamp=validate_timestamp,
                 )
                 if validation_error is not None:
-                    raise TrendCLIError(
-                        f"Config validation failed:\n{validation_details}"
-                    )
+                    raise TrendCLIError(f"Config validation failed:\n{validation_details}")
             _confirm_risky_patch(patch, no_confirm=args.no_confirm)
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_text(
@@ -2266,18 +2186,14 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
             raise TrendCLIError(f"Unknown command: {command}")
 
         if command != "mc" and not args.config:
-            raise TrendCLIError(
-                f"The --config option is required for the '{command}' command"
-            )
+            raise TrendCLIError(f"The --config option is required for the '{command}' command")
 
         load_config_fn = _legacy_callable("_load_configuration", _load_configuration)
         cfg_path, cfg = load_config_fn(args.config)
         if coverage_tracker is not None:
             wrap_config_for_coverage(cfg, coverage_tracker)
         ensure_run_spec(cfg, base_path=cfg_path.parent)
-        resolve_returns = _legacy_callable(
-            "_resolve_returns_path", _resolve_returns_path
-        )
+        resolve_returns = _legacy_callable("_resolve_returns_path", _resolve_returns_path)
         returns_path = resolve_returns(cfg_path, cfg, getattr(args, "returns", None))
         ensure_df = _legacy_callable("_ensure_dataframe", _ensure_dataframe)
         returns_df = ensure_df(returns_path)
@@ -2298,9 +2214,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     portfolio_preset = get_trend_preset(args.preset)
                 except KeyError:
                     available = ", ".join(list_preset_slugs())
-                    raise TrendCLIError(
-                        f"Unknown preset '{args.preset}'. Available: {available}"
-                    )
+                    raise TrendCLIError(f"Unknown preset '{args.preset}'. Available: {available}")
                 apply_trend_preset(cfg, portfolio_preset)
             if getattr(args, "universe", None):
                 mask, universe_spec = load_universe(args.universe, prices=returns_df)
@@ -2331,9 +2245,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     "The 'report' command requires --out for artefacts or --output for the HTML report"
                 )
             formats = args.formats or DEFAULT_REPORT_FORMATS
-            _prepare_export_config(
-                cfg, export_dir, formats if export_dir is not None else None
-            )
+            _prepare_export_config(cfg, export_dir, formats if export_dir is not None else None)
             run_pipeline = _legacy_callable("_run_pipeline", _run_pipeline)
             result, run_id, _ = run_pipeline(
                 cfg,
@@ -2346,9 +2258,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
             print_summary = _legacy_callable("_print_summary", _print_summary)
             print_summary(cfg, result)
             if export_dir is not None:
-                write_report = _legacy_callable(
-                    "_write_report_files", _write_report_files
-                )
+                write_report = _legacy_callable("_write_report_files", _write_report_files)
                 write_report(export_dir, cfg, result, run_id=run_id)
             report_path = _resolve_report_output_path(args.output, export_dir, run_id)
             report_path.parent.mkdir(parents=True, exist_ok=True)
@@ -2377,9 +2287,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
 
         if command == "stress":
             if not args.scenario:
-                raise TrendCLIError(
-                    "The --scenario option is required for the 'stress' command"
-                )
+                raise TrendCLIError("The --scenario option is required for the 'stress' command")
             _adjust_for_scenario(cfg, args.scenario)
             export_dir = Path(args.out) if args.out else None
             _prepare_export_config(cfg, export_dir, None)
@@ -2396,9 +2304,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
             print_summary = _legacy_callable("_print_summary", _print_summary)
             print_summary(cfg, result)
             if export_dir:
-                write_report = _legacy_callable(
-                    "_write_report_files", _write_report_files
-                )
+                write_report = _legacy_callable("_write_report_files", _write_report_files)
                 write_report(export_dir, cfg, result, run_id=run_id)
             _finalize_config_coverage()
             return 0

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -524,8 +524,9 @@ def build_parser(
         "--fold",
         type=int,
         help=(
-            "Fold id to load fold-exported NAV paths (nav_paths_fold_<id>.parquet) when "
-            "nav_paths.parquet is absent."
+            "Fold id to load fold-exported NAV paths (nav_paths_fold_<id>.parquet) from "
+            "the bundle; when provided, this takes precedence over the bundle's "
+            "nav_paths.parquet."
         ),
     )
     nav_paths_group.add_argument(

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -91,7 +91,9 @@ LegacyExtractCacheStats = Callable[[object], dict[str, int] | None]
 
 
 class LegacyMaybeLogStep(Protocol):
-    def __call__(self, enabled: bool, run_id: str, event: str, message: str, **fields: Any) -> None:
+    def __call__(
+        self, enabled: bool, run_id: str, event: str, message: str, **fields: Any
+    ) -> None:
         # Protocol method intentionally empty; implementors provide behaviour.
         ...
 
@@ -160,7 +162,9 @@ def _apply_trend_spec_preset(cfg: Any, preset: TrendSpecPreset) -> None:
         object.__setattr__(cfg, "trend_spec_preset", preset.name)
 
 
-def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: str) -> pd.DataFrame:
+def _apply_universe_mask(
+    df: pd.DataFrame, mask: pd.DataFrame, *, date_column: str
+) -> pd.DataFrame:
     """Apply a time-varying membership mask to returns data."""
 
     if mask.empty:
@@ -170,7 +174,9 @@ def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: s
     try:
         date_col = lookup[date_column.lower()]
     except KeyError as exc:  # pragma: no cover - defensive guard
-        raise KeyError(f"Date column '{date_column}' is missing from the returns data") from exc
+        raise KeyError(
+            f"Date column '{date_column}' is missing from the returns data"
+        ) from exc
 
     working[date_col] = pd.to_datetime(working[date_col])
     working = working.set_index(date_col)
@@ -185,12 +191,16 @@ def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: s
         )
 
     masked = working.copy()
-    masked.loc[:, aligned_mask.columns] = masked.loc[:, aligned_mask.columns].where(aligned_mask)
+    masked.loc[:, aligned_mask.columns] = masked.loc[:, aligned_mask.columns].where(
+        aligned_mask
+    )
     masked.reset_index(inplace=True)
     return masked
 
 
-def _attach_universe_paths(cfg: Any, spec: NamedUniverse, *, csv_path: str | None) -> None:
+def _attach_universe_paths(
+    cfg: Any, spec: NamedUniverse, *, csv_path: str | None
+) -> None:
     """Persist the selected universe paths onto ``cfg.data`` when possible."""
 
     membership_value = str(spec.membership_path)
@@ -221,7 +231,9 @@ def _attach_universe_paths(cfg: Any, spec: NamedUniverse, *, csv_path: str | Non
         setattr(data_section, "universe_membership_path", membership_value)
     except Exception:
         try:
-            object.__setattr__(data_section, "universe_membership_path", membership_value)
+            object.__setattr__(
+                data_section, "universe_membership_path", membership_value
+            )
         except Exception:
             data_section = None
 
@@ -430,7 +442,9 @@ def build_parser(
         help="Report which config keys were validated vs read",
     )
 
-    report_p = sub.add_parser("report", help="Generate summary artefacts for a configuration")
+    report_p = sub.add_parser(
+        "report", help="Generate summary artefacts for a configuration"
+    )
     report_p.add_argument("-c", "--config", help="Path to YAML config")
     report_p.add_argument(
         "-i",
@@ -464,7 +478,9 @@ def build_parser(
         help="Report which config keys were validated vs read",
     )
 
-    stress_p = sub.add_parser("stress", help="Run the pipeline against a canned stress scenario")
+    stress_p = sub.add_parser(
+        "stress", help="Run the pipeline against a canned stress scenario"
+    )
     stress_p.add_argument("-c", "--config", help="Path to YAML config")
     stress_p.add_argument(
         "--scenario",
@@ -484,7 +500,9 @@ def build_parser(
 
     mc_p = sub.add_parser("mc", help="Monte Carlo visualization workflows")
     mc_sub = mc_p.add_subparsers(dest="mc_command", required=True)
-    mc_viz_p = mc_sub.add_parser("viz", help="Render Monte Carlo chart artifacts from a bundle")
+    mc_viz_p = mc_sub.add_parser(
+        "viz", help="Render Monte Carlo chart artifacts from a bundle"
+    )
     mc_viz_p.add_argument(
         "--bundle",
         required=True,
@@ -500,6 +518,21 @@ def build_parser(
         "--charts",
         default="fan,path_dist,risk_return",
         help="Comma-separated chart identifiers (fan,path_dist,risk_return)",
+    )
+    nav_paths_group = mc_viz_p.add_mutually_exclusive_group()
+    nav_paths_group.add_argument(
+        "--fold",
+        type=int,
+        help=(
+            "Fold id to load fold-exported NAV paths (nav_paths_fold_<id>.parquet) when "
+            "nav_paths.parquet is absent."
+        ),
+    )
+    nav_paths_group.add_argument(
+        "--nav-paths",
+        type=Path,
+        dest="nav_paths",
+        help="Explicit path to a nav_paths parquet file to use instead of bundle nav_paths.parquet.",
     )
     mc_viz_p.add_argument(
         "--html",
@@ -521,8 +554,12 @@ def build_parser(
     if include_gui_alias:
         sub.add_parser("gui", help="Launch the app (legacy alias for app)")
 
-    quick_p = sub.add_parser("quick-report", help="Build a compact HTML report from run artefacts")
-    quick_p.add_argument("--run-id", help="Run identifier (defaults to artefact inference)")
+    quick_p = sub.add_parser(
+        "quick-report", help="Build a compact HTML report from run artefacts"
+    )
+    quick_p.add_argument(
+        "--run-id", help="Run identifier (defaults to artefact inference)"
+    )
     quick_p.add_argument(
         "--artifacts",
         type=Path,
@@ -752,7 +789,9 @@ def _determine_seed(cfg: Any, override: int | None) -> int:
     return seed
 
 
-def _prepare_export_config(cfg: Any, directory: Path | None, formats: Iterable[str] | None) -> None:
+def _prepare_export_config(
+    cfg: Any, directory: Path | None, formats: Iterable[str] | None
+) -> None:
     if directory is None and formats is None:
         return
     export_cfg = dict(getattr(cfg, "export", {}) or {})
@@ -789,7 +828,9 @@ def _run_pipeline(
     if structured_log:
         log_path = log_file or run_logging.get_default_log_path(run_id)
         run_logging.init_run_logger(run_id, log_path)
-    _legacy_maybe_log_step(structured_log, run_id, "start", "trend CLI execution started")
+    _legacy_maybe_log_step(
+        structured_log, run_id, "start", "trend CLI execution started"
+    )
 
     result = run_simulation(cfg, returns_df)
     diagnostic = getattr(result, "diagnostic", None)
@@ -838,7 +879,9 @@ def _run_pipeline(
 _register_fallback("_run_pipeline", _run_pipeline)
 
 
-def _handle_exports(cfg: Any, result: RunResult, structured_log: bool, run_id: str) -> None:
+def _handle_exports(
+    cfg: Any, result: RunResult, structured_log: bool, run_id: str
+) -> None:
     export_cfg = getattr(cfg, "export", {}) or {}
     out_dir = export_cfg.get("directory")
     out_formats = export_cfg.get("formats")
@@ -933,7 +976,9 @@ def _print_summary(cfg: Any, result: RunResult) -> None:
 _register_fallback("_print_summary", _print_summary)
 
 
-def _write_report_files(out_dir: Path, cfg: Any, result: RunResult, *, run_id: str) -> None:
+def _write_report_files(
+    out_dir: Path, cfg: Any, result: RunResult, *, run_id: str
+) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     metrics_path = out_dir / f"metrics_{run_id}.csv"
     result.metrics.to_csv(metrics_path)
@@ -950,7 +995,9 @@ def _write_report_files(out_dir: Path, cfg: Any, result: RunResult, *, run_id: s
     details_path = out_dir / f"details_{run_id}.json"
     with details_path.open("w", encoding="utf-8") as fh:
         json.dump(result.details, fh, default=_json_default, indent=2)
-    turnover_csv_result = _maybe_write_turnover_csv(out_dir, getattr(result, "details", {}))
+    turnover_csv_result = _maybe_write_turnover_csv(
+        out_dir, getattr(result, "details", {})
+    )
     if turnover_csv_result.diagnostic:
         logger.info(turnover_csv_result.diagnostic.message)
     print(f"Report artefacts written to {out_dir}")
@@ -959,7 +1006,9 @@ def _write_report_files(out_dir: Path, cfg: Any, result: RunResult, *, run_id: s
 _register_fallback("_write_report_files", _write_report_files)
 
 
-def _resolve_report_output_path(output: str | None, export_dir: Path | None, run_id: str) -> Path:
+def _resolve_report_output_path(
+    output: str | None, export_dir: Path | None, run_id: str
+) -> Path:
     if output:
         base = Path(output).expanduser()
         if base.exists() and base.is_dir():
@@ -1066,9 +1115,13 @@ def _require_transaction_cost_controls(cfg: Any) -> None:
             try:
                 slip_value = float(slippage)
             except (TypeError, ValueError) as exc:
-                raise TrendCLIError("portfolio.cost_model.slippage_bps must be numeric") from exc
+                raise TrendCLIError(
+                    "portfolio.cost_model.slippage_bps must be numeric"
+                ) from exc
             if slip_value < 0:
-                raise TrendCLIError("portfolio.cost_model.slippage_bps cannot be negative")
+                raise TrendCLIError(
+                    "portfolio.cost_model.slippage_bps cannot be negative"
+                )
     if cost_value is None:
         raise TrendCLIError(
             "Configuration must define portfolio.transaction_cost_bps for honest costs."
@@ -1171,7 +1224,9 @@ def _load_configuration(path: str) -> Any:
         load_core_config(cfg_path)
     except CoreConfigError as exc:
         raise TrendCLIError(str(exc)) from exc
-    validation = validate_config(payload, base_path=cfg_path.parent, skip_required_fields=True)
+    validation = validate_config(
+        payload, base_path=cfg_path.parent, skip_required_fields=True
+    )
     if not validation.valid:
         details = "\n".join(format_validation_messages(validation))
         raise TrendCLIError(f"Config validation failed:\n{details}")
@@ -1340,7 +1395,9 @@ def _resolve_llm_provider_config(
     *,
     model: str | None = None,
 ) -> LLMProviderConfig:
-    provider_name = (provider or os.environ.get("TREND_LLM_PROVIDER") or "openai").lower()
+    provider_name = (
+        provider or os.environ.get("TREND_LLM_PROVIDER") or "openai"
+    ).lower()
     supported = {"openai", "anthropic", "ollama"}
     if provider_name not in supported:
         raise TrendCLIError(
@@ -1435,7 +1492,9 @@ def _replay_nl_entry(
 ) -> ReplayResult:
     from trend_analysis.llm.replay import replay_nl_entry
 
-    return replay_nl_entry(entry, provider=provider, model=model, temperature=temperature)
+    return replay_nl_entry(
+        entry, provider=provider, model=model, temperature=temperature
+    )
 
 
 def _build_nl_replay_parser() -> argparse.ArgumentParser:
@@ -1443,12 +1502,18 @@ def _build_nl_replay_parser() -> argparse.ArgumentParser:
         prog="trend nl replay",
         description="Replay a logged NL operation entry.",
     )
-    parser.add_argument("log_file", type=Path, help="Path to nl_ops_<date>.jsonl log file")
+    parser.add_argument(
+        "log_file", type=Path, help="Path to nl_ops_<date>.jsonl log file"
+    )
     parser.add_argument("--entry", type=int, required=True, help="1-based entry index")
     parser.add_argument("--provider", help="Override the logged LLM provider")
     parser.add_argument("--model", help="Override the logged LLM model")
-    parser.add_argument("--temperature", type=float, help="Override the logged temperature")
-    parser.add_argument("--show-prompt", action="store_true", help="Print the prompt text")
+    parser.add_argument(
+        "--temperature", type=float, help="Override the logged temperature"
+    )
+    parser.add_argument(
+        "--show-prompt", action="store_true", help="Print the prompt text"
+    )
     return parser
 
 
@@ -1568,7 +1633,9 @@ def _apply_nl_instruction(
 ) -> tuple[ConfigPatch, dict[str, Any], str, str, float]:
     chain = _build_nl_chain(provider, model=model, temperature=temperature)
     try:
-        patch = chain.run(current_config=config, instruction=instruction, request_id=request_id)
+        patch = chain.run(
+            current_config=config, instruction=instruction, request_id=request_id
+        )
     except Exception as exc:
         raise TrendCLIError(str(exc)) from exc
     apply_started = time.perf_counter()
@@ -1645,7 +1712,11 @@ def _confirm_risky_patch(patch: ConfigPatch, *, no_confirm: bool) -> None:
 
 def _validate_mc_viz_output_flags(args: argparse.Namespace) -> None:
     if not any(
-        (getattr(args, "html", False), getattr(args, "json", False), getattr(args, "png", False))
+        (
+            getattr(args, "html", False),
+            getattr(args, "json", False),
+            getattr(args, "png", False),
+        )
     ):
         raise TrendCLIError(
             "The 'mc viz' command requires at least one output flag: --html, --json, or --png"
@@ -1674,7 +1745,9 @@ def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
     except TrendCLIError:
         raise
     except Exception as exc:
-        raise TrendCLIError(f"Failed to read {label} data from '{path}': {exc}") from exc
+        raise TrendCLIError(
+            f"Failed to read {label} data from '{path}': {exc}"
+        ) from exc
     if isinstance(frame, pd.Series):
         return frame.to_frame()
     if not isinstance(frame, pd.DataFrame):
@@ -1683,7 +1756,9 @@ def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
 
 
 def _load_mc_frame(bundle_dir: Path, *, stem: str) -> pd.DataFrame:
-    candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
+    candidates = tuple(
+        bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json")
+    )
     existing = next((candidate for candidate in candidates if candidate.exists()), None)
     if existing is None:
         expected = ", ".join(path.name for path in candidates)
@@ -1701,7 +1776,9 @@ def _load_mc_results_frame(bundle_dir: Path) -> pd.DataFrame:
     return _load_mc_frame(bundle_dir, stem="results")
 
 
-def _load_mc_bundle_frames(bundle: str | os.PathLike[str]) -> tuple[pd.DataFrame, pd.DataFrame]:
+def _load_mc_bundle_frames(
+    bundle: str | os.PathLike[str],
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     bundle_dir = Path(bundle).expanduser().resolve()
     if not bundle_dir.exists():
         raise TrendCLIError(f"MC bundle directory does not exist: {bundle_dir}")
@@ -1711,7 +1788,9 @@ def _load_mc_bundle_frames(bundle: str | os.PathLike[str]) -> tuple[pd.DataFrame
     missing_inputs: list[str] = []
     expected_by_stem: dict[str, str] = {}
     for stem in required_stems:
-        candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
+        candidates = tuple(
+            bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json")
+        )
         if not any(candidate.exists() for candidate in candidates):
             missing_inputs.append(stem)
             expected_by_stem[stem] = ", ".join(path.name for path in candidates)
@@ -1723,7 +1802,9 @@ def _load_mc_bundle_frames(bundle: str | os.PathLike[str]) -> tuple[pd.DataFrame
                 f"Missing required MC {stem} file in '{bundle_dir}'. Expected one of: {expected}"
             )
         missing_text = ", ".join(missing_inputs)
-        expected_text = "; ".join(f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs)
+        expected_text = "; ".join(
+            f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs
+        )
         raise TrendCLIError(
             f"Missing required MC input files in '{bundle_dir}': {missing_text}. "
             f"Expected one of each: {expected_text}"
@@ -1732,9 +1813,13 @@ def _load_mc_bundle_frames(bundle: str | os.PathLike[str]) -> tuple[pd.DataFrame
 
 
 def _parse_mc_chart_selection(charts_value: str) -> list[str]:
-    requested = [token.strip().lower() for token in charts_value.split(",") if token.strip()]
+    requested = [
+        token.strip().lower() for token in charts_value.split(",") if token.strip()
+    ]
     if not requested:
-        raise TrendCLIError("The 'mc viz' command requires at least one chart in --charts.")
+        raise TrendCLIError(
+            "The 'mc viz' command requires at least one chart in --charts."
+        )
 
     seen: set[str] = set()
     ordered: list[str] = []
@@ -1804,10 +1889,14 @@ def _build_mc_risk_return_chart(
     from trend_analysis.viz import risk_return
 
     nav_frame = _mc_nav_source_frame(summary_frame, results_frame, nav_paths_frame)
-    returns_frame = nav_frame.pct_change(fill_method=None).replace([np.inf, -np.inf], np.nan)
+    returns_frame = nav_frame.pct_change(fill_method=None).replace(
+        [np.inf, -np.inf], np.nan
+    )
     returns_frame = returns_frame.dropna(how="all")
     if returns_frame.empty:
-        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(how="all")
+        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(
+            how="all"
+        )
     return risk_return.make(returns_frame)
 
 
@@ -1865,22 +1954,28 @@ def _inject_mc_html_chart_markers(
                 continue
             body_token = "<body>"
             if body_token in html_text:
-                updated_html = html_text.replace(body_token, f"{body_token}\n{marker}", 1)
+                updated_html = html_text.replace(
+                    body_token, f"{body_token}\n{marker}", 1
+                )
             else:
                 updated_html = f"{marker}\n{html_text}"
             html_path.parent.mkdir(parents=True, exist_ok=True)
             html_path.write_text(updated_html, encoding="utf-8")
         except Exception as exc:
-            warnings.append(f"Unable to inject HTML chart marker for '{chart_id}': {exc}.")
+            warnings.append(
+                f"Unable to inject HTML chart marker for '{chart_id}': {exc}."
+            )
 
 
 def _run_mc_viz_command(args: argparse.Namespace) -> int:
-    from trend.mc.viz import execute_mc_viz
+    from trend.mc.viz import execute_mc_viz_cli
 
-    return execute_mc_viz(
+    return execute_mc_viz_cli(
         bundle_path=args.bundle,
         out_dir=args.out,
         charts=args.charts,
+        fold_id=getattr(args, "fold", None),
+        nav_paths=getattr(args, "nav_paths", None),
         html=args.html,
         json=args.json,
         png=args.png,
@@ -2004,7 +2099,9 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                 fallback = _fallback_explanation(metric_catalog)
                 fallback = append_discrepancy_log(fallback, claim_issues)
                 explanation_text = fallback
-            explanation_text = _finalize_explanation_text(explanation_text, claim_issues)
+            explanation_text = _finalize_explanation_text(
+                explanation_text, claim_issues
+            )
             if args.output:
                 payload = _build_explain_artifact_payload(
                     run_id=run_id,
@@ -2053,7 +2150,9 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     print("No changes.")
                 return 0
             if args.dry_run:
-                sys.stdout.write(yaml.safe_dump(updated, sort_keys=False, default_flow_style=False))
+                sys.stdout.write(
+                    yaml.safe_dump(updated, sort_keys=False, default_flow_style=False)
+                )
                 return 0
             if args.run:
                 validate_started = time.perf_counter()
@@ -2083,7 +2182,9 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     )
                     raise TrendCLIError(str(exc)) from exc
                 if not validation.valid:
-                    validation_details = "\n".join(format_validation_messages(validation))
+                    validation_details = "\n".join(
+                        format_validation_messages(validation)
+                    )
                     validation_error = f"validation failed: {validation_details}"
                 _log_nl_operation(
                     request_id=request_id,
@@ -2098,7 +2199,9 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     timestamp=validate_timestamp,
                 )
                 if validation_error is not None:
-                    raise TrendCLIError(f"Config validation failed:\n{validation_details}")
+                    raise TrendCLIError(
+                        f"Config validation failed:\n{validation_details}"
+                    )
             _confirm_risky_patch(patch, no_confirm=args.no_confirm)
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_text(
@@ -2162,14 +2265,18 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
             raise TrendCLIError(f"Unknown command: {command}")
 
         if command != "mc" and not args.config:
-            raise TrendCLIError(f"The --config option is required for the '{command}' command")
+            raise TrendCLIError(
+                f"The --config option is required for the '{command}' command"
+            )
 
         load_config_fn = _legacy_callable("_load_configuration", _load_configuration)
         cfg_path, cfg = load_config_fn(args.config)
         if coverage_tracker is not None:
             wrap_config_for_coverage(cfg, coverage_tracker)
         ensure_run_spec(cfg, base_path=cfg_path.parent)
-        resolve_returns = _legacy_callable("_resolve_returns_path", _resolve_returns_path)
+        resolve_returns = _legacy_callable(
+            "_resolve_returns_path", _resolve_returns_path
+        )
         returns_path = resolve_returns(cfg_path, cfg, getattr(args, "returns", None))
         ensure_df = _legacy_callable("_ensure_dataframe", _ensure_dataframe)
         returns_df = ensure_df(returns_path)
@@ -2190,7 +2297,9 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     portfolio_preset = get_trend_preset(args.preset)
                 except KeyError:
                     available = ", ".join(list_preset_slugs())
-                    raise TrendCLIError(f"Unknown preset '{args.preset}'. Available: {available}")
+                    raise TrendCLIError(
+                        f"Unknown preset '{args.preset}'. Available: {available}"
+                    )
                 apply_trend_preset(cfg, portfolio_preset)
             if getattr(args, "universe", None):
                 mask, universe_spec = load_universe(args.universe, prices=returns_df)
@@ -2221,7 +2330,9 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     "The 'report' command requires --out for artefacts or --output for the HTML report"
                 )
             formats = args.formats or DEFAULT_REPORT_FORMATS
-            _prepare_export_config(cfg, export_dir, formats if export_dir is not None else None)
+            _prepare_export_config(
+                cfg, export_dir, formats if export_dir is not None else None
+            )
             run_pipeline = _legacy_callable("_run_pipeline", _run_pipeline)
             result, run_id, _ = run_pipeline(
                 cfg,
@@ -2234,7 +2345,9 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
             print_summary = _legacy_callable("_print_summary", _print_summary)
             print_summary(cfg, result)
             if export_dir is not None:
-                write_report = _legacy_callable("_write_report_files", _write_report_files)
+                write_report = _legacy_callable(
+                    "_write_report_files", _write_report_files
+                )
                 write_report(export_dir, cfg, result, run_id=run_id)
             report_path = _resolve_report_output_path(args.output, export_dir, run_id)
             report_path.parent.mkdir(parents=True, exist_ok=True)
@@ -2263,7 +2376,9 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
 
         if command == "stress":
             if not args.scenario:
-                raise TrendCLIError("The --scenario option is required for the 'stress' command")
+                raise TrendCLIError(
+                    "The --scenario option is required for the 'stress' command"
+                )
             _adjust_for_scenario(cfg, args.scenario)
             export_dir = Path(args.out) if args.out else None
             _prepare_export_config(cfg, export_dir, None)
@@ -2280,7 +2395,9 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
             print_summary = _legacy_callable("_print_summary", _print_summary)
             print_summary(cfg, result)
             if export_dir:
-                write_report = _legacy_callable("_write_report_files", _write_report_files)
+                write_report = _legacy_callable(
+                    "_write_report_files", _write_report_files
+                )
                 write_report(export_dir, cfg, result, run_id=run_id)
             _finalize_config_coverage()
             return 0

--- a/src/trend/mc/viz.py
+++ b/src/trend/mc/viz.py
@@ -74,10 +74,11 @@ def check_png_dependency() -> bool:
     try:
         if importlib.util.find_spec("kaleido") is None:
             return False
-        import plotly.graph_objects as go  # noqa: WPS433
         import plotly.io as pio  # noqa: WPS433
 
-        fig = go.Figure(data=[go.Scatter(x=[0, 1], y=[0, 1])])
+        # Use a minimal figure dict (not `go.Figure`) to avoid triggering
+        # template initialization during dependency checks.
+        fig = {"data": [{"type": "scatter", "x": [0, 1], "y": [0, 1]}]}
         pio.to_image(fig, format="png", validate=True)
         return True
     except Exception:  # noqa: BLE001 – broad catch intentional
@@ -91,7 +92,9 @@ def check_png_dependency() -> bool:
 
 def _normalize_chart_ids(charts: Sequence[str] | str) -> list[str]:
     if isinstance(charts, str):
-        normalized = [part.strip().lower() for part in charts.split(",") if part.strip()]
+        normalized = [
+            part.strip().lower() for part in charts.split(",") if part.strip()
+        ]
     else:
         normalized = [str(part).strip().lower() for part in charts if str(part).strip()]
     return normalized
@@ -99,7 +102,9 @@ def _normalize_chart_ids(charts: Sequence[str] | str) -> list[str]:
 
 def _collect_required_inputs(charts: Sequence[str] | str) -> list[str]:
     requested_charts = _normalize_chart_ids(charts)
-    unsupported = [chart for chart in requested_charts if chart not in CHART_REQUIREMENTS]
+    unsupported = [
+        chart for chart in requested_charts if chart not in CHART_REQUIREMENTS
+    ]
     if unsupported:
         invalid = ", ".join(sorted(set(unsupported)))
         raise ValueError(f"Unsupported chart identifier(s): {invalid}")
@@ -117,7 +122,10 @@ def _collect_required_inputs(charts: Sequence[str] | str) -> list[str]:
 def _requirement_is_present(bundle_dir: Path, requirement: str) -> bool:
     if "." in requirement:
         return (bundle_dir / requirement).exists()
-    return any((bundle_dir / f"{requirement}.{ext}").exists() for ext in _OPTIONAL_STEM_EXTENSIONS)
+    return any(
+        (bundle_dir / f"{requirement}.{ext}").exists()
+        for ext in _OPTIONAL_STEM_EXTENSIONS
+    )
 
 
 def _missing_requirement_label(requirement: str) -> str:
@@ -155,7 +163,9 @@ def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
     except TrendCLIError:
         raise
     except Exception as exc:
-        raise TrendCLIError(f"Failed to read {label} data from '{path}': {exc}") from exc
+        raise TrendCLIError(
+            f"Failed to read {label} data from '{path}': {exc}"
+        ) from exc
     if isinstance(frame, pd.Series):
         return frame.to_frame()
     if not isinstance(frame, pd.DataFrame):
@@ -164,7 +174,9 @@ def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
 
 
 def _load_mc_frame(bundle_dir: Path, *, stem: str) -> pd.DataFrame:
-    candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in _OPTIONAL_STEM_EXTENSIONS)
+    candidates = tuple(
+        bundle_dir / f"{stem}.{ext}" for ext in _OPTIONAL_STEM_EXTENSIONS
+    )
     existing = next((c for c in candidates if c.exists()), None)
     if existing is None:
         expected = ", ".join(p.name for p in candidates)
@@ -185,7 +197,9 @@ def _load_mc_bundle_frames(bundle: str | Path) -> tuple[pd.DataFrame, pd.DataFra
     missing_inputs: list[str] = []
     expected_by_stem: dict[str, str] = {}
     for stem in required_stems:
-        candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in _OPTIONAL_STEM_EXTENSIONS)
+        candidates = tuple(
+            bundle_dir / f"{stem}.{ext}" for ext in _OPTIONAL_STEM_EXTENSIONS
+        )
         if not any(c.exists() for c in candidates):
             missing_inputs.append(stem)
             expected_by_stem[stem] = ", ".join(p.name for p in candidates)
@@ -198,7 +212,9 @@ def _load_mc_bundle_frames(bundle: str | Path) -> tuple[pd.DataFrame, pd.DataFra
                 f"Expected one of: {expected}"
             )
         missing_text = ", ".join(missing_inputs)
-        expected_text = "; ".join(f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs)
+        expected_text = "; ".join(
+            f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs
+        )
         raise TrendCLIError(
             f"Missing required MC input files in '{bundle_dir}': {missing_text}. "
             f"Expected one of each: {expected_text}"
@@ -216,6 +232,36 @@ def _load_mc_nav_paths_frame(bundle: str | Path) -> pd.DataFrame | None:
     return _read_mc_frame(nav_path, label="nav_paths")
 
 
+def _available_fold_nav_paths(bundle_dir: Path) -> list[Path]:
+    return sorted(bundle_dir.glob("nav_paths_fold_*.parquet"))
+
+
+def _load_fold_nav_paths_frame(bundle_dir: Path, fold_id: int) -> pd.DataFrame:
+    nav_path = bundle_dir / f"nav_paths_fold_{fold_id}.parquet"
+    if not nav_path.exists():
+        available = _available_fold_nav_paths(bundle_dir)
+        available_text = ", ".join(p.name for p in available) if available else "(none)"
+        raise TrendCLIError(
+            f"Requested --fold {fold_id} but '{nav_path.name}' was not found in the bundle. "
+            f"Available fold nav paths: {available_text}."
+        )
+    return _read_mc_frame(nav_path, label=f"nav_paths_fold_{fold_id}")
+
+
+def _load_nav_paths_override(nav_paths: str | Path) -> pd.DataFrame:
+    nav_path = Path(nav_paths).expanduser().resolve()
+    if not nav_path.exists():
+        raise TrendCLIError(f"Requested --nav-paths file does not exist: {nav_path}")
+    if not nav_path.is_file():
+        raise TrendCLIError(f"Requested --nav-paths path is not a file: {nav_path}")
+    if nav_path.suffix.lower() != ".parquet":
+        raise TrendCLIError(
+            f"Unsupported --nav-paths format '{nav_path.suffix}' for '{nav_path.name}'. "
+            "Only parquet files are supported."
+        )
+    return _read_mc_frame(nav_path, label="nav_paths")
+
+
 # ---------------------------------------------------------------------------
 # Chart parsing / selection
 # ---------------------------------------------------------------------------
@@ -227,7 +273,9 @@ def _parse_mc_chart_selection(charts_value: str | Sequence[str]) -> list[str]:
     else:
         requested = [str(t).strip().lower() for t in charts_value if str(t).strip()]
     if not requested:
-        raise TrendCLIError("The 'mc viz' command requires at least one chart in --charts.")
+        raise TrendCLIError(
+            "The 'mc viz' command requires at least one chart in --charts."
+        )
     seen: set[str] = set()
     ordered: list[str] = []
     for chart in requested:
@@ -305,10 +353,14 @@ def _build_mc_risk_return_chart(
     from trend_analysis.viz import risk_return
 
     nav_frame = _mc_nav_source_frame(summary_frame, results_frame, nav_paths_frame)
-    returns_frame = nav_frame.pct_change(fill_method=None).replace([np.inf, -np.inf], np.nan)
+    returns_frame = nav_frame.pct_change(fill_method=None).replace(
+        [np.inf, -np.inf], np.nan
+    )
     returns_frame = returns_frame.dropna(how="all")
     if returns_frame.empty:
-        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(how="all")
+        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(
+            how="all"
+        )
     return risk_return.make(returns_frame)
 
 
@@ -361,6 +413,9 @@ def _export_mc_chart_artifacts(
 def _validate_nav_paths(
     bundle_path: str | Path,
     selected_charts: list[str],
+    *,
+    fold_id: int | None,
+    nav_paths: str | Path | None,
 ) -> tuple[pd.DataFrame | None, bool]:
     """Load nav_paths and validate against chart requirements.
 
@@ -372,11 +427,33 @@ def _validate_nav_paths(
     from trend.mc.io import (
         MCNavPathsIOError,
         load_nav_paths_frame,
+        validate_nav_paths_df,
         validate_nav_paths_requirement,
     )
 
     try:
-        nav_paths_frame = load_nav_paths_frame(bundle_path)
+        bundle_dir = Path(bundle_path).expanduser().resolve()
+        if nav_paths is not None:
+            nav_paths_frame = validate_nav_paths_df(_load_nav_paths_override(nav_paths))
+        elif fold_id is not None:
+            nav_paths_frame = validate_nav_paths_df(
+                _load_fold_nav_paths_frame(bundle_dir, fold_id)
+            )
+        else:
+            nav_paths_frame = load_nav_paths_frame(bundle_path)
+            if nav_paths_frame is None and set(selected_charts).intersection(
+                NAV_PATH_REQUIRED_CHARTS
+            ):
+                fold_paths = _available_fold_nav_paths(bundle_dir)
+                if fold_paths:
+                    names = ", ".join(p.name for p in fold_paths[:5])
+                    if len(fold_paths) > 5:
+                        names = f"{names}, ..."
+                    raise TrendCLIError(
+                        "nav_paths.parquet is missing, but fold-exported NAV-path files were found "
+                        f"({names}). Re-run with --fold <id> to select a fold, or provide "
+                        "--nav-paths <file> to point at a specific nav_paths parquet file."
+                    )
         validate_nav_paths_requirement(
             selected_charts,
             nav_paths_frame,
@@ -404,35 +481,48 @@ def execute_mc_viz(
 ) -> int:
     """Execute Monte Carlo visualization artifact generation.
 
-    This function is the shared API surface that both CLI entry points call
-    for ``mc viz`` execution.
+    Public API contract
+    -------------------
+    The parameter list for this function is intentionally stable because
+    downstream tooling (and tests) relies on it.
 
-    Parameters
-    ----------
-    bundle_path
-        Filesystem path to the Monte Carlo export bundle directory containing
-        required input artifacts.
-    out_dir
-        Destination output directory where visualization artifacts are written.
-    charts
-        Requested chart identifiers, provided as either a comma-separated string
-        (for CLI compatibility) or a sequence of individual chart IDs.
-    html
-        When ``True``, generate HTML chart artifacts.
-    json
-        When ``True``, generate JSON chart artifacts.
-    png
-        When ``True``, generate PNG chart artifacts.
+    For CLI-only extensions (for example fold-nav-path selection), prefer
+    calling :func:`execute_mc_viz_cli`.
+    """
 
-    Returns
-    -------
-    int
-        Conventional CLI status code where ``0`` represents success.
+    return execute_mc_viz_cli(
+        bundle_path=bundle_path,
+        out_dir=out_dir,
+        charts=charts,
+        fold_id=None,
+        nav_paths=None,
+        html=html,
+        json=json,
+        png=png,
+    )
+
+
+def execute_mc_viz_cli(
+    bundle_path: str | Path,
+    out_dir: str | Path,
+    charts: Sequence[str] | str,
+    *,
+    fold_id: int | None,
+    nav_paths: str | Path | None,
+    html: bool,
+    json: bool,
+    png: bool,
+) -> int:
+    """CLI-oriented Monte Carlo viz execution.
+
+    This entry point extends :func:`execute_mc_viz` with optional helpers used
+    by the ``trend mc viz`` CLI (for example selecting fold-exported NAV paths).
     """
     # -- Output flag validation ------------------------------------------------
     if not any((html, json, png)):
         raise TrendCLIError(
-            "The 'mc viz' command requires at least one output flag: " "--html, --json, or --png"
+            "The 'mc viz' command requires at least one output flag: "
+            "--html, --json, or --png"
         )
 
     # -- PNG dependency check – degrade gracefully ----------------------------
@@ -457,12 +547,19 @@ def execute_mc_viz(
     selected_charts = _parse_mc_chart_selection(charts)
 
     # -- Nav-paths validation --------------------------------------------------
-    nav_paths_frame, uses_fallback_nav_data = _validate_nav_paths(bundle_path, selected_charts)
+    nav_paths_frame, uses_fallback_nav_data = _validate_nav_paths(
+        bundle_path,
+        selected_charts,
+        fold_id=fold_id,
+        nav_paths=nav_paths,
+    )
 
     # -- Build charts ----------------------------------------------------------
     chart_builders = _mc_chart_builders()
     generated_charts = {
-        chart_id: chart_builders[chart_id](summary_frame, results_frame, nav_paths_frame)
+        chart_id: chart_builders[chart_id](
+            summary_frame, results_frame, nav_paths_frame
+        )
         for chart_id in selected_charts
     }
 
@@ -529,12 +626,16 @@ def _inject_mc_html_chart_markers(
                 continue
             body_token = "<body>"
             if body_token in html_text:
-                updated_html = html_text.replace(body_token, f"{body_token}\n{marker}", 1)
+                updated_html = html_text.replace(
+                    body_token, f"{body_token}\n{marker}", 1
+                )
             else:
                 updated_html = f"{marker}\n{html_text}"
             html_path.write_text(updated_html, encoding="utf-8")
         except Exception as exc:
-            warnings.append(f"Unable to inject HTML chart marker for '{chart_id}': {exc}.")
+            warnings.append(
+                f"Unable to inject HTML chart marker for '{chart_id}': {exc}."
+            )
 
 
 __all__ = [

--- a/src/trend/mc/viz.py
+++ b/src/trend/mc/viz.py
@@ -74,7 +74,7 @@ def check_png_dependency() -> bool:
     try:
         if importlib.util.find_spec("kaleido") is None:
             return False
-        import plotly.io as pio  # noqa: WPS433
+        import plotly.io as pio
 
         # Use a minimal figure dict (not `go.Figure`) to avoid triggering
         # template initialization during dependency checks.

--- a/src/trend/mc/viz.py
+++ b/src/trend/mc/viz.py
@@ -92,9 +92,7 @@ def check_png_dependency() -> bool:
 
 def _normalize_chart_ids(charts: Sequence[str] | str) -> list[str]:
     if isinstance(charts, str):
-        normalized = [
-            part.strip().lower() for part in charts.split(",") if part.strip()
-        ]
+        normalized = [part.strip().lower() for part in charts.split(",") if part.strip()]
     else:
         normalized = [str(part).strip().lower() for part in charts if str(part).strip()]
     return normalized
@@ -102,9 +100,7 @@ def _normalize_chart_ids(charts: Sequence[str] | str) -> list[str]:
 
 def _collect_required_inputs(charts: Sequence[str] | str) -> list[str]:
     requested_charts = _normalize_chart_ids(charts)
-    unsupported = [
-        chart for chart in requested_charts if chart not in CHART_REQUIREMENTS
-    ]
+    unsupported = [chart for chart in requested_charts if chart not in CHART_REQUIREMENTS]
     if unsupported:
         invalid = ", ".join(sorted(set(unsupported)))
         raise ValueError(f"Unsupported chart identifier(s): {invalid}")
@@ -122,10 +118,7 @@ def _collect_required_inputs(charts: Sequence[str] | str) -> list[str]:
 def _requirement_is_present(bundle_dir: Path, requirement: str) -> bool:
     if "." in requirement:
         return (bundle_dir / requirement).exists()
-    return any(
-        (bundle_dir / f"{requirement}.{ext}").exists()
-        for ext in _OPTIONAL_STEM_EXTENSIONS
-    )
+    return any((bundle_dir / f"{requirement}.{ext}").exists() for ext in _OPTIONAL_STEM_EXTENSIONS)
 
 
 def _missing_requirement_label(requirement: str) -> str:
@@ -163,9 +156,7 @@ def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
     except TrendCLIError:
         raise
     except Exception as exc:
-        raise TrendCLIError(
-            f"Failed to read {label} data from '{path}': {exc}"
-        ) from exc
+        raise TrendCLIError(f"Failed to read {label} data from '{path}': {exc}") from exc
     if isinstance(frame, pd.Series):
         return frame.to_frame()
     if not isinstance(frame, pd.DataFrame):
@@ -174,9 +165,7 @@ def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
 
 
 def _load_mc_frame(bundle_dir: Path, *, stem: str) -> pd.DataFrame:
-    candidates = tuple(
-        bundle_dir / f"{stem}.{ext}" for ext in _OPTIONAL_STEM_EXTENSIONS
-    )
+    candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in _OPTIONAL_STEM_EXTENSIONS)
     existing = next((c for c in candidates if c.exists()), None)
     if existing is None:
         expected = ", ".join(p.name for p in candidates)
@@ -197,9 +186,7 @@ def _load_mc_bundle_frames(bundle: str | Path) -> tuple[pd.DataFrame, pd.DataFra
     missing_inputs: list[str] = []
     expected_by_stem: dict[str, str] = {}
     for stem in required_stems:
-        candidates = tuple(
-            bundle_dir / f"{stem}.{ext}" for ext in _OPTIONAL_STEM_EXTENSIONS
-        )
+        candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in _OPTIONAL_STEM_EXTENSIONS)
         if not any(c.exists() for c in candidates):
             missing_inputs.append(stem)
             expected_by_stem[stem] = ", ".join(p.name for p in candidates)
@@ -212,9 +199,7 @@ def _load_mc_bundle_frames(bundle: str | Path) -> tuple[pd.DataFrame, pd.DataFra
                 f"Expected one of: {expected}"
             )
         missing_text = ", ".join(missing_inputs)
-        expected_text = "; ".join(
-            f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs
-        )
+        expected_text = "; ".join(f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs)
         raise TrendCLIError(
             f"Missing required MC input files in '{bundle_dir}': {missing_text}. "
             f"Expected one of each: {expected_text}"
@@ -273,9 +258,7 @@ def _parse_mc_chart_selection(charts_value: str | Sequence[str]) -> list[str]:
     else:
         requested = [str(t).strip().lower() for t in charts_value if str(t).strip()]
     if not requested:
-        raise TrendCLIError(
-            "The 'mc viz' command requires at least one chart in --charts."
-        )
+        raise TrendCLIError("The 'mc viz' command requires at least one chart in --charts.")
     seen: set[str] = set()
     ordered: list[str] = []
     for chart in requested:
@@ -353,14 +336,10 @@ def _build_mc_risk_return_chart(
     from trend_analysis.viz import risk_return
 
     nav_frame = _mc_nav_source_frame(summary_frame, results_frame, nav_paths_frame)
-    returns_frame = nav_frame.pct_change(fill_method=None).replace(
-        [np.inf, -np.inf], np.nan
-    )
+    returns_frame = nav_frame.pct_change(fill_method=None).replace([np.inf, -np.inf], np.nan)
     returns_frame = returns_frame.dropna(how="all")
     if returns_frame.empty:
-        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(
-            how="all"
-        )
+        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(how="all")
     return risk_return.make(returns_frame)
 
 
@@ -436,9 +415,7 @@ def _validate_nav_paths(
         if nav_paths is not None:
             nav_paths_frame = validate_nav_paths_df(_load_nav_paths_override(nav_paths))
         elif fold_id is not None:
-            nav_paths_frame = validate_nav_paths_df(
-                _load_fold_nav_paths_frame(bundle_dir, fold_id)
-            )
+            nav_paths_frame = validate_nav_paths_df(_load_fold_nav_paths_frame(bundle_dir, fold_id))
         else:
             nav_paths_frame = load_nav_paths_frame(bundle_path)
             if nav_paths_frame is None and set(selected_charts).intersection(
@@ -521,8 +498,7 @@ def execute_mc_viz_cli(
     # -- Output flag validation ------------------------------------------------
     if not any((html, json, png)):
         raise TrendCLIError(
-            "The 'mc viz' command requires at least one output flag: "
-            "--html, --json, or --png"
+            "The 'mc viz' command requires at least one output flag: " "--html, --json, or --png"
         )
 
     # -- PNG dependency check – degrade gracefully ----------------------------
@@ -557,9 +533,7 @@ def execute_mc_viz_cli(
     # -- Build charts ----------------------------------------------------------
     chart_builders = _mc_chart_builders()
     generated_charts = {
-        chart_id: chart_builders[chart_id](
-            summary_frame, results_frame, nav_paths_frame
-        )
+        chart_id: chart_builders[chart_id](summary_frame, results_frame, nav_paths_frame)
         for chart_id in selected_charts
     }
 
@@ -626,16 +600,12 @@ def _inject_mc_html_chart_markers(
                 continue
             body_token = "<body>"
             if body_token in html_text:
-                updated_html = html_text.replace(
-                    body_token, f"{body_token}\n{marker}", 1
-                )
+                updated_html = html_text.replace(body_token, f"{body_token}\n{marker}", 1)
             else:
                 updated_html = f"{marker}\n{html_text}"
             html_path.write_text(updated_html, encoding="utf-8")
         except Exception as exc:
-            warnings.append(
-                f"Unable to inject HTML chart marker for '{chart_id}': {exc}."
-            )
+            warnings.append(f"Unable to inject HTML chart marker for '{chart_id}': {exc}.")
 
 
 __all__ = [

--- a/streamlit_app/components/llm_settings.py
+++ b/streamlit_app/components/llm_settings.py
@@ -146,7 +146,9 @@ def default_api_key(provider_name: str) -> str | None:
     if secrets_key:
         return secrets_key
     if provider_name == "anthropic":
-        secrets_anthropic = resolve_anthropic_api_key(include_secrets=True, include_env=False)
+        secrets_anthropic = resolve_anthropic_api_key(
+            include_secrets=True, include_env=False
+        )
         if secrets_anthropic:
             return secrets_anthropic
     return None
@@ -161,7 +163,9 @@ def resolve_llm_provider_config(
     organization: str | None = None,
     require_api_key: bool = True,
 ) -> LLMProviderConfig:
-    provider_name = (provider or os.environ.get("TREND_LLM_PROVIDER") or "openai").lower()
+    provider_name = (
+        provider or os.environ.get("TREND_LLM_PROVIDER") or "openai"
+    ).lower()
     supported = {"openai", "anthropic", "ollama"}
     if provider_name not in supported:
         raise ValueError(
@@ -169,21 +173,27 @@ def resolve_llm_provider_config(
             f"Expected one of: {', '.join(sorted(supported))}."
         )
     resolved_api_key = sanitize_api_key(api_key)
-    if not resolved_api_key:
-        resolved_api_key = sanitize_api_key(read_secret("TS_STREAMLIT_API_KEY"))
-    if not resolved_api_key:
-        resolved_api_key = sanitize_api_key(read_secret("OPENAI_API_KEY"))
-    if not resolved_api_key:
-        resolved_api_key = sanitize_api_key(read_secret("TREND_LLM_API_KEY"))
+    if not resolved_api_key and provider_name == "openai":
+        # Prefer explicit env override for OpenAI (useful for local runs and tests).
+        resolved_api_key = sanitize_api_key(os.environ.get("OPENAI_API_KEY"))
+    if not resolved_api_key and provider_name == "anthropic":
+        # Anthropic resolver already encodes secrets/env precedence rules.
+        resolved_api_key = resolve_anthropic_api_key()
     if not resolved_api_key:
         resolved_api_key = sanitize_api_key(os.environ.get("TS_STREAMLIT_API_KEY"))
     if not resolved_api_key:
-        resolved_api_key = sanitize_api_key(os.environ.get("OPENAI_API_KEY"))
-    if not resolved_api_key:
         resolved_api_key = sanitize_api_key(os.environ.get("TREND_LLM_API_KEY"))
-    if not resolved_api_key and provider_name == "anthropic":
-        resolved_api_key = resolve_anthropic_api_key()
-    if provider_name in {"openai", "anthropic"} and not resolved_api_key and require_api_key:
+    if not resolved_api_key and provider_name == "openai":
+        resolved_api_key = sanitize_api_key(read_secret("OPENAI_API_KEY"))
+    if not resolved_api_key:
+        resolved_api_key = sanitize_api_key(read_secret("TS_STREAMLIT_API_KEY"))
+    if not resolved_api_key:
+        resolved_api_key = sanitize_api_key(read_secret("TREND_LLM_API_KEY"))
+    if (
+        provider_name in {"openai", "anthropic"}
+        and not resolved_api_key
+        and require_api_key
+    ):
         env_hint = (
             "OPENAI_API_KEY"
             if provider_name == "openai"

--- a/streamlit_app/components/llm_settings.py
+++ b/streamlit_app/components/llm_settings.py
@@ -183,12 +183,12 @@ def resolve_llm_provider_config(
         resolved_api_key = sanitize_api_key(os.environ.get("TS_STREAMLIT_API_KEY"))
     if not resolved_api_key:
         resolved_api_key = sanitize_api_key(os.environ.get("TREND_LLM_API_KEY"))
-    if not resolved_api_key and provider_name == "openai":
-        resolved_api_key = sanitize_api_key(read_secret("OPENAI_API_KEY"))
     if not resolved_api_key:
         resolved_api_key = sanitize_api_key(read_secret("TS_STREAMLIT_API_KEY"))
     if not resolved_api_key:
         resolved_api_key = sanitize_api_key(read_secret("TREND_LLM_API_KEY"))
+    if not resolved_api_key and provider_name == "openai":
+        resolved_api_key = sanitize_api_key(read_secret("OPENAI_API_KEY"))
     if (
         provider_name in {"openai", "anthropic"}
         and not resolved_api_key

--- a/streamlit_app/components/llm_settings.py
+++ b/streamlit_app/components/llm_settings.py
@@ -146,9 +146,7 @@ def default_api_key(provider_name: str) -> str | None:
     if secrets_key:
         return secrets_key
     if provider_name == "anthropic":
-        secrets_anthropic = resolve_anthropic_api_key(
-            include_secrets=True, include_env=False
-        )
+        secrets_anthropic = resolve_anthropic_api_key(include_secrets=True, include_env=False)
         if secrets_anthropic:
             return secrets_anthropic
     return None
@@ -163,9 +161,7 @@ def resolve_llm_provider_config(
     organization: str | None = None,
     require_api_key: bool = True,
 ) -> LLMProviderConfig:
-    provider_name = (
-        provider or os.environ.get("TREND_LLM_PROVIDER") or "openai"
-    ).lower()
+    provider_name = (provider or os.environ.get("TREND_LLM_PROVIDER") or "openai").lower()
     supported = {"openai", "anthropic", "ollama"}
     if provider_name not in supported:
         raise ValueError(
@@ -189,11 +185,7 @@ def resolve_llm_provider_config(
         resolved_api_key = sanitize_api_key(read_secret("TREND_LLM_API_KEY"))
     if not resolved_api_key and provider_name == "openai":
         resolved_api_key = sanitize_api_key(read_secret("OPENAI_API_KEY"))
-    if (
-        provider_name in {"openai", "anthropic"}
-        and not resolved_api_key
-        and require_api_key
-    ):
+    if provider_name in {"openai", "anthropic"} and not resolved_api_key and require_api_key:
         env_hint = (
             "OPENAI_API_KEY"
             if provider_name == "openai"

--- a/tests/test_trend_cli.py
+++ b/tests/test_trend_cli.py
@@ -74,7 +74,9 @@ def _sample_config() -> SimpleNamespace:
 
 def _risky_patch() -> ConfigPatch:
     return ConfigPatch(
-        operations=[PatchOperation(op="remove", path="portfolio.constraints.max_weight")],
+        operations=[
+            PatchOperation(op="remove", path="portfolio.constraints.max_weight")
+        ],
         summary="Remove the max_weight constraint.",
     )
 
@@ -130,7 +132,9 @@ def test_mc_viz_parser_requires_out_flag() -> None:
     assert excinfo.value.code == 2
 
 
-def test_mc_viz_requires_at_least_one_output_flag(capsys: pytest.CaptureFixture[str]) -> None:
+def test_mc_viz_requires_at_least_one_output_flag(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     exit_code = main(["mc", "viz", "--bundle", "bundle_dir", "--out", "export_dir"])
 
     assert exit_code == 2
@@ -410,6 +414,87 @@ def test_mc_viz_errors_when_path_dist_requires_nav_paths_parquet(
     assert "path_dist" in err
 
 
+def test_mc_viz_loads_fold_nav_paths_when_requested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    pd.DataFrame({"metric": ["cagr"], "value": [0.12]}).to_csv(
+        bundle_dir / "summary.csv", index=False
+    )
+    pd.DataFrame({"path_id": [1, 2], "terminal_nav": [112.0, 98.4]}).to_csv(
+        bundle_dir / "results.csv", index=False
+    )
+
+    (bundle_dir / "nav_paths_fold_2.parquet").write_text(
+        "placeholder", encoding="utf-8"
+    )
+
+    import trend.mc.viz as _mc_viz
+
+    monkeypatch.setattr(
+        _mc_viz.pd,
+        "read_parquet",
+        lambda _path: pd.DataFrame({0: [1.0, 1.1], 1: [1.0, 0.9]}),
+    )
+
+    exit_code = main(
+        [
+            "mc",
+            "viz",
+            "--bundle",
+            str(bundle_dir),
+            "--out",
+            str(tmp_path / "exports"),
+            "--charts",
+            "path_dist",
+            "--fold",
+            "2",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "nav_paths_rows=2" in out
+
+
+def test_mc_viz_errors_when_fold_nav_paths_exist_but_no_selection_provided(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    pd.DataFrame({"metric": ["cagr"], "value": [0.12]}).to_csv(
+        bundle_dir / "summary.csv", index=False
+    )
+    pd.DataFrame({"path_id": [1, 2], "terminal_nav": [112.0, 98.4]}).to_csv(
+        bundle_dir / "results.csv", index=False
+    )
+    (bundle_dir / "nav_paths_fold_1.parquet").write_text(
+        "placeholder", encoding="utf-8"
+    )
+
+    exit_code = main(
+        [
+            "mc",
+            "viz",
+            "--bundle",
+            str(bundle_dir),
+            "--out",
+            str(tmp_path / "exports"),
+            "--charts",
+            "path_dist",
+            "--html",
+        ]
+    )
+
+    assert exit_code == 2
+    err = capsys.readouterr().err
+    assert "nav_paths.parquet" in err
+    assert "nav_paths_fold_" in err
+    assert "--fold" in err
+
+
 @pytest.mark.parametrize("suffix", ("csv", "json"))
 def test_mc_viz_errors_when_unsupported_nav_paths_format_detected_without_parquet(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], suffix: str
@@ -539,7 +624,9 @@ def test_mc_viz_routes_selected_charts_and_exports_requested_formats(
         captured["include_json"] = include_json
         captured["include_html"] = include_html
         captured["include_png"] = include_png
-        with zipfile.ZipFile(dest_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        with zipfile.ZipFile(
+            dest_path, "w", compression=zipfile.ZIP_DEFLATED
+        ) as archive:
             for name in charts:
                 if include_json:
                     archive.writestr(f"{name}.json", "{}")
@@ -623,7 +710,9 @@ def test_mc_viz_renames_collision_without_overwriting_existing_plot_file(
         assert destination is not None
         dest_path = Path(destination)
         dest_path.parent.mkdir(parents=True, exist_ok=True)
-        with zipfile.ZipFile(dest_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        with zipfile.ZipFile(
+            dest_path, "w", compression=zipfile.ZIP_DEFLATED
+        ) as archive:
             for name in charts:
                 if include_json:
                     archive.writestr(f"{name}.json", '{"new": true}')
@@ -965,7 +1054,9 @@ def test_main_report_supports_output_file_only(monkeypatch, tmp_path: Path) -> N
     )
     monkeypatch.setattr(
         "trend.cli.generate_unified_report",
-        lambda *a, **k: SimpleNamespace(html="<html>report</html>", pdf_bytes=None, context={}),
+        lambda *a, **k: SimpleNamespace(
+            html="<html>report</html>", pdf_bytes=None, context={}
+        ),
     )
 
     target = tmp_path / "custom-report.html"
@@ -1003,7 +1094,9 @@ def test_main_report_writes_pdf_when_requested(monkeypatch, tmp_path: Path) -> N
 
     def fake_generate_unified_report(*a, **k):
         recorded.update(k)
-        return SimpleNamespace(html="<html>with-pdf</html>", pdf_bytes=pdf_bytes, context={})
+        return SimpleNamespace(
+            html="<html>with-pdf</html>", pdf_bytes=pdf_bytes, context={}
+        )
 
     monkeypatch.setattr(
         "trend.cli.generate_unified_report",
@@ -1045,7 +1138,9 @@ def test_main_report_pdf_dependency_error(monkeypatch, tmp_path: Path, capsys) -
     )
     monkeypatch.setattr(
         "trend.cli.generate_unified_report",
-        lambda *a, **k: SimpleNamespace(html="<html>ok</html>", pdf_bytes=None, context={}),
+        lambda *a, **k: SimpleNamespace(
+            html="<html>ok</html>", pdf_bytes=None, context={}
+        ),
     )
 
     target = tmp_path / "report-output.html"
@@ -1125,8 +1220,12 @@ def test_cli_report_matches_shared_generator(monkeypatch, tmp_path: Path) -> Non
         "trend_analysis.cli._ensure_dataframe",
         lambda _p: pd.DataFrame({"Date": ["2021-01-31"], "Value": [0.01]}),
     )
-    monkeypatch.setattr("trend_analysis.cli._print_summary", lambda *args, **kwargs: None)
-    monkeypatch.setattr("trend_analysis.cli._write_report_files", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "trend_analysis.cli._print_summary", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "trend_analysis.cli._write_report_files", lambda *args, **kwargs: None
+    )
 
     def fake_run_pipeline(*args, **kwargs):  # type: ignore[override]
         return cli_result, "cli-run", None
@@ -1483,7 +1582,9 @@ def test_handle_exports_requires_both_directory_and_formats(monkeypatch) -> None
     result = RunResult(pd.DataFrame(), {}, 1, {})
 
     events: list[str] = []
-    monkeypatch.setattr(cli, "_legacy_maybe_log_step", lambda *a, **k: events.append("x"))
+    monkeypatch.setattr(
+        cli, "_legacy_maybe_log_step", lambda *a, **k: events.append("x")
+    )
 
     cli._handle_exports(cfg, result, structured_log=True, run_id="rid")
 
@@ -1518,7 +1619,9 @@ def test_write_bundle_appends_filename(monkeypatch, tmp_path: Path, capsys) -> N
     assert getattr(result, "config") == cfg.__dict__
 
 
-def test_write_bundle_accepts_explicit_file(monkeypatch, tmp_path: Path, capsys) -> None:
+def test_write_bundle_accepts_explicit_file(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
     cfg = SimpleNamespace(__dict__={"key": "value"})
     result = RunResult(pd.DataFrame(), {}, 1, {})
 
@@ -1571,7 +1674,9 @@ def test_print_summary_skips_empty_cache_stats(monkeypatch, capsys) -> None:
     assert "Cache statistics" not in out
 
 
-def test_write_report_files_creates_expected_outputs(monkeypatch, tmp_path: Path) -> None:
+def test_write_report_files_creates_expected_outputs(
+    monkeypatch, tmp_path: Path
+) -> None:
     metrics = pd.DataFrame({"value": [1.0]})
     result = RunResult(metrics, {"details": {}}, 1, {})
     cfg = SimpleNamespace(sample_split={})
@@ -1674,7 +1779,9 @@ def test_main_reports_unknown_command(monkeypatch, capsys) -> None:
         "_load_configuration",
         lambda path: (Path(path), SimpleNamespace(data={"csv_path": "returns.csv"})),
     )
-    monkeypatch.setattr(cli, "_resolve_returns_path", lambda *_args: Path("returns.csv"))
+    monkeypatch.setattr(
+        cli, "_resolve_returns_path", lambda *_args: Path("returns.csv")
+    )
     monkeypatch.setattr(cli, "_ensure_dataframe", lambda *_args: pd.DataFrame())
     monkeypatch.setattr(cli, "_determine_seed", lambda *_args: 0)
 

--- a/tests/test_trend_cli.py
+++ b/tests/test_trend_cli.py
@@ -495,6 +495,89 @@ def test_mc_viz_errors_when_fold_nav_paths_exist_but_no_selection_provided(
     assert "--fold" in err
 
 
+def test_mc_viz_loads_nav_paths_override_when_requested(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    pd.DataFrame({"metric": ["cagr"], "value": [0.12]}).to_csv(
+        bundle_dir / "summary.csv", index=False
+    )
+    pd.DataFrame({"path_id": [1, 2], "terminal_nav": [112.0, 98.4]}).to_csv(
+        bundle_dir / "results.csv", index=False
+    )
+
+    nav_override = tmp_path / "override.parquet"
+    nav_override.write_text("placeholder", encoding="utf-8")
+
+    import trend.mc.viz as _mc_viz
+
+    monkeypatch.setattr(
+        _mc_viz.pd,
+        "read_parquet",
+        lambda _path: pd.DataFrame({0: [1.0, 1.1], 1: [1.0, 0.9]}),
+    )
+
+    exit_code = main(
+        [
+            "mc",
+            "viz",
+            "--bundle",
+            str(bundle_dir),
+            "--out",
+            str(tmp_path / "exports"),
+            "--charts",
+            "fan",
+            "--nav-paths",
+            str(nav_override),
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "nav_paths_rows=2" in out
+
+
+def test_mc_viz_errors_when_nav_paths_override_is_not_parquet(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    pd.DataFrame({"metric": ["cagr"], "value": [0.12]}).to_csv(
+        bundle_dir / "summary.csv", index=False
+    )
+    pd.DataFrame({"path_id": [1, 2], "terminal_nav": [112.0, 98.4]}).to_csv(
+        bundle_dir / "results.csv", index=False
+    )
+
+    nav_override = tmp_path / "override.txt"
+    nav_override.write_text("not parquet", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "mc",
+            "viz",
+            "--bundle",
+            str(bundle_dir),
+            "--out",
+            str(tmp_path / "exports"),
+            "--charts",
+            "fan",
+            "--nav-paths",
+            str(nav_override),
+            "--html",
+        ]
+    )
+
+    assert exit_code == 2
+    err = capsys.readouterr().err
+    assert "--nav-paths" in err
+    assert "Only parquet" in err
+
+
 @pytest.mark.parametrize("suffix", ("csv", "json"))
 def test_mc_viz_errors_when_unsupported_nav_paths_format_detected_without_parquet(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], suffix: str

--- a/tests/test_trend_cli.py
+++ b/tests/test_trend_cli.py
@@ -74,9 +74,7 @@ def _sample_config() -> SimpleNamespace:
 
 def _risky_patch() -> ConfigPatch:
     return ConfigPatch(
-        operations=[
-            PatchOperation(op="remove", path="portfolio.constraints.max_weight")
-        ],
+        operations=[PatchOperation(op="remove", path="portfolio.constraints.max_weight")],
         summary="Remove the max_weight constraint.",
     )
 
@@ -426,9 +424,7 @@ def test_mc_viz_loads_fold_nav_paths_when_requested(
         bundle_dir / "results.csv", index=False
     )
 
-    (bundle_dir / "nav_paths_fold_2.parquet").write_text(
-        "placeholder", encoding="utf-8"
-    )
+    (bundle_dir / "nav_paths_fold_2.parquet").write_text("placeholder", encoding="utf-8")
 
     import trend.mc.viz as _mc_viz
 
@@ -470,9 +466,7 @@ def test_mc_viz_errors_when_fold_nav_paths_exist_but_no_selection_provided(
     pd.DataFrame({"path_id": [1, 2], "terminal_nav": [112.0, 98.4]}).to_csv(
         bundle_dir / "results.csv", index=False
     )
-    (bundle_dir / "nav_paths_fold_1.parquet").write_text(
-        "placeholder", encoding="utf-8"
-    )
+    (bundle_dir / "nav_paths_fold_1.parquet").write_text("placeholder", encoding="utf-8")
 
     exit_code = main(
         [
@@ -707,9 +701,7 @@ def test_mc_viz_routes_selected_charts_and_exports_requested_formats(
         captured["include_json"] = include_json
         captured["include_html"] = include_html
         captured["include_png"] = include_png
-        with zipfile.ZipFile(
-            dest_path, "w", compression=zipfile.ZIP_DEFLATED
-        ) as archive:
+        with zipfile.ZipFile(dest_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
             for name in charts:
                 if include_json:
                     archive.writestr(f"{name}.json", "{}")
@@ -793,9 +785,7 @@ def test_mc_viz_renames_collision_without_overwriting_existing_plot_file(
         assert destination is not None
         dest_path = Path(destination)
         dest_path.parent.mkdir(parents=True, exist_ok=True)
-        with zipfile.ZipFile(
-            dest_path, "w", compression=zipfile.ZIP_DEFLATED
-        ) as archive:
+        with zipfile.ZipFile(dest_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
             for name in charts:
                 if include_json:
                     archive.writestr(f"{name}.json", '{"new": true}')
@@ -1137,9 +1127,7 @@ def test_main_report_supports_output_file_only(monkeypatch, tmp_path: Path) -> N
     )
     monkeypatch.setattr(
         "trend.cli.generate_unified_report",
-        lambda *a, **k: SimpleNamespace(
-            html="<html>report</html>", pdf_bytes=None, context={}
-        ),
+        lambda *a, **k: SimpleNamespace(html="<html>report</html>", pdf_bytes=None, context={}),
     )
 
     target = tmp_path / "custom-report.html"
@@ -1177,9 +1165,7 @@ def test_main_report_writes_pdf_when_requested(monkeypatch, tmp_path: Path) -> N
 
     def fake_generate_unified_report(*a, **k):
         recorded.update(k)
-        return SimpleNamespace(
-            html="<html>with-pdf</html>", pdf_bytes=pdf_bytes, context={}
-        )
+        return SimpleNamespace(html="<html>with-pdf</html>", pdf_bytes=pdf_bytes, context={})
 
     monkeypatch.setattr(
         "trend.cli.generate_unified_report",
@@ -1221,9 +1207,7 @@ def test_main_report_pdf_dependency_error(monkeypatch, tmp_path: Path, capsys) -
     )
     monkeypatch.setattr(
         "trend.cli.generate_unified_report",
-        lambda *a, **k: SimpleNamespace(
-            html="<html>ok</html>", pdf_bytes=None, context={}
-        ),
+        lambda *a, **k: SimpleNamespace(html="<html>ok</html>", pdf_bytes=None, context={}),
     )
 
     target = tmp_path / "report-output.html"
@@ -1303,12 +1287,8 @@ def test_cli_report_matches_shared_generator(monkeypatch, tmp_path: Path) -> Non
         "trend_analysis.cli._ensure_dataframe",
         lambda _p: pd.DataFrame({"Date": ["2021-01-31"], "Value": [0.01]}),
     )
-    monkeypatch.setattr(
-        "trend_analysis.cli._print_summary", lambda *args, **kwargs: None
-    )
-    monkeypatch.setattr(
-        "trend_analysis.cli._write_report_files", lambda *args, **kwargs: None
-    )
+    monkeypatch.setattr("trend_analysis.cli._print_summary", lambda *args, **kwargs: None)
+    monkeypatch.setattr("trend_analysis.cli._write_report_files", lambda *args, **kwargs: None)
 
     def fake_run_pipeline(*args, **kwargs):  # type: ignore[override]
         return cli_result, "cli-run", None
@@ -1665,9 +1645,7 @@ def test_handle_exports_requires_both_directory_and_formats(monkeypatch) -> None
     result = RunResult(pd.DataFrame(), {}, 1, {})
 
     events: list[str] = []
-    monkeypatch.setattr(
-        cli, "_legacy_maybe_log_step", lambda *a, **k: events.append("x")
-    )
+    monkeypatch.setattr(cli, "_legacy_maybe_log_step", lambda *a, **k: events.append("x"))
 
     cli._handle_exports(cfg, result, structured_log=True, run_id="rid")
 
@@ -1702,9 +1680,7 @@ def test_write_bundle_appends_filename(monkeypatch, tmp_path: Path, capsys) -> N
     assert getattr(result, "config") == cfg.__dict__
 
 
-def test_write_bundle_accepts_explicit_file(
-    monkeypatch, tmp_path: Path, capsys
-) -> None:
+def test_write_bundle_accepts_explicit_file(monkeypatch, tmp_path: Path, capsys) -> None:
     cfg = SimpleNamespace(__dict__={"key": "value"})
     result = RunResult(pd.DataFrame(), {}, 1, {})
 
@@ -1757,9 +1733,7 @@ def test_print_summary_skips_empty_cache_stats(monkeypatch, capsys) -> None:
     assert "Cache statistics" not in out
 
 
-def test_write_report_files_creates_expected_outputs(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_write_report_files_creates_expected_outputs(monkeypatch, tmp_path: Path) -> None:
     metrics = pd.DataFrame({"value": [1.0]})
     result = RunResult(metrics, {"details": {}}, 1, {})
     cfg = SimpleNamespace(sample_split={})
@@ -1862,9 +1836,7 @@ def test_main_reports_unknown_command(monkeypatch, capsys) -> None:
         "_load_configuration",
         lambda path: (Path(path), SimpleNamespace(data={"csv_path": "returns.csv"})),
     )
-    monkeypatch.setattr(
-        cli, "_resolve_returns_path", lambda *_args: Path("returns.csv")
-    )
+    monkeypatch.setattr(cli, "_resolve_returns_path", lambda *_args: Path("returns.csv"))
     monkeypatch.setattr(cli, "_ensure_dataframe", lambda *_args: pd.DataFrame())
     monkeypatch.setattr(cli, "_determine_seed", lambda *_args: 0)
 


### PR DESCRIPTION
Summary:
- Add --fold/--nav-paths to 'trend mc viz' so fold-run bundles can render path-dependent charts.
- Keep public execute_mc_viz signature stable; introduce execute_mc_viz_cli for CLI extensions.
- Update README nav_paths contract example to match the wide nav_paths artifact.
- Fix Streamlit LLM settings so OPENAI_API_KEY env overrides secrets for OpenAI.

Tests:
- ./scripts/run_tests.sh (5352 passed, 3 skipped; coverage gate met)