### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,10 +102,10 @@ notebooks = [
 dev = [
     "pre-commit==4.5.1",
     "black==26.3.1",
-    "ruff==0.15.10",
+    "ruff>=0.15.12",
     "isort==8.0.1",
     "docformatter==1.7.7",
-    "mypy==1.20.1",
+    "mypy>=1.20.2",
     "flake8==7.3.0",
     "pytest==9.0.3",
     "pytest-cov==7.1.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -245,7 +245,7 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==1.20.1
+mypy==1.20.2
     # via trend-model (pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -428,7 +428,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.10
+ruff==0.15.12
     # via trend-model (pyproject.toml)
 scipy==1.17.1
     # via trend-model (pyproject.toml)


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 4 version updates:
  - ruff: ==0.15.10 -> >=0.15.12
  - mypy: ==1.20.1 -> >=1.20.2
  - requirements.lock:mypy: 1.20.1 -> ==1.20.2
  - requirements.lock:ruff: 0.15.10 -> ==0.15.12

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`