### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "minimatch": "^9.0.5"
+    "minimatch": "^10.2.1"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Pin build dependencies to ensure reproducible installs during Docker builds
-requires = ["setuptools==82.0.0", "wheel==0.46.3"]
+requires = ["setuptools==80.10.2", "wheel==0.46.3"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/scripts/langchain/progress_reviewer.py
+++ b/scripts/langchain/progress_reviewer.py
@@ -263,6 +263,25 @@ def heuristic_alignment_check(
 # ---------------------------------------------------------------------------
 
 
+# Patterns for orchestrator bookkeeping files that should not count as "agent work".
+# These files are written by the keepalive orchestrator, not the coding agent.
+_BOOKKEEPING_PATTERNS = re.compile(
+    r"(?:^|\/)(?:"
+    r"claude-(?:prompt|output)-\d+\.md"
+    r"|codex-(?:prompt|output)-\d+\.md"
+    r"|claude-(?:session|analysis)-\d+\.(?:jsonl|json)"
+    r"|agents/claude-\d+\.md"
+    r"|\.agents/"
+    r"|autofix-.*"
+    r")",
+)
+
+
+def _filter_bookkeeping_files(files: list[str]) -> list[str]:
+    """Remove orchestrator bookkeeping files that don't represent agent work."""
+    return [f for f in files if not _BOOKKEEPING_PATTERNS.search(f)]
+
+
 def build_review_prompt(
     acceptance_criteria: list[str],
     recent_commits: list[str],
@@ -537,10 +556,42 @@ def review_progress(
     Returns:
         ProgressReviewResult with recommendation and analysis
     """
+    # Filter out orchestrator bookkeeping files (claude-prompt-*.md, etc.)
+    # so they don't inflate alignment scores or file-change counts
+    files_changed = _filter_bookkeeping_files(files_changed)
+
     # Quick heuristic check first
     heuristic_score, aligned, unaligned = heuristic_alignment_check(
         acceptance_criteria, recent_commits, files_changed
     )
+
+    # Zero files changed = infrastructure failure (auth, permissions, sandbox).
+    # Commit message alignment is meaningless when the agent can't write code.
+    # Orchestrator bookkeeping files (claude-prompt-*.md, claude-output-*.md)
+    # artificially inflate alignment because they contain acceptance criteria text.
+    if not files_changed and rounds_without_completion >= 2:
+        return ProgressReviewResult(
+            recommendation="STOP",
+            confidence=0.9,
+            alignment_score=0.0,
+            trajectory="diverging",
+            analysis=ProgressAnalysis(
+                blocking_issues=[
+                    "Zero source files changed across multiple rounds",
+                    "Likely infrastructure failure: auth, permissions, or sandbox",
+                ],
+            ),
+            feedback_for_agent=(
+                "No source files have been modified. This indicates an infrastructure "
+                "problem (authentication, permissions, or sandbox configuration). "
+                "Human intervention is required."
+            ),
+            summary=(
+                f"Zero files changed for {rounds_without_completion} rounds — "
+                "infrastructure failure, not scope drift"
+            ),
+            used_llm=False,
+        )
 
     # If clearly aligned or clearly not, skip LLM
     if heuristic_score >= 8 and rounds_without_completion < 12:


### PR DESCRIPTION
## Sync Summary

### Files Updated
- package.json: Node package manifest for .github scripts (vendored minimatch)
- keepalive_loop.js: Core keepalive loop logic
- progress_reviewer.py: Progress reviewer - evaluates agent progress for keepalive rounds

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Manifest:** `.github/sync-manifest.yml`