### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -4,12 +4,12 @@
 # NOTE: Only include dev tools here (linters, formatters, test runners).
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
-BLACK_VERSION=26.1.0
-RUFF_VERSION=0.15.0
-ISORT_VERSION=7.0.0
+BLACK_VERSION=26.3.1
+RUFF_VERSION=0.15.10
+ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.7
-MYPY_VERSION=1.19.1
-PYTEST_VERSION=9.0.2
-PYTEST_COV_VERSION=7.0.0
+MYPY_VERSION=1.20.1
+PYTEST_VERSION=9.0.3
+PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0
-COVERAGE_VERSION=7.13.4
+COVERAGE_VERSION=7.13.5


### PR DESCRIPTION
## Sync Summary

### Files Updated
- autofix-versions.env: Autofix tool version pins - shared dev tool versions (synced)

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- AGENTS.md: Repo keeps historical Agents.md casing to avoid case-only path conflicts
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Manifest:** `.github/sync-manifest.yml`