### PR TITLE
ci: gate mc viz integration tests by paths

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -47,6 +47,9 @@ jobs:
       format_check: false  # Using ruff for formatting
       working-directory: "."
       artifact-prefix: "gate-"
+      # Keep PR Gate fast: the MC-viz CLI integration suite runs in a dedicated
+      # workflow triggered by relevant file changes.
+      pytest_markers: "not mc_viz_integration"
       # Enable soft coverage gate for trend tracking and hotspot reporting
       enable-soft-gate: true
     secrets: inherit

--- a/.github/workflows/pr-13-mc-viz-integration.yml
+++ b/.github/workflows/pr-13-mc-viz-integration.yml
@@ -1,0 +1,37 @@
+name: MC Viz Integration
+
+on:
+  pull_request:
+    paths:
+      - "src/trend/mc/**"
+      - "src/trend/cli.py"
+      - "src/trend_analysis/monte_carlo/**"
+      - "src/trend_analysis/viz/**"
+      - "streamlit_app/pages/monte_carlo.py"
+      - "streamlit_app/components/mc_*.py"
+      - "tests/integration/test_mc_viz.py"
+      - "tests/fixtures/mc_bundle/**"
+      - ".github/workflows/pr-13-mc-viz-integration.yml"
+  push:
+    branches: [phase-3]
+  workflow_dispatch:
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number || github.ref_name }}-mc-viz-integration
+  cancel-in-progress: true
+
+jobs:
+  mc-viz-integration:
+    name: MC Viz Integration (py3.12)
+    uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
+    with:
+      working-directory: "."
+      python-versions: '["3.12"]'
+      lint: false
+      format_check: false
+      typecheck: false
+      coverage: false
+      cache: true
+      pytest_markers: "mc_viz_integration"
+      pytest_args: "tests/integration/test_mc_viz.py"
+    secrets: inherit

--- a/.github/workflows/pr-13-mc-viz-integration.yml
+++ b/.github/workflows/pr-13-mc-viz-integration.yml
@@ -3,6 +3,9 @@ name: MC Viz Integration
 on:
   pull_request:
     paths:
+      - "pyproject.toml"
+      - "requirements.lock"
+      - "pytest.ini"
       - "src/trend/mc/**"
       - "src/trend/cli.py"
       - "src/trend_analysis/monte_carlo/**"

--- a/Agents.md
+++ b/Agents.md
@@ -273,6 +273,18 @@ gh issue close BROKEN_ISSUE --comment "Closed due to task explosion. Recreated a
 
 ---
 
+## MC Viz Integration Tests (CI)
+
+The end-to-end `trend mc viz` suite lives in `tests/integration/test_mc_viz.py` and is marked with `mc_viz_integration`.
+
+- Gate excludes it by default (for PR latency).
+- `.github/workflows/pr-13-mc-viz-integration.yml` runs it automatically when MC-viz codepaths change, and on pushes to `phase-3`.
+
+Local run:
+`PYTHONPATH=./src python -m pytest -m mc_viz_integration tests/integration/test_mc_viz.py`
+
+---
+
 ## Related Documentation
 
 - [docs/phase-2/Agents.md](docs/phase-2/Agents.md) - Complete implementation spec

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,26 @@ For detailed docs, see **stranske/Workflows**:
 - `docs/keepalive/GoalsAndPlumbing.md` - Keepalive system design
 - `docs/keepalive/SETUP_CHECKLIST.md` - Required files and secrets
 
+## MC Viz Integration Tests (CI Performance)
+
+This repo has an integration-heavy suite in `tests/integration/test_mc_viz.py` that exercises the `trend mc viz` CLI end-to-end (bundle inputs → chart artifacts).
+
+To keep PR Gate latency reasonable:
+- The Gate workflow excludes these tests by default via the `mc_viz_integration` marker.
+- A dedicated workflow runs the suite only when MC-viz-related files change.
+
+**CI wiring**
+- Gate: `.github/workflows/pr-00-gate.yml` passes `pytest_markers: "not mc_viz_integration"` into the shared reusable workflow.
+- Dedicated run: `.github/workflows/pr-13-mc-viz-integration.yml` runs only `tests/integration/test_mc_viz.py` with `pytest_markers: "mc_viz_integration"`.
+
+**When it runs**
+- On PRs that touch MC-viz paths (see the `paths:` filter in `.github/workflows/pr-13-mc-viz-integration.yml`).
+- On pushes to `phase-3` (safety net).
+- Manually via `workflow_dispatch`.
+
+**Local run**
+- `PYTHONPATH=./src python -m pytest -m mc_viz_integration tests/integration/test_mc_viz.py`
+
 ## Quick Debug Commands
 
 ```bash

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ markers =
     smoke: smoke tests for app launch
     slow: marks tests as slow, long-running; excluded from required checks (deselect with '-m "not slow"')
     integration: marks integration tests that exercise external tooling
+    mc_viz_integration: integration tests for `trend mc viz` (CLI + bundle artifacts); run via dedicated workflow when MC-viz codepaths change
     quarantine(reason): known failing or flaky; excluded from required checks
     runtime: critical pipeline or engine behaviour; failures block merges and automation will alert humans
     performance: runtime-sensitive performance regression checks

--- a/tests/integration/test_mc_viz.py
+++ b/tests/integration/test_mc_viz.py
@@ -134,7 +134,6 @@ def _expected_png_paths(plots_dir: Path, charts: tuple[str, ...]) -> list[Path]:
     return [plots_dir / f"{chart}.png" for chart in charts]
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_errors_when_nav_paths_missing_for_path_dist(tmp_path: Path) -> None:
     """Missing nav_paths.parquet for path_dist -> non-zero exit code."""
     bundle_dir = _fixture_bundle_dir()
@@ -156,7 +155,6 @@ def test_mc_viz_cli_errors_when_nav_paths_missing_for_path_dist(tmp_path: Path) 
     )
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_full_run_with_html_markers_and_chart_consistency(
     tmp_path: Path,
 ) -> None:
@@ -206,7 +204,6 @@ def test_mc_viz_cli_full_run_with_html_markers_and_chart_consistency(
         assert "PNG export skipped" in result.stderr
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_outputs_only_selected_chart_set_across_formats(
     tmp_path: Path,
 ) -> None:
@@ -236,7 +233,6 @@ def test_mc_viz_cli_outputs_only_selected_chart_set_across_formats(
         assert "PNG export skipped" in result.stderr
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_renames_existing_plot_file_collision_without_overwrite(
     tmp_path: Path,
 ) -> None:
@@ -261,7 +257,6 @@ def test_mc_viz_cli_renames_existing_plot_file_collision_without_overwrite(
     )
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_errors_when_nav_paths_missing_for_required_chart(
     tmp_path: Path,
 ) -> None:
@@ -284,7 +279,6 @@ def test_mc_viz_cli_errors_when_nav_paths_missing_for_required_chart(
     )
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_error_message_lists_exact_missing_filename(tmp_path: Path) -> None:
     """Error message contains the literal string 'nav_paths.parquet'."""
     bundle_dir = _fixture_bundle_dir()
@@ -299,7 +293,6 @@ def test_mc_viz_cli_error_message_lists_exact_missing_filename(tmp_path: Path) -
     assert "nav_paths.parquet" in result.stderr
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_error_lists_multiple_missing_files(tmp_path: Path) -> None:
     """When multiple required inputs are absent, all are listed."""
     empty_bundle = tmp_path / "empty_bundle"
@@ -313,7 +306,6 @@ def test_mc_viz_cli_error_lists_multiple_missing_files(tmp_path: Path) -> None:
     assert "results" in result.stderr
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_fan_missing_required_inputs(tmp_path: Path) -> None:
     """fan chart with missing required inputs -> non-zero exit and error."""
     empty_bundle = tmp_path / "empty_bundle"
@@ -326,7 +318,6 @@ def test_mc_viz_cli_fan_missing_required_inputs(tmp_path: Path) -> None:
     assert "summary" in result.stderr or "results" in result.stderr
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_risk_return_missing_required_inputs(tmp_path: Path) -> None:
     """risk_return chart with missing required inputs -> non-zero exit."""
     empty_bundle = tmp_path / "empty_bundle"
@@ -344,7 +335,6 @@ def test_mc_viz_cli_risk_return_missing_required_inputs(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_creates_plots_directory(tmp_path: Path) -> None:
     """On success, <out_dir>/plots/ is created."""
     bundle_dir = _fixture_bundle_dir()
@@ -356,7 +346,6 @@ def test_mc_viz_cli_creates_plots_directory(tmp_path: Path) -> None:
     assert (out_dir / "plots").is_dir()
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_generates_html_artifacts(tmp_path: Path) -> None:
     """HTML files matching *fan*.html etc. are generated when --html is set."""
     bundle_dir = _fixture_bundle_dir()
@@ -371,7 +360,6 @@ def test_mc_viz_cli_generates_html_artifacts(tmp_path: Path) -> None:
         assert len(matches) >= 1, f"No HTML file found for chart '{chart}'"
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_generates_json_artifacts(tmp_path: Path) -> None:
     """JSON files matching *fan*.json etc. are generated when --json is set."""
     bundle_dir = _fixture_bundle_dir()
@@ -386,7 +374,6 @@ def test_mc_viz_cli_generates_json_artifacts(tmp_path: Path) -> None:
         assert len(matches) >= 1, f"No JSON file found for chart '{chart}'"
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_correct_artifact_count(tmp_path: Path) -> None:
     """3 HTML + 3 JSON for --charts fan,path_dist,risk_return --html --json."""
     bundle_dir = _fixture_bundle_dir()
@@ -402,7 +389,6 @@ def test_mc_viz_cli_correct_artifact_count(tmp_path: Path) -> None:
     assert len(json_files) == 3
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_artifact_filenames(tmp_path: Path) -> None:
     """Artifact filenames follow the expected naming convention."""
     bundle_dir = _fixture_bundle_dir()
@@ -422,7 +408,6 @@ def test_mc_viz_cli_artifact_filenames(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.integration
 @pytest.mark.skipif(not _kaleido_available(), reason="kaleido not functional")
 def test_mc_viz_cli_generates_png_when_kaleido_available(tmp_path: Path) -> None:
     """PNGs generated (>=3) when kaleido works and --png is set."""
@@ -437,7 +422,6 @@ def test_mc_viz_cli_generates_png_when_kaleido_available(tmp_path: Path) -> None
     assert len(png_files) >= 3
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_fails_when_kaleido_missing_and_png_requested(
     tmp_path: Path,
 ) -> None:
@@ -453,7 +437,6 @@ def test_mc_viz_cli_fails_when_kaleido_missing_and_png_requested(
     assert len(list(plots_dir.glob("*.png"))) == 0
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_error_contains_install_hint_when_kaleido_missing(
     tmp_path: Path,
 ) -> None:
@@ -468,7 +451,6 @@ def test_mc_viz_cli_error_contains_install_hint_when_kaleido_missing(
     assert "pip install kaleido" in result.stderr
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_no_png_when_flag_not_set(tmp_path: Path) -> None:
     """No PNG files when --png is not set, regardless of kaleido."""
     bundle_dir = _fixture_bundle_dir()
@@ -487,7 +469,6 @@ def test_mc_viz_cli_no_png_when_flag_not_set(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_warns_and_continues_when_nav_paths_missing_for_non_required_charts(
     tmp_path: Path,
 ) -> None:
@@ -510,7 +491,6 @@ def test_mc_viz_cli_warns_and_continues_when_nav_paths_missing_for_non_required_
     assert (out_dir / "plots" / "risk_return.html").is_file()
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_creates_nested_output_directory_tree(tmp_path: Path) -> None:
     """Deeply nested output directories are created automatically."""
     bundle_dir = _fixture_bundle_dir()
@@ -526,7 +506,6 @@ def test_mc_viz_cli_creates_nested_output_directory_tree(tmp_path: Path) -> None
     assert (plots_dir / "fan.json").is_file()
 
 
-@pytest.mark.integration
 def test_mc_viz_cli_skips_existing_plot_file_without_overwrite(tmp_path: Path) -> None:
     """Pre-existing files in plots/ are renamed to avoid collision."""
     bundle_dir = _fixture_bundle_dir()

--- a/tests/integration/test_mc_viz.py
+++ b/tests/integration/test_mc_viz.py
@@ -11,6 +11,8 @@ import pytest
 
 CHARTS = ("fan", "path_dist", "risk_return")
 
+pytestmark = [pytest.mark.integration, pytest.mark.mc_viz_integration]
+
 
 def _fixture_bundle_dir() -> Path:
     return Path(__file__).resolve().parents[1] / "fixtures" / "mc_bundle"
@@ -145,12 +147,19 @@ def test_mc_viz_cli_errors_when_nav_paths_missing_for_path_dist(tmp_path: Path) 
     result = _run_mc_viz(missing_nav_bundle, out_dir, charts="fan,path_dist", png=False)
 
     assert result.returncode != 0
-    assert "Chart(s) path_dist require nav_paths.parquet in the MC bundle." in result.stderr
-    assert "Add nav_paths.parquet or remove these chart(s) from --charts." in result.stderr
+    assert (
+        "Chart(s) path_dist require nav_paths.parquet in the MC bundle."
+        in result.stderr
+    )
+    assert (
+        "Add nav_paths.parquet or remove these chart(s) from --charts." in result.stderr
+    )
 
 
 @pytest.mark.integration
-def test_mc_viz_cli_full_run_with_html_markers_and_chart_consistency(tmp_path: Path) -> None:
+def test_mc_viz_cli_full_run_with_html_markers_and_chart_consistency(
+    tmp_path: Path,
+) -> None:
     """Full run asserts HTML markers, JSON payloads, and chart-set consistency."""
     bundle_dir = _fixture_bundle_dir()
     assert bundle_dir.is_dir()
@@ -198,7 +207,9 @@ def test_mc_viz_cli_full_run_with_html_markers_and_chart_consistency(tmp_path: P
 
 
 @pytest.mark.integration
-def test_mc_viz_cli_outputs_only_selected_chart_set_across_formats(tmp_path: Path) -> None:
+def test_mc_viz_cli_outputs_only_selected_chart_set_across_formats(
+    tmp_path: Path,
+) -> None:
     bundle_dir = _fixture_bundle_dir()
     assert bundle_dir.is_dir()
 
@@ -226,7 +237,9 @@ def test_mc_viz_cli_outputs_only_selected_chart_set_across_formats(tmp_path: Pat
 
 
 @pytest.mark.integration
-def test_mc_viz_cli_renames_existing_plot_file_collision_without_overwrite(tmp_path: Path) -> None:
+def test_mc_viz_cli_renames_existing_plot_file_collision_without_overwrite(
+    tmp_path: Path,
+) -> None:
     bundle_dir = _fixture_bundle_dir()
     assert bundle_dir.is_dir()
 
@@ -243,11 +256,15 @@ def test_mc_viz_cli_renames_existing_plot_file_collision_without_overwrite(tmp_p
     assert existing_path.read_bytes() == original_bytes
     assert (plots_dir / "risk_return-1.json").is_file()
     assert "risk_return.json" in result.stderr
-    assert "Renamed extracted 'risk_return.json' to 'risk_return-1.json'" in result.stderr
+    assert (
+        "Renamed extracted 'risk_return.json' to 'risk_return-1.json'" in result.stderr
+    )
 
 
 @pytest.mark.integration
-def test_mc_viz_cli_errors_when_nav_paths_missing_for_required_chart(tmp_path: Path) -> None:
+def test_mc_viz_cli_errors_when_nav_paths_missing_for_required_chart(
+    tmp_path: Path,
+) -> None:
     bundle_dir = _fixture_bundle_dir()
     assert bundle_dir.is_dir()
     missing_nav_bundle_dir = tmp_path / "bundle_no_nav_paths"
@@ -258,8 +275,13 @@ def test_mc_viz_cli_errors_when_nav_paths_missing_for_required_chart(tmp_path: P
     result = _run_mc_viz(missing_nav_bundle_dir, out_dir, charts="fan,path_dist")
 
     assert result.returncode != 0
-    assert "Chart(s) path_dist require nav_paths.parquet in the MC bundle." in result.stderr
-    assert "Add nav_paths.parquet or remove these chart(s) from --charts." in result.stderr
+    assert (
+        "Chart(s) path_dist require nav_paths.parquet in the MC bundle."
+        in result.stderr
+    )
+    assert (
+        "Add nav_paths.parquet or remove these chart(s) from --charts." in result.stderr
+    )
 
 
 @pytest.mark.integration
@@ -416,7 +438,9 @@ def test_mc_viz_cli_generates_png_when_kaleido_available(tmp_path: Path) -> None
 
 
 @pytest.mark.integration
-def test_mc_viz_cli_fails_when_kaleido_missing_and_png_requested(tmp_path: Path) -> None:
+def test_mc_viz_cli_fails_when_kaleido_missing_and_png_requested(
+    tmp_path: Path,
+) -> None:
     """Graceful degradation when --png is requested but kaleido unavailable."""
     bundle_dir = _fixture_bundle_dir()
     out_dir = tmp_path / "out"
@@ -474,7 +498,9 @@ def test_mc_viz_cli_warns_and_continues_when_nav_paths_missing_for_non_required_
     (missing_nav_bundle / "nav_paths.parquet").unlink()
 
     out_dir = tmp_path / "out"
-    result = _run_mc_viz(missing_nav_bundle, out_dir, charts="fan,risk_return", png=False)
+    result = _run_mc_viz(
+        missing_nav_bundle, out_dir, charts="fan,risk_return", png=False
+    )
 
     assert result.returncode == 0, result.stderr
     assert "Missing optional nav_paths.parquet file in MC bundle:" in result.stderr


### PR DESCRIPTION
Summary:
- Mark tests/integration/test_mc_viz.py with a dedicated mc_viz_integration pytest marker.
- Exclude mc_viz_integration from Gate's default Python CI to reduce PR latency.
- Add a path-filtered workflow that runs the MC-viz integration suite when MC-viz codepaths change (and on pushes to phase-3).
- Document the contract in CLAUDE.md and Agents.md so it doesn't get forgotten.

Local run:
- PYTHONPATH=./src python -m pytest -m mc_viz_integration tests/integration/test_mc_viz.py

Notes:
- Some PNG/Kaleido assertions may be skipped when Kaleido is not functional in the environment.
