### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/actions/setup-api-client/action.yml
+++ b/.github/actions/setup-api-client/action.yml
@@ -69,6 +69,9 @@ outputs:
   available_tokens:
     description: 'Comma-separated list of available token names'
     value: ${{ steps.export-tokens.outputs.available_tokens }}
+  setup_contract:
+    description: 'Redacted machine-readable setup/auth/dependency contract JSON'
+    value: ${{ steps.export-tokens.outputs.setup_contract }}
 
 runs:
   using: composite
@@ -214,8 +217,8 @@ runs:
           CREATED_PACKAGE_JSON=true
         fi
 
-        # Check if already installed (including lru-cache, a required transitive dep
-        # of @octokit/auth-app used for GitHub App token minting).
+        # Check if already installed (including lru-cache@10.4.3, a required
+        # transitive dep of @octokit/auth-app used for GitHub App token minting).
         if [ -d "node_modules/@octokit/rest" ] && [ -d "node_modules/lru-cache" ]; then
           echo "✅ @octokit/rest already installed"
         else
@@ -360,6 +363,7 @@ runs:
         INPUT_APP_1_PRIVATE_KEY: ${{ inputs.app_1_private_key }}
         INPUT_APP_2_ID: ${{ inputs.app_2_id }}
         INPUT_APP_2_PRIVATE_KEY: ${{ inputs.app_2_private_key }}
+        INPUT_INSTALL_DIR: ${{ inputs.install_dir }}
         INPUT_VERBOSE: ${{ inputs.verbose }}
       run: |
         set -euo pipefail
@@ -489,11 +493,76 @@ runs:
         echo "token_count=${token_count}" >> "$GITHUB_OUTPUT"
         echo "available_tokens=${available_tokens}" >> "$GITHUB_OUTPUT"
 
+        install_dir="${INPUT_INSTALL_DIR:-}"
+        if [ -z "$install_dir" ]; then
+          install_dir="${GITHUB_WORKSPACE}/.github/scripts"
+        fi
+        setup_contract="$(
+          AVAILABLE_TOKENS="${available_tokens}" \
+          TOKEN_COUNT="${token_count}" \
+          INSTALL_DIR="${install_dir}" \
+          node <<'NODE'
+        const fs = require('node:fs');
+        const path = require('node:path');
+
+        const installDir = process.env.INSTALL_DIR || '';
+        const tokenNames = (process.env.AVAILABLE_TOKENS || '')
+          .split(',')
+          .map((value) => value.trim())
+          .filter(Boolean);
+        const tokenSet = new Set(tokenNames);
+        const appPairs = [
+          ['WORKFLOWS_APP', 'WORKFLOWS_APP_ID', 'WORKFLOWS_APP_PRIVATE_KEY'],
+          ['KEEPALIVE_APP', 'KEEPALIVE_APP_ID', 'KEEPALIVE_APP_PRIVATE_KEY'],
+          ['GH_APP', 'GH_APP_ID', 'GH_APP_PRIVATE_KEY'],
+          ['APP_1', 'APP_1_ID', 'APP_1_PRIVATE_KEY'],
+          ['APP_2', 'APP_2_ID', 'APP_2_PRIVATE_KEY'],
+        ];
+        const authModes = [];
+        if (tokenSet.has('GITHUB_TOKEN')) {
+          authModes.push({ source: 'GITHUB_TOKEN', mode: 'github-token' });
+        }
+        for (const name of tokenNames) {
+          if (name.endsWith('_PAT')) {
+            authModes.push({ source: name, mode: 'pat' });
+          }
+        }
+        for (const [source, idName, keyName] of appPairs) {
+          if (tokenSet.has(idName) && tokenSet.has(keyName)) {
+            authModes.push({
+              source,
+              mode: 'github-app',
+              credential_names: [idName, keyName],
+            });
+          }
+        }
+
+        const moduleDir = path.join(installDir, 'node_modules');
+        const hasModule = (name) => fs.existsSync(path.join(moduleDir, ...name.split('/')));
+        const contract = {
+          schema: 'workflows-api-client-setup/v1',
+          token_count: Number.parseInt(process.env.TOKEN_COUNT || '0', 10) || 0,
+          available_token_names: tokenNames,
+          auth_modes: authModes,
+          dependency_state: {
+            node_path_ready: fs.existsSync(moduleDir),
+            octokit_rest_ready: hasModule('@octokit/rest'),
+            octokit_auth_app_ready: hasModule('@octokit/auth-app'),
+            lru_cache_ready: hasModule('lru-cache'),
+          },
+        };
+        process.stdout.write(JSON.stringify(contract));
+        NODE
+        )"
+        printf 'setup_contract=%s\n' "$setup_contract" >> "$GITHUB_OUTPUT"
+
         echo ""
         echo "📊 Token Setup Summary:"
         echo "  Total tokens exported: ${token_count}"
+        echo "  Setup contract schema: workflows-api-client-setup/v1"
         if [ "${INPUT_VERBOSE}" = "true" ]; then
           echo "  Available: ${available_tokens}"
+          echo "  Setup contract: ${setup_contract}"
         fi
 
         # Warn if no tokens were exported

--- a/.github/scripts/agents_pr_meta_update_body.js
+++ b/.github/scripts/agents_pr_meta_update_body.js
@@ -919,12 +919,29 @@ function fallbackChecklist(message) {
   return `- [ ] ${message}`;
 }
 
+function issueLabelNames(issue = {}) {
+  return Array.isArray(issue.labels)
+    ? issue.labels.map((label) => String(typeof label === 'string' ? label : label?.name || '').trim())
+    : [];
+}
+
+function isCampaignIssue(issue = {}) {
+  const labels = new Set(issueLabelNames(issue));
+  return labels.has('campaign:sync-dependabot') || labels.has('campaign:active');
+}
+
 function buildPreamble(sections) {
   const lines = ['<!-- pr-preamble:start -->'];
   
   // Add reference to source issue if available
   if (sections.issueNumber) {
+    lines.push(`<!-- meta:issue:${sections.issueNumber} -->`);
     lines.push(`> **Source:** Issue #${sections.issueNumber}`, '');
+    if (isCampaignIssue(sections.sourceIssue)) {
+      lines.push(`Related to campaign issue #${sections.issueNumber}`, '');
+    } else {
+      lines.push(`Closes #${sections.issueNumber}`, '');
+    }
   }
   
   if (sections.summary && sections.summary.trim()) {
@@ -1300,7 +1317,13 @@ async function run({github: rawGithub, context, core, inputs}) {
     || '';
   contextSection = augmentContextWithRelatedIssues(contextSection, issueBody);
 
-  const preamble = buildPreamble({summary, testing, ci, issueNumber});
+  const preamble = buildPreamble({
+    summary,
+    testing,
+    ci,
+    issueNumber,
+    sourceIssue: issueResponse.data,
+  });
 
   const workflowRunResponse = await withRetries(
     () => github.rest.actions.listWorkflowRunsForRepo({
@@ -1412,6 +1435,7 @@ module.exports = {
   filterWorkflowRunsForStatus,
   buildContextBlock,
   buildPreamble,
+  isCampaignIssue,
   buildStatusBlock,
   withRetries,
   RateLimitError,

--- a/.github/scripts/bot_comment_auth_coverage.js
+++ b/.github/scripts/bot_comment_auth_coverage.js
@@ -73,6 +73,11 @@ function normalizeRecordBoolean(value) {
   return Boolean(value);
 }
 
+function normalizeOptionalRecordBoolean(value) {
+  if (value === null || value === undefined || cleanString(value) === '') return null;
+  return normalizeRecordBoolean(value);
+}
+
 function normalizeMode(value) {
   const text = cleanString(value).toLowerCase();
   if (['hard-block', 'hard_block', 'hard', 'block', 'blocking', 'enforce'].includes(text)) {
@@ -133,6 +138,12 @@ function normalizeRecord(raw = {}, sourcePath = '') {
     private_key_configured: normalizeRecordBoolean(raw.private_key_configured ?? raw.privateKeyConfigured),
     fallback_warning_active: normalizeRecordBoolean(
       raw.fallback_warning_active ?? raw.fallbackWarningActive
+    ),
+    reusable_invocation_expected: normalizeOptionalRecordBoolean(
+      raw.reusable_invocation_expected ?? raw.reusableInvocationExpected
+    ),
+    reusable_invocation_reason: cleanString(
+      raw.reusable_invocation_reason ?? raw.reusableInvocationReason
     ),
     source_path: sourcePath,
   };
@@ -216,12 +227,17 @@ function summarizeOrganicEvidence(records = [], options = {}) {
     const blockers = organicChecksDisabled
       ? []
       : missingOrganicEvidenceBlockers(components, requiredEvents);
+    const missingRequirements = organicChecksDisabled
+      ? []
+      : missingOrganicEvidenceRequirements(components, requiredEvents);
     return {
       schema: 'workflows-bot-comment-auth-organic-evidence/v1',
       required_events: requiredEvents,
       required_components: components,
       expected_mode: expectedMode === 'unknown' ? '' : expectedMode,
       event_counts: eventCounts,
+      skipped_requirements: [],
+      missing_requirements: missingRequirements,
       blockers,
       status: organicChecksDisabled ? 'pass' : 'no-data',
     };
@@ -240,11 +256,35 @@ function summarizeOrganicEvidence(records = [], options = {}) {
   }
 
   const blockers = [];
+  const skippedRequirements = [];
+  const missingRequirements = [];
   for (const component of components) {
     for (const eventName of requiredEvents) {
       const latest = latestByComponentEvent[`${component}:${eventName}`];
+      const latestWrapper = latestByComponentEvent[
+        `agents-bot-comment-handler-wrapper:${eventName}`
+      ];
+      const reusableWasNotExpected = component === 'reusable-bot-comment-handler' &&
+        latestWrapper &&
+        latestWrapper.reusable_invocation_expected === false;
+      if (!latest && reusableWasNotExpected) {
+        skippedRequirements.push({
+          component,
+          event_name: eventName,
+          reason: latestWrapper.reusable_invocation_reason || 'wrapper-did-not-call-reusable',
+          wrapper_run_id: latestWrapper.run_id,
+        });
+        continue;
+      }
       if (!latest) {
-        blockers.push(`missing-organic-${component}-${eventName}`);
+        const blocker = `missing-organic-${component}-${eventName}`;
+        blockers.push(blocker);
+        missingRequirements.push(missingOrganicEvidenceRequirement({
+          component,
+          eventName,
+          blocker,
+          latestWrapper,
+        }));
         continue;
       }
       if (latest.fallback_warning_active) {
@@ -265,6 +305,8 @@ function summarizeOrganicEvidence(records = [], options = {}) {
     required_components: components,
     expected_mode: expectedMode === 'unknown' ? '' : expectedMode,
     event_counts: eventCounts,
+    skipped_requirements: skippedRequirements,
+    missing_requirements: missingRequirements,
     blockers,
     status: blockers.length > 0 ? 'warning' : 'pass',
   };
@@ -274,6 +316,38 @@ function missingOrganicEvidenceBlockers(components = [], requiredEvents = []) {
   return components.flatMap((component) =>
     requiredEvents.map((eventName) => `missing-organic-${component}-${eventName}`)
   );
+}
+
+function missingOrganicEvidenceRequirements(components = [], requiredEvents = []) {
+  return components.flatMap((component) =>
+    requiredEvents.map((eventName) => missingOrganicEvidenceRequirement({
+      component,
+      eventName,
+      blocker: `missing-organic-${component}-${eventName}`,
+      latestWrapper: null,
+    }))
+  );
+}
+
+function missingOrganicEvidenceRequirement({
+  component,
+  eventName,
+  blocker,
+  latestWrapper,
+}) {
+  return {
+    component,
+    event_name: eventName,
+    blocker,
+    latest_wrapper_run_id: latestWrapper?.run_id || '',
+    latest_wrapper_reusable_invocation_expected:
+      latestWrapper?.reusable_invocation_expected ?? null,
+    latest_wrapper_reusable_invocation_reason:
+      latestWrapper?.reusable_invocation_reason || '',
+    latest_wrapper_has_reusable_decision:
+      latestWrapper?.reusable_invocation_expected !== null &&
+      latestWrapper?.reusable_invocation_expected !== undefined,
+  };
 }
 
 function componentPolicy(component, options = {}) {
@@ -555,6 +629,22 @@ function formatBotCommentAuthCoverageMarkdown(report) {
   if (report.organic_evidence?.required_events?.length > 0) {
     lines.push(`- Required organic events: ${report.organic_evidence.required_events.join(', ')}`);
     lines.push(`- Organic evidence status: ${report.organic_evidence.status}`);
+    const skipped = report.organic_evidence.skipped_requirements || [];
+    if (skipped.length > 0) {
+      lines.push(
+        `- Skipped organic requirements: ${skipped
+          .map((item) => `${item.component}/${item.event_name}`)
+          .join(', ')}`
+      );
+    }
+    const missing = report.organic_evidence.missing_requirements || [];
+    if (missing.length > 0) {
+      lines.push(
+        `- Missing organic requirements: ${missing
+          .map((item) => `${item.component}/${item.event_name}`)
+          .join(', ')}`
+      );
+    }
   }
   if (report.enforcement.blockers.length > 0) {
     lines.push(`- Blockers: ${report.enforcement.blockers.join(', ')}`);

--- a/.github/scripts/coverage_monitor_summary.js
+++ b/.github/scripts/coverage_monitor_summary.js
@@ -1,0 +1,261 @@
+const fs = require('fs');
+
+const SUMMARY_SCHEMA = 'workflows-weekly-coverage-monitor/v1';
+
+function cleanString(value) {
+  if (value === null || value === undefined) return '';
+  return String(value).trim();
+}
+
+function readJsonReport(filePath, label) {
+  const cleanedPath = cleanString(filePath);
+  if (!cleanedPath) {
+    return {
+      label,
+      path: '',
+      status: 'missing',
+      error_message: 'report path was not configured',
+      report: null,
+    };
+  }
+  if (!fs.existsSync(cleanedPath)) {
+    return {
+      label,
+      path: cleanedPath,
+      status: 'missing',
+      error_message: `report not found: ${cleanedPath}`,
+      report: null,
+    };
+  }
+  try {
+    const report = JSON.parse(fs.readFileSync(cleanedPath, 'utf8'));
+    return {
+      label,
+      path: cleanedPath,
+      status: 'pass',
+      error_message: '',
+      report,
+    };
+  } catch (error) {
+    return {
+      label,
+      path: cleanedPath,
+      status: 'parse-error',
+      error_message: error?.message || 'failed to parse report',
+      report: null,
+    };
+  }
+}
+
+function normalizeStatus(value) {
+  const status = cleanString(value).toLowerCase();
+  return ['pass', 'warning', 'no-data', 'fail', 'missing', 'parse-error'].includes(status)
+    ? status
+    : 'unknown';
+}
+
+function reportBlockers(report = {}) {
+  const enforcement = report.enforcement || {};
+  return Array.isArray(enforcement.blockers) ? enforcement.blockers.map(cleanString).filter(Boolean) : [];
+}
+
+function policyBlockers(report = {}) {
+  const enforcement = report.enforcement || {};
+  return Array.isArray(enforcement.policy_blockers)
+    ? enforcement.policy_blockers.map(cleanString).filter(Boolean)
+    : [];
+}
+
+function normalizeMonitorArtifactSelection(selection = null) {
+  if (!selection || typeof selection !== 'object' || Array.isArray(selection)) return null;
+  const familyStatuses = Array.isArray(selection.terminal_priority_family_statuses)
+    ? selection.terminal_priority_family_statuses
+      .filter((status) => status && typeof status === 'object' && !Array.isArray(status))
+      .map((status) => ({
+        family: cleanString(status.family),
+        status: cleanString(status.status),
+        candidate_count: Number(status.candidate_count) || 0,
+        selected_count: Number(status.selected_count) || 0,
+      }))
+      .filter((status) => status.family)
+    : [];
+  const missingFamilies = Array.isArray(selection.missing_terminal_priority_families)
+    ? selection.missing_terminal_priority_families.map(cleanString).filter(Boolean)
+    : [];
+  return {
+    status: cleanString(selection.status),
+    candidate_terminal_artifact_count: Number(selection.candidate_terminal_artifact_count) || 0,
+    selected_terminal_artifact_count: Number(selection.selected_terminal_artifact_count) || 0,
+    missing_terminal_priority_families: missingFamilies,
+    terminal_priority_family_statuses: familyStatuses,
+  };
+}
+
+function summarizeReport(readResult) {
+  const report = readResult.report || {};
+  const enforcement = report.enforcement || {};
+  const status = readResult.report ? normalizeStatus(report.status) : readResult.status;
+  const coverageStatus = readResult.report
+    ? normalizeStatus(report.coverage_status || report.status)
+    : readResult.status;
+
+  return {
+    label: readResult.label,
+    path: readResult.path,
+    status,
+    coverage_status: coverageStatus,
+    mode: cleanString(report.mode || enforcement.mode),
+    requested_mode: cleanString(report.requested_mode || enforcement.requested_mode),
+    hard_block_active: Boolean(enforcement.hard_block_active),
+    hard_block_eligible: Boolean(enforcement.hard_block_eligible),
+    should_fail: Boolean(enforcement.should_fail || status === 'fail'),
+    blockers: reportBlockers(report),
+    policy_blockers: policyBlockers(report),
+    artifact_selection: normalizeMonitorArtifactSelection(report.artifact_selection),
+    read_status: readResult.status,
+    error_message: cleanString(readResult.error_message),
+  };
+}
+
+function overallStatus(monitors) {
+  if (monitors.some((monitor) => monitor.should_fail || monitor.status === 'fail')) return 'fail';
+  if (monitors.some((monitor) => ['missing', 'parse-error', 'warning', 'unknown'].includes(monitor.status))) {
+    return 'warning';
+  }
+  if (monitors.length > 0 && monitors.every((monitor) => monitor.status === 'no-data')) return 'no-data';
+  if (monitors.some((monitor) => monitor.status === 'no-data')) return 'warning';
+  return 'pass';
+}
+
+function nextAction(status, monitors) {
+  if (status === 'fail') return 'honor-approved-hard-block';
+  if (monitors.some((monitor) => monitor.read_status !== 'pass')) return 'repair-monitor-report-input';
+  if (monitors.some((monitor) => monitor.policy_blockers.length > 0)) return 'keep-warning-only-until-approved';
+  if (status === 'warning') return 'inspect-monitor-warnings';
+  if (status === 'no-data') return 'wait-for-telemetry';
+  return 'continue-monitoring';
+}
+
+function buildCoverageMonitorSummary(options = {}) {
+  const terminal = summarizeReport(readJsonReport(options.terminal_report, 'terminal-disposition'));
+  const botAuth = summarizeReport(readJsonReport(options.bot_auth_report, 'bot-comment-auth'));
+  const monitors = [terminal, botAuth];
+  const status = overallStatus(monitors);
+  const hardBlockActive = monitors.some((monitor) => monitor.hard_block_active);
+  const shouldFail = monitors.some((monitor) => monitor.should_fail);
+  const policyBlockerCount = monitors.reduce(
+    (total, monitor) => total + monitor.policy_blockers.length,
+    0
+  );
+
+  return {
+    schema: SUMMARY_SCHEMA,
+    status,
+    generated_at: cleanString(options.generated_at) || new Date().toISOString(),
+    hard_block_active: hardBlockActive,
+    should_fail: shouldFail,
+    warning_only: !hardBlockActive,
+    policy_blocker_count: policyBlockerCount,
+    next_action: nextAction(status, monitors),
+    monitors,
+  };
+}
+
+function formatMonitorMarkdown(summary) {
+  const lines = [
+    '## Weekly Coverage Monitor Contract',
+    '',
+    `- Schema: ${summary.schema}`,
+    `- Status: ${summary.status}`,
+    `- Warning-only: ${summary.warning_only}`,
+    `- Hard block active: ${summary.hard_block_active}`,
+    `- Should fail: ${summary.should_fail}`,
+    `- Policy blockers: ${summary.policy_blocker_count}`,
+    `- Next action: ${summary.next_action}`,
+    '',
+    '| Monitor | Status | Coverage | Mode | Hard block | Blockers |',
+    '|---------|--------|----------|------|------------|----------|',
+  ];
+
+  for (const monitor of summary.monitors) {
+    const blockers = [
+      ...monitor.blockers,
+      ...monitor.policy_blockers.map((blocker) => `policy:${blocker}`),
+      monitor.error_message,
+    ].filter(Boolean);
+    lines.push(
+      [
+        monitor.label,
+        monitor.status,
+        monitor.coverage_status,
+        monitor.mode || 'unknown',
+        monitor.hard_block_active ? 'active' : 'inactive',
+        blockers.join(', ') || 'none',
+      ].join(' | ').replace(/^/, '| ').replace(/$/, ' |')
+    );
+  }
+
+  for (const monitor of summary.monitors) {
+    const missingFamilies = monitor.artifact_selection?.missing_terminal_priority_families || [];
+    if (missingFamilies.length > 0) {
+      lines.push(`- ${monitor.label} missing artifact families: ${missingFamilies.join(', ')}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    terminal_report:
+      process.env.COVERAGE_MONITOR_TERMINAL_JSON || 'terminal-disposition-coverage.json',
+    bot_auth_report:
+      process.env.COVERAGE_MONITOR_BOT_AUTH_JSON || 'bot-comment-auth-coverage-summary.json',
+    output_json:
+      process.env.COVERAGE_MONITOR_SUMMARY_JSON || 'coverage-monitor-summary.json',
+    output_md:
+      process.env.COVERAGE_MONITOR_SUMMARY_MD || 'coverage-monitor-summary.md',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === '--terminal-report') {
+      options.terminal_report = next;
+      index += 1;
+    } else if (arg === '--bot-auth-report') {
+      options.bot_auth_report = next;
+      index += 1;
+    } else if (arg === '--output-json') {
+      options.output_json = next;
+      index += 1;
+    } else if (arg === '--output-md') {
+      options.output_md = next;
+      index += 1;
+    }
+  }
+
+  return options;
+}
+
+function main() {
+  const options = parseArgs();
+  const summary = buildCoverageMonitorSummary(options);
+  const markdown = formatMonitorMarkdown(summary);
+  fs.writeFileSync(options.output_json, `${JSON.stringify(summary, null, 2)}\n`);
+  fs.writeFileSync(options.output_md, markdown);
+  process.stdout.write(markdown);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  SUMMARY_SCHEMA,
+  buildCoverageMonitorSummary,
+  formatMonitorMarkdown,
+  normalizeMonitorArtifactSelection,
+  parseArgs,
+  readJsonReport,
+};

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -1178,6 +1178,79 @@ function extractChecklistItems(markdown) {
   return items;
 }
 
+const STATUS_METRIC_LABELS = new Set([
+  'updated',
+  'repos checked',
+  'open sync prs',
+  'open dependabot prs',
+  'active review threads queued',
+  'items needing local codex',
+  'actionable local codex items',
+  'claimable local codex items',
+  'source-fixed candidates',
+  'superseded sync candidates',
+  'finished local results without published source changes',
+  'claimed local codex items',
+  'next claim lease expires',
+]);
+
+function normaliseChecklistText(value) {
+  return normaliseTaskText(value)
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/[*_~]/g, '')
+    .trim()
+    .toLowerCase();
+}
+
+function isStatusMetricChecklistItem(text) {
+  const normalized = normaliseChecklistText(text);
+  if (!normalized || !normalized.includes(':')) {
+    return false;
+  }
+  const [labelRaw, ...valueParts] = normalized.split(':');
+  const label = labelRaw.trim();
+  const value = valueParts.join(':').trim();
+  if (!label || !value) {
+    return false;
+  }
+  if (!STATUS_METRIC_LABELS.has(label)) {
+    return false;
+  }
+  return true;
+}
+
+function isPlaceholderChecklistItem(text) {
+  const normalized = normaliseChecklistText(text);
+  if (!normalized) {
+    return true;
+  }
+  if (normalized.includes('section missing from source issue')) {
+    return true;
+  }
+  if (/^no tasks defined\.?$/.test(normalized)) {
+    return true;
+  }
+  if (/^no acceptance criteria defined\.?$/.test(normalized)) {
+    return true;
+  }
+  return false;
+}
+
+function isActionableChecklistItemText(text) {
+  return !isStatusMetricChecklistItem(text) && !isPlaceholderChecklistItem(text);
+}
+
+function toActionableChecklistCounts(markdown) {
+  const actionable = extractChecklistItems(markdown).filter((item) => isActionableChecklistItemText(item.text));
+  const checked = actionable.filter((item) => item.checked).length;
+  const total = actionable.length;
+  return {
+    total,
+    checked,
+    unchecked: Math.max(0, total - checked),
+  };
+}
+
 /**
  * Extract file-path glob patterns from the scope section text.
  * Looks for patterns like `runtime/**`, `src/foo.py`, or backtick-quoted paths.
@@ -1345,7 +1418,9 @@ function buildTaskAppendix(sections, checkboxCounts, state = {}, options = {}) {
 
   const attemptedTasks = normaliseAttemptedTasks(state?.attempted_tasks);
   const candidateSource = sections?.tasks || sections?.acceptance || '';
-  const taskItems = extractChecklistItems(candidateSource);
+  const taskItems = extractChecklistItems(candidateSource).filter((item) =>
+    isActionableChecklistItemText(item.text)
+  );
   const unchecked = taskItems.filter((item) => !item.checked);
   const attemptedKeys = new Set(attemptedTasks.map((entry) => entry.key));
   const suggested = unchecked.find((item) => !attemptedKeys.has(normaliseTaskKey(item.text))) || unchecked[0];
@@ -2283,7 +2358,7 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     const combinedChecklist = [normalisedSections?.tasks, normalisedSections?.acceptance]
       .filter(Boolean)
       .join('\n');
-    const checkboxCounts = countCheckboxes(combinedChecklist);
+    const checkboxCounts = toActionableChecklistCounts(combinedChecklist);
     const tasksPresent = checkboxCounts.total > 0;
     const tasksRemaining = checkboxCounts.unchecked > 0;
 
@@ -2291,8 +2366,8 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     // Tasks = what the agent works on (checkable by agent and auto-reconciliation).
     // Acceptance criteria = what must be independently verified (only verifier or agent).
     // The stop decision requires BOTH to be satisfied.
-    const taskCounts = countCheckboxes(normalisedSections?.tasks || '');
-    const acceptanceCounts = countCheckboxes(normalisedSections?.acceptance || '');
+    const taskCounts = toActionableChecklistCounts(normalisedSections?.tasks || '');
+    const acceptanceCounts = toActionableChecklistCounts(normalisedSections?.acceptance || '');
     const allTasksDone = taskCounts.total === 0 || taskCounts.unchecked === 0;
     const allCriteriaMet = acceptanceCounts.total === 0 || acceptanceCounts.unchecked === 0;
     const allComplete = tasksPresent && !tasksRemaining && allTasksDone && allCriteriaMet;
@@ -2946,18 +3021,16 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
       const liveCombined = [focusSections.tasks, focusSections.acceptance]
         .filter(Boolean)
         .join('\n');
-      const liveCounts = countCheckboxes(liveCombined);
-      if (liveCounts.total > 0) {
-        const staleTotal = tasksTotal;
-        const staleUnchecked = tasksUnchecked;
-        tasksTotal = liveCounts.total;
-        tasksUnchecked = liveCounts.unchecked;
-        if (staleTotal !== tasksTotal || staleUnchecked !== tasksUnchecked) {
-          core?.info?.(
-            `[summary] Re-counted checkboxes from live PR body: ` +
-            `total ${staleTotal}→${tasksTotal}, unchecked ${staleUnchecked}→${tasksUnchecked}`,
-          );
-        }
+      const liveCounts = toActionableChecklistCounts(liveCombined);
+      const staleTotal = tasksTotal;
+      const staleUnchecked = tasksUnchecked;
+      tasksTotal = liveCounts.total;
+      tasksUnchecked = liveCounts.unchecked;
+      if (staleTotal !== tasksTotal || staleUnchecked !== tasksUnchecked) {
+        core?.info?.(
+          `[summary] Re-counted actionable checkboxes from live PR body: ` +
+          `total ${staleTotal}→${tasksTotal}, unchecked ${staleUnchecked}→${tasksUnchecked}`,
+        );
       }
     }
 
@@ -3052,6 +3125,7 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
       runResult === 'success' &&
       agentChangesMade === 'true' &&
       agentFilesChanged > 0 &&
+      tasksTotal > 0 &&
       tasksCompletedThisRound <= 0;
 
     if (action === 'run' || action === 'fix') {

--- a/.github/scripts/terminal_disposition.js
+++ b/.github/scripts/terminal_disposition.js
@@ -10,6 +10,20 @@ function cleanInt(value) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function cleanBool(value) {
+  if (typeof value === 'boolean') return value;
+  const text = cleanString(value).toLowerCase();
+  if (['true', '1', 'yes', 'on'].includes(text)) return true;
+  if (['false', '0', 'no', 'off'].includes(text)) return false;
+  return null;
+}
+
+function normalizeToken(value, fallback = 'unknown') {
+  const text = cleanString(value).toLowerCase().replace(/_/g, '-');
+  const normalized = text.replace(/[^a-z0-9_.:-]+/g, '-').replace(/^-+|-+$/g, '');
+  return normalized || fallback;
+}
+
 function normalizeSourceType(value) {
   const text = cleanString(value).toLowerCase();
   if (!text) return 'unknown';
@@ -25,6 +39,132 @@ function normalizeSourceId(value, fallback) {
 
 function sourceKey(sourceType, sourceId) {
   return `${normalizeSourceType(sourceType)}:${normalizeSourceId(sourceId)}`;
+}
+
+function cleanIntArray(value) {
+  const rawItems = Array.isArray(value) ? value : [value];
+  return [...new Set(
+    rawItems
+      .flatMap((item) => {
+        if (Array.isArray(item)) return item;
+        if (typeof item === 'string') return item.split(',');
+        return [item];
+      })
+      .map((item) => cleanInt(item))
+      .filter((item) => item !== null && item > 0)
+  )].sort((a, b) => a - b);
+}
+
+function normalizeLedgerDisposition(input = {}) {
+  const explicit = cleanString(input.disposition ?? input.terminal_disposition);
+  const normalized = explicit.toLowerCase().replace(/_/g, '-');
+  const allowed = new Set(['merge', 'supersede', 'follow-up', 'accept-risk', 'needs-human']);
+  if (allowed.has(normalized)) return normalized;
+
+  const terminalDisposition = cleanString(input.terminal_state ?? input.terminalState).toLowerCase();
+  if (terminalDisposition.includes('follow-up')) return 'follow-up';
+  if (terminalDisposition.includes('needs-human') || terminalDisposition.includes('verifier-error')) {
+    return 'needs-human';
+  }
+  if (terminalDisposition.includes('verified-pass')) return 'merge';
+
+  const verdict = cleanString(input.verdict).toLowerCase();
+  const hasFollowup = cleanInt(input.followup_issue_number ?? input.followupIssueNumber) !== null ||
+    cleanInt(input.followup_pr_number ?? input.followupPrNumber) !== null;
+  if (hasFollowup) return 'follow-up';
+  if (input.needs_human === true || input.needsHuman === true) return 'needs-human';
+  if (['pass', 'passed'].includes(verdict)) return 'merge';
+  if (['fail', 'failed', 'concerns', 'error'].includes(verdict)) return 'needs-human';
+  return 'needs-human';
+}
+
+function normalizeVerifierFollowupPolicy(input = {}) {
+  const embedded = input.followup_policy ?? input.followupPolicy ?? {};
+  const policy = embedded && typeof embedded === 'object' ? embedded : {};
+  const disposition = normalizeLedgerDisposition(input);
+  const followupIssue = cleanInt(
+    input.followup_issue_number ?? input.followupIssueNumber ?? input.created_issue_number
+  );
+  const followupPr = cleanInt(input.followup_pr_number ?? input.followupPrNumber);
+  const needsHuman = cleanBool(input.needs_human ?? input.needsHuman);
+  const chainDepth = cleanInt(policy.chain_depth ?? input.chain_depth ?? input.chainDepth);
+  const maxChainDepth = cleanInt(
+    policy.max_chain_depth ??
+      policy.maxChainDepth ??
+      input.max_chain_depth ??
+      input.maxChainDepth
+  );
+  const nextChainDepth = cleanInt(
+    policy.next_chain_depth ??
+      policy.nextChainDepth ??
+      input.next_chain_depth ??
+      input.nextChainDepth
+  );
+
+  let action = normalizeToken(
+    policy.action ??
+      input.followup_policy_action ??
+      input.followupPolicyAction ??
+      input.policy_action ??
+      input.policyAction,
+    ''
+  );
+  const allowedActions = new Set([
+    'create-follow-up',
+    'needs-human',
+    'skip-follow-up',
+    'accept-risk',
+    'no-op',
+    'unknown',
+  ]);
+  if (!allowedActions.has(action)) action = '';
+  if (!action) {
+    if (needsHuman === true || disposition === 'needs-human') {
+      action = 'needs-human';
+    } else if (followupIssue !== null || followupPr !== null || disposition === 'follow-up') {
+      action = 'create-follow-up';
+    } else if (disposition === 'merge') {
+      action = 'no-op';
+    } else if (disposition === 'accept-risk') {
+      action = 'accept-risk';
+    } else {
+      action = 'skip-follow-up';
+    }
+  }
+
+  const reason = cleanString(
+    policy.reason ??
+      input.followup_policy_reason ??
+      input.followupPolicyReason ??
+      input.policy_reason ??
+      input.policyReason
+  );
+  const trigger = normalizeToken(
+    policy.trigger ??
+      input.followup_policy_trigger ??
+      input.followupPolicyTrigger ??
+      input.policy_trigger ??
+      input.policyTrigger,
+    ''
+  );
+  const depthLimitExceeded = cleanBool(
+    policy.depth_limit_exceeded ??
+      policy.depthLimitExceeded ??
+      input.depth_limit_exceeded ??
+      input.depthLimitExceeded
+  );
+
+  const record = {
+    schema: 'workflows-verifier-followup-policy/v1',
+    action,
+  };
+  if (reason) record.reason = reason;
+  if (trigger) record.trigger = trigger;
+  if (chainDepth !== null) record.chain_depth = chainDepth;
+  if (maxChainDepth !== null) record.max_chain_depth = maxChainDepth;
+  if (nextChainDepth !== null) record.next_chain_depth = nextChainDepth;
+  if (depthLimitExceeded !== null) record.depth_limit_exceeded = depthLimitExceeded;
+  return record;
 }
 
 function normalizeTerminalDisposition(input = {}) {
@@ -69,10 +209,76 @@ function normalizeTerminalDisposition(input = {}) {
       input.followup_issue_url ?? input.followupIssueUrl ?? input.created_issue_url,
     needs_human: input.needs_human ?? input.needsHuman,
     dispatch_outcome: input.dispatch_outcome ?? input.dispatchOutcome,
+    llm_model: input.llm_model ?? input.llmModel ?? input.model,
+    model_selection_reason: input.model_selection_reason ?? input.modelSelectionReason,
+    verifier_mode: input.verifier_mode ?? input.verifierMode,
   };
 
   for (const [key, value] of Object.entries(optional)) {
     if (value === null || value === undefined) continue;
+    const cleaned = typeof value === 'boolean' ? value : cleanString(value);
+    if (cleaned === '') continue;
+    record[key] = typeof value === 'string' ? cleaned : value;
+  }
+
+  return record;
+}
+
+function normalizeVerifierFollowupLedger(input = {}) {
+  const prNumber = cleanInt(input.pr_number ?? input.prNumber ?? input.pr);
+  const verificationRunId = normalizeSourceId(
+    input.verification_run_id ?? input.verificationRunId ?? input.run_id ?? input.runId,
+    prNumber ?? input.timestamp
+  );
+  const timestamp = cleanString(input.timestamp) || new Date().toISOString();
+  const sourceIssueNumbers = cleanIntArray(
+    input.source_issue_numbers ?? input.sourceIssueNumbers ?? input.issue_numbers ?? input.issueNumbers
+  );
+  const disposition = normalizeLedgerDisposition(input);
+  const stateKey = `pr:${prNumber || 'unknown'}:run:${verificationRunId}`;
+
+  const record = {
+    schema: 'workflows-verifier-followup-ledger/v1',
+    metric_type: 'verifier_followup_ledger',
+    timestamp,
+    state_key: stateKey,
+    pr_number: prNumber,
+    verification_run_id: verificationRunId,
+    verdict: cleanString(input.verdict) || 'unknown',
+    disposition,
+    source_issue_numbers: sourceIssueNumbers,
+    followup_policy: normalizeVerifierFollowupPolicy({ ...input, disposition }),
+  };
+
+  const optional = {
+    verification_run_attempt:
+      input.verification_run_attempt ??
+      input.verificationRunAttempt ??
+      input.run_attempt ??
+      input.runAttempt,
+    concerns_hash: input.concerns_hash ?? input.concernsHash,
+    followup_issue_number:
+      input.followup_issue_number ?? input.followupIssueNumber ?? input.created_issue_number,
+    followup_issue_url:
+      input.followup_issue_url ?? input.followupIssueUrl ?? input.created_issue_url,
+    followup_pr_number: input.followup_pr_number ?? input.followupPrNumber,
+    followup_pr_url: input.followup_pr_url ?? input.followupPrUrl,
+    chain_depth: input.chain_depth ?? input.chainDepth,
+    workflow: input.workflow,
+    actor: input.actor,
+    terminal_disposition_artifact:
+      input.terminal_disposition_artifact ?? input.terminalDispositionArtifact,
+    dispatch_outcome: input.dispatch_outcome ?? input.dispatchOutcome,
+    needs_human: input.needs_human ?? input.needsHuman,
+  };
+
+  for (const [key, value] of Object.entries(optional)) {
+    if (value === null || value === undefined) continue;
+    if (key.endsWith('_number') || key === 'chain_depth' || key === 'verification_run_attempt') {
+      const parsed = cleanInt(value);
+      if (parsed !== null) record[key] = parsed;
+      continue;
+    }
     const cleaned = typeof value === 'boolean' ? value : cleanString(value);
     if (cleaned === '') continue;
     record[key] = typeof value === 'string' ? cleaned : value;
@@ -152,6 +358,9 @@ function formatTerminalDispositionMarkdown(records = []) {
 
 module.exports = {
   normalizeTerminalDisposition,
+  normalizeVerifierFollowupLedger,
+  normalizeVerifierFollowupPolicy,
+  normalizeLedgerDisposition,
   summarizeTerminalDispositionSources,
   formatTerminalDispositionMarkdown,
   sourceKey,

--- a/.github/scripts/terminal_disposition_coverage.js
+++ b/.github/scripts/terminal_disposition_coverage.js
@@ -12,6 +12,8 @@ const TERMINAL_ARTIFACT_FAMILIES = new Set([
   'verifier-terminal-disposition',
   'review-thread-terminal-disposition',
 ]);
+const DEFAULT_UNSUPPORTED_CODEX_MODELS = ['gpt-5.2-codex'];
+const DEFAULT_VERIFIER_MODEL_METADATA_REQUIRED_AFTER = '';
 const DEFAULT_ENFORCEMENT_MODE = 'warning-only';
 const HARD_BLOCK_MODE = 'hard-block';
 
@@ -24,6 +26,13 @@ function cleanInt(value) {
   const text = cleanString(value);
   if (!text) return null;
   const parsed = Number.parseInt(text, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseTimestampMs(value) {
+  const text = cleanString(value);
+  if (!text) return null;
+  const parsed = Date.parse(text);
   return Number.isFinite(parsed) ? parsed : null;
 }
 
@@ -70,6 +79,160 @@ function normalizeEnforcementPolicy(options = {}) {
   };
 }
 
+function normalizeUnsupportedCodexModels(value) {
+  const raw = value ??
+    process.env.TERMINAL_DISPOSITION_UNSUPPORTED_CODEX_MODELS ??
+    DEFAULT_UNSUPPORTED_CODEX_MODELS.join(',');
+  const items = Array.isArray(raw) ? raw : String(raw).split(',');
+  return [...new Set(items.map((item) => cleanString(item).toLowerCase()).filter(Boolean))]
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function normalizeVerifierModelMetadataContract(value) {
+  const raw = value ??
+    process.env.TERMINAL_DISPOSITION_VERIFIER_MODEL_METADATA_REQUIRED_AFTER ??
+    DEFAULT_VERIFIER_MODEL_METADATA_REQUIRED_AFTER;
+  const text = cleanString(raw);
+  if (['', '0', 'false', 'none', 'off', 'disabled'].includes(text.toLowerCase())) {
+    return {
+      required_after: '',
+      required_after_epoch_ms: null,
+      model_metadata_required: false,
+      suppress_pre_contract_missing_metadata: false,
+    };
+  }
+  const epochMs = parseTimestampMs(text);
+  return {
+    required_after: text,
+    required_after_epoch_ms: epochMs,
+    model_metadata_required: true,
+    suppress_pre_contract_missing_metadata: epochMs !== null,
+  };
+}
+
+function runIdFromArtifactName(name) {
+  const match = cleanString(name).match(/-(\d+)$/);
+  return match ? match[1] : '';
+}
+
+function artifactMetadataByRunId(artifactSelection) {
+  const byRunId = new Map();
+  const artifacts = artifactSelection?.selected_terminal_artifacts || [];
+  for (const artifact of artifacts) {
+    if (artifact?.family !== 'verifier-terminal-disposition') continue;
+    const runId = runIdFromArtifactName(artifact.name);
+    if (!runId) continue;
+    byRunId.set(runId, {
+      artifact_name: cleanString(artifact.name),
+      created_at: cleanString(artifact.created_at),
+      updated_at: cleanString(artifact.updated_at),
+    });
+  }
+  return byRunId;
+}
+
+function isPreContractVerifierModelRecord(record, artifactMetadata, contract) {
+  if (!contract.suppress_pre_contract_missing_metadata) return false;
+  const requiredAfter = contract.required_after_epoch_ms;
+  const candidates = [
+    record.created_at,
+    record.timestamp,
+    artifactMetadata?.created_at,
+    artifactMetadata?.updated_at,
+  ];
+  return candidates.some((value) => {
+    const epochMs = parseTimestampMs(value);
+    return epochMs !== null && epochMs < requiredAfter;
+  });
+}
+
+function summarizeVerifierModelCompatibility(records = [], options = {}) {
+  const unsupportedModels = normalizeUnsupportedCodexModels(
+    options.unsupported_codex_models ?? options.unsupportedCodexModels
+  );
+  const modelMetadataContract = normalizeVerifierModelMetadataContract(
+    options.model_metadata_required_after ?? options.modelMetadataRequiredAfter
+  );
+  const artifactMetadata = artifactMetadataByRunId(options.artifact_selection);
+  const unsupportedSet = new Set(unsupportedModels);
+  const selectedModels = {};
+  const modelSelectionReasons = {};
+  const unsupportedRecords = [];
+  const missingModelRecords = [];
+  const legacyMissingModelRecords = [];
+  let verifierRecordCount = 0;
+
+  for (const raw of records) {
+    if (!isTerminalDispositionRecord(raw)) continue;
+    const record = normalizeTerminalDisposition(raw);
+    const isVerifierRecord = record.artifact_family === 'verifier-terminal-disposition' ||
+      Boolean(record.verifier_mode) ||
+      cleanString(record.workflow).toLowerCase().includes('verifier');
+    if (!isVerifierRecord) continue;
+    verifierRecordCount += 1;
+
+    const model = cleanString(record.llm_model ?? record.model).toLowerCase();
+    const reason = cleanString(record.model_selection_reason);
+    const verifierMode = cleanString(record.verifier_mode).toLowerCase();
+    const requiresCodexModel = Boolean(verifierMode) && verifierMode !== 'evaluate';
+    if (model) selectedModels[model] = (selectedModels[model] || 0) + 1;
+    if (reason) modelSelectionReasons[reason] = (modelSelectionReasons[reason] || 0) + 1;
+    if (!model && requiresCodexModel && modelMetadataContract.model_metadata_required) {
+      const runId = cleanString(record.run_id);
+      const metadata = artifactMetadata.get(runId);
+      const missingRecord = {
+        source_key: record.source_key,
+        pr_number: record.pr_number || null,
+        run_id: runId,
+        disposition: record.disposition,
+        verifier_mode: verifierMode || 'unknown',
+      };
+      if (metadata?.created_at) missingRecord.artifact_created_at = metadata.created_at;
+      if (isPreContractVerifierModelRecord(record, metadata, modelMetadataContract)) {
+        legacyMissingModelRecords.push(missingRecord);
+      } else {
+        missingModelRecords.push(missingRecord);
+      }
+    }
+    if (model && unsupportedSet.has(model)) {
+      unsupportedRecords.push({
+        source_key: record.source_key,
+        pr_number: record.pr_number || null,
+        run_id: cleanString(record.run_id),
+        model,
+        disposition: record.disposition,
+        model_selection_reason: reason,
+      });
+    }
+  }
+
+  return {
+    schema: 'workflows-verifier-model-compatibility/v1',
+    status: unsupportedRecords.length > 0 || missingModelRecords.length > 0 ? 'warning' : 'pass',
+    model_metadata_contract: modelMetadataContract,
+    verifier_record_count: verifierRecordCount,
+    unsupported_models: unsupportedModels,
+    unsupported_record_count: unsupportedRecords.length,
+    missing_model_record_count: missingModelRecords.length,
+    legacy_missing_model_record_count: legacyMissingModelRecords.length,
+    selected_models: Object.fromEntries(
+      Object.entries(selectedModels).sort((a, b) => a[0].localeCompare(b[0]))
+    ),
+    model_selection_reasons: Object.fromEntries(
+      Object.entries(modelSelectionReasons).sort((a, b) => a[0].localeCompare(b[0]))
+    ),
+    unsupported_records: unsupportedRecords.sort((a, b) =>
+      `${a.source_key}:${a.run_id}`.localeCompare(`${b.source_key}:${b.run_id}`)
+    ),
+    missing_model_records: missingModelRecords.sort((a, b) =>
+      `${a.source_key}:${a.run_id}`.localeCompare(`${b.source_key}:${b.run_id}`)
+    ),
+    legacy_missing_model_records: legacyMissingModelRecords.sort((a, b) =>
+      `${a.source_key}:${a.run_id}`.localeCompare(`${b.source_key}:${b.run_id}`)
+    ),
+  };
+}
+
 function normalizeExpectedSource(input = {}) {
   const sourceType = cleanString(input.source_type ?? input.sourceType) || 'review-thread';
   const prNumber = cleanInt(input.pr_number ?? input.prNumber ?? input.pr);
@@ -95,6 +258,7 @@ function expectedReviewThreadSources(records = []) {
   for (const raw of records) {
     if (!isTerminalDispositionRecord(raw)) continue;
     const record = normalizeTerminalDisposition(raw);
+    if (record.artifact_family === 'verifier-terminal-disposition') continue;
     const prNumber = cleanInt(record.pr_number);
     if (prNumber === null) continue;
     const source = normalizeExpectedSource({
@@ -119,6 +283,10 @@ function summarizeTerminalDispositionCoverage(records = [], options = {}) {
   const terminalRecords = records
     .filter(isTerminalDispositionRecord)
     .map((record) => normalizeTerminalDisposition(record));
+  const verifierModelCompatibility = summarizeVerifierModelCompatibility(terminalRecords, {
+    ...options,
+    artifact_selection: artifactSelection,
+  });
   const scannedRecordCount = records.length;
   const nonTerminalRecordCount = scannedRecordCount - terminalRecords.length;
   const inputFiles = Array.isArray(options.input_files) ? options.input_files.map(cleanString).filter(Boolean) : [];
@@ -174,7 +342,12 @@ function summarizeTerminalDispositionCoverage(records = [], options = {}) {
       terminalArtifactInputMismatch
       ? 'warning'
       : 'no-data';
-  } else if (missing.length > 0 || parseErrors > 0 || artifactSelectionWarning) {
+  } else if (
+    missing.length > 0 ||
+    parseErrors > 0 ||
+    artifactSelectionWarning ||
+    verifierModelCompatibility.status !== 'pass'
+  ) {
     status = 'warning';
   }
 
@@ -186,6 +359,12 @@ function summarizeTerminalDispositionCoverage(records = [], options = {}) {
   if (missing.length > 0) enforcementBlockers.push('missing-review-thread-sources');
   if (parseErrors > 0) enforcementBlockers.push('parse-errors');
   if (artifactSelectionWarning) enforcementBlockers.push('artifact-selection-warning');
+  if (verifierModelCompatibility.unsupported_record_count > 0) {
+    enforcementBlockers.push('unsupported-verifier-model');
+  }
+  if (verifierModelCompatibility.missing_model_record_count > 0) {
+    enforcementBlockers.push('missing-verifier-model-metadata');
+  }
 
   const hardBlockEligible = enforcementBlockers.length === 0;
   const hardBlockActive = policy.effective_mode === HARD_BLOCK_MODE;
@@ -221,6 +400,7 @@ function summarizeTerminalDispositionCoverage(records = [], options = {}) {
     parse_errors: parseErrors,
     terminal_artifact_input_mismatch: terminalArtifactInputMismatch,
     artifact_selection: artifactSelection,
+    verifier_model_compatibility: verifierModelCompatibility,
     observed_sources: observedSources,
     expected_sources: expected,
     missing_sources: missing,
@@ -246,6 +426,76 @@ function terminalFamilyCount(counts = {}) {
   );
 }
 
+function normalizeSelectionArtifact(artifact = {}) {
+  if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) return null;
+  const name = cleanString(artifact.name);
+  const normalized = {
+    id: artifact.id ?? artifact.artifact_id ?? artifact.artifactId ?? null,
+    name,
+  };
+  const createdAt = cleanString(artifact.created_at ?? artifact.createdAt);
+  const updatedAt = cleanString(artifact.updated_at ?? artifact.updatedAt);
+  if (createdAt) normalized.created_at = createdAt;
+  if (updatedAt) normalized.updated_at = updatedAt;
+  return normalized;
+}
+
+function latestCandidateFromSelectionReport(report = {}, family = '') {
+  const candidateMaps = [
+    report.latest_candidate_by_family,
+    report.latest_candidates_by_family,
+  ];
+  for (const candidatesByFamily of candidateMaps) {
+    if (!candidatesByFamily || typeof candidatesByFamily !== 'object' || Array.isArray(candidatesByFamily)) {
+      continue;
+    }
+    const candidate = normalizeSelectionArtifact(candidatesByFamily[family]);
+    if (candidate) return candidate;
+  }
+  return null;
+}
+
+function normalizeTerminalPriorityFamilyStatuses(report = {}, selectedArtifacts = []) {
+  const rawStatuses = Array.isArray(report.priority_family_statuses)
+    ? report.priority_family_statuses
+    : [];
+  const byFamily = new Map();
+
+  for (const status of rawStatuses) {
+    if (!status || typeof status !== 'object' || Array.isArray(status)) continue;
+    const family = cleanString(status.family);
+    if (!TERMINAL_ARTIFACT_FAMILIES.has(family)) continue;
+    byFamily.set(family, {
+      family,
+      status: cleanString(status.status) || 'missing',
+      candidate_count: Number(status.candidate_count) || 0,
+      selected_count: Number(status.selected_count) || 0,
+      latest_candidate: normalizeSelectionArtifact(status.latest_candidate),
+      selected_artifact: normalizeSelectionArtifact(status.selected_artifact),
+    });
+  }
+
+  for (const family of TERMINAL_ARTIFACT_FAMILIES) {
+    if (byFamily.has(family)) continue;
+    const candidateCount = Number(report.candidate_family_counts?.[family]) || 0;
+    const selectedCount = Number(report.selected_family_counts?.[family]) ||
+      selectedArtifacts.filter((artifact) => artifact.family === family).length;
+    const selectedArtifact = selectedArtifacts.find((artifact) => artifact.family === family) || null;
+    const latestCandidate = latestCandidateFromSelectionReport(report, family) ||
+      (selectedArtifact ? normalizeSelectionArtifact(selectedArtifact) : null);
+    byFamily.set(family, {
+      family,
+      status: selectedCount > 0 ? 'selected' : (candidateCount > 0 ? 'available' : 'missing'),
+      candidate_count: candidateCount,
+      selected_count: selectedCount,
+      latest_candidate: latestCandidate,
+      selected_artifact: selectedArtifact ? normalizeSelectionArtifact(selectedArtifact) : null,
+    });
+  }
+
+  return [...byFamily.values()].sort((a, b) => a.family.localeCompare(b.family));
+}
+
 function normalizeArtifactSelectionSummary(report) {
   if (!report) return null;
   if (report.status === 'missing' || report.status === 'parse-error') {
@@ -256,6 +506,8 @@ function normalizeArtifactSelectionSummary(report) {
       candidate_terminal_artifact_count: 0,
       selected_terminal_artifact_count: 0,
       selected_terminal_artifacts: [],
+      terminal_priority_family_statuses: [],
+      missing_terminal_priority_families: [],
     };
   }
   if (typeof report !== 'object' || Array.isArray(report)) {
@@ -266,18 +518,28 @@ function normalizeArtifactSelectionSummary(report) {
       candidate_terminal_artifact_count: 0,
       selected_terminal_artifact_count: 0,
       selected_terminal_artifacts: [],
+      terminal_priority_family_statuses: [],
+      missing_terminal_priority_families: [],
     };
   }
 
   const selectedArtifacts = Array.isArray(report.selected_artifacts)
     ? report.selected_artifacts
-      .map((artifact) => ({
-        id: artifact.id ?? artifact.artifact_id ?? artifact.artifactId ?? null,
-        name: cleanString(artifact.name),
-        family: artifactFamilyFromSelection(artifact),
-      }))
+      .map((artifact) => {
+        const normalized = {
+          id: artifact.id ?? artifact.artifact_id ?? artifact.artifactId ?? null,
+          name: cleanString(artifact.name),
+          family: artifactFamilyFromSelection(artifact),
+        };
+        const createdAt = cleanString(artifact.created_at ?? artifact.createdAt);
+        const updatedAt = cleanString(artifact.updated_at ?? artifact.updatedAt);
+        if (createdAt) normalized.created_at = createdAt;
+        if (updatedAt) normalized.updated_at = updatedAt;
+        return normalized;
+      })
       .filter((artifact) => TERMINAL_ARTIFACT_FAMILIES.has(artifact.family))
     : [];
+  const terminalFamilyStatuses = normalizeTerminalPriorityFamilyStatuses(report, selectedArtifacts);
 
   return {
     schema: cleanString(report.schema) || 'workflows-weekly-metrics-artifact-selection/v1',
@@ -287,6 +549,10 @@ function normalizeArtifactSelectionSummary(report) {
     selected_terminal_artifact_count: terminalFamilyCount(report.selected_family_counts) ||
       selectedArtifacts.length,
     selected_terminal_artifacts: selectedArtifacts,
+    terminal_priority_family_statuses: terminalFamilyStatuses,
+    missing_terminal_priority_families: terminalFamilyStatuses
+      .filter((status) => status.status === 'missing')
+      .map((status) => status.family),
   };
 }
 
@@ -329,12 +595,35 @@ function formatTerminalDispositionCoverageMarkdown(report) {
     if (selection.error_message) {
       lines.push(`- Artifact selector error: ${selection.error_message}`);
     }
+    if (selection.missing_terminal_priority_families?.length > 0) {
+      lines.push(
+        `- Missing terminal artifact families: ${selection.missing_terminal_priority_families.join(', ')}`
+      );
+    }
   }
 
   if (report.terminal_artifact_input_mismatch) {
     lines.push(
       '- Terminal artifact input mismatch: selected terminal artifacts did not yield terminal NDJSON input files'
     );
+  }
+
+  const modelCompatibility = report.verifier_model_compatibility;
+  if (modelCompatibility) {
+    lines.push(
+      `- Verifier model compatibility: ${modelCompatibility.status}`,
+      `- Unsupported verifier model records: ${modelCompatibility.unsupported_record_count}`,
+      `- Missing verifier model metadata records: ${modelCompatibility.missing_model_record_count}`,
+      `- Legacy missing verifier model metadata records: ${modelCompatibility.legacy_missing_model_record_count || 0}`
+    );
+    if (modelCompatibility.model_metadata_contract?.required_after) {
+      lines.push(
+        `- Verifier model metadata required after: ${modelCompatibility.model_metadata_contract.required_after}`
+      );
+    }
+    if (modelCompatibility.unsupported_models?.length > 0) {
+      lines.push(`- Unsupported verifier models: ${modelCompatibility.unsupported_models.join(', ')}`);
+    }
   }
 
   const policyBlockers = report.enforcement?.policy_blockers || [];
@@ -355,6 +644,72 @@ function formatTerminalDispositionCoverageMarkdown(report) {
       const prs = source.pr_numbers.length ? source.pr_numbers.map((value) => `#${value}`).join(', ') : 'n/a';
       lines.push(
         `| ${source.source_key} | ${source.count} | ${formatDispositions(source.dispositions)} | ${prs} |`
+      );
+    }
+  }
+
+  const terminalFamilyStatuses = report.artifact_selection?.terminal_priority_family_statuses || [];
+  if (terminalFamilyStatuses.length > 0) {
+    lines.push(
+      '',
+      '| Terminal artifact family | Status | Candidates | Selected | Latest artifact |',
+      '|--------------------------|--------|------------|----------|-----------------|'
+    );
+    for (const familyStatus of terminalFamilyStatuses) {
+      const latest = familyStatus.selected_artifact?.name ||
+        familyStatus.latest_candidate?.name ||
+        'n/a';
+      lines.push(
+        `| ${familyStatus.family} | ${familyStatus.status} | ${familyStatus.candidate_count} | ${familyStatus.selected_count} | ${latest} |`
+      );
+    }
+  }
+
+  const unsupportedRecords = modelCompatibility?.unsupported_records || [];
+  if (unsupportedRecords.length > 0) {
+    lines.push(
+      '',
+      '| Unsupported verifier model source | Model | Disposition | PR | Run |',
+      '|-----------------------------------|-------|-------------|----|-----|'
+    );
+    for (const record of unsupportedRecords) {
+      const pr = record.pr_number ? `#${record.pr_number}` : 'n/a';
+      const run = record.run_id || 'n/a';
+      lines.push(
+        `| ${record.source_key} | ${record.model} | ${record.disposition} | ${pr} | ${run} |`
+      );
+    }
+  }
+
+  const missingModelRecords = modelCompatibility?.missing_model_records || [];
+  if (missingModelRecords.length > 0) {
+    lines.push(
+      '',
+      '| Missing verifier model source | Disposition | Mode | PR | Run |',
+      '|-------------------------------|-------------|------|----|-----|'
+    );
+    for (const record of missingModelRecords) {
+      const pr = record.pr_number ? `#${record.pr_number}` : 'n/a';
+      const run = record.run_id || 'n/a';
+      lines.push(
+        `| ${record.source_key} | ${record.disposition} | ${record.verifier_mode} | ${pr} | ${run} |`
+      );
+    }
+  }
+
+  const legacyMissingModelRecords = modelCompatibility?.legacy_missing_model_records || [];
+  if (legacyMissingModelRecords.length > 0) {
+    lines.push(
+      '',
+      '| Legacy missing verifier model source | Disposition | Mode | PR | Run | Artifact created |',
+      '|--------------------------------------|-------------|------|----|-----|------------------|'
+    );
+    for (const record of legacyMissingModelRecords) {
+      const pr = record.pr_number ? `#${record.pr_number}` : 'n/a';
+      const run = record.run_id || 'n/a';
+      const createdAt = record.artifact_created_at || 'n/a';
+      lines.push(
+        `| ${record.source_key} | ${record.disposition} | ${record.verifier_mode} | ${pr} | ${run} | ${createdAt} |`
       );
     }
   }
@@ -544,7 +899,11 @@ module.exports = {
   normalizeEnforcementMode,
   normalizeEnforcementPolicy,
   normalizeArtifactSelectionSummary,
+  normalizeTerminalPriorityFamilyStatuses,
+  normalizeUnsupportedCodexModels,
+  normalizeVerifierModelMetadataContract,
   readNdjsonFiles,
   readArtifactSelectionReport,
+  summarizeVerifierModelCompatibility,
   summarizeTerminalDispositionCoverage,
 };

--- a/.github/scripts/weekly_metrics_artifacts.js
+++ b/.github/scripts/weekly_metrics_artifacts.js
@@ -128,6 +128,79 @@ function sortedCountObject(counts) {
   );
 }
 
+function missingPriorityFamilies(candidateFamilyCounts = new Map()) {
+  return PRIORITY_METRICS_FAMILIES.filter((family) => !candidateFamilyCounts.has(family));
+}
+
+function priorityFamilyStatuses({
+  candidates = [],
+  selected = [],
+  candidateFamilyCounts = new Map(),
+  selectedFamilyCounts = new Map(),
+} = {}) {
+  return PRIORITY_METRICS_FAMILIES.map((family) => {
+    const latestCandidate = candidates.find((candidate) => candidate.family === family);
+    const selectedArtifact = selected.find((artifact) => artifact.family === family);
+    return {
+      family,
+      status: selectedArtifact ? 'selected' : candidateFamilyCounts.has(family) ? 'available' : 'missing',
+      candidate_count: candidateFamilyCounts.get(family) || 0,
+      selected_count: selectedFamilyCounts.get(family) || 0,
+      latest_candidate: latestCandidate
+        ? {
+            id: latestCandidate.id,
+            name: latestCandidate.name,
+            created_at: latestCandidate.created_at,
+            updated_at: latestCandidate.updated_at,
+          }
+        : null,
+      selected_artifact: selectedArtifact
+        ? {
+            id: selectedArtifact.id,
+            name: selectedArtifact.name,
+            created_at: selectedArtifact.created_at,
+            updated_at: selectedArtifact.updated_at,
+          }
+        : null,
+    };
+  });
+}
+
+function latestCandidateByFamily(candidates = []) {
+  const latestByFamily = new Map();
+  for (const candidate of candidates) {
+    const family = cleanString(candidate.family);
+    if (!PRIORITY_METRICS_FAMILIES.includes(family)) continue;
+    const existing = latestByFamily.get(family);
+    const candidateTimestamp = Number(candidate.timestamp_ms) || artifactTimestampMs(candidate);
+    const existingTimestamp = existing ? Number(existing.timestamp_ms) || artifactTimestampMs(existing) : -1;
+    const candidateId = Number(candidate.id) || 0;
+    const existingId = existing ? Number(existing.id) || 0 : -1;
+    if (
+      !existing ||
+      candidateTimestamp > existingTimestamp ||
+      (candidateTimestamp === existingTimestamp && candidateId > existingId)
+    ) {
+      latestByFamily.set(family, candidate);
+    }
+  }
+  const entries = [];
+  for (const family of PRIORITY_METRICS_FAMILIES) {
+    const latestCandidate = latestByFamily.get(family);
+    if (!latestCandidate) continue;
+    entries.push([
+      family,
+      {
+        id: latestCandidate.id,
+        name: latestCandidate.name,
+        created_at: latestCandidate.created_at,
+        updated_at: latestCandidate.updated_at,
+      },
+    ]);
+  }
+  return Object.fromEntries(entries);
+}
+
 function selectMetricsArtifacts(artifacts = [], options = {}) {
   const config = normalizeSelectionOptions(options);
   const stats = {
@@ -223,6 +296,14 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
     ...stats,
     candidate_family_counts: sortedCountObject(candidateFamilyCounts),
     selected_family_counts: sortedCountObject(familyCounts),
+    latest_candidate_by_family: latestCandidateByFamily(candidates),
+    missing_priority_families: missingPriorityFamilies(candidateFamilyCounts),
+    priority_family_statuses: priorityFamilyStatuses({
+      candidates,
+      selected,
+      candidateFamilyCounts,
+      selectedFamilyCounts: familyCounts,
+    }),
     selected_artifacts: selected.map((artifact) => ({
       id: artifact.id,
       name: artifact.name,
@@ -257,6 +338,9 @@ function buildSelectionErrorReport(options = {}, error = {}) {
     ignored_total_limit_count: 0,
     candidate_family_counts: {},
     selected_family_counts: {},
+    latest_candidate_by_family: {},
+    missing_priority_families: [...PRIORITY_METRICS_FAMILIES],
+    priority_family_statuses: priorityFamilyStatuses(),
     selected_artifacts: [],
   };
 }
@@ -283,6 +367,7 @@ function formatSelectionMarkdown(report) {
     `- Scanned artifacts: ${report.scanned_count}`,
     `- Candidate artifacts: ${report.candidate_count}`,
     `- Selected artifacts: ${report.selected_count}`,
+    `- Missing priority families: ${(report.missing_priority_families || []).join(', ') || 'none'}`,
     `- Ignored: ${report.ignored_old_count} old, ${report.ignored_expired_count} expired, ` +
       `${report.ignored_name_count} non-metrics, ${report.ignored_family_limit_count} over family cap, ` +
       `${report.ignored_total_limit_count} over total cap`,
@@ -296,6 +381,19 @@ function formatSelectionMarkdown(report) {
     lines.push('', '| Artifact family | Candidates | Selected |', '|-----------------|------------|----------|');
     for (const family of familyNames) {
       lines.push(`| ${family} | ${candidateFamilyCounts[family] || 0} | ${selectedFamilyCounts[family] || 0} |`);
+    }
+  }
+
+  if (Array.isArray(report.priority_family_statuses) && report.priority_family_statuses.length > 0) {
+    lines.push('', '| Priority family | Status | Candidates | Selected artifact |');
+    lines.push('|-----------------|--------|------------|-------------------|');
+    for (const family of report.priority_family_statuses) {
+      lines.push([
+        family.family,
+        family.status,
+        family.candidate_count || 0,
+        family.selected_artifact?.name || 'none',
+      ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
     }
   }
 
@@ -428,6 +526,9 @@ module.exports = {
   collectRepoArtifacts,
   formatArtifactTsv,
   formatSelectionMarkdown,
+  latestCandidateByFamily,
+  missingPriorityFamilies,
   normalizeSelectionOptions,
+  priorityFamilyStatuses,
   selectMetricsArtifacts,
 };

--- a/.github/scripts/weekly_metrics_download_manifest.js
+++ b/.github/scripts/weekly_metrics_download_manifest.js
@@ -1,0 +1,320 @@
+const fs = require('fs');
+const path = require('path');
+
+const DOWNLOAD_MANIFEST_SCHEMA = 'workflows-weekly-metrics-artifact-download-manifest/v1';
+
+function cleanString(value) {
+  if (value === null || value === undefined) return '';
+  return String(value).trim();
+}
+
+function normalizeStatus(value, allowed, fallback) {
+  const cleaned = cleanString(value).toLowerCase();
+  return allowed.includes(cleaned) ? cleaned : fallback;
+}
+
+function readJsonFile(filePath, fallback = {}) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (_error) {
+    return fallback;
+  }
+}
+
+function writeJsonFile(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+function safeArtifactPathSegment(value) {
+  const sanitized = cleanString(value)
+    .replace(/[\\/]+/g, '_')
+    .replace(/[^A-Za-z0-9._-]/g, '_')
+    .replace(/\.\.+/g, '_')
+    .replace(/^\.{1,2}$/, '_');
+  return sanitized || 'unknown';
+}
+
+function selectedArtifactsFromSelection(selection = {}) {
+  return Array.isArray(selection.selected_artifacts) ? selection.selected_artifacts : [];
+}
+
+function defaultArtifactDir(root, artifact) {
+  return path.posix.join(root, safeArtifactPathSegment(artifact.name), String(artifact.id || ''));
+}
+
+function defaultZipPath(root, artifact) {
+  return path.posix.join(defaultArtifactDir(root, artifact), `${artifact.id}.zip`);
+}
+
+function buildInitialManifest(selection = {}, options = {}) {
+  const artifactsRoot = cleanString(options.artifacts_root || options.artifactsRoot) || 'artifacts';
+  const selectionPath = cleanString(options.selection_path || options.selectionPath);
+  const selected = selectedArtifactsFromSelection(selection);
+  const generatedAt = cleanString(options.generated_at || options.generatedAt) || new Date().toISOString();
+  return {
+    schema: DOWNLOAD_MANIFEST_SCHEMA,
+    status: selection.status === 'error' ? 'error' : 'pending',
+    generated_at: generatedAt,
+    selection: {
+      path: selectionPath,
+      schema: cleanString(selection.schema),
+      status: cleanString(selection.status || 'pass'),
+      selected_count: selected.length,
+    },
+    stats: {
+      selected_count: selected.length,
+      download_pass_count: 0,
+      download_failed_count: 0,
+      unzip_pass_count: 0,
+      unzip_failed_count: 0,
+      unzip_skipped_count: 0,
+    },
+    artifacts: selected.map((artifact, index) => ({
+      id: artifact.id,
+      name: cleanString(artifact.name),
+      family: cleanString(artifact.family),
+      created_at: cleanString(artifact.created_at),
+      updated_at: cleanString(artifact.updated_at),
+      selected_index: index,
+      artifact_dir: defaultArtifactDir(artifactsRoot, artifact),
+      zip_path: defaultZipPath(artifactsRoot, artifact),
+      download: {
+        status: 'pending',
+        bytes: null,
+        error: '',
+      },
+      unzip: {
+        status: 'pending',
+        path: defaultArtifactDir(artifactsRoot, artifact),
+        error: '',
+      },
+    })),
+  };
+}
+
+function findArtifact(manifest, id, name) {
+  const cleanId = cleanString(id);
+  const cleanName = cleanString(name);
+  if (cleanId) {
+    return (manifest.artifacts || []).find((artifact) => cleanString(artifact.id) === cleanId);
+  }
+  return (manifest.artifacts || []).find((artifact) => {
+    return cleanName && cleanString(artifact.name) === cleanName;
+  });
+}
+
+function updateArtifactResult(manifest, result = {}) {
+  const artifact = findArtifact(manifest, result.id, result.name);
+  if (!artifact) {
+    throw new Error(`Artifact is not present in manifest: ${cleanString(result.id || result.name)}`);
+  }
+  const artifactDir = cleanString(result.artifact_dir || result.artifactDir);
+  const zipPath = cleanString(result.zip_path || result.zipPath);
+  const zipBytes = Number.parseInt(cleanString(result.zip_bytes || result.zipBytes), 10);
+  const downloadStatus = normalizeStatus(
+    result.download_status || result.downloadStatus,
+    ['pending', 'pass', 'failed', 'skipped'],
+    artifact.download?.status || 'pending'
+  );
+  const unzipStatus = normalizeStatus(
+    result.unzip_status || result.unzipStatus,
+    ['pending', 'pass', 'failed', 'skipped'],
+    artifact.unzip?.status || 'pending'
+  );
+
+  if (artifactDir) {
+    artifact.artifact_dir = artifactDir;
+    artifact.unzip.path = artifactDir;
+  }
+  if (zipPath) artifact.zip_path = zipPath;
+
+  artifact.download = {
+    status: downloadStatus,
+    bytes: Number.isFinite(zipBytes) && zipBytes >= 0 ? zipBytes : artifact.download?.bytes ?? null,
+    error: cleanString(result.download_error || result.downloadError),
+  };
+  artifact.unzip = {
+    status: unzipStatus,
+    path: artifact.unzip?.path || artifact.artifact_dir,
+    error: cleanString(result.unzip_error || result.unzipError),
+  };
+  return artifact;
+}
+
+function finalizeManifest(manifest = {}) {
+  const artifacts = Array.isArray(manifest.artifacts) ? manifest.artifacts : [];
+  const stats = {
+    selected_count: artifacts.length,
+    download_pass_count: 0,
+    download_failed_count: 0,
+    unzip_pass_count: 0,
+    unzip_failed_count: 0,
+    unzip_skipped_count: 0,
+  };
+
+  for (const artifact of artifacts) {
+    const downloadStatus = artifact.download?.status || 'pending';
+    const unzipStatus = artifact.unzip?.status || 'pending';
+    if (downloadStatus === 'pass') stats.download_pass_count += 1;
+    if (downloadStatus === 'failed') stats.download_failed_count += 1;
+    if (unzipStatus === 'pass') stats.unzip_pass_count += 1;
+    if (unzipStatus === 'failed') stats.unzip_failed_count += 1;
+    if (unzipStatus === 'skipped') stats.unzip_skipped_count += 1;
+  }
+
+  let status = 'pass';
+  if (manifest.selection?.status === 'error') {
+    status = 'error';
+  } else if (
+    stats.download_failed_count > 0 ||
+    stats.unzip_failed_count > 0 ||
+    artifacts.some((artifact) => artifact.download?.status === 'pending' || artifact.unzip?.status === 'pending')
+  ) {
+    status = 'warning';
+  }
+
+  manifest.status = status;
+  manifest.stats = stats;
+  manifest.finalized_at = new Date().toISOString();
+  return manifest;
+}
+
+function markdownTableCell(value) {
+  return cleanString(value).replace(/\r?\n/g, ' ').replace(/\|/g, '\\|');
+}
+
+function formatMarkdown(manifest = {}) {
+  const stats = manifest.stats || {};
+  const lines = [
+    '## Weekly Metrics Artifact Downloads',
+    '',
+    `- Schema: ${manifest.schema || DOWNLOAD_MANIFEST_SCHEMA}`,
+    `- Status: ${manifest.status || 'pending'}`,
+    `- Selected artifacts: ${stats.selected_count || 0}`,
+    `- Downloads: ${stats.download_pass_count || 0} passed, ${stats.download_failed_count || 0} failed`,
+    `- Unzip: ${stats.unzip_pass_count || 0} passed, ${stats.unzip_failed_count || 0} failed, ` +
+      `${stats.unzip_skipped_count || 0} skipped`,
+  ];
+
+  const artifacts = Array.isArray(manifest.artifacts) ? manifest.artifacts : [];
+  if (artifacts.length > 0) {
+    lines.push('', '| Artifact | ID | Download | Unzip | Path |');
+    lines.push('|----------|----|----------|-------|------|');
+    for (const artifact of artifacts) {
+      const download = artifact.download || {};
+      const unzip = artifact.unzip || {};
+      const downloadLabel = download.error
+        ? `${download.status || 'pending'} (${download.error})`
+        : download.status || 'pending';
+      const unzipLabel = unzip.error
+        ? `${unzip.status || 'pending'} (${unzip.error})`
+        : unzip.status || 'pending';
+      lines.push(
+        `| ${markdownTableCell(artifact.name || 'unknown')} | ${markdownTableCell(
+          artifact.id || ''
+        )} | ${markdownTableCell(downloadLabel)} | ` +
+          `${markdownTableCell(unzipLabel)} | ${markdownTableCell(artifact.artifact_dir || '')} |`
+      );
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    mode: '',
+    manifest: process.env.METRICS_ARTIFACT_DOWNLOAD_MANIFEST_JSON ||
+      'artifacts/metric-artifact-download-manifest.json',
+    markdown: process.env.METRICS_ARTIFACT_DOWNLOAD_MANIFEST_MD || '',
+    selection: process.env.METRICS_ARTIFACT_SELECTION_JSON ||
+      'artifacts/metric-artifacts-selection.json',
+    artifacts_root: process.env.METRICS_ARTIFACTS_ROOT || 'artifacts',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === '--init' || arg === '--record' || arg === '--finalize') {
+      options.mode = arg.slice(2);
+    } else if (arg === '--manifest') {
+      options.manifest = next;
+      index += 1;
+    } else if (arg === '--markdown') {
+      options.markdown = next;
+      index += 1;
+    } else if (arg === '--selection') {
+      options.selection = next;
+      index += 1;
+    } else if (arg === '--artifacts-root') {
+      options.artifacts_root = next;
+      index += 1;
+    } else if (arg.startsWith('--')) {
+      const key = arg.slice(2).replace(/-/g, '_');
+      options[key] = next;
+      index += 1;
+    }
+  }
+
+  return options;
+}
+
+function writeMarkdownIfRequested(markdownPath, manifest) {
+  if (!markdownPath) return;
+  fs.mkdirSync(path.dirname(markdownPath), { recursive: true });
+  fs.writeFileSync(markdownPath, formatMarkdown(manifest), 'utf8');
+}
+
+function main() {
+  const options = parseArgs();
+  if (options.mode === 'init') {
+    const selection = readJsonFile(options.selection, { status: 'error', selected_artifacts: [] });
+    const manifest = buildInitialManifest(selection, {
+      artifacts_root: options.artifacts_root,
+      selection_path: options.selection,
+    });
+    writeJsonFile(options.manifest, manifest);
+    writeMarkdownIfRequested(options.markdown, manifest);
+    return 0;
+  }
+
+  const manifest = readJsonFile(options.manifest, null);
+  if (!manifest) {
+    throw new Error(`Manifest does not exist or is invalid JSON: ${options.manifest}`);
+  }
+
+  if (options.mode === 'record') {
+    updateArtifactResult(manifest, options);
+    writeJsonFile(options.manifest, manifest);
+    writeMarkdownIfRequested(options.markdown, manifest);
+    return 0;
+  }
+
+  if (options.mode === 'finalize') {
+    finalizeManifest(manifest);
+    writeJsonFile(options.manifest, manifest);
+    writeMarkdownIfRequested(options.markdown, manifest);
+    return 0;
+  }
+
+  throw new Error('Expected one of --init, --record, or --finalize');
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  DOWNLOAD_MANIFEST_SCHEMA,
+  buildInitialManifest,
+  finalizeManifest,
+  formatMarkdown,
+  safeArtifactPathSegment,
+  updateArtifactResult,
+};

--- a/.github/workflows/agents-81-gate-followups.yml
+++ b/.github/workflows/agents-81-gate-followups.yml
@@ -402,7 +402,7 @@ jobs:
           tasks_completed=$(( tasks_total - tasks_unchecked ))
           if [ "$tasks_completed" -lt 0 ]; then tasks_completed=0; fi
 
-          metrics_json=$(jq -n \
+          metrics_json=$(jq -cn \
             --arg pr "${PR_NUMBER:-0}" \
             --arg iteration "${ITERATION:-0}" \
             --arg action "${ACTION:-}" \

--- a/.github/workflows/agents-bot-comment-handler.yml
+++ b/.github/workflows/agents-bot-comment-handler.yml
@@ -63,6 +63,7 @@ jobs:
     outputs:
       pr_number: ${{ steps.resolve.outputs.pr_number }}
       should_run: ${{ steps.resolve.outputs.should_run }}
+      skip_reason: ${{ steps.resolve.outputs.skip_reason }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -70,6 +71,7 @@ jobs:
           sparse-checkout: |
             .github/actions/setup-api-client
             .github/scripts/github-api-with-retry.js
+            .github/scripts/terminal_disposition.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
 
@@ -90,10 +92,12 @@ jobs:
             const eventName = context.eventName;
             let prNumber = null;
             let shouldRun = false;
+            let skipReason = 'unmatched-trigger';
 
             if (eventName === 'workflow_dispatch') {
               prNumber = '${{ inputs.pr_number }}';
               shouldRun = true;
+              skipReason = '';
               console.log(`Manual dispatch for PR #${prNumber}`);
             }
             else if (eventName === 'pull_request') {
@@ -102,8 +106,10 @@ jobs:
               if (label === 'autofix:bot-comments') {
                 prNumber = context.payload.pull_request.number;
                 shouldRun = true;
+                skipReason = '';
                 console.log(`Label trigger for PR #${prNumber}`);
               } else {
+                skipReason = 'non-bot-comment-label';
                 console.log(`Ignoring label: ${label}`);
               }
             }
@@ -121,6 +127,7 @@ jobs:
               }
               if (!defaultBranch) {
                 console.log('Could not determine default branch; skipping.');
+                core.setOutput('skip_reason', 'missing-default-branch');
                 core.setOutput('should_run', 'false');
                 return;
               }
@@ -128,12 +135,14 @@ jobs:
               // Skip default branch
               if (workflowRun.head_branch === defaultBranch) {
                 console.log(`Skipping default branch ${defaultBranch}`);
+                core.setOutput('skip_reason', 'gate-run-on-default-branch');
                 core.setOutput('should_run', 'false');
                 return;
               }
 
               if (workflowRun.conclusion !== 'success') {
                 console.log(`Gate did not succeed (${workflowRun.conclusion}), skipping`);
+                core.setOutput('skip_reason', 'gate-not-success');
                 core.setOutput('should_run', 'false');
                 return;
               }
@@ -142,6 +151,7 @@ jobs:
               const prs = workflowRun.pull_requests;
               if (!prs || prs.length === 0) {
                 console.log('No PR associated with workflow run');
+                core.setOutput('skip_reason', 'no-pull-request-associated-with-workflow-run');
                 core.setOutput('should_run', 'false');
                 return;
               }
@@ -162,6 +172,8 @@ jobs:
                   `Failed to fetch PR #${prNumber} details, skipping. ` +
                     `Error: ${error.message || error}`
                 );
+                core.setOutput('pr_number', prNumber || '');
+                core.setOutput('skip_reason', 'pr-fetch-failed');
                 core.setOutput('should_run', 'false');
                 return;
               }
@@ -169,6 +181,8 @@ jobs:
               const hasAgentLabel = pr.labels.some(l => /^agent:/.test(l.name));
               if (!hasAgentLabel) {
                 console.log(`PR #${prNumber} has no agent label, skipping`);
+                core.setOutput('pr_number', prNumber || '');
+                core.setOutput('skip_reason', 'missing-agent-label');
                 core.setOutput('should_run', 'false');
                 return;
               }
@@ -177,16 +191,83 @@ jobs:
               const hasAutoPilot = pr.labels.some(l => l.name === 'agents:auto-pilot');
               if (hasAutoPilot) {
                 console.log(`PR #${prNumber} is auto-pilot managed, skipping bot-comment handler`);
+                core.setOutput('pr_number', prNumber || '');
+                core.setOutput('skip_reason', 'auto-pilot-managed');
                 core.setOutput('should_run', 'false');
                 return;
               }
 
               shouldRun = true;
+              skipReason = '';
               console.log(`Gate completion trigger for agent PR #${prNumber}`);
             }
 
             core.setOutput('pr_number', prNumber || '');
             core.setOutput('should_run', shouldRun ? 'true' : 'false');
+            core.setOutput('skip_reason', skipReason);
+
+      - name: Write wrapper terminal disposition
+        if: always()
+        env:
+          RESOLVED_PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+          REUSABLE_INVOCATION_EXPECTED: ${{ steps.resolve.outputs.should_run }}
+          SKIP_REASON: ${{ steps.resolve.outputs.skip_reason }}
+        run: |
+          mkdir -p agent-metrics
+          node <<'NODE'
+          const fs = require('fs');
+          const helperPath = './.github/scripts/terminal_disposition.js';
+          const fallback = {
+            normalizeTerminalDisposition: (value) => value,
+            formatTerminalDispositionMarkdown: (records) =>
+              records.map((record) => `- ${record.source_type}:${record.source_id} ${record.disposition}`).join('\n'),
+          };
+          const {
+            normalizeTerminalDisposition,
+            formatTerminalDispositionMarkdown,
+          } = fs.existsSync(helperPath) ? require(helperPath) : fallback;
+          const reusableExpected =
+            String(process.env.REUSABLE_INVOCATION_EXPECTED || '').toLowerCase() === 'true';
+          const prNumber = Number.parseInt(process.env.RESOLVED_PR_NUMBER || '', 10) || null;
+          const disposition = reusableExpected ? 'reusable-invocation-expected' : 'wrapper-skipped';
+          const reason = reusableExpected
+            ? 'Wrapper resolved an eligible PR and invoked the reusable bot-comment handler.'
+            : (process.env.SKIP_REASON || 'Wrapper did not find eligible bot-comment work.');
+          const record = normalizeTerminalDisposition({
+            source_type: 'review-thread',
+            source_id: prNumber || process.env.GITHUB_RUN_ID || 'unknown',
+            pr_number: prNumber,
+            disposition,
+            reason,
+            workflow: process.env.GITHUB_WORKFLOW || '',
+            run_id: process.env.GITHUB_RUN_ID || '',
+            run_attempt: process.env.GITHUB_RUN_ATTEMPT || '',
+            artifact_name: `review-thread-terminal-disposition-${process.env.GITHUB_RUN_ID || ''}`,
+            artifact_family: 'review-thread-terminal-disposition',
+            actor: process.env.GITHUB_ACTOR || '',
+            needs_human: false,
+            dispatch_outcome: reusableExpected ? 'reusable-expected' : 'wrapper-skipped',
+          });
+          fs.writeFileSync(
+            'agent-metrics/review-thread-terminal-disposition.ndjson',
+            `${JSON.stringify(record)}\n`
+          );
+          fs.writeFileSync(
+            'terminal-disposition-summary.md',
+            `${formatTerminalDispositionMarkdown([record])}\n`
+          );
+          NODE
+
+      - name: Upload wrapper terminal disposition
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: review-thread-terminal-disposition-${{ github.run_id }}
+          path: |
+            agent-metrics/review-thread-terminal-disposition.ndjson
+            terminal-disposition-summary.md
+          if-no-files-found: error
+          retention-days: 14
 
   # Dismiss ignored-path bot reviews to prevent noisy inline comments
   dismiss_ignored:

--- a/.github/workflows/agents-verify-to-new-pr.yml
+++ b/.github/workflows/agents-verify-to-new-pr.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Check PR is merged
         id: check-merged
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         with:
           github-token: ${{ github.token }}
           script: |
@@ -66,7 +66,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
         with:
           repository: stranske/Workflows
           token: ${{ steps.select-token.outputs.token }}
@@ -91,7 +91,7 @@ jobs:
 
       - name: Set up Python
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -103,7 +103,7 @@ jobs:
       - name: Collect verification and original issue data
         id: collect
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.select-token.outputs.token }}
           script: |
@@ -248,7 +248,7 @@ jobs:
       - name: Check chain depth limit
         id: chain-check
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         env:
           CHAIN_DEPTH: ${{ steps.collect.outputs.chain_depth }}
           MAX_CHAIN_DEPTH: '2'
@@ -389,7 +389,7 @@ jobs:
           steps.check-merged.outputs.merged == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         env:
           LINKED_ISSUE: ${{ steps.collect.outputs.original_issue_number }}
           NEEDS_HUMAN_REASON: ${{ steps.extract-verdict.outputs.needs_human_reason }}
@@ -505,7 +505,7 @@ jobs:
           steps.check-merged.outputs.merged == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         env:
           FOLLOW_UP_DEPTH: ${{ steps.chain-check.outputs.next_depth }}
           EXTRACTED_VERDICT: ${{ steps.extract-verdict.outputs.verdict }}
@@ -677,7 +677,7 @@ jobs:
           steps.check-merged.outputs.merged == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         env:
           ISSUE_TITLE: >-
             ${{ steps.generate.outputs.issue_title ||
@@ -736,7 +736,13 @@ jobs:
               return;
             }
 
-            let agentKey = 'codex';
+            // Resolve agent from PR labels; fall back to registry default
+            let _defaultAgent = 'codex';
+            try {
+              const { loadAgentRegistry } = require('./.github/scripts/agent_registry.js');
+              _defaultAgent = loadAgentRegistry('./.github/agents/registry.yml').default_agent || 'codex';
+            } catch (_) {}
+            let agentKey = _defaultAgent;
             try {
               const { resolveAgentFromLabels } = require('./.github/scripts/agent_registry.js');
               const labels =
@@ -746,11 +752,11 @@ jobs:
               });
             } catch (err) {
               core.warning(
-                `Failed to resolve agent from PR labels; defaulting to codex: ${err.message}`
+                `Failed to resolve agent from PR labels; defaulting to ${_defaultAgent}: ${err.message}`
               );
-              agentKey = 'codex';
+              agentKey = _defaultAgent;
             }
-            const normalized = String(agentKey || 'codex').trim().toLowerCase() || 'codex';
+            const normalized = String(agentKey || _defaultAgent).trim().toLowerCase() || _defaultAgent;
             const agentLabel = `agent:${normalized}`;
             const fromLabel = `from:${normalized}`;
 
@@ -759,7 +765,7 @@ jobs:
               repo: context.repo.repo,
               title: title,
               body: body,
-              labels: ['follow-up', agentLabel, fromLabel, 'agents:auto-pilot']
+              labels: ['follow-up', agentLabel, fromLabel, `runner:${normalized}`, 'agents:auto-pilot']
             }));
 
             core.info(`Created issue #${issue.data.number}`);
@@ -773,7 +779,7 @@ jobs:
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true' &&
           steps.create-issue.outputs.issue_number != ''
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         env:
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -803,14 +809,14 @@ jobs:
                 force_step: 'optimize'
               }
             }));
-            core.info(`Dispatched agents-auto-pilot for follow-up issue #${issueNumber}.`);
+            core.info(`Dispatched agents-auto-pilot for follow-up issue #${issueNumber}.`)
 
       - name: Comment on original PR
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         env:
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
           ISSUE_URL: ${{ steps.create-issue.outputs.issue_url }}
@@ -855,6 +861,8 @@ jobs:
         env:
           ORIGINAL_ISSUE_NUMBER: ${{ steps.collect.outputs.original_issue_number }}
           ORIGINAL_ISSUE_TITLE: ${{ steps.collect.outputs.original_issue_title }}
+          CHAIN_DEPTH: ${{ steps.collect.outputs.chain_depth }}
+          MAX_CHAIN_DEPTH: '2'
           CHAIN_EXCEEDED: ${{ steps.chain-check.outputs.exceeded }}
           NEEDS_HUMAN: ${{ steps.extract-verdict.outputs.needs_human }}
           NEEDS_HUMAN_REASON: ${{ steps.extract-verdict.outputs.needs_human_reason }}
@@ -862,13 +870,15 @@ jobs:
           FOLLOWUP_ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
           FOLLOWUP_ISSUE_URL: ${{ steps.create-issue.outputs.issue_url }}
           DISPATCH_AUTOPILOT_OUTCOME: ${{ steps.dispatch-autopilot.outcome }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.select-token.outputs.token }}
           script: |
             const fs = require('fs');
+            const crypto = require('crypto');
             const {
               normalizeTerminalDisposition,
+              normalizeVerifierFollowupLedger,
               formatTerminalDispositionMarkdown,
             } = require('./.github/scripts/terminal_disposition.js');
 
@@ -879,30 +889,48 @@ jobs:
 
             const followupIssue = process.env.FOLLOWUP_ISSUE_NUMBER || '';
             const dispatchOutcome = (process.env.DISPATCH_AUTOPILOT_OUTCOME || '').trim();
+            const chainDepth = Number.parseInt(process.env.CHAIN_DEPTH || '0', 10) || 0;
+            const maxChainDepth = Number.parseInt(process.env.MAX_CHAIN_DEPTH || '2', 10) || 2;
 
             let disposition = 'follow-up-created';
             let reason = 'Verification follow-up issue was created.';
             let needsHuman = false;
+            let policyAction = 'create-follow-up';
+            let policyTrigger = 'verifier-concerns';
+            let policyReason = 'Verifier concerns require another implementation pass.';
 
             if (process.env.CHAIN_EXCEEDED === 'true') {
               disposition = 'needs-human-depth-limit';
               reason = 'Follow-up chain depth limit was reached.';
               needsHuman = true;
+              policyAction = 'needs-human';
+              policyTrigger = 'chain-depth-limit';
+              policyReason = reason;
             } else if (process.env.NEEDS_HUMAN === 'true') {
               disposition = 'needs-human-verdict-policy';
               reason = process.env.NEEDS_HUMAN_REASON || 'Verdict policy requested human review.';
               needsHuman = true;
+              policyAction = 'needs-human';
+              policyTrigger = 'verdict-policy';
+              policyReason = reason;
             } else if (!process.env.FOLLOWUP_ISSUE_NUMBER) {
               disposition = 'no-follow-up-created';
               reason = 'Workflow completed without a follow-up issue output.';
+              policyAction = 'skip-follow-up';
+              policyTrigger = 'missing-follow-up-output';
+              policyReason = reason;
             } else if (dispatchOutcome === 'success') {
               reason = 'Verification follow-up issue was created and auto-pilot was dispatched.';
+              policyReason = reason;
             } else if (dispatchOutcome === 'failure' || dispatchOutcome === 'cancelled') {
               reason = `Verification follow-up issue was created, but auto-pilot dispatch ${dispatchOutcome}.`;
+              policyReason = reason;
             } else if (dispatchOutcome === 'skipped') {
               reason = 'Verification follow-up issue was created; auto-pilot dispatch was skipped.';
+              policyReason = reason;
             } else if (followupIssue) {
               reason = 'Verification follow-up issue was created; auto-pilot dispatch status was not reported.';
+              policyReason = reason;
             }
 
             const record = normalizeTerminalDisposition({
@@ -931,6 +959,44 @@ jobs:
               'agent-metrics/verifier-terminal-disposition.ndjson',
               `${JSON.stringify(record)}\n`
             );
+
+            let concernsHash = '';
+            try {
+              const raw = fs.readFileSync('verification_data.txt', 'utf8');
+              if (raw.trim()) {
+                concernsHash = crypto.createHash('sha256').update(raw).digest('hex');
+              }
+            } catch (_) { /* best effort */ }
+            const ledgerRecord = normalizeVerifierFollowupLedger({
+              pr_number: prNumber,
+              verification_run_id: context.runId,
+              verification_run_attempt: context.runAttempt,
+              verdict: process.env.VERDICT || undefined,
+              terminal_state: disposition,
+              concerns_hash: concernsHash || undefined,
+              followup_issue_number: followupIssue || undefined,
+              followup_issue_url: process.env.FOLLOWUP_ISSUE_URL || undefined,
+              source_issue_numbers: sourceIssue ? [sourceIssue] : [],
+              chain_depth: chainDepth,
+              followup_policy: {
+                action: policyAction,
+                trigger: policyTrigger,
+                reason: policyReason,
+                chain_depth: chainDepth,
+                max_chain_depth: maxChainDepth,
+                next_chain_depth: policyAction === 'create-follow-up' ? chainDepth + 1 : undefined,
+                depth_limit_exceeded: process.env.CHAIN_EXCEEDED === 'true',
+              },
+              workflow: context.workflow,
+              actor: context.actor,
+              terminal_disposition_artifact: `verifier-terminal-disposition-${context.runId}`,
+              dispatch_outcome: dispatchOutcome || undefined,
+              needs_human: needsHuman,
+            });
+            fs.writeFileSync(
+              'agent-metrics/verifier-followup-ledger.ndjson',
+              `${JSON.stringify(ledgerRecord)}\n`
+            );
             const markdown = formatTerminalDispositionMarkdown([record]);
             fs.writeFileSync('terminal-disposition-summary.md', `${markdown}\n`);
             await core.summary
@@ -940,17 +1006,18 @@ jobs:
 
       - name: Upload terminal disposition artifact
         if: always() && steps.check-merged.outputs.merged == 'true'
-        uses: actions/upload-artifact@65ecb0ca2d3e252f7b82842cd0489c883189f7d0 # v7
+        uses: actions/upload-artifact@v7
         with:
           name: verifier-terminal-disposition-${{ github.run_id }}
           path: |
             agent-metrics/verifier-terminal-disposition.ndjson
+            agent-metrics/verifier-followup-ledger.ndjson
             terminal-disposition-summary.md
           retention-days: 14
 
       - name: Remove trigger label
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         continue-on-error: true
         with:
           github-token: ${{ steps.select-token.outputs.token }}

--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -39,6 +39,7 @@ jobs:
             .github/scripts/terminal_disposition_coverage.js
             .github/scripts/token_load_balancer.js
             .github/scripts/weekly_metrics_artifacts.js
+            .github/scripts/weekly_metrics_download_manifest.js
             scripts/aggregate_agent_metrics.py
           sparse-checkout-cone-mode: false
 
@@ -73,21 +74,38 @@ jobs:
           artifact_list="artifacts/metric-artifacts.tsv"
           selection_report="artifacts/metric-artifacts-selection.json"
           selection_markdown="artifacts/metric-artifacts-selection.md"
+          download_manifest="artifacts/metric-artifact-download-manifest.json"
+          download_manifest_markdown="artifacts/metric-artifact-download-manifest.md"
+          set +e
           node .github/scripts/weekly_metrics_artifacts.js \
             --output "$artifact_list" \
             --report "$selection_report" \
             --markdown "$selection_markdown"
-          cat "$selection_report"
+          selector_status=$?
+          set -e
+          if [ -f "$selection_report" ]; then
+            cat "$selection_report"
+          fi
+          node .github/scripts/weekly_metrics_download_manifest.js \
+            --init \
+            --selection "$selection_report" \
+            --manifest "$download_manifest" \
+            --markdown "$download_manifest_markdown"
+          if [ "$selector_status" != "0" ]; then
+            exit "$selector_status"
+          fi
           if [ ! -s "$artifact_list" ]; then
             echo "No metrics artifacts found"
           fi
           while IFS=$'\t' read -r id name; do
             echo "Downloading artifact $id ($name)"
-            mkdir -p "artifacts/$name"
+            safe_name="$(node -e 'const name = process.argv[1] || ""; const safe = name.trim().replace(/[\\\\/]+/g, "_").replace(/[^A-Za-z0-9._-]/g, "_").replace(/\.\.+/g, "_").replace(/^\.{1,2}$/, "_") || "unknown"; process.stdout.write(safe);' "$name")"
+            artifact_dir="artifacts/$safe_name/$id"
+            mkdir -p "$artifact_dir"
             # shellcheck disable=SC1009,SC1073,SC1039,SC1072
             export ARTIFACT_ID="$id"
-            export ARTIFACT_DIR="artifacts/$name"
-            export ARTIFACT_ZIP="artifacts/$name/$id.zip"
+            export ARTIFACT_DIR="$artifact_dir"
+            export ARTIFACT_ZIP="$artifact_dir/$id.zip"
             if ! node - <<'NODE'
           const fs = require('fs');
           const { Octokit } = require('@octokit/rest');
@@ -125,16 +143,59 @@ jobs:
           NODE
             then
               echo "Warning: Could not download artifact $id ($name)"
+              node .github/scripts/weekly_metrics_download_manifest.js \
+                --record \
+                --manifest "$download_manifest" \
+                --markdown "$download_manifest_markdown" \
+                --id "$id" \
+                --name "$name" \
+                --artifact-dir "$ARTIFACT_DIR" \
+                --zip-path "$ARTIFACT_ZIP" \
+                --download-status failed \
+                --download-error download-command-failed \
+                --unzip-status skipped \
+                --unzip-error download-failed
               continue
             fi
-            unzip -o "artifacts/$name/$id.zip" -d "artifacts/$name" >/dev/null || \
+            zip_bytes="$(wc -c < "$ARTIFACT_ZIP" | tr -d ' ')"
+            if unzip -o "$ARTIFACT_ZIP" -d "$ARTIFACT_DIR" >/dev/null; then
+              node .github/scripts/weekly_metrics_download_manifest.js \
+                --record \
+                --manifest "$download_manifest" \
+                --markdown "$download_manifest_markdown" \
+                --id "$id" \
+                --name "$name" \
+                --artifact-dir "$ARTIFACT_DIR" \
+                --zip-path "$ARTIFACT_ZIP" \
+                --zip-bytes "$zip_bytes" \
+                --download-status pass \
+                --unzip-status pass
+            else
               echo "Warning: Could not unzip artifact $id ($name)"
+              node .github/scripts/weekly_metrics_download_manifest.js \
+                --record \
+                --manifest "$download_manifest" \
+                --markdown "$download_manifest_markdown" \
+                --id "$id" \
+                --name "$name" \
+                --artifact-dir "$ARTIFACT_DIR" \
+                --zip-path "$ARTIFACT_ZIP" \
+                --zip-bytes "$zip_bytes" \
+                --download-status pass \
+                --unzip-status failed \
+                --unzip-error unzip-command-failed
+            fi
           done < "$artifact_list"
+          node .github/scripts/weekly_metrics_download_manifest.js \
+            --finalize \
+            --manifest "$download_manifest" \
+            --markdown "$download_manifest_markdown"
 
       - name: Aggregate metrics
         env:
           METRICS_DIR: artifacts
           OUTPUT_PATH: agent-weekly-metrics.md
+          OUTPUT_JSON_PATH: agent-weekly-metrics.json
         run: |
           python scripts/aggregate_agent_metrics.py
 
@@ -146,6 +207,15 @@ jobs:
               {
                 printf '\n'
                 cat artifacts/metric-artifacts-selection.md
+              } >> agent-weekly-metrics.md
+            fi
+          fi
+          if [ -f artifacts/metric-artifact-download-manifest.md ]; then
+            cat artifacts/metric-artifact-download-manifest.md >> "$GITHUB_STEP_SUMMARY"
+            if [ -f agent-weekly-metrics.md ]; then
+              {
+                printf '\n'
+                cat artifacts/metric-artifact-download-manifest.md
               } >> agent-weekly-metrics.md
             fi
           fi
@@ -228,8 +298,11 @@ jobs:
           name: agent-weekly-metrics
           path: |
             agent-weekly-metrics.md
+            agent-weekly-metrics.json
             artifacts/metric-artifacts-selection.json
             artifacts/metric-artifacts-selection.md
+            artifacts/metric-artifact-download-manifest.json
+            artifacts/metric-artifact-download-manifest.md
             terminal-disposition-coverage.json
             terminal-disposition-coverage.md
             bot-comment-auth-coverage-summary.json

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -6,14 +6,71 @@ from __future__ import annotations
 import datetime as _dt
 import json
 import os
+import re
 import sys
 from collections import Counter
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 _DEFAULT_METRICS_DIR = "agent-metrics"
 _DEFAULT_OUTPUT = "agent-metrics-summary.md"
+_DEFAULT_JSON_OUTPUT = "agent-metrics-summary.json"
+_DEFAULT_DOWNLOAD_MANIFEST_PATH = "artifacts/metric-artifact-download-manifest.json"
+_DEFAULT_UNSUPPORTED_VERIFIER_MODELS = {"gpt-5.2-codex"}
+_DEFAULT_VERIFIER_MODEL_METADATA_REQUIRED_AFTER = ""
+_EXACT_ARTIFACT_FAMILIES = {
+    "keepalive-metrics",
+    "agents-autofix-metrics",
+    "agents-verifier-metrics",
+    "agents-verifier-disposition-metrics",
+}
+_PREFIXED_ARTIFACT_FAMILIES = (
+    "autopilot-metrics-",
+    "issue-optimizer-metrics-",
+    "issue-intake-format-metrics-",
+    "verifier-terminal-disposition-",
+    "review-thread-terminal-disposition-",
+)
+_PATTERNED_ARTIFACT_FAMILIES = (
+    (
+        "bot-comment-auth-coverage-wrapper",
+        re.compile(r"^bot-comment-auth-coverage-wrapper(?:-[A-Za-z0-9][A-Za-z0-9._-]*)?$"),
+    ),
+    (
+        "bot-comment-auth-coverage-reusable",
+        re.compile(r"^bot-comment-auth-coverage-reusable(?:-[A-Za-z0-9][A-Za-z0-9._-]*)?$"),
+    ),
+)
+_MAX_PARSE_ERROR_ROWS = 25
+_MAX_LEGACY_JSON_FALLBACK_LINES = 5000
+_MAX_LEGACY_JSON_FALLBACK_BYTES = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ParseErrorDetail:
+    path: str
+    artifact: str
+    artifact_family: str
+    line: int | None
+    reason: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "artifact": self.artifact,
+            "artifact_family": self.artifact_family,
+            "line": self.line,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class MetricSource:
+    path: str
+    artifact: str
+    artifact_family: str
 
 
 def _parse_timestamp(value: Any) -> _dt.datetime | None:
@@ -50,29 +107,133 @@ def _gather_metrics_files(metrics_paths: list[str], metrics_dir: str) -> list[Pa
     return sorted(path for path in root.rglob("*.ndjson") if path.is_file())
 
 
-def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], int]:
+def _artifact_family(artifact: str) -> str:
+    if artifact in _EXACT_ARTIFACT_FAMILIES:
+        return artifact
+    for family, pattern in _PATTERNED_ARTIFACT_FAMILIES:
+        if pattern.match(artifact):
+            return family
+    for prefix in _PREFIXED_ARTIFACT_FAMILIES:
+        if artifact.startswith(prefix):
+            return prefix.rstrip("-")
+    return "unknown"
+
+
+def _is_artifact_id_segment(value: str) -> bool:
+    return bool(value) and value.isdigit()
+
+
+def _infer_artifact_name(path: Path) -> str:
+    parts = path.parts
+    for index, part in enumerate(parts):
+        if part == "agent-metrics" and index > 0:
+            candidate = parts[index - 1]
+            if _is_artifact_id_segment(candidate) and index > 1:
+                return parts[index - 2]
+            return candidate
+    parent = path.parent.name
+    if _is_artifact_id_segment(parent) and path.parent.parent.name:
+        return path.parent.parent.name
+    if path.parent.name:
+        return path.parent.name
+    return "unknown"
+
+
+def _metric_source(path: Path) -> MetricSource:
+    artifact = _infer_artifact_name(path)
+    return MetricSource(
+        path=path.as_posix(),
+        artifact=artifact,
+        artifact_family=_artifact_family(artifact),
+    )
+
+
+def _attach_metric_source(entry: dict[str, Any], path: Path) -> dict[str, Any]:
+    source = _metric_source(path)
+    enriched = dict(entry)
+    enriched.setdefault("artifact_name", source.artifact)
+    enriched.setdefault("artifact_family", source.artifact_family)
+    enriched.setdefault("metric_artifact", source.artifact)
+    enriched.setdefault("metric_artifact_family", source.artifact_family)
+    enriched.setdefault("metric_path", source.path)
+    return enriched
+
+
+def _parse_error_detail(path: Path, line: int | None, reason: str) -> ParseErrorDetail:
+    source = _metric_source(path)
+    return ParseErrorDetail(
+        path=source.path,
+        artifact=source.artifact,
+        artifact_family=source.artifact_family,
+        line=line,
+        reason=reason,
+    )
+
+
+def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], list[ParseErrorDetail]]:
     entries: list[dict[str, Any]] = []
-    errors = 0
+    errors: list[ParseErrorDetail] = []
     for path in files:
         try:
             handle = path.open("r", encoding="utf-8")
         except OSError:
-            errors += 1
+            errors.append(_parse_error_detail(path, None, "unreadable-file"))
             continue
+        file_entries: list[dict[str, Any]] = []
+        file_errors: list[ParseErrorDetail] = []
+        raw_lines_for_fallback: list[str] = []
+        raw_fallback_bytes = 0
+        raw_fallback_truncated = False
         with handle:
-            for line in handle:
+            for line_number, line in enumerate(handle, start=1):
                 raw = line.strip()
                 if not raw:
                     continue
+                if not file_entries and not raw_fallback_truncated:
+                    raw_bytes = len(raw.encode("utf-8")) + 1
+                    fallback_within_limit = (
+                        len(raw_lines_for_fallback) < _MAX_LEGACY_JSON_FALLBACK_LINES
+                        and raw_fallback_bytes + raw_bytes <= _MAX_LEGACY_JSON_FALLBACK_BYTES
+                    )
+                    if fallback_within_limit:
+                        raw_fallback_bytes += raw_bytes
+                        raw_lines_for_fallback.append(raw)
+                    else:
+                        raw_fallback_truncated = True
+                        raw_lines_for_fallback = []
                 try:
                     parsed = json.loads(raw)
                 except json.JSONDecodeError:
-                    errors += 1
+                    file_errors.append(_parse_error_detail(path, line_number, "invalid-json"))
                     continue
                 if isinstance(parsed, dict):
-                    entries.append(parsed)
+                    file_entries.append(_attach_metric_source(parsed, path))
+                    raw_lines_for_fallback = []
                 else:
-                    errors += 1
+                    file_errors.append(_parse_error_detail(path, line_number, "non-object-json"))
+        if file_errors and not file_entries and raw_fallback_truncated:
+            file_errors.append(_parse_error_detail(path, None, "legacy-json-fallback-buffer-limit"))
+        if (
+            file_errors
+            and not file_entries
+            and raw_lines_for_fallback
+            and not raw_fallback_truncated
+        ):
+            try:
+                parsed_file = json.loads("\n".join(raw_lines_for_fallback))
+            except json.JSONDecodeError:
+                pass
+            else:
+                if isinstance(parsed_file, dict):
+                    file_entries.append(_attach_metric_source(parsed_file, path))
+                    file_errors = []
+                elif isinstance(parsed_file, list) and all(
+                    isinstance(item, dict) for item in parsed_file
+                ):
+                    file_entries.extend(_attach_metric_source(item, path) for item in parsed_file)
+                    file_errors = []
+        entries.extend(file_entries)
+        errors.extend(file_errors)
     return entries, errors
 
 
@@ -80,6 +241,8 @@ def _classify_entry(entry: dict[str, Any]) -> str:
     schema = entry.get("schema")
     if schema == "workflows-terminal-disposition/v1":
         return "terminal_disposition"
+    if schema == "workflows-verifier-followup-ledger/v1":
+        return "verifier_followup_ledger"
     explicit = entry.get("metric_type") or entry.get("type") or entry.get("workflow")
     if isinstance(explicit, str):
         lowered = explicit.lower()
@@ -121,6 +284,66 @@ def _safe_int(value: Any) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def _unsupported_verifier_models() -> set[str]:
+    raw = ""
+    for env_name in (
+        "UNSUPPORTED_VERIFIER_MODELS",
+        "TERMINAL_DISPOSITION_UNSUPPORTED_CODEX_MODELS",
+    ):
+        candidate = os.environ.get(env_name, "")
+        if candidate.strip():
+            raw = candidate
+            break
+    if not raw:
+        return set(_DEFAULT_UNSUPPORTED_VERIFIER_MODELS)
+    return {item.strip().lower() for item in raw.split(",") if item.strip()}
+
+
+def _verifier_model_metadata_required_after() -> _dt.datetime | None:
+    raw = (
+        os.environ.get("TERMINAL_DISPOSITION_VERIFIER_MODEL_METADATA_REQUIRED_AFTER")
+        or os.environ.get("VERIFIER_MODEL_METADATA_REQUIRED_AFTER")
+        or _DEFAULT_VERIFIER_MODEL_METADATA_REQUIRED_AFTER
+    ).strip()
+    if raw.lower() in {"", "0", "false", "none", "off", "disabled"}:
+        return None
+    return _parse_timestamp(raw)
+
+
+def _verifier_model_metadata_required() -> bool:
+    raw = (
+        os.environ.get("TERMINAL_DISPOSITION_VERIFIER_MODEL_METADATA_REQUIRED_AFTER")
+        or os.environ.get("VERIFIER_MODEL_METADATA_REQUIRED_AFTER")
+        or _DEFAULT_VERIFIER_MODEL_METADATA_REQUIRED_AFTER
+    ).strip()
+    return raw.lower() not in {"", "0", "false", "none", "off", "disabled"}
+
+
+def _is_pre_contract_verifier_model_record(
+    entry: dict[str, Any], required_after: _dt.datetime | None
+) -> bool:
+    if required_after is None:
+        return False
+    for key in ("created_at", "timestamp", "run_started_at", "time"):
+        timestamp = _parse_timestamp(entry.get(key))
+        if timestamp is not None:
+            return timestamp < required_after
+    return False
+
+
+def _is_verifier_terminal_entry(entry: dict[str, Any]) -> bool:
+    if entry.get("schema") != "workflows-terminal-disposition/v1":
+        return False
+    artifact_family = str(entry.get("artifact_family") or "").strip().lower()
+    workflow = str(entry.get("workflow") or "").strip().lower()
+    verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
+    return (
+        artifact_family == "verifier-terminal-disposition"
+        or bool(verifier_mode)
+        or "verifier" in workflow
+    )
 
 
 def _summarise_keepalive(entries: list[dict[str, Any]]) -> dict[str, Any]:
@@ -194,10 +417,32 @@ def _summarise_autofix(entries: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
+def _summarise_verifier(
+    entries: list[dict[str, Any]],
+    ledger_entries: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     verdicts = Counter()
     terminal_dispositions = Counter()
     terminal_sources = Counter()
+    verifier_models = Counter()
+    model_selection_reasons = Counter()
+    unsupported_verifier_models = Counter()
+    unsupported_model_dispositions = Counter()
+    missing_verifier_model_metadata = Counter()
+    unsupported_models = _unsupported_verifier_models()
+    model_metadata_required = _verifier_model_metadata_required()
+    model_metadata_required_after = _verifier_model_metadata_required_after()
+    legacy_missing_verifier_model_metadata = Counter()
+    verifier_modes = Counter()
+    ledger_dispositions = Counter()
+    ledger_followup_issues: set[int] = set()
+    ledger_prs: set[int] = set()
+    ledger_needs_human = 0
+    ledger_chain_depths: list[int] = []
+    ledger_policy_records = 0
+    ledger_policy_actions = Counter()
+    ledger_policy_triggers = Counter()
+    ledger_policy_depth_limit_exceeded = 0
     verifier_run_keys: set[str] = set()
     prs: set[int] = set()
     issues_created = 0
@@ -205,6 +450,7 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
     terminal_records = 0
     for index, entry in enumerate(entries):
         is_terminal_disposition = entry.get("schema") == "workflows-terminal-disposition/v1"
+        is_verifier_terminal = _is_verifier_terminal_entry(entry)
         if not is_terminal_disposition:
             run_id = entry.get("run_id") or entry.get("workflow_run_id")
             run_attempt = entry.get("run_attempt")
@@ -226,6 +472,31 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
             source_type = entry.get("source_type") or "unknown"
             source_id = entry.get("source_id") or "unknown"
             terminal_sources[f"{source_type}:{source_id}"] += 1
+        model = entry.get("codex_model") or entry.get("llm_model") or entry.get("model")
+        model_text = str(model).strip() if model is not None else ""
+        if model_text:
+            normalized_model_text = model_text.lower()
+            verifier_models[normalized_model_text] += 1
+            if normalized_model_text in unsupported_models:
+                unsupported_verifier_models[normalized_model_text] += 1
+                disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"
+                unsupported_model_dispositions[str(disposition)] += 1
+        elif is_verifier_terminal and model_metadata_required:
+            verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
+            if verifier_mode and verifier_mode != "evaluate":
+                disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"
+                if _is_pre_contract_verifier_model_record(entry, model_metadata_required_after):
+                    legacy_missing_verifier_model_metadata[str(disposition)] += 1
+                else:
+                    missing_verifier_model_metadata[str(disposition)] += 1
+        model_selection_reason = entry.get("codex_model_selection_reason") or entry.get(
+            "model_selection_reason"
+        )
+        if model_selection_reason:
+            model_selection_reasons[str(model_selection_reason)] += 1
+        verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
+        if verifier_mode:
+            verifier_modes[verifier_mode] += 1
         pr_number = _safe_int(entry.get("pr_number") or entry.get("pr"))
         if pr_number is not None:
             prs.add(pr_number)
@@ -235,7 +506,33 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
         acceptance = _safe_int(entry.get("acceptance_criteria_count"))
         if acceptance is not None:
             acceptance_counts.append(acceptance)
+    for entry in ledger_entries or []:
+        disposition = str(entry.get("disposition") or "unknown")
+        ledger_dispositions[disposition] += 1
+        pr_number = _safe_int(entry.get("pr_number") or entry.get("pr"))
+        if pr_number is not None:
+            ledger_prs.add(pr_number)
+        followup_issue = _safe_int(entry.get("followup_issue_number"))
+        if followup_issue is not None:
+            ledger_followup_issues.add(followup_issue)
+        if bool(entry.get("needs_human")) or disposition == "needs-human":
+            ledger_needs_human += 1
+        chain_depth = _safe_int(entry.get("chain_depth"))
+        if chain_depth is not None:
+            ledger_chain_depths.append(chain_depth)
+        policy = entry.get("followup_policy")
+        if isinstance(policy, dict):
+            ledger_policy_records += 1
+            action = str(policy.get("action") or "unknown")
+            trigger = str(policy.get("trigger") or "unknown")
+            ledger_policy_actions[action] += 1
+            ledger_policy_triggers[trigger] += 1
+            if policy.get("depth_limit_exceeded") in (True, "true", "True", "1", 1):
+                ledger_policy_depth_limit_exceeded += 1
     avg_acceptance = sum(acceptance_counts) / len(acceptance_counts) if acceptance_counts else 0.0
+    avg_ledger_chain_depth = (
+        sum(ledger_chain_depths) / len(ledger_chain_depths) if ledger_chain_depths else 0.0
+    )
     return {
         "runs": len(verifier_run_keys),
         "prs": len(prs),
@@ -245,6 +542,24 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
         "terminal_records": terminal_records,
         "terminal_dispositions": terminal_dispositions,
         "terminal_sources": terminal_sources,
+        "verifier_models": verifier_models,
+        "unsupported_verifier_models": unsupported_verifier_models,
+        "unsupported_model_dispositions": unsupported_model_dispositions,
+        "missing_verifier_model_metadata": missing_verifier_model_metadata,
+        "legacy_missing_verifier_model_metadata": legacy_missing_verifier_model_metadata,
+        "model_selection_reasons": model_selection_reasons,
+        "verifier_modes": verifier_modes,
+        "ledger_records": len(ledger_entries or []),
+        "ledger_dispositions": ledger_dispositions,
+        "ledger_prs": len(ledger_prs),
+        "ledger_followup_issues": len(ledger_followup_issues),
+        "ledger_needs_human": ledger_needs_human,
+        "ledger_avg_chain_depth": avg_ledger_chain_depth,
+        "ledger_max_chain_depth": max(ledger_chain_depths) if ledger_chain_depths else 0,
+        "ledger_policy_records": ledger_policy_records,
+        "ledger_policy_actions": ledger_policy_actions,
+        "ledger_policy_triggers": ledger_policy_triggers,
+        "ledger_policy_depth_limit_exceeded": ledger_policy_depth_limit_exceeded,
     }
 
 
@@ -340,6 +655,12 @@ def _format_counter(counter: Counter[str]) -> str:
     return ", ".join(parts)
 
 
+def _markdown_table_cell(value: Any) -> str:
+    text = str(value).replace("\r\n", "\n").replace("\r", "\n")
+    text = " ".join(part.strip() for part in text.split("\n"))
+    return text.replace("|", "\\|")
+
+
 def _format_rate(numerator: int, denominator: int) -> str:
     if denominator <= 0:
         return "n/a"
@@ -347,20 +668,186 @@ def _format_rate(numerator: int, denominator: int) -> str:
     return f"{rate:.1f}% ({numerator}/{denominator})"
 
 
-def build_summary(entries: list[dict[str, Any]], errors: int) -> str:
+def _json_contract_value(value: Any) -> Any:
+    if isinstance(value, Counter):
+        return dict(sorted(value.items()))
+    if isinstance(value, dict):
+        return {str(key): _json_contract_value(item) for key, item in sorted(value.items())}
+    if isinstance(value, list):
+        return [_json_contract_value(item) for item in value]
+    return value
+
+
+def _bucket_entries(entries: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
     buckets: dict[str, list[dict[str, Any]]] = {
         "keepalive": [],
         "autofix": [],
         "verifier": [],
         "terminal_disposition": [],
+        "verifier_followup_ledger": [],
         "autopilot": [],
         "unknown": [],
     }
-    timestamps: list[_dt.datetime] = []
-
     for entry in entries:
         bucket = _classify_entry(entry)
         buckets.setdefault(bucket, []).append(entry)
+    return buckets
+
+
+def _summary_metrics_contract(buckets: dict[str, list[dict[str, Any]]]) -> dict[str, Any]:
+    return _json_contract_value(
+        {
+            "keepalive": _summarise_keepalive(buckets["keepalive"]),
+            "autofix": _summarise_autofix(buckets["autofix"]),
+            "verifier": _summarise_verifier(
+                buckets["verifier"] + buckets["terminal_disposition"],
+                buckets["verifier_followup_ledger"],
+            ),
+            "autopilot": _summarise_autopilot(buckets["autopilot"]),
+            "unknown": {"records": len(buckets["unknown"])},
+        }
+    )
+
+
+def _format_parse_error_details(parse_error_details: list[ParseErrorDetail]) -> list[str]:
+    if not parse_error_details:
+        return []
+    family_counts = Counter(detail.artifact_family for detail in parse_error_details)
+    artifact_counts = Counter(detail.artifact for detail in parse_error_details)
+    lines = [
+        "",
+        "## Parse Error Details",
+        f"- By artifact family: {_format_counter(family_counts)}",
+        f"- By artifact: {_format_counter(artifact_counts)}",
+        "",
+        "| Artifact family | Artifact | File | Line | Reason |",
+        "|-----------------|----------|------|------|--------|",
+    ]
+    for detail in parse_error_details[:_MAX_PARSE_ERROR_ROWS]:
+        line = str(detail.line) if detail.line is not None else "n/a"
+        lines.append(
+            "| "
+            f"{_markdown_table_cell(detail.artifact_family)} | "
+            f"{_markdown_table_cell(detail.artifact)} | "
+            f"{_markdown_table_cell(detail.path)} | "
+            f"{_markdown_table_cell(line)} | "
+            f"{_markdown_table_cell(detail.reason)} |"
+        )
+    remaining = len(parse_error_details) - _MAX_PARSE_ERROR_ROWS
+    if remaining > 0:
+        lines.append("")
+        lines.append(f"- Additional parse errors omitted from table: {remaining}")
+    return lines
+
+
+def _parse_error_contract(parse_error_details: list[ParseErrorDetail]) -> dict[str, Any]:
+    family_counts = Counter(detail.artifact_family for detail in parse_error_details)
+    artifact_counts = Counter(detail.artifact for detail in parse_error_details)
+    reason_counts = Counter(detail.reason for detail in parse_error_details)
+    details = [detail.as_dict() for detail in parse_error_details[:_MAX_PARSE_ERROR_ROWS]]
+    omitted_count = max(0, len(parse_error_details) - len(details))
+    return {
+        "count": len(parse_error_details),
+        "by_artifact_family": dict(sorted(family_counts.items())),
+        "by_artifact": dict(sorted(artifact_counts.items())),
+        "by_reason": dict(sorted(reason_counts.items())),
+        "details": details,
+        "details_truncated": omitted_count > 0,
+        "omitted_count": omitted_count,
+    }
+
+
+def _metric_source_contract(entries: list[dict[str, Any]]) -> dict[str, Any]:
+    family_counts = Counter(
+        str(entry.get("metric_artifact_family") or entry.get("artifact_family") or "unknown")
+        for entry in entries
+    )
+    artifact_counts = Counter(
+        str(entry.get("metric_artifact") or entry.get("artifact_name") or "unknown")
+        for entry in entries
+    )
+    file_counts = Counter(str(entry.get("metric_path") or "unknown") for entry in entries)
+    return {
+        "by_artifact_family": dict(sorted(family_counts.items())),
+        "by_artifact": dict(sorted(artifact_counts.items())),
+        "by_file": dict(sorted(file_counts.items())),
+    }
+
+
+def _artifact_download_contract(manifest: dict[str, Any], manifest_path: Path) -> dict[str, Any]:
+    artifacts = manifest.get("artifacts")
+    failed_artifacts: list[dict[str, Any]] = []
+    pending_artifacts: list[dict[str, Any]] = []
+    if isinstance(artifacts, list):
+        for artifact in artifacts:
+            if not isinstance(artifact, dict):
+                continue
+            download_status = str((artifact.get("download") or {}).get("status") or "pending")
+            unzip_status = str((artifact.get("unzip") or {}).get("status") or "pending")
+            entry = {
+                "id": artifact.get("id"),
+                "name": artifact.get("name") or "unknown",
+                "family": artifact.get("family") or "unknown",
+                "artifact_dir": artifact.get("artifact_dir") or "",
+                "download_status": download_status,
+                "unzip_status": unzip_status,
+                "download_error": (artifact.get("download") or {}).get("error") or "",
+                "unzip_error": (artifact.get("unzip") or {}).get("error") or "",
+            }
+            if download_status == "failed" or unzip_status == "failed":
+                failed_artifacts.append(entry)
+            elif download_status == "pending" or unzip_status == "pending":
+                pending_artifacts.append(entry)
+    return {
+        "schema": manifest.get("schema") or "unknown",
+        "path": manifest_path.as_posix(),
+        "status": manifest.get("status") or "unknown",
+        "selection": manifest.get("selection") or {},
+        "stats": manifest.get("stats") or {},
+        "failed_artifacts": failed_artifacts,
+        "pending_artifacts": pending_artifacts,
+    }
+
+
+def _read_artifact_download_contract(manifest_path: Path) -> dict[str, Any] | None:
+    if not manifest_path.exists():
+        return None
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {
+            "schema": "workflows-weekly-metrics-artifact-download-manifest/v1",
+            "path": manifest_path.as_posix(),
+            "status": "error",
+            "error_message": str(exc),
+            "selection": {},
+            "stats": {},
+            "failed_artifacts": [],
+            "pending_artifacts": [],
+        }
+    if not isinstance(manifest, dict):
+        return {
+            "schema": "workflows-weekly-metrics-artifact-download-manifest/v1",
+            "path": manifest_path.as_posix(),
+            "status": "error",
+            "error_message": "manifest-not-object",
+            "selection": {},
+            "stats": {},
+            "failed_artifacts": [],
+            "pending_artifacts": [],
+        }
+    return _artifact_download_contract(manifest, manifest_path)
+
+
+def build_summary(
+    entries: list[dict[str, Any]],
+    errors: int,
+    parse_error_details: list[ParseErrorDetail] | None = None,
+) -> str:
+    buckets = _bucket_entries(entries)
+    timestamps: list[_dt.datetime] = []
+
+    for entry in entries:
         for key in ("timestamp", "created_at", "time", "run_started_at"):
             ts = _parse_timestamp(entry.get(key))
             if ts is not None:
@@ -369,7 +856,10 @@ def build_summary(entries: list[dict[str, Any]], errors: int) -> str:
 
     keepalive = _summarise_keepalive(buckets["keepalive"])
     autofix = _summarise_autofix(buckets["autofix"])
-    verifier = _summarise_verifier(buckets["verifier"] + buckets["terminal_disposition"])
+    verifier = _summarise_verifier(
+        buckets["verifier"] + buckets["terminal_disposition"],
+        buckets["verifier_followup_ledger"],
+    )
     autopilot = _summarise_autopilot(buckets["autopilot"])
 
     now = _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
@@ -382,6 +872,7 @@ def build_summary(entries: list[dict[str, Any]], errors: int) -> str:
             f"(keepalive {keepalive['runs']}, autofix {autofix['attempts']}, "
             f"verifier {verifier['runs']}, "
             f"terminal dispositions {verifier['terminal_records']}, "
+            f"verifier follow-up ledgers {verifier['ledger_records']}, "
             f"autopilot {autopilot['records']}, "
             f"unknown {len(buckets['unknown'])})"
         ),
@@ -392,6 +883,9 @@ def build_summary(entries: list[dict[str, Any]], errors: int) -> str:
         earliest = min(timestamps).isoformat().replace("+00:00", "Z")
         latest = max(timestamps).isoformat().replace("+00:00", "Z")
         lines.append(f"Range: {earliest} to {latest}")
+
+    if parse_error_details:
+        lines.extend(_format_parse_error_details(parse_error_details))
 
     lines.extend(
         [
@@ -421,6 +915,39 @@ def build_summary(entries: list[dict[str, Any]], errors: int) -> str:
             f"- Terminal disposition records: {verifier['terminal_records']}",
             f"- Terminal dispositions: {_format_counter(verifier['terminal_dispositions'])}",
             f"- Terminal disposition sources: {_format_counter(verifier['terminal_sources'])}",
+            f"- Verifier follow-up ledger records: {verifier['ledger_records']}",
+            f"- Verifier follow-up ledger dispositions: {_format_counter(verifier['ledger_dispositions'])}",
+            f"- Verifier follow-up ledger PRs: {verifier['ledger_prs']}",
+            f"- Verifier follow-up issues linked: {verifier['ledger_followup_issues']}",
+            f"- Verifier follow-up needs-human records: {verifier['ledger_needs_human']}",
+            f"- Verifier follow-up avg chain depth: {verifier['ledger_avg_chain_depth']:.1f}",
+            f"- Verifier follow-up max chain depth: {verifier['ledger_max_chain_depth']}",
+            f"- Verifier follow-up policy records: {verifier['ledger_policy_records']}",
+            f"- Verifier follow-up policy actions: {_format_counter(verifier['ledger_policy_actions'])}",
+            (
+                "- Verifier follow-up policy triggers: "
+                f"{_format_counter(verifier['ledger_policy_triggers'])}"
+            ),
+            (
+                "- Verifier follow-up depth-limit records: "
+                f"{verifier['ledger_policy_depth_limit_exceeded']}"
+            ),
+            f"- Verifier models: {_format_counter(verifier['verifier_models'])}",
+            f"- Unsupported verifier models: {_format_counter(verifier['unsupported_verifier_models'])}",
+            (
+                "- Unsupported model dispositions: "
+                f"{_format_counter(verifier['unsupported_model_dispositions'])}"
+            ),
+            (
+                "- Missing verifier model metadata: "
+                f"{_format_counter(verifier['missing_verifier_model_metadata'])}"
+            ),
+            (
+                "- Legacy missing verifier model metadata: "
+                f"{_format_counter(verifier['legacy_missing_verifier_model_metadata'])}"
+            ),
+            f"- Model selection reasons: {_format_counter(verifier['model_selection_reasons'])}",
+            f"- Verifier modes: {_format_counter(verifier['verifier_modes'])}",
         ]
     )
 
@@ -461,25 +988,85 @@ def build_summary(entries: list[dict[str, Any]], errors: int) -> str:
     return "\n".join(lines) + "\n"
 
 
+def build_summary_contract(
+    entries: list[dict[str, Any]],
+    parse_error_details: list[ParseErrorDetail],
+    artifact_downloads: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    entry_buckets = _bucket_entries(entries)
+    buckets: dict[str, int] = Counter(
+        name for name, bucket_entries in entry_buckets.items() for _ in bucket_entries
+    )
+    timestamps: list[_dt.datetime] = []
+    for entry in entries:
+        for key in ("timestamp", "created_at", "time", "run_started_at"):
+            ts = _parse_timestamp(entry.get(key))
+            if ts is not None:
+                timestamps.append(ts)
+                break
+    generated_at = (
+        _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+    contract: dict[str, Any] = {
+        "schema": "workflows-agent-metrics-summary/v1",
+        "generated_at": generated_at,
+        "record_count": len(entries),
+        "record_buckets": dict(sorted(buckets.items())),
+        "metric_sources": _metric_source_contract(entries),
+        "parse_errors": _parse_error_contract(parse_error_details),
+        "summaries": _summary_metrics_contract(entry_buckets),
+    }
+    if artifact_downloads is not None:
+        contract["artifact_downloads"] = artifact_downloads
+    if timestamps:
+        contract["range"] = {
+            "earliest": min(timestamps).isoformat().replace("+00:00", "Z"),
+            "latest": max(timestamps).isoformat().replace("+00:00", "Z"),
+        }
+    return contract
+
+
 def main() -> int:
     metrics_paths_raw = os.environ.get("METRICS_PATHS", "")
     metrics_paths = [item.strip() for item in metrics_paths_raw.split(",") if item.strip()]
     metrics_dir = os.environ.get("METRICS_DIR", _DEFAULT_METRICS_DIR)
     output_path = Path(os.environ.get("OUTPUT_PATH", _DEFAULT_OUTPUT))
+    output_json_path = Path(os.environ.get("OUTPUT_JSON_PATH", _DEFAULT_JSON_OUTPUT))
+    download_manifest_path = Path(
+        os.environ.get("METRICS_ARTIFACT_DOWNLOAD_MANIFEST_JSON", _DEFAULT_DOWNLOAD_MANIFEST_PATH)
+    )
+    artifact_downloads = _read_artifact_download_contract(download_manifest_path)
 
     files = _gather_metrics_files(metrics_paths, metrics_dir)
     if not files:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text("No metrics files found to aggregate.\n", encoding="utf-8")
+        output_json_path.parent.mkdir(parents=True, exist_ok=True)
+        output_json_path.write_text(
+            json.dumps(
+                build_summary_contract([], [], artifact_downloads),
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
         print("No metrics files found to aggregate.", file=sys.stderr)
         return 0
 
-    entries, errors = _read_ndjson(files)
-    summary = build_summary(entries, errors)
+    entries, parse_error_details = _read_ndjson(files)
+    summary = build_summary(entries, len(parse_error_details), parse_error_details)
+    summary_contract = build_summary_contract(entries, parse_error_details, artifact_downloads)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(summary, encoding="utf-8")
+    output_json_path.parent.mkdir(parents=True, exist_ok=True)
+    output_json_path.write_text(
+        json.dumps(summary_contract, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
     print(f"Wrote metrics summary to {output_path}")
+    print(f"Wrote metrics summary JSON to {output_json_path}")
     return 0
 
 


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-81-gate-followups.yml: Gate followups hub - consolidates keepalive and autofix followups
- agents-bot-comment-handler.yml: Bot comment handler - dispatches agents to address bot review comments (deprecated; replaced by agents-80-pr-event-hub.yml, removal no earlier than 2026-02-15)
- agents-verify-to-new-pr.yml: Verify to new PR - creates follow-up issue and immediately dispatches auto-pilot to prepare a replacement PR (bridge inlined)
- agents-weekly-metrics.yml: Weekly metrics - aggregates auto-pilot, keepalive, autofix and verifier metrics into summary reports
- aggregate_agent_metrics.py: Aggregates downloaded weekly agent metrics - required by agents-weekly-metrics.yml
- terminal_disposition.js: Machine-readable terminal disposition records and source summaries
- terminal_disposition_coverage.js: Warning-only terminal disposition source coverage preflight
- bot_comment_auth_coverage.js: Warning-only bot-comment App auth coverage preflight
- coverage_monitor_summary.js: Machine-readable weekly coverage monitor checkpoint
- weekly_metrics_artifacts.js: Bounded weekly metrics artifact selection contract
- weekly_metrics_download_manifest.js: Weekly metrics artifact download and extraction manifest contract
- keepalive_loop.js: Core keepalive loop logic
- agents_pr_meta_update_body.js: Updates PR body with agent metadata
- setup-api-client/ (1 files): Unified API client setup - installs @octokit deps and exports all load balancer tokens

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- AGENTS.md: Repo keeps historical Agents.md casing to avoid case-only path conflicts
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Manifest:** `.github/sync-manifest.yml`