### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/agents_pr_meta_update_body.js
+++ b/.github/scripts/agents_pr_meta_update_body.js
@@ -234,7 +234,13 @@ function extractContextSectionWithPython(issueBody, comments, core) {
     const output = childProcess.execFileSync(
       'python3',
       ['scripts/langchain/context_extractor.py', '--input-file', issuePath, '--comments-file', commentsPath],
-      { encoding: 'utf8' },
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ISSUE_PR_CONTEXT_WORKFLOW: 'agents-pr-meta-v4',
+        },
+      },
     );
     return String(output || '').trim();
   } catch (error) {

--- a/.github/scripts/issue_context_utils.js
+++ b/.github/scripts/issue_context_utils.js
@@ -2,13 +2,53 @@ const {
   extractScopeTasksAcceptanceSections,
   analyzeSectionPresence,
 } = require('./issue_scope_parser.js');
+const childProcess = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
 // Note: Scope is optional; only Tasks and Acceptance Criteria are required
 const EXPECTED_SECTIONS = ['Tasks', 'Acceptance Criteria'];
 const ALL_SECTIONS = ['Scope', 'Tasks', 'Acceptance Criteria'];
 
-function buildIssueContext(issueBody) {
-  const body = issueBody || '';
+function buildCappedIssuePayload(issueBody, options = {}) {
+  const body = String(issueBody || '');
+  if (!body.trim()) {
+    return { formattedBody: body, truncated: false };
+  }
+
+  try {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'workflows-issue-context-'));
+    const inputPath = path.join(tmpDir, 'issue.md');
+    fs.writeFileSync(inputPath, body, 'utf8');
+    const args = [
+      'scripts/langchain/issue_pr_context.py',
+      '--kind',
+      'issue',
+      '--input-file',
+      inputPath,
+      '--json',
+      '--token-budget',
+      String(options.tokenBudget || process.env.ISSUE_PR_CONTEXT_TOKEN_BUDGET || 4000),
+      '--downstream-workflow',
+      options.downstreamWorkflow || process.env.ISSUE_PR_CONTEXT_WORKFLOW || 'issue_context_utils',
+    ];
+    const output = childProcess.execFileSync('python3', args, { encoding: 'utf8' });
+    const payload = JSON.parse(output);
+    return {
+      formattedBody: String(payload.formatted_body || body),
+      truncated: Boolean(payload.truncated),
+      estimatedTokens: payload.estimated_tokens,
+      tokenBudget: payload.token_budget,
+    };
+  } catch (_error) {
+    return { formattedBody: body, truncated: false };
+  }
+}
+
+function buildIssueContext(issueBody, options = {}) {
+  const cappedPayload = buildCappedIssuePayload(issueBody, options);
+  const body = cappedPayload.formattedBody || '';
   const scopeBlockWithPlaceholders = extractScopeTasksAcceptanceSections(body, {
     includePlaceholders: true,
   });
@@ -60,11 +100,16 @@ function buildIssueContext(issueBody) {
     missingSections,
     summaryContentBlock,
     hasActionableContent,
+    formattedBody: body,
+    contextTruncated: cappedPayload.truncated,
+    estimatedTokens: cappedPayload.estimatedTokens,
+    tokenBudget: cappedPayload.tokenBudget,
   };
 }
 
 module.exports = {
   EXPECTED_SECTIONS,
   ALL_SECTIONS,
+  buildCappedIssuePayload,
   buildIssueContext,
 };

--- a/.github/scripts/sync_tracker_state/index.js
+++ b/.github/scripts/sync_tracker_state/index.js
@@ -1,0 +1,513 @@
+'use strict';
+
+// API guard: callers pass createTokenAwareRetry / github-api-with-retry.js
+// `withRetry` wrappers into these helpers; tests use lightweight mock clients.
+const DURABLE_TRACKER_LABEL = 'tracker:durable';
+const AUTOMATED_LABEL = 'automated';
+const DEFAULT_STUCK_WINDOW_SCHEMA = 'sync-tracker-stuck-window/v1';
+const STUCK_WINDOW_MARKER_RE = /<!--\s*sync-tracker-stuck-window:v1\s+([\s\S]*?)\s*-->/;
+const DURABLE_HEADER_RE = /^>\s*\*\*Durable tracker\*\*[\s\S]*?(?=\n(?!>)|\n*$)/im;
+
+function cleanString(value) {
+  return String(value || '').trim();
+}
+
+function cleanArray(value) {
+  return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+function unique(values) {
+  return [...new Set(cleanArray(values).map(cleanString).filter(Boolean))];
+}
+
+function labelNames(issue = {}) {
+  return cleanArray(issue.labels).map((label) =>
+    typeof label === 'string' ? label : cleanString(label?.name)
+  );
+}
+
+function normaliseRepo(repoFullName, fallbackOwner = '') {
+  const value = cleanString(repoFullName);
+  if (!value) {
+    return null;
+  }
+  const parts = value.split('/').map(cleanString).filter(Boolean);
+  if (parts.length === 2) {
+    return { owner: parts[0], repo: parts[1], fullName: `${parts[0]}/${parts[1]}` };
+  }
+  if (parts.length === 1 && fallbackOwner) {
+    return { owner: fallbackOwner, repo: parts[0], fullName: `${fallbackOwner}/${parts[0]}` };
+  }
+  return null;
+}
+
+function patternMatches(value, pattern) {
+  const text = cleanString(value);
+  if (!pattern) {
+    return true;
+  }
+  if (pattern instanceof RegExp) {
+    pattern.lastIndex = 0;
+    return pattern.test(text);
+  }
+  const patternText = cleanString(pattern);
+  if (!patternText) {
+    return true;
+  }
+  if (patternText.startsWith('/') && patternText.lastIndexOf('/') > 0) {
+    const lastSlash = patternText.lastIndexOf('/');
+    const source = patternText.slice(1, lastSlash);
+    const flags = patternText.slice(lastSlash + 1);
+    try {
+      return new RegExp(source, flags).test(text);
+    } catch {
+      return text.includes(patternText);
+    }
+  }
+  return text.includes(patternText);
+}
+
+async function callWithRetry(
+  fn,
+  label,
+  { github = null, withRetry = null, core = console, allowNonIdempotentRetries = false } = {},
+) {
+  if (typeof withRetry === 'function') {
+    return withRetry(
+      (client) => fn(client || github),
+      { github, maxRetries: 3, allowNonIdempotentRetries },
+    );
+  }
+  try {
+    return await fn(github);
+  } catch (error) {
+    if (core && typeof core.warning === 'function') {
+      core.warning(`${label} failed: ${error.status || error.message}`);
+    }
+    throw error;
+  }
+}
+
+async function listAllPages({
+  github,
+  methodForClient,
+  params,
+  label,
+  core = console,
+  withRetry = null,
+  allowNonIdempotentRetries = true,
+}) {
+  const results = [];
+  const perPage = params.per_page || 100;
+  for (let page = 1; ; page += 1) {
+    const response = await callWithRetry(
+      (client = github) => methodForClient(client)({ ...params, page }),
+      `${label} page ${page}`,
+      { github, core, withRetry, allowNonIdempotentRetries },
+    );
+    const data = cleanArray(response?.data);
+    results.push(...data);
+    if (data.length < perPage) {
+      return results;
+    }
+  }
+}
+
+async function paginateIssues({ github, owner, repo, labels = '', core, withRetry }) {
+  const params = { owner, repo, state: 'open', per_page: 100 };
+  if (labels) {
+    params.labels = labels;
+  }
+  if (typeof github.paginate === 'function') {
+    return cleanArray(await callWithRetry(
+      (client = github) => client.paginate(client.rest.issues.listForRepo, params),
+      `${owner}/${repo} open issues`,
+      { github, core, withRetry, allowNonIdempotentRetries: true },
+    ));
+  }
+  return listAllPages({
+    github,
+    methodForClient: (client = github) => client.rest.issues.listForRepo,
+    params,
+    label: `${owner}/${repo} open issues`,
+    core,
+    withRetry,
+  });
+}
+
+async function getIssue({ github, owner, repo, issueNumber, core, withRetry }) {
+  const response = await callWithRetry(
+    (client = github) => client.rest.issues.get({ owner, repo, issue_number: issueNumber }),
+    `${owner}/${repo}#${issueNumber}`,
+    { github, core, withRetry, allowNonIdempotentRetries: true },
+  );
+  return response?.data || null;
+}
+
+function issueHasMarker(issue = {}, markerPattern = null) {
+  if (!markerPattern) {
+    return false;
+  }
+  return patternMatches(issue.body || '', markerPattern);
+}
+
+function issueMatchesTracker(issue = {}, { label, titlePattern, markerPattern } = {}) {
+  if (issue.pull_request) {
+    return false;
+  }
+  const names = labelNames(issue);
+  const requiredLabels = unique([label]).filter(Boolean);
+  const hasRequiredLabel = requiredLabels.length === 0 ||
+    requiredLabels.some((name) => names.includes(name));
+  const hasDurableLabel = names.includes(DURABLE_TRACKER_LABEL);
+  const hasTitle = patternMatches(issue.title || '', titlePattern);
+  const hasMarker = issueHasMarker(issue, markerPattern);
+  if (markerPattern && hasTitle && !cleanString(issue.body)) {
+    return true;
+  }
+  return (hasDurableLabel || hasRequiredLabel || hasMarker) && (hasTitle || hasMarker);
+}
+
+async function ensureLabels({
+  github,
+  owner,
+  repo,
+  issueNumber,
+  labels = [],
+  core,
+  withRetry,
+}) {
+  const names = unique(labels);
+  if (!names.length) {
+    return;
+  }
+  await callWithRetry(
+    (client = github) =>
+      client.rest.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: names }),
+    `${owner}/${repo}#${issueNumber} add labels`,
+    { github, core, withRetry, allowNonIdempotentRetries: true },
+  );
+}
+
+async function findTracker({ github, owner, repo, label, titlePattern, markerPattern, core, withRetry }) {
+  const labeledIssueGroups = await Promise.all(
+    unique([DURABLE_TRACKER_LABEL, label]).map((labelName) =>
+      paginateIssues({
+        github,
+        owner,
+        repo,
+        labels: labelName,
+        core,
+        withRetry,
+      })
+    )
+  );
+  const openIssues = titlePattern || markerPattern
+    ? await paginateIssues({ github, owner, repo, core, withRetry })
+    : [];
+  const byNumber = new Map();
+  for (const issueGroup of [...labeledIssueGroups, openIssues]) {
+    for (const issue of issueGroup) {
+      byNumber.set(issue.number, issue);
+    }
+  }
+  for (const issue of byNumber.values()) {
+    if (!issueMatchesTracker(issue, { label, titlePattern, markerPattern })) {
+      continue;
+    }
+    const fullIssue = await getIssue({ github, owner, repo, issueNumber: issue.number, core, withRetry });
+    if (issueMatchesTracker(fullIssue, { label, titlePattern, markerPattern })) {
+      return fullIssue;
+    }
+  }
+  return null;
+}
+
+async function findOrCreateTracker({
+  github,
+  context = null,
+  owner = context?.repo?.owner,
+  repo = context?.repo?.repo,
+  label = '',
+  titlePattern = '',
+  markerPattern = null,
+  title = '',
+  body = '',
+  markerComment = '',
+  labels = [],
+  createIfMissing = true,
+  core = console,
+  withRetry = null,
+} = {}) {
+  if (!github || !owner || !repo) {
+    throw new Error('findOrCreateTracker requires github, owner, and repo');
+  }
+  const tracker = await findTracker({ github, owner, repo, label, titlePattern, markerPattern, core, withRetry });
+  if (tracker) {
+    if (createIfMissing) {
+      await ensureLabels({
+        github,
+        owner,
+        repo,
+        issueNumber: tracker.number,
+        labels: [DURABLE_TRACKER_LABEL, AUTOMATED_LABEL, label, ...labels],
+        core,
+        withRetry,
+      });
+    }
+    tracker.sync_tracker_created = false;
+    return tracker;
+  }
+
+  if (!createIfMissing) {
+    return null;
+  }
+
+  const issueTitle = cleanString(title) || cleanString(titlePattern);
+  if (!issueTitle) {
+    throw new Error('findOrCreateTracker requires title when no tracker exists');
+  }
+  const createBody = markerComment
+    ? `${cleanString(body)}\n\n${cleanString(markerComment)}`.trim()
+    : cleanString(body);
+  const response = await callWithRetry(
+    (client = github) => client.rest.issues.create({
+      owner,
+      repo,
+      title: issueTitle,
+      body: createBody,
+      labels: unique([DURABLE_TRACKER_LABEL, AUTOMATED_LABEL, label, ...labels]),
+    }),
+    `${owner}/${repo} create durable tracker`,
+    { github, core, withRetry },
+  );
+  const created = response?.data || null;
+  if (created) {
+    created.sync_tracker_created = true;
+  }
+  return created;
+}
+
+function extractDurableTrackerHeader(body = '') {
+  const match = cleanString(body).match(DURABLE_HEADER_RE);
+  return match ? match[0].trim() : '';
+}
+
+function bodyHasDurableHeader(body = '') {
+  return Boolean(extractDurableTrackerHeader(body));
+}
+
+function preserveDurableTrackerHeader(existingBody = '', newBody = '') {
+  const nextBody = cleanString(newBody);
+  const existingHeader = extractDurableTrackerHeader(existingBody);
+  if (!existingHeader || bodyHasDurableHeader(nextBody)) {
+    return nextBody;
+  }
+
+  const lines = nextBody.split(/\r?\n/);
+  const headingIndex = lines.findIndex((line) => /^#{1,6}\s+\S/.test(line));
+  if (headingIndex === -1) {
+    return `${existingHeader}\n\n${nextBody}`.trim();
+  }
+  const insertAt = headingIndex + 1;
+  const before = lines.slice(0, insertAt);
+  const after = lines.slice(insertAt);
+  return [...before, '', existingHeader, '', ...after].join('\n').trim();
+}
+
+async function updateTrackerBody({
+  github,
+  context = null,
+  owner = context?.repo?.owner,
+  repo = context?.repo?.repo,
+  tracker,
+  newBody,
+  title = null,
+  core = console,
+  withRetry = null,
+} = {}) {
+  if (!github || !owner || !repo || !tracker?.number) {
+    throw new Error('updateTrackerBody requires github, owner, repo, and tracker.number');
+  }
+  const body = preserveDurableTrackerHeader(tracker.body || '', newBody);
+  const params = { owner, repo, issue_number: tracker.number, body };
+  if (title) {
+    params.title = title;
+  }
+  const response = await callWithRetry(
+    (client = github) => client.rest.issues.update(params),
+    `${owner}/${repo}#${tracker.number} update durable tracker`,
+    { github, core, withRetry },
+  );
+  return response?.data || null;
+}
+
+async function appendTrackerComment({
+  github,
+  context = null,
+  owner = context?.repo?.owner,
+  repo = context?.repo?.repo,
+  tracker,
+  comment,
+  core = console,
+  withRetry = null,
+} = {}) {
+  if (!github || !owner || !repo || !tracker?.number) {
+    throw new Error('appendTrackerComment requires github, owner, repo, and tracker.number');
+  }
+  const response = await callWithRetry(
+    (client = github) => client.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: tracker.number,
+      body: cleanString(comment),
+    }),
+    `${owner}/${repo}#${tracker.number} append tracker comment`,
+    { github, core, withRetry },
+  );
+  return response?.data || null;
+}
+
+async function isConsumerOpenPr({
+  github,
+  consumerRepo,
+  branchPattern,
+  state = 'open',
+  core = console,
+  withRetry = null,
+  defaultOwner = '',
+} = {}) {
+  const parsed = normaliseRepo(consumerRepo, defaultOwner);
+  if (!github || !parsed) {
+    throw new Error('isConsumerOpenPr requires github and consumerRepo');
+  }
+  const params = { owner: parsed.owner, repo: parsed.repo, state, per_page: 100 };
+  const pulls = typeof github.paginate === 'function'
+    ? cleanArray(await callWithRetry(
+        (client = github) => client.paginate(client.rest.pulls.list, params),
+        `${parsed.fullName} open pulls`,
+        { github, core, withRetry, allowNonIdempotentRetries: true },
+      ))
+    : await listAllPages({
+        github,
+        methodForClient: (client = github) => client.rest.pulls.list,
+        params,
+        label: `${parsed.fullName} open pulls`,
+        core,
+        withRetry,
+      });
+  if (!branchPattern) {
+    return false;
+  }
+  return pulls.some((pull) => {
+    const headRef = cleanString(pull?.head?.ref || pull?.headRefName || pull?.head_ref);
+    return patternMatches(headRef, branchPattern);
+  });
+}
+
+function formatStuckWindowMarker(sinceTimestamp, options = {}) {
+  const payload = {
+    schema: DEFAULT_STUCK_WINDOW_SCHEMA,
+    since: cleanString(sinceTimestamp),
+    updated_at: cleanString(options.updatedAt) || new Date().toISOString(),
+  };
+  if (options.reason) {
+    payload.reason = cleanString(options.reason);
+  }
+  return `<!-- sync-tracker-stuck-window:v1 ${JSON.stringify(payload)} -->`;
+}
+
+function parseStuckWindow(body = '') {
+  const match = cleanString(body).match(STUCK_WINDOW_MARKER_RE);
+  if (!match) {
+    return null;
+  }
+  try {
+    const payload = JSON.parse(match[1]);
+    return payload && payload.schema === DEFAULT_STUCK_WINDOW_SCHEMA ? payload : null;
+  } catch {
+    return null;
+  }
+}
+
+function markStuckWindowBody(body = '', sinceTimestamp, options = {}) {
+  const source = cleanString(body);
+  const marker = formatStuckWindowMarker(sinceTimestamp, options);
+  if (STUCK_WINDOW_MARKER_RE.test(source)) {
+    return source.replace(STUCK_WINDOW_MARKER_RE, marker);
+  }
+  return `${source.trimEnd()}\n\n${marker}`.trim();
+}
+
+function clearStuckWindowBody(body = '') {
+  return cleanString(body).replace(STUCK_WINDOW_MARKER_RE, '').replace(/\n{3,}/g, '\n\n').trim();
+}
+
+async function markStuckWindow({
+  github,
+  context = null,
+  owner = context?.repo?.owner,
+  repo = context?.repo?.repo,
+  tracker,
+  sinceTimestamp,
+  core = console,
+  withRetry = null,
+  ...options
+} = {}) {
+  return updateTrackerBody({
+    github,
+    owner,
+    repo,
+    tracker,
+    newBody: markStuckWindowBody(tracker?.body || '', sinceTimestamp, options),
+    core,
+    withRetry,
+  });
+}
+
+async function clearStuckWindow({
+  github,
+  context = null,
+  owner = context?.repo?.owner,
+  repo = context?.repo?.repo,
+  tracker,
+  core = console,
+  withRetry = null,
+} = {}) {
+  return updateTrackerBody({
+    github,
+    owner,
+    repo,
+    tracker,
+    newBody: clearStuckWindowBody(tracker?.body || ''),
+    core,
+    withRetry,
+  });
+}
+
+module.exports = {
+  AUTOMATED_LABEL,
+  DEFAULT_STUCK_WINDOW_SCHEMA,
+  DURABLE_TRACKER_LABEL,
+  appendTrackerComment,
+  append_tracker_comment: appendTrackerComment,
+  bodyHasDurableHeader,
+  clearStuckWindow,
+  clearStuckWindowBody,
+  clear_stuck_window: clearStuckWindow,
+  extractDurableTrackerHeader,
+  findOrCreateTracker,
+  find_or_create_tracker: findOrCreateTracker,
+  formatStuckWindowMarker,
+  isConsumerOpenPr,
+  is_consumer_open_pr: isConsumerOpenPr,
+  issueMatchesTracker,
+  markStuckWindow,
+  markStuckWindowBody,
+  mark_stuck_window: markStuckWindow,
+  parseStuckWindow,
+  patternMatches,
+  preserveDurableTrackerHeader,
+  updateTrackerBody,
+  update_tracker_body: updateTrackerBody,
+};

--- a/.github/workflows/agents-81-gate-followups.yml
+++ b/.github/workflows/agents-81-gate-followups.yml
@@ -74,6 +74,8 @@ jobs:
       agent_routing_mode: ${{ steps.evaluate.outputs.agent_routing_mode }}
       security_blocked: ${{ steps.security_gate.outputs.blocked }}
       security_reason: ${{ steps.security_gate.outputs.reason }}
+      dispatch_should_run: ${{ steps.runner_dispatch.outputs.should_dispatch || 'true' }}
+      dispatch_reason: ${{ steps.runner_dispatch.outputs.reason }}
       fingerprint_should_run: ${{ steps.fingerprint.outputs.should_run || 'true' }}
       fingerprint_reason: ${{ steps.fingerprint.outputs.reason }}
       fingerprint_current_hash: ${{ steps.fingerprint.outputs.current_hash }}
@@ -280,13 +282,42 @@ jobs:
             // Task appendix needs special handling due to multiline content
             core.setOutput('task_appendix', result.taskAppendix || '');
 
+      - name: Check runner dispatch debounce
+        id: runner_dispatch
+        if: >
+          steps.fingerprint.outputs.should_run == 'true' &&
+          (steps.evaluate.outputs.action == 'run' ||
+          steps.evaluate.outputs.action == 'fix' ||
+          steps.evaluate.outputs.action == 'conflict')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.evaluate.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.evaluate.outputs.head_sha }}
+          PROVIDER: ${{ steps.evaluate.outputs.agent_type || 'codex' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            {
+              echo "should_dispatch=true"
+              echo "reason=missing-pr-or-sha"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python -m scripts.runner_lib should-dispatch \
+            --provider "$PROVIDER" \
+            --pr-number "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --storage auto
+
   preflight:
     name: Verify secrets available
     needs: evaluate
     if: |
-      needs.evaluate.outputs.action == 'run' ||
+      needs.evaluate.outputs.dispatch_should_run == 'true' &&
+      (needs.evaluate.outputs.action == 'run' ||
       needs.evaluate.outputs.action == 'fix' ||
-      needs.evaluate.outputs.action == 'conflict'
+      needs.evaluate.outputs.action == 'conflict')
     runs-on: ubuntu-latest
     environment: agent-standard
     outputs:
@@ -343,9 +374,10 @@ jobs:
       - evaluate
       - preflight
     if: |
-      needs.evaluate.outputs.action == 'run' ||
+      needs.evaluate.outputs.dispatch_should_run == 'true' &&
+      (needs.evaluate.outputs.action == 'run' ||
       needs.evaluate.outputs.action == 'fix' ||
-      needs.evaluate.outputs.action == 'conflict'
+      needs.evaluate.outputs.action == 'conflict')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -387,7 +419,9 @@ jobs:
       - preflight
       - mark-running
     # Only run for agent:codex label
-    if: needs.evaluate.outputs.agent_type == 'codex'
+    if: >-
+      needs.evaluate.outputs.agent_type == 'codex' &&
+      needs.evaluate.outputs.dispatch_should_run == 'true'
     uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
     secrets:
       CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
@@ -418,6 +452,7 @@ jobs:
       - mark-running
     if: |
       needs.evaluate.outputs.agent_type == 'claude' &&
+      needs.evaluate.outputs.dispatch_should_run == 'true' &&
       (needs.evaluate.outputs.action == 'run' ||
        needs.evaluate.outputs.action == 'fix' ||
        needs.evaluate.outputs.action == 'conflict')
@@ -434,6 +469,64 @@ jobs:
       pr_ref: ${{ needs.evaluate.outputs.pr_ref }}
       appendix: ${{ needs.evaluate.outputs.task_appendix }}
       iteration: ${{ needs.evaluate.outputs.iteration }}
+
+  record-keepalive-completion:
+    name: Record keepalive dispatch completion
+    needs:
+      - evaluate
+      - run-codex
+      - run-claude
+    if: >-
+      always() &&
+      needs.evaluate.outputs.dispatch_should_run == 'true' &&
+      (needs.run-codex.result != 'skipped' || needs.run-claude.result != 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout runner library
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: |
+            scripts/runner_lib
+            scripts/state_fingerprint.py
+            scripts/reference_packs.py
+          sparse-checkout-cone-mode: false
+
+      - name: Record completion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROVIDER: ${{ needs.evaluate.outputs.agent_type || 'codex' }}
+          PR_NUMBER: ${{ needs.evaluate.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.evaluate.outputs.head_sha }}
+          SUMMARY: >-
+            ${{ needs.run-codex.outputs.final-message-summary ||
+                needs.run-claude.outputs.final-message-summary || '' }}
+          EXIT_CODE: >-
+            ${{ needs.run-codex.outputs.exit-code ||
+                needs.run-claude.outputs.exit-code || '' }}
+          JOB_RESULT: >-
+            ${{ needs.run-codex.result != 'skipped' &&
+                needs.run-codex.result || needs.run-claude.result }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            echo "Runner completion state missing PR or SHA; skipping."
+            exit 0
+          fi
+          if [ -z "${EXIT_CODE:-}" ]; then
+            if [ "${JOB_RESULT:-}" = "success" ]; then
+              EXIT_CODE=0
+            else
+              EXIT_CODE=1
+            fi
+          fi
+          python -m scripts.runner_lib record-completion \
+            --provider "$PROVIDER" \
+            --pr-number "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --summary "$SUMMARY" \
+            --exit-code "$EXIT_CODE" \
+            --storage auto
 
   summary:
     name: Update keepalive summary
@@ -746,6 +839,8 @@ jobs:
       gate_run_id: ${{ steps.evaluate.outputs.gate_run_id }}
       security_blocked: ${{ steps.security_gate.outputs.blocked }}
       security_reason: ${{ steps.security_gate.outputs.reason }}
+      dispatch_should_run: ${{ steps.runner_dispatch.outputs.should_dispatch || 'true' }}
+      dispatch_reason: ${{ steps.runner_dispatch.outputs.reason }}
     steps:
       - name: Checkout (for security gate + agent registry)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -756,6 +851,9 @@ jobs:
             .github/scripts/github-rate-limited-wrapper.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
+            scripts/runner_lib
+            scripts/state_fingerprint.py
+            scripts/reference_packs.py
             .github/scripts/agent_registry.js
             .github/agents/registry.yml
           sparse-checkout-cone-mode: false
@@ -1110,10 +1208,35 @@ jobs:
               core.setOutput(key, value);
             }
 
+      - name: Check runner dispatch debounce
+        id: runner_dispatch
+        if: steps.evaluate.outputs.should_run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.evaluate.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.evaluate.outputs.head_sha }}
+          PROVIDER: ${{ steps.evaluate.outputs.agent_type || 'codex' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            {
+              echo "should_dispatch=true"
+              echo "reason=missing-pr-or-sha"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python -m scripts.runner_lib should-dispatch \
+            --provider "$PROVIDER" \
+            --pr-number "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --storage auto
+
   autofix:
     needs: prepare
     if: >-
       needs.prepare.outputs.should_run == 'true' &&
+      needs.prepare.outputs.dispatch_should_run == 'true' &&
       needs.prepare.outputs.agent_type == 'codex'
     name: Run Codex autofix
     uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
@@ -1132,6 +1255,7 @@ jobs:
     needs: prepare
     if: >-
       needs.prepare.outputs.should_run == 'true' &&
+      needs.prepare.outputs.dispatch_should_run == 'true' &&
       needs.prepare.outputs.agent_type == 'claude'
     name: Run Claude autofix
     uses: stranske/Workflows/.github/workflows/reusable-claude-run.yml@main

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -64,6 +64,9 @@ jobs:
       pr_labels_json: ${{ steps.context.outputs.pr_labels_json }}
       same_repo: ${{ steps.context.outputs.same_repo }}
       caller_actor: ${{ steps.context.outputs.caller_actor }}
+      head_sha: ${{ steps.context.outputs.head_sha }}
+      dispatch_should_run: ${{ steps.runner_dispatch.outputs.should_dispatch || 'true' }}
+      dispatch_reason: ${{ steps.runner_dispatch.outputs.reason }}
     steps:
       # Escape hatch: set mode: warning if false-negative skips appear post-merge.
       - name: Check event eligibility
@@ -87,6 +90,9 @@ jobs:
             .github/actions/setup-api-client
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
+            scripts/runner_lib
+            scripts/state_fingerprint.py
+            scripts/reference_packs.py
           sparse-checkout-cone-mode: false
 
       - name: Setup API client
@@ -216,6 +222,7 @@ jobs:
               core.setOutput('pr_labels_json', JSON.stringify(labels));
               core.setOutput('same_repo', sameRepo ? 'true' : 'false');
               core.setOutput('caller_actor', callerActor);
+              core.setOutput('head_sha', pr.head?.sha || '');
             };
 
             // --- workflow_run trigger (after Gate/CI completes) ---
@@ -560,9 +567,38 @@ jobs:
             });
 
   # Call reusable autofix workflow
+      - name: Check runner dispatch debounce
+        id: runner_dispatch
+        if: steps.context.outputs.should_run == 'true'
+        env:
+          GH_TOKEN: >-
+            ${{ secrets.AGENTS_AUTOMATION_PAT || secrets.ACTIONS_BOT_PAT ||
+                secrets.SERVICE_BOT_PAT || github.token }}
+          GITHUB_TOKEN: >-
+            ${{ secrets.AGENTS_AUTOMATION_PAT || secrets.ACTIONS_BOT_PAT ||
+                secrets.SERVICE_BOT_PAT || github.token }}
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.context.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            {
+              echo "should_dispatch=true"
+              echo "reason=missing-pr-or-sha"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python -m scripts.runner_lib should-dispatch \
+            --provider autofix \
+            --pr-number "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --storage auto
+
   autofix:
     needs: resolve
-    if: needs.resolve.outputs.should_run == 'true'
+    if: >-
+      needs.resolve.outputs.should_run == 'true' &&
+      needs.resolve.outputs.dispatch_should_run == 'true'
     uses: stranske/Workflows/.github/workflows/reusable-18-autofix.yml@main
     with:
       pr_number: ${{ fromJson(needs.resolve.outputs.pr_number) }}
@@ -576,3 +612,49 @@ jobs:
       service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
       WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
       WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+
+  record-autofix-dispatch:
+    name: Record autofix dispatch completion
+    needs:
+      - resolve
+      - autofix
+    if: >-
+      always() &&
+      needs.resolve.outputs.dispatch_should_run == 'true' &&
+      needs.autofix.result != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout runner library
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: |
+            scripts/runner_lib
+            scripts/state_fingerprint.py
+            scripts/reference_packs.py
+          sparse-checkout-cone-mode: false
+
+      - name: Record completion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          JOB_RESULT: ${{ needs.autofix.result }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            echo "Autofix completion state missing PR or SHA; skipping."
+            exit 0
+          fi
+          if [ "${JOB_RESULT:-}" = "success" ]; then
+              EXIT_CODE=0
+            else
+              EXIT_CODE=1
+            fi
+          python -m scripts.runner_lib record-completion \
+            --provider autofix \
+            --pr-number "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --summary "autofix workflow result: ${JOB_RESULT:-unknown}" \
+            --exit-code "$EXIT_CODE" \
+            --storage auto

--- a/scripts/langchain/context_extractor.py
+++ b/scripts/langchain/context_extractor.py
@@ -10,10 +10,16 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from collections.abc import Iterable
 from pathlib import Path
+
+try:
+    from scripts.langchain.issue_pr_context import ContextOptions, build_issue_context
+except ModuleNotFoundError:
+    from issue_pr_context import ContextOptions, build_issue_context
 
 CONTEXT_EXTRACTOR_PROMPT = """
 From this issue and related discussion, extract:
@@ -38,6 +44,27 @@ REFERENCE_REGEX = re.compile(r"https?://[^\s)>\"]+")
 ISSUE_REF_REGEX = re.compile(r"\b[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#\d+\b|(?<!\w)#\d+\b")
 LIST_ITEM_REGEX = re.compile(r"^\s*[-*+]\s+(.*)$")
 CHECKBOX_REGEX = re.compile(r"^\s*[-*+]\s+\[[ xX]\]\s+")
+
+
+def _context_token_budget() -> int:
+    raw = os.environ.get("ISSUE_PR_CONTEXT_TOKEN_BUDGET", "")
+    return int(raw) if raw.isdigit() and int(raw) > 0 else 4000
+
+
+def _context_workflow(default: str) -> str:
+    return os.environ.get("ISSUE_PR_CONTEXT_WORKFLOW") or default
+
+
+def _capped_issue_body(issue_body: str, workflow: str) -> str:
+    context = build_issue_context(
+        {"body": issue_body},
+        ContextOptions(
+            token_budget=_context_token_budget(),
+            downstream_workflow=workflow,
+        ),
+    )
+    return context["formatted_body"]
+
 
 DECISION_KEYWORDS = (
     "decision",
@@ -218,6 +245,7 @@ def extract_context(
     if not issue_body:
         issue_body = ""
 
+    issue_body = _capped_issue_body(issue_body, _context_workflow("context_extractor"))
     comments = comments or []
 
     if use_llm:

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1784,10 +1784,14 @@ def _build_why_section(
     return " ".join(parts)
 
 
+WORKFLOW_SYNC_PATH_MARKERS = (
+    ".github/actions",
+    ".github/scripts",
+    ".github/sync-manifest.yml",
+    ".github/workflows",
+)
+
 WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
-    "consumer sync",
-    "consumer-sync",
-    ".github/workflows/",
     "workflow file",
     "workflow files",
     "workflow-owned",
@@ -1795,6 +1799,9 @@ WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
     "workflows-owned scripts",
     "gate workflow",
     "maint-68",
+    "synced automation",
+    "synced script",
+    "synced scripts",
     "synced workflow",
     "sync pr",
     "sync-generated",
@@ -1802,6 +1809,42 @@ WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
     "template sync",
     "workflow template sync",
     "workflow-template",
+)
+
+EXPLICIT_WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
+    "workflow-owned",
+    "workflows-owned",
+    "maint-68",
+    "synced automation",
+    "synced script",
+    "synced scripts",
+    "synced workflow",
+    "sync pr",
+    "sync-generated",
+    "sync workflow templates",
+    "template sync",
+    "workflow template sync",
+    "workflow-template",
+)
+
+WORKFLOW_SYNC_CONTEXT_MARKERS = (
+    "consumer sync",
+    "consumer-sync",
+    "consumer",
+    "consumers",
+    "from the template",
+    "maint-68",
+    "synced",
+    "sync-generated",
+)
+
+WORKFLOW_SYNC_REPO_LOCAL_MARKERS = (
+    "repo-local",
+    "repository-local",
+    "local-only",
+    "project-specific",
+    "this repository",
+    "this repo",
 )
 
 
@@ -1817,7 +1860,21 @@ def _acceptance_criteria_from_original_issue(
 
 def _is_workflow_sync_acceptance_criterion(criterion: str) -> bool:
     normalized = str(criterion or "").strip().lower()
-    return any(marker in normalized for marker in WORKFLOW_SYNC_ACCEPTANCE_MARKERS)
+    has_repo_local_marker = any(marker in normalized for marker in WORKFLOW_SYNC_REPO_LOCAL_MARKERS)
+    if any(marker in normalized for marker in WORKFLOW_SYNC_PATH_MARKERS):
+        return not has_repo_local_marker
+    if any(marker in normalized for marker in WORKFLOW_SYNC_ACCEPTANCE_MARKERS):
+        return not has_repo_local_marker or any(
+            marker in normalized for marker in EXPLICIT_WORKFLOW_SYNC_ACCEPTANCE_MARKERS
+        )
+    return False
+
+
+def _mentions_workflow_sync_context(value: str) -> bool:
+    normalized = str(value or "").strip().lower()
+    return _is_workflow_sync_acceptance_criterion(normalized) or any(
+        marker in normalized for marker in WORKFLOW_SYNC_CONTEXT_MARKERS
+    )
 
 
 def _has_mixed_repo_and_workflow_acceptance_criteria(
@@ -1840,7 +1897,7 @@ def _verification_feedback_mentions_workflow_sync(verification_data: Verificatio
         *verification_data.non_pass_findings,
         *verification_data.structural_issues,
     ]
-    return any(_is_workflow_sync_acceptance_criterion(part) for part in parts)
+    return any(_mentions_workflow_sync_context(part) for part in parts)
 
 
 def _select_followup_acceptance_criteria(

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -18,8 +19,10 @@ from typing import Any
 
 try:
     from scripts.langchain.injection_guard import check_prompt_injection
+    from scripts.langchain.issue_pr_context import ContextOptions, build_issue_context
 except ImportError:  # pragma: no cover - fallback for direct invocation
     from injection_guard import check_prompt_injection
+    from issue_pr_context import ContextOptions, build_issue_context
 
 # Maximum issue body size to prevent OpenAI rate limit errors (30k TPM limit)
 # ~4 chars per token, so 50k chars ≈ 12.5k tokens, leaving headroom for prompt + output
@@ -84,6 +87,26 @@ SECTION_TITLES = {
 
 LIST_ITEM_REGEX = re.compile(r"^(\s*)([-*+]|\d+[.)]|[A-Za-z][.)])\s+(.*)$")
 CHECKBOX_REGEX = re.compile(r"^\[([ xX])\]\s*(.*)$")
+
+
+def _context_token_budget() -> int:
+    raw = os.environ.get("ISSUE_PR_CONTEXT_TOKEN_BUDGET", "")
+    return int(raw) if raw.isdigit() and int(raw) > 0 else 4000
+
+
+def _context_workflow(default: str) -> str:
+    return os.environ.get("ISSUE_PR_CONTEXT_WORKFLOW") or default
+
+
+def _capped_issue_body(issue_body: str, workflow: str) -> str:
+    context = build_issue_context(
+        {"body": issue_body},
+        ContextOptions(
+            token_budget=_context_token_budget(),
+            downstream_workflow=workflow,
+        ),
+    )
+    return context["formatted_body"]
 
 
 def _load_prompt() -> str:
@@ -456,6 +479,8 @@ def format_issue_body(issue_body: str, *, use_llm: bool = True) -> dict[str, Any
             "guard_blocked": True,
             "guard_reason": guard_result["reason"],
         }
+
+    issue_body = _capped_issue_body(issue_body, _context_workflow("issue_formatter"))
 
     # Check size before processing to avoid rate limit errors
     if len(issue_body) > MAX_ISSUE_BODY_SIZE:

--- a/scripts/langchain/issue_optimizer.py
+++ b/scripts/langchain/issue_optimizer.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from dataclasses import dataclass
@@ -27,8 +28,10 @@ from scripts.langchain.structured_output import (
 
 try:
     from scripts.langchain.injection_guard import check_prompt_injection
+    from scripts.langchain.issue_pr_context import ContextOptions, build_issue_context
 except ModuleNotFoundError:
     from injection_guard import check_prompt_injection
+    from issue_pr_context import ContextOptions, build_issue_context
 
 AGENT_LIMITATIONS = [
     "Cannot modify .github/workflows/*.yml (protected)",
@@ -37,6 +40,27 @@ AGENT_LIMITATIONS = [
     "Cannot make subjective design decisions",
     "Cannot retry CI pipelines",
 ]
+
+
+def _context_token_budget() -> int:
+    raw = os.environ.get("ISSUE_PR_CONTEXT_TOKEN_BUDGET", "")
+    return int(raw) if raw.isdigit() and int(raw) > 0 else 4000
+
+
+def _context_workflow(default: str) -> str:
+    return os.environ.get("ISSUE_PR_CONTEXT_WORKFLOW") or default
+
+
+def _capped_issue_body(issue_body: str, workflow: str) -> str:
+    context = build_issue_context(
+        {"body": issue_body},
+        ContextOptions(
+            token_budget=_context_token_budget(),
+            downstream_workflow=workflow,
+        ),
+    )
+    return context["formatted_body"]
+
 
 ANALYZE_ISSUE_PROMPT = """
 Analyze this issue for agent compatibility and formatting quality.
@@ -788,6 +812,8 @@ def analyze_issue(issue_body: str, *, use_llm: bool = True) -> IssueOptimization
             guard_reason=guard_result["reason"],
         )
 
+    issue_body = _capped_issue_body(issue_body, _context_workflow("issue_optimizer"))
+
     last_error: str | None = None
     if use_llm:
         from tools.llm_provider import _is_token_limit_error
@@ -1027,6 +1053,8 @@ def apply_suggestions(
             "guard_blocked": True,
             "guard_reason": guard_result["reason"],
         }
+
+    issue_body = _capped_issue_body(issue_body, _context_workflow("issue_optimizer"))
 
     if use_llm:
         from tools.llm_provider import _is_token_limit_error

--- a/scripts/langchain/issue_pr_context.py
+++ b/scripts/langchain/issue_pr_context.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Shared issue and PR context assembly with prompt budget caps."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import json
+import math
+import re
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_TOKEN_BUDGET = 4000
+TOKEN_CHARS = 4
+MARKER_VERSION = "v1"
+MARKER_PREFIX = "issue-pr-context:formatted-body"
+MARKER_RE = re.compile(
+    rf"<!--\s*{re.escape(MARKER_PREFIX)}:{MARKER_VERSION}\s+(.+?)\s*-->",
+    re.DOTALL,
+)
+
+
+@dataclass(frozen=True)
+class ContextOptions:
+    token_budget: int = DEFAULT_TOKEN_BUDGET
+    include_diff: bool = False
+    include_labels: bool = True
+    include_author: bool = True
+    include_url: bool = True
+    downstream_workflow: str | None = None
+    model: str | None = None
+
+
+def estimate_tokens(text: str, *, model: str | None = None) -> int:
+    """Estimate prompt tokens using tiktoken when available, else 4 chars/token.
+
+    Returns ``max(tiktoken_count, chars/4)``: tiktoken's BPE encoding aggressively
+    compresses repeated patterns (e.g. 60K of the same character collapses to a
+    handful of tokens), which would let oversized inputs slip past token-budget
+    truncation. The chars/4 floor keeps the cap honest against compressible
+    inputs while preserving accurate counts on normal prose.
+    """
+    value = text or ""
+    if not value:
+        return 0
+
+    chars_estimate = math.ceil(len(value) / TOKEN_CHARS)
+
+    try:
+        import tiktoken  # type: ignore[import-not-found]
+    except ImportError:
+        return chars_estimate
+
+    try:
+        encoding = (
+            tiktoken.encoding_for_model(model) if model else tiktoken.get_encoding("cl100k_base")
+        )
+    except Exception:
+        encoding = tiktoken.get_encoding("cl100k_base")
+    return max(len(encoding.encode(value)), chars_estimate)
+
+
+def build_issue_context(
+    issue: Mapping[str, Any],
+    options: ContextOptions | None = None,
+) -> dict[str, Any]:
+    """Return a capped context payload for a GitHub issue object."""
+    resolved = options or ContextOptions()
+    body = reuse_formatted_body(issue, resolved.downstream_workflow)
+    if body is None:
+        body = _text(issue.get("formatted_body") or issue.get("body"))
+
+    metadata_block = _issue_metadata(issue, resolved)
+    return _build_payload(
+        kind="issue",
+        body_heading="## Issue Body",
+        body=body,
+        metadata_block=metadata_block,
+        options=resolved,
+    )
+
+
+def build_pr_context(
+    pr: Mapping[str, Any],
+    options: ContextOptions | None = None,
+) -> dict[str, Any]:
+    """Return a capped context payload for a GitHub pull request object."""
+    resolved = options or ContextOptions()
+    body = reuse_formatted_body(pr, resolved.downstream_workflow)
+    if body is None:
+        body = _text(pr.get("formatted_body") or pr.get("body"))
+
+    diff_body = _diff_text(pr) if resolved.include_diff else ""
+    metadata_block = _pr_metadata(pr, resolved, diff_body=diff_body)
+    extra_sections = [("## Pull Request Diff", diff_body)] if diff_body else None
+    return _build_payload(
+        kind="pr",
+        body_heading="## Pull Request Body",
+        body=body,
+        metadata_block=metadata_block,
+        options=resolved,
+        extra_sections=extra_sections,
+    )
+
+
+def reuse_formatted_body(
+    issue_or_pr: Mapping[str, Any],
+    downstream_workflow: str | None,
+) -> str | None:
+    """Return a marker-backed formatted body for the same issue or PR, if present."""
+    body = _text(issue_or_pr.get("body"))
+    if not body:
+        return None
+
+    for match in MARKER_RE.finditer(body):
+        payload = _loads_marker(match.group(1))
+        if payload is None:
+            continue
+        if not _workflow_matches(payload, downstream_workflow):
+            continue
+
+        embedded = _embedded_body(payload)
+        if embedded is not None:
+            if ("sha256" in payload or "body_sha256" in payload) and not _body_hash_matches(
+                payload,
+                embedded,
+            ):
+                continue
+            return embedded
+
+        cleaned = (body[: match.start()] + body[match.end() :]).strip()
+        if _body_hash_matches(payload, cleaned):
+            return cleaned
+        if "sha256" not in payload and "body_sha256" not in payload:
+            return cleaned
+    return None
+
+
+def build_formatted_body_marker(
+    *,
+    downstream_workflow: str | None = None,
+    workflows: list[str] | tuple[str, ...] | None = None,
+    formatted_body: str | None = None,
+) -> str:
+    """Build a compact marker that downstream callers can store with a body."""
+    payload: dict[str, Any] = {}
+    if downstream_workflow:
+        payload["workflow"] = downstream_workflow
+    if workflows:
+        payload["workflows"] = list(workflows)
+    if formatted_body is not None:
+        payload["body_b64"] = base64.b64encode(formatted_body.encode("utf-8")).decode("ascii")
+        payload["sha256"] = hashlib.sha256(formatted_body.encode("utf-8")).hexdigest()
+    marker_payload = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    return f"<!-- {MARKER_PREFIX}:{MARKER_VERSION} {marker_payload} -->"
+
+
+def _build_payload(
+    *,
+    kind: str,
+    body_heading: str,
+    body: str,
+    metadata_block: str,
+    options: ContextOptions,
+    extra_sections: list[tuple[str, str]] | None = None,
+) -> dict[str, Any]:
+    sections = [(body_heading, body)]
+    sections.extend(extra_sections or [])
+
+    metadata_block, metadata_truncated = _cap_block(
+        metadata_block,
+        max(1, options.token_budget),
+        model=options.model,
+    )
+    capped_sections, truncated = _cap_sections(metadata_block, sections, options)
+    context = "\n\n".join(part for part in [metadata_block, *capped_sections] if part).strip()
+    return {
+        "kind": kind,
+        "metadata_block": metadata_block,
+        "formatted_body": (
+            capped_sections[0].split("\n", 1)[1].strip()
+            if capped_sections and "\n" in capped_sections[0]
+            else ""
+        ),
+        "context": context,
+        "truncated": truncated or metadata_truncated,
+        "estimated_tokens": estimate_tokens(context, model=options.model),
+        "token_budget": max(1, options.token_budget),
+    }
+
+
+def _cap_block(text: str, token_budget: int, *, model: str | None = None) -> tuple[str, bool]:
+    if estimate_tokens(text, model=model) <= token_budget:
+        return text, False
+
+    marker = "\n[truncated: context exceeded token budget]"
+    return _truncate_with_suffix(text, token_budget, suffix=marker, model=model), True
+
+
+def _cap_sections(
+    metadata_block: str,
+    sections: list[tuple[str, str]],
+    options: ContextOptions,
+) -> tuple[list[str], bool]:
+    budget = max(1, options.token_budget)
+    rendered: list[str] = []
+    truncated = False
+
+    prefix = metadata_block.strip()
+    for heading, text in sections:
+        base_context = _join_context([prefix, *rendered])
+        section_prefix = "\n\n" if base_context else ""
+        remaining = budget - estimate_tokens(f"{base_context}{section_prefix}", model=options.model)
+        if remaining <= 0:
+            truncated = True
+            continue
+
+        section = f"{heading}\n{_text(text).strip()}".rstrip()
+        if (
+            estimate_tokens(f"{base_context}{section_prefix}{section}", model=options.model)
+            <= budget
+        ):
+            rendered.append(section)
+            continue
+
+        marker = "\n\n[truncated: context exceeded token budget]"
+        capped_section = _truncate_section(
+            heading,
+            _text(text).strip(),
+            remaining,
+            suffix=marker,
+            model=options.model,
+        )
+        if capped_section:
+            rendered.append(capped_section)
+        truncated = True
+
+    context = "\n\n".join(part for part in [metadata_block, *rendered] if part)
+    while estimate_tokens(context, model=options.model) > budget and rendered:
+        truncated = True
+        previous = context
+        heading = rendered[-1].split("\n", 1)[0]
+        base_context = _join_context([metadata_block, *rendered[:-1]])
+        section_prefix = "\n\n" if base_context else ""
+        remaining = budget - estimate_tokens(f"{base_context}{section_prefix}", model=options.model)
+        rendered[-1] = _truncate_section(
+            heading,
+            "",
+            remaining,
+            suffix="\n[truncated: token budget exhausted before this section]",
+            model=options.model,
+        )
+        if not rendered[-1]:
+            rendered.pop()
+        context = "\n\n".join(part for part in [metadata_block, *rendered] if part)
+        if context == previous:
+            rendered.pop()
+            context = "\n\n".join(part for part in [metadata_block, *rendered] if part)
+
+    return rendered, truncated
+
+
+def _join_context(parts: list[str]) -> str:
+    return "\n\n".join(part for part in parts if part)
+
+
+def _truncate_with_suffix(
+    text: str,
+    token_budget: int,
+    *,
+    suffix: str = "",
+    model: str | None = None,
+) -> str:
+    budget = max(0, token_budget)
+    source = _text(text).rstrip()
+    suffix_text = suffix if estimate_tokens(suffix, model=model) <= budget else ""
+    low = 0
+    high = len(source)
+    best = ""
+    while low <= high:
+        midpoint = (low + high) // 2
+        candidate = f"{source[:midpoint].rstrip()}{suffix_text}".rstrip()
+        if estimate_tokens(candidate, model=model) <= budget:
+            best = candidate
+            low = midpoint + 1
+        else:
+            high = midpoint - 1
+    return best
+
+
+def _truncate_section(
+    heading: str,
+    text: str,
+    token_budget: int,
+    *,
+    suffix: str,
+    model: str | None = None,
+) -> str:
+    budget = max(0, token_budget)
+    prefix = f"{heading}\n"
+    if estimate_tokens(prefix.rstrip(), model=model) > budget:
+        return _truncate_with_suffix(heading, budget, model=model)
+
+    suffix_text = (
+        suffix if estimate_tokens(f"{prefix}{suffix}".rstrip(), model=model) <= budget else ""
+    )
+    low = 0
+    high = len(text)
+    best = prefix.rstrip()
+    while low <= high:
+        midpoint = (low + high) // 2
+        candidate = f"{prefix}{text[:midpoint].rstrip()}{suffix_text}".rstrip()
+        if estimate_tokens(candidate, model=model) <= budget:
+            best = candidate
+            low = midpoint + 1
+        else:
+            high = midpoint - 1
+    return best
+
+
+def _issue_metadata(issue: Mapping[str, Any], options: ContextOptions) -> str:
+    lines = ["## Issue Metadata"]
+    number = issue.get("number")
+    if number is not None:
+        lines.append(f"- Number: #{number}")
+    _append_value(lines, "Title", issue.get("title"))
+    _append_value(lines, "State", issue.get("state"))
+    if options.include_author:
+        _append_value(lines, "Author", _login(issue.get("user")))
+    if options.include_url:
+        _append_value(lines, "URL", issue.get("html_url") or issue.get("url"))
+    if options.include_labels:
+        labels = _labels(issue.get("labels"))
+        if labels:
+            lines.append(f"- Labels: {', '.join(labels)}")
+    return "\n".join(lines)
+
+
+def _pr_metadata(pr: Mapping[str, Any], options: ContextOptions, *, diff_body: str = "") -> str:
+    lines = ["## Pull Request Metadata"]
+    number = pr.get("number")
+    if number is not None:
+        lines.append(f"- Number: #{number}")
+    _append_value(lines, "Title", pr.get("title"))
+    _append_value(lines, "State", pr.get("state"))
+    if options.include_author:
+        _append_value(lines, "Author", _login(pr.get("user")))
+    if options.include_url:
+        _append_value(lines, "URL", pr.get("html_url") or pr.get("url"))
+    _append_value(lines, "Base", _branch_name(pr.get("base")))
+    _append_value(lines, "Head", _branch_name(pr.get("head")))
+    for key in ("changed_files", "additions", "deletions"):
+        if pr.get(key) is not None:
+            lines.append(f"- {key.replace('_', ' ').title()}: {pr[key]}")
+    if options.include_labels:
+        labels = _labels(pr.get("labels"))
+        if labels:
+            lines.append(f"- Labels: {', '.join(labels)}")
+    if options.include_diff and diff_body:
+        lines.append("- Diff: included")
+    return "\n".join(lines)
+
+
+def _loads_marker(value: str) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _workflow_matches(payload: Mapping[str, Any], downstream_workflow: str | None) -> bool:
+    if not downstream_workflow:
+        return True
+    workflow = payload.get("workflow") or payload.get("downstream_workflow")
+    workflows = payload.get("workflows")
+    if workflow in (downstream_workflow, "*", "all"):
+        return True
+    if isinstance(workflows, list):
+        return downstream_workflow in workflows or "*" in workflows or "all" in workflows
+    return workflow is None and workflows is None
+
+
+def _embedded_body(payload: Mapping[str, Any]) -> str | None:
+    body = payload.get("formatted_body")
+    if isinstance(body, str):
+        return body
+    body_b64 = payload.get("body_b64")
+    if not isinstance(body_b64, str):
+        return None
+    try:
+        return base64.b64decode(body_b64.encode("ascii")).decode("utf-8")
+    except (binascii.Error, UnicodeEncodeError, UnicodeDecodeError, ValueError):
+        return None
+
+
+def _body_hash_matches(payload: Mapping[str, Any], body: str) -> bool:
+    expected = payload.get("sha256") or payload.get("body_sha256")
+    if not isinstance(expected, str):
+        return False
+    return hashlib.sha256(body.encode("utf-8")).hexdigest() == expected
+
+
+def _diff_text(pr: Mapping[str, Any]) -> str:
+    diff = pr.get("diff") or pr.get("patch")
+    if isinstance(diff, str):
+        return diff
+    files = pr.get("files")
+    if not isinstance(files, list):
+        return ""
+    parts: list[str] = []
+    for entry in files:
+        if not isinstance(entry, Mapping):
+            continue
+        filename = _text(entry.get("filename"))
+        patch = _text(entry.get("patch"))
+        if filename and patch:
+            parts.append(f"diff -- {filename}\n{patch}")
+    return "\n\n".join(parts)
+
+
+def _append_value(lines: list[str], label: str, value: Any) -> None:
+    text = _text(value).strip()
+    if text:
+        lines.append(f"- {label}: {text}")
+
+
+def _labels(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    labels: list[str] = []
+    for item in value:
+        if isinstance(item, str):
+            labels.append(item)
+        elif isinstance(item, Mapping) and item.get("name"):
+            labels.append(str(item["name"]))
+    return labels
+
+
+def _login(value: Any) -> str:
+    if isinstance(value, Mapping):
+        return _text(value.get("login"))
+    return _text(value)
+
+
+def _branch_name(value: Any) -> str:
+    if isinstance(value, Mapping):
+        return _text(value.get("label") or value.get("ref"))
+    return _text(value)
+
+
+def _text(value: Any) -> str:
+    return value if isinstance(value, str) else "" if value is None else str(value)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build capped issue or PR context.")
+    parser.add_argument("--kind", choices=("issue", "pr"), default="issue")
+    parser.add_argument(
+        "--input-file", required=True, help="Path containing issue or PR body text."
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Emit the full context payload as JSON."
+    )
+    parser.add_argument("--token-budget", type=int, default=DEFAULT_TOKEN_BUDGET)
+    parser.add_argument("--downstream-workflow")
+    parser.add_argument("--include-diff", action="store_true")
+    parser.add_argument("--no-labels", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    from pathlib import Path
+
+    body = Path(args.input_file).read_text(encoding="utf-8")
+    options = ContextOptions(
+        token_budget=args.token_budget,
+        include_diff=args.include_diff,
+        include_labels=not args.no_labels,
+        downstream_workflow=args.downstream_workflow,
+    )
+    subject = {"body": body}
+    payload = (
+        build_pr_context(subject, options)
+        if args.kind == "pr"
+        else build_issue_context(subject, options)
+    )
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=True, sort_keys=True))
+    else:
+        print(payload["context"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/runner_lib/__init__.py
+++ b/scripts/runner_lib/__init__.py
@@ -1,0 +1,21 @@
+"""Shared helpers for dual-provider agent runner workflows."""
+
+from .core import (
+    DebounceDecision,
+    RunnerPrompt,
+    RunnerResult,
+    assemble_prompt,
+    parse_runner_output,
+    record_completion,
+    should_dispatch,
+)
+
+__all__ = [
+    "DebounceDecision",
+    "RunnerPrompt",
+    "RunnerResult",
+    "assemble_prompt",
+    "parse_runner_output",
+    "record_completion",
+    "should_dispatch",
+]

--- a/scripts/runner_lib/__main__.py
+++ b/scripts/runner_lib/__main__.py
@@ -1,0 +1,4 @@
+from .core import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -1,0 +1,730 @@
+"""Shared runner prompt, output parsing, and dispatch debounce utilities."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import dataclasses
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Protocol
+
+from scripts import reference_packs
+from scripts.state_fingerprint import GitHubApi, _github_context
+
+MARKER_VERSION = "v1"
+MARKER_PREFIX = "runner-dispatch"
+PROVIDERS = {"autofix", "claude", "codex"}
+PROMPT_PROVIDERS = {"claude", "codex"}
+TERMINAL_STATUSES = {"completed", "error"}
+
+
+@dataclasses.dataclass(frozen=True)
+class RunnerPrompt:
+    provider: str
+    file: str
+    text: str
+    reference_pack_name: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class RunnerResult:
+    provider: str
+    success: bool
+    final_message: str
+    summary: str
+    error: str | None = None
+    truncated: bool = False
+
+
+@dataclasses.dataclass(frozen=True)
+class DebounceDecision:
+    should_dispatch: bool
+    reason: str
+    key: str
+    prior_status: str | None = None
+    prior_head_sha: str | None = None
+
+
+class RunnerDispatchStorage(Protocol):
+    def read_record(self, pr_number: int, provider: str) -> dict[str, Any] | None: ...
+
+    def write_record(self, pr_number: int, provider: str, record: dict[str, Any]) -> None: ...
+
+
+def _utc_now() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _validate_provider(provider: str) -> str:
+    normalized = provider.strip().lower()
+    if normalized not in PROVIDERS:
+        raise ValueError(f"unsupported provider: {provider}")
+    return normalized
+
+
+def _runner_key(pr_number: int, head_sha: str, provider: str) -> str:
+    payload = f"{provider}:{pr_number}:{head_sha}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"{path} must be valid UTF-8") from exc
+
+
+def _provider_instruction_path(workspace: Path, provider: str) -> Path:
+    if provider == "codex":
+        return workspace / ".github" / "codex" / "AGENT_INSTRUCTIONS.md"
+    return workspace / ".github" / "claude" / "AGENT_INSTRUCTIONS.md"
+
+
+def _prompt_output_name(provider: str, pr_number: str | int | None) -> str:
+    suffix = f"-{pr_number}" if pr_number not in (None, "") else ""
+    return f"{provider}-prompt{suffix}.md"
+
+
+def materialize_reference_packs(
+    workspace: str | Path = ".",
+    reference_pack_name: str | None = None,
+    token: str | None = None,
+) -> Path | None:
+    """Validate and materialize configured reference packs into `.reference/`."""
+    workspace_path = Path(workspace).resolve()
+    snapshot = reference_packs.load_reference_packs(workspace_path)
+    if not snapshot.exists:
+        return None
+
+    plans = reference_packs.build_checkout_plan(snapshot.packs)
+    if reference_pack_name:
+        plans = [plan for plan in plans if plan.name == reference_pack_name]
+        if not plans:
+            raise ValueError(f"reference pack not found: {reference_pack_name}")
+
+    reference_dir = workspace_path / ".reference"
+    reference_dir.mkdir(exist_ok=True)
+
+    for plan in plans:
+        clone_dir = Path("/tmp") / f"ref-pack-{plan.name}"
+        shutil.rmtree(clone_dir, ignore_errors=True)
+        clone_url = f"https://github.com/{plan.repo}.git"
+        if token:
+            clone_url = f"https://x-access-token:{token}@github.com/{plan.repo}.git"
+
+        clone_cmd = ["git", "clone", "--depth=1", "--filter=blob:none", "--sparse"]
+        is_sha = bool(re.fullmatch(r"[0-9a-fA-F]{40}", plan.ref))
+        if not is_sha:
+            clone_cmd.extend(["--branch", plan.ref])
+        clone_cmd.extend([clone_url, str(clone_dir)])
+        subprocess.check_call(clone_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        if is_sha:
+            subprocess.check_call(
+                ["git", "-C", str(clone_dir), "fetch", "origin", plan.ref, "--depth=1"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            subprocess.check_call(
+                ["git", "-C", str(clone_dir), "checkout", plan.ref],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+        subprocess.check_call(
+            ["git", "-C", str(clone_dir), "sparse-checkout", "set", "--no-cone", *plan.paths],
+            stdout=subprocess.DEVNULL,
+        )
+        subprocess.check_call(
+            ["git", "-C", str(clone_dir), "sparse-checkout", "reapply"],
+            stdout=subprocess.DEVNULL,
+        )
+
+        checkout_path = workspace_path / plan.checkout_path
+        checkout_path.mkdir(parents=True, exist_ok=True)
+        for rel_path in plan.paths:
+            src = clone_dir / rel_path
+            dst = checkout_path / rel_path
+            if src.is_dir():
+                shutil.copytree(src, dst, dirs_exist_ok=True)
+            elif src.is_file():
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dst)
+            else:
+                print(
+                    f"warning: path '{rel_path}' not found in {plan.repo}@{plan.ref}",
+                    file=sys.stderr,
+                )
+        shutil.rmtree(clone_dir, ignore_errors=True)
+
+    summary_path = reference_dir / "REFERENCE_PACKS.md"
+    with summary_path.open("w", encoding="utf-8") as handle:
+        for plan in plans:
+            checkout_path = workspace_path / plan.checkout_path
+            handle.write(f"## {plan.name}\n")
+            handle.write(f"- **Repo:** `{plan.repo}`\n")
+            handle.write(f"- **Ref:** `{plan.ref}`\n")
+            handle.write(f"- **Paths:** {', '.join(f'`{path}`' for path in plan.paths)}\n")
+            handle.write(f"- **Location:** `{plan.checkout_path}/`\n\n")
+            handle.write("### Contents\n")
+            for path in sorted(item for item in checkout_path.rglob("*") if item.is_file()):
+                handle.write(f"- `{path.relative_to(checkout_path)}`\n")
+            handle.write("\n")
+    return summary_path
+
+
+def assemble_prompt(
+    reference_pack_name: str | None, context: dict[str, Any], provider: str
+) -> RunnerPrompt:
+    """Assemble a provider-specific prompt from template, context, and references."""
+    provider = _validate_provider(provider)
+    if provider not in PROMPT_PROVIDERS:
+        raise ValueError(f"provider does not support prompt assembly: {provider}")
+    workspace = Path(str(context.get("workspace", "."))).resolve()
+    base_prompt_raw = context.get("base_prompt_file") or context.get("prompt_file")
+    if not base_prompt_raw:
+        raise ValueError("base_prompt_file is required")
+
+    base_prompt = workspace / str(base_prompt_raw)
+    if not base_prompt.is_file():
+        raise FileNotFoundError(f"base prompt file not found: {base_prompt}")
+
+    if context.get("materialize_reference_packs"):
+        materialize_reference_packs(
+            workspace,
+            reference_pack_name=reference_pack_name,
+            token=context.get("github_token") or context.get("token"),
+        )
+
+    output_file = str(
+        context.get("output_file") or _prompt_output_name(provider, context.get("pr_number"))
+    )
+    output_path = workspace / output_file
+
+    parts: list[str] = []
+    instructions = _provider_instruction_path(workspace, provider)
+    if instructions.is_file():
+        parts.extend([_read_text(instructions).rstrip(), "\n---\n\n## Task Prompt\n"])
+    parts.append(_read_text(base_prompt).rstrip())
+
+    appendix = str(context.get("appendix") or "")
+    mode = str(context.get("mode") or "")
+    task_appendix_file = context.get("task_appendix_file")
+    if mode == "keepalive" and task_appendix_file:
+        task_path = Path(str(task_appendix_file))
+        if not task_path.is_absolute():
+            task_path = workspace / task_path
+        if task_path.is_file() and task_path.stat().st_size > 0:
+            appendix = _read_text(task_path)
+
+    if appendix:
+        parts.extend(["\n\n## Run context\n", appendix.rstrip()])
+
+    reference_summary = workspace / ".reference" / "REFERENCE_PACKS.md"
+    if reference_summary.is_file():
+        parts.extend(["\n\n## Reference Packs\n", _read_text(reference_summary).rstrip()])
+
+    text = "".join(parts).rstrip() + "\n"
+    output_path.write_text(text, encoding="utf-8")
+    return RunnerPrompt(
+        provider=provider,
+        file=output_file,
+        text=text,
+        reference_pack_name=reference_pack_name,
+    )
+
+
+def _extract_text_from_json_event(event: dict[str, Any]) -> str | None:
+    for key in ("message", "text", "output", "final_message"):
+        value = event.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    content = event.get("content")
+    if isinstance(content, str) and content.strip():
+        return content.strip()
+    if isinstance(content, list):
+        chunks = [
+            item.get("text", "")
+            for item in content
+            if isinstance(item, dict) and isinstance(item.get("text"), str)
+        ]
+        text = "\n".join(chunk for chunk in chunks if chunk.strip())
+        if text.strip():
+            return text.strip()
+    return None
+
+
+def _parse_jsonl_output(raw_output: str) -> tuple[list[str], list[str]]:
+    messages: list[str] = []
+    errors: list[str] = []
+    parsed_any = False
+    for line in raw_output.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        parsed_any = True
+        event_type = str(event.get("type") or event.get("status") or "").lower()
+        text = _extract_text_from_json_event(event)
+        if "error" in event_type or event.get("error"):
+            errors.append(text or json.dumps(event, sort_keys=True))
+        elif text:
+            messages.append(text)
+    if not parsed_any:
+        return [], []
+    return messages, errors
+
+
+def parse_runner_output(provider: str, raw_output: str) -> RunnerResult:
+    """Parse raw Codex/Claude output into a common result shape."""
+    provider = _validate_provider(provider)
+    if provider not in PROMPT_PROVIDERS:
+        raise ValueError(f"provider does not support output parsing: {provider}")
+    raw = raw_output or ""
+    truncated = len(raw) > 64000 or bool(re.search(r"\btruncated\b", raw, re.IGNORECASE))
+    clipped = raw[:64000] if len(raw) > 64000 else raw
+
+    messages, errors = _parse_jsonl_output(clipped) if provider == "codex" else ([], [])
+    final_message = messages[-1] if messages else clipped.strip()
+
+    if not errors and re.search(r"(^::error::|\bTraceback\b|\bError:|\bException\b)", clipped):
+        first = next((line.strip() for line in clipped.splitlines() if line.strip()), "")
+        errors.append(first or "runner output indicates an error")
+
+    if not final_message:
+        final_message = "No output captured"
+
+    summary = re.sub(r"\s+", " ", final_message).strip()[:500] or "No output captured"
+    return RunnerResult(
+        provider=provider,
+        success=not errors,
+        final_message=final_message,
+        summary=summary,
+        error=errors[0] if errors else None,
+        truncated=truncated,
+    )
+
+
+def _marker_re(pr_number: int, provider: str) -> re.Pattern[str]:
+    return re.compile(
+        rf"<!--\s*{MARKER_PREFIX}:{provider}:{pr_number}:{MARKER_VERSION}\s+(\{{.*?\}})\s*-->",
+        re.DOTALL,
+    )
+
+
+def _build_marker(pr_number: int, provider: str, record: dict[str, Any]) -> str:
+    payload = json.dumps(record, sort_keys=True, separators=(",", ":"))
+    return (
+        f"Runner dispatch state for {provider} on PR #{pr_number}. Do not edit.\n\n"
+        f"<!-- {MARKER_PREFIX}:{provider}:{pr_number}:{MARKER_VERSION} {payload} -->"
+    )
+
+
+def _extract_record(value: str | None, pr_number: int, provider: str) -> dict[str, Any] | None:
+    if not value:
+        return None
+    candidates: list[str] = []
+    match = _marker_re(pr_number, provider).search(value)
+    if match:
+        candidates.append(match.group(1))
+    stripped = value.strip()
+    if stripped.startswith("{"):
+        candidates.append(stripped)
+    for candidate in candidates:
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and payload.get("provider") == provider:
+            return payload
+    return None
+
+
+def _variable_name(pr_number: int, provider: str) -> str:
+    digest = hashlib.sha1(f"{provider}:{pr_number}".encode()).hexdigest()[:12]
+    return f"RUNNER_DISPATCH_{provider.upper()}_{pr_number}_{digest}"[:100]
+
+
+class PrCommentRunnerStorage:
+    def __init__(self, api: GitHubApi) -> None:
+        self.api = api
+
+    @classmethod
+    def from_environment(cls) -> PrCommentRunnerStorage:
+        repo, token = _github_context()
+        return cls(GitHubApi(repo, token))
+
+    def _comments(self, pr_number: int) -> list[dict[str, Any]]:
+        return self.api.paged_get(f"/repos/{self.api.repo}/issues/{pr_number}/comments")
+
+    def _find_comment(self, pr_number: int, provider: str) -> dict[str, Any] | None:
+        pattern = _marker_re(pr_number, provider)
+        for comment in reversed(self._comments(pr_number)):
+            body = comment.get("body")
+            if isinstance(body, str) and pattern.search(body):
+                return comment
+        return None
+
+    def read_record(self, pr_number: int, provider: str) -> dict[str, Any] | None:
+        comment = self._find_comment(pr_number, provider)
+        if not comment:
+            return None
+        body = comment.get("body")
+        return _extract_record(body if isinstance(body, str) else None, pr_number, provider)
+
+    def write_record(self, pr_number: int, provider: str, record: dict[str, Any]) -> None:
+        body = _build_marker(pr_number, provider, record)
+        existing = self._find_comment(pr_number, provider)
+        if existing and existing.get("id"):
+            self.api.request(
+                "PATCH",
+                f"/repos/{self.api.repo}/issues/comments/{existing['id']}",
+                {"body": body},
+            )
+            return
+        self.api.request(
+            "POST",
+            f"/repos/{self.api.repo}/issues/{pr_number}/comments",
+            {"body": body},
+        )
+
+
+class RepoVariableRunnerStorage:
+    def __init__(self, api: GitHubApi) -> None:
+        self.api = api
+
+    @classmethod
+    def from_environment(cls) -> RepoVariableRunnerStorage:
+        repo, token = _github_context()
+        return cls(GitHubApi(repo, token))
+
+    def read_record(self, pr_number: int, provider: str) -> dict[str, Any] | None:
+        name = _variable_name(pr_number, provider)
+        try:
+            payload = self.api.request("GET", f"/repos/{self.api.repo}/actions/variables/{name}")
+        except RuntimeError as exc:
+            message = str(exc)
+            if (
+                " failed: 404 " in message
+                or " failed: 401 " in message
+                or " failed: 403 " in message
+            ):
+                return None
+            raise
+        value = payload.get("value") if isinstance(payload, dict) else None
+        return _extract_record(value if isinstance(value, str) else None, pr_number, provider)
+
+    def write_record(self, pr_number: int, provider: str, record: dict[str, Any]) -> None:
+        name = _variable_name(pr_number, provider)
+        value = json.dumps(record, sort_keys=True, separators=(",", ":"))
+        try:
+            self.api.request(
+                "PATCH",
+                f"/repos/{self.api.repo}/actions/variables/{name}",
+                {"name": name, "value": value},
+            )
+        except RuntimeError as exc:
+            message = str(exc)
+            if " failed: 404 " in message:
+                self.api.request(
+                    "POST",
+                    f"/repos/{self.api.repo}/actions/variables",
+                    {"name": name, "value": value},
+                )
+                return
+            if " failed: 401 " in message or " failed: 403 " in message:
+                print(
+                    f"warning: runner dispatch write skipped for {name}: {message}",
+                    file=sys.stderr,
+                )
+                return
+            raise
+
+
+class FallbackRunnerStorage:
+    def __init__(self, primary: RunnerDispatchStorage, fallback: RunnerDispatchStorage) -> None:
+        self.primary = primary
+        self.fallback = fallback
+        self._use_fallback = False
+
+    def read_record(self, pr_number: int, provider: str) -> dict[str, Any] | None:
+        try:
+            record = self.primary.read_record(pr_number, provider)
+        except Exception as exc:
+            print(f"warning: runner dispatch primary storage unavailable: {exc}", file=sys.stderr)
+            self._use_fallback = True
+            return self.fallback.read_record(pr_number, provider)
+        if record is not None:
+            return record
+        return self.fallback.read_record(pr_number, provider)
+
+    def write_record(self, pr_number: int, provider: str, record: dict[str, Any]) -> None:
+        if not self._use_fallback:
+            try:
+                self.primary.write_record(pr_number, provider, record)
+                return
+            except Exception as exc:
+                print(f"warning: runner dispatch primary write failed: {exc}", file=sys.stderr)
+                self._use_fallback = True
+        self.fallback.write_record(pr_number, provider, record)
+
+
+def _storage_from_name(name: str) -> RunnerDispatchStorage:
+    if name == "pr-comment":
+        return PrCommentRunnerStorage.from_environment()
+    if name == "repo-variable":
+        return RepoVariableRunnerStorage.from_environment()
+    if name == "auto":
+        return FallbackRunnerStorage(
+            PrCommentRunnerStorage.from_environment(),
+            RepoVariableRunnerStorage.from_environment(),
+        )
+    raise ValueError(f"unsupported storage backend: {name}")
+
+
+def should_dispatch(
+    pr_number: int,
+    head_sha: str,
+    provider: str,
+    storage: RunnerDispatchStorage | None = None,
+) -> DebounceDecision:
+    """Reserve a provider dispatch unless the same PR/head SHA was already seen."""
+    provider = _validate_provider(provider)
+    storage = storage or _storage_from_name("auto")
+    key = _runner_key(pr_number, head_sha, provider)
+    prior = storage.read_record(pr_number, provider)
+
+    if prior and prior.get("head_sha") == head_sha:
+        status = str(prior.get("status") or "")
+        if status in {"pending", "completed"}:
+            return DebounceDecision(
+                False,
+                f"duplicate-{status}",
+                key,
+                prior_status=status,
+                prior_head_sha=head_sha,
+            )
+
+    reason = "first-dispatch" if prior is None else "head-sha-changed"
+    record = {
+        "provider": provider,
+        "pr_number": pr_number,
+        "head_sha": head_sha,
+        "key": key,
+        "status": "pending",
+        "started_at": _utc_now(),
+    }
+    storage.write_record(pr_number, provider, record)
+    return DebounceDecision(
+        True,
+        reason,
+        key,
+        prior_status=str(prior.get("status")) if prior else None,
+        prior_head_sha=str(prior.get("head_sha")) if prior else None,
+    )
+
+
+def record_completion(
+    pr_number: int,
+    head_sha: str,
+    provider: str,
+    result: RunnerResult | dict[str, Any],
+    storage: RunnerDispatchStorage | None = None,
+) -> dict[str, Any]:
+    """Persist terminal runner state after a dispatch finishes."""
+    provider = _validate_provider(provider)
+    storage = storage or _storage_from_name("auto")
+    key = _runner_key(pr_number, head_sha, provider)
+    result_payload = (
+        dataclasses.asdict(result) if dataclasses.is_dataclass(result) else dict(result)
+    )
+    status = "completed" if result_payload.get("success") else "error"
+    prior = storage.read_record(pr_number, provider) or {}
+    completed_at = (
+        prior.get("completed_at")
+        if prior.get("key") == key and prior.get("status") in TERMINAL_STATUSES
+        else _utc_now()
+    )
+    record = {
+        **prior,
+        "provider": provider,
+        "pr_number": pr_number,
+        "head_sha": head_sha,
+        "key": key,
+        "status": status,
+        "completed_at": completed_at,
+        "result": result_payload,
+    }
+    storage.write_record(pr_number, provider, record)
+    return record
+
+
+def _github_output_value(value: str) -> str:
+    return value.replace("%", "%25").replace("\n", "%0A").replace("\r", "%0D")
+
+
+def _write_github_output(outputs: dict[str, str]) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with open(output_path, "a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={_github_output_value(value)}\n")
+
+
+def _cmd_assemble(args: argparse.Namespace) -> int:
+    context = {
+        "workspace": args.workspace,
+        "base_prompt_file": args.base_prompt,
+        "appendix": args.appendix or "",
+        "mode": args.mode,
+        "pr_number": args.pr_number,
+        "output_file": args.output,
+        "task_appendix_file": args.task_appendix_file,
+        "materialize_reference_packs": args.materialize_reference_packs,
+        "github_token": os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"),
+    }
+    prompt = assemble_prompt(args.reference_pack_name, context, args.provider)
+    outputs = {"file": prompt.file, "provider": prompt.provider}
+    _write_github_output(outputs)
+    print(json.dumps({**outputs, "chars": len(prompt.text)}, sort_keys=True))
+    return 0
+
+
+def _cmd_parse(args: argparse.Namespace) -> int:
+    raw = (
+        Path(args.raw_output_file).read_text(encoding="utf-8")
+        if args.raw_output_file
+        else sys.stdin.read()
+    )
+    result = parse_runner_output(args.provider, raw)
+    outputs = {
+        "success": "true" if result.success else "false",
+        "summary": result.summary,
+        "final-message-summary": result.summary,
+        "error": result.error or "",
+        "error-summary": result.error or result.summary,
+        "truncated": "true" if result.truncated else "false",
+        "final-message": base64.b64encode(result.final_message.encode("utf-8")).decode("ascii"),
+    }
+    _write_github_output(outputs)
+    print(json.dumps(dataclasses.asdict(result), sort_keys=True))
+    return 0
+
+
+def _cmd_should_dispatch(args: argparse.Namespace) -> int:
+    decision = should_dispatch(
+        int(args.pr_number),
+        args.head_sha,
+        args.provider,
+        storage=_storage_from_name(args.storage),
+    )
+    outputs = {
+        "should_dispatch": "true" if decision.should_dispatch else "false",
+        "reason": decision.reason,
+        "key": decision.key,
+        "prior_status": decision.prior_status or "",
+        "prior_head_sha": decision.prior_head_sha or "",
+    }
+    _write_github_output(outputs)
+    print(json.dumps(outputs, sort_keys=True))
+    return 0
+
+
+def _cmd_record_completion(args: argparse.Namespace) -> int:
+    raw = ""
+    if args.raw_output_file:
+        path = Path(args.raw_output_file)
+        if path.is_file():
+            raw = path.read_text(encoding="utf-8")
+    provider = _validate_provider(args.provider)
+    if provider in PROMPT_PROVIDERS:
+        result = parse_runner_output(provider, raw or args.summary or "")
+    else:
+        summary = args.summary or raw or "No output captured"
+        result = RunnerResult(
+            provider=provider,
+            success=args.exit_code is None or int(args.exit_code) == 0,
+            final_message=summary,
+            summary=re.sub(r"\s+", " ", summary).strip()[:500] or "No output captured",
+        )
+    if args.exit_code is not None and int(args.exit_code) != 0 and result.success:
+        result = dataclasses.replace(result, success=False, error=result.summary)
+    record = record_completion(
+        int(args.pr_number),
+        args.head_sha,
+        args.provider,
+        result,
+        storage=_storage_from_name(args.storage),
+    )
+    outputs = {"recorded": "true", "status": str(record["status"]), "key": str(record["key"])}
+    _write_github_output(outputs)
+    print(json.dumps(outputs, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    assemble = subparsers.add_parser("assemble-prompt", help="assemble provider prompt")
+    assemble.add_argument("--provider", choices=sorted(PROVIDERS), required=True)
+    assemble.add_argument("--base-prompt", required=True)
+    assemble.add_argument("--workspace", default=".")
+    assemble.add_argument("--appendix", default="")
+    assemble.add_argument("--mode", default="")
+    assemble.add_argument("--pr-number", default="")
+    assemble.add_argument("--output", default="")
+    assemble.add_argument("--task-appendix-file", default="")
+    assemble.add_argument("--reference-pack-name", default="")
+    assemble.add_argument("--materialize-reference-packs", action="store_true")
+    assemble.set_defaults(func=_cmd_assemble)
+
+    parse = subparsers.add_parser("parse-output", help="parse provider output")
+    parse.add_argument("--provider", choices=sorted(PROVIDERS), required=True)
+    parse.add_argument("--raw-output-file", default="")
+    parse.set_defaults(func=_cmd_parse)
+
+    dispatch = subparsers.add_parser("should-dispatch", help="reserve a runner dispatch")
+    dispatch.add_argument("--provider", choices=sorted(PROVIDERS), required=True)
+    dispatch.add_argument("--pr-number", required=True)
+    dispatch.add_argument("--head-sha", required=True)
+    dispatch.add_argument(
+        "--storage", choices=["auto", "pr-comment", "repo-variable"], default="auto"
+    )
+    dispatch.set_defaults(func=_cmd_should_dispatch)
+
+    complete = subparsers.add_parser("record-completion", help="persist runner completion")
+    complete.add_argument("--provider", choices=sorted(PROVIDERS), required=True)
+    complete.add_argument("--pr-number", required=True)
+    complete.add_argument("--head-sha", required=True)
+    complete.add_argument(
+        "--storage", choices=["auto", "pr-comment", "repo-variable"], default="auto"
+    )
+    complete.add_argument("--raw-output-file", default="")
+    complete.add_argument("--summary", default="")
+    complete.add_argument("--exit-code", default=None)
+    complete.set_defaults(func=_cmd_record_completion)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1


### PR DESCRIPTION
## Sync Summary

### Files Updated
- autofix.yml: Autofix workflow - automatically fixes lint/format issues
- agents-81-gate-followups.yml: Gate followups hub - consolidates keepalive and autofix followups
- runner_lib/ (3 files): Shared runner prompt assembly, output parsing, and dispatch debounce helpers
- issue_context_utils.js: Utilities for issue context extraction
- sync_tracker_state/ (1 files): Shared durable tracker and open PR state helpers for consumer sync workflows
- agents_pr_meta_update_body.js: Updates PR body with agent metadata
- issue_optimizer.py: Issue optimizer - analyzes issues and suggests improvements
- issue_formatter.py: Issue formatter - converts raw text to AGENT_ISSUE_TEMPLATE format
- issue_pr_context.py: Issue/PR context assembly helper with shared token budget caps
- context_extractor.py: Context extractor - extracts relevant context from issues/PRs
- followup_issue_generator.py: Follow-up issue generator - creates issues from verification feedback

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- AGENTS.md: Repo keeps historical Agents.md casing to avoid case-only path conflicts
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `8226332fd9e28145d7c2440ec3a464357a3901f4`
**Template hash:** `d48bfb527398`
**Sync branch:** `sync/workflows-d48bfb527398`
**Consumer repo:** `stranske/Trend_Model_Project`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Trend_Model_Project","source_repository":"stranske/Workflows","source_sha":"8226332fd9e28145d7c2440ec3a464357a3901f4","template_hash":"d48bfb527398","sync_branch":"sync/workflows-d48bfb527398","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"25445464303","run_attempt":"1","changes_count":11} -->