### PR TITLE
Issue #5169: Document cost scenario discoverability

### DIFF
--- a/config/scenarios/monte_carlo/cost_regime_example.yml
+++ b/config/scenarios/monte_carlo/cost_regime_example.yml
@@ -2,6 +2,7 @@
 # - Demonstrates stochastic calm/stress switching for transaction costs.
 # - Demonstrates regime-specific slippage multipliers.
 # - Intended as a known-good reference for regression tests and CLI examples.
+# - Run with: trend mc run --scenario cost_regime_example --dry-run --n-paths 10
 scenario:
   name: cost_regime_example
   description: "Example scenario exercising regime-switching costs and slippage."

--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -697,6 +697,9 @@ trend mc run --scenario hf_equity_ls_10y --n-paths 500 --jobs 4
 # Quick test run
 trend mc run --scenario hf_equity_ls_10y --dry-run --n-paths 10
 
+# Cost regime example dry-run (exact command)
+trend mc run --scenario cost_regime_example --dry-run --n-paths 10
+
 # Export MC charts from an existing bundle
 trend mc viz \
   --bundle outputs/mc_run_1 \

--- a/tests/monte_carlo/test_costs.py
+++ b/tests/monte_carlo/test_costs.py
@@ -9,7 +9,7 @@ import pandas as pd
 import trend_analysis.monte_carlo.runner as runner_module
 from trend_analysis.api import RunResult
 from trend_analysis.monte_carlo.costs import CostProcess
-from trend_analysis.monte_carlo.registry import load_scenario
+from trend_analysis.monte_carlo.registry import list_scenarios, load_scenario
 from trend_analysis.monte_carlo.runner import MonteCarloRunner
 from trend_analysis.monte_carlo.scenario import MonteCarloScenario
 from trend_analysis.monte_carlo.strategy import StrategyVariant
@@ -206,6 +206,12 @@ def test_cost_regime_scenario_loads_from_registry() -> None:
     assert isinstance(scenario, MonteCarloScenario)
     assert scenario.name == "cost_regime_example"
     assert scenario.costs is not None
+
+
+def test_cost_regime_scenario_is_filterable_by_example_and_cost_tags() -> None:
+    for tag in ("example", "costs"):
+        names = {entry.name for entry in list_scenarios(tags=[tag])}
+        assert "cost_regime_example" in names
 
 
 def test_runner_injects_cash_series_when_override_enabled(monkeypatch: Any) -> None:

--- a/tests/monte_carlo/test_costs.py
+++ b/tests/monte_carlo/test_costs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -212,6 +213,15 @@ def test_cost_regime_scenario_is_filterable_by_example_and_cost_tags() -> None:
     for tag in ("example", "costs"):
         names = {entry.name for entry in list_scenarios(tags=[tag])}
         assert "cost_regime_example" in names
+
+
+def test_cost_regime_scenario_documents_exact_dry_run_command() -> None:
+    scenario_file = Path("config/scenarios/monte_carlo/cost_regime_example.yml")
+    scenario_text = scenario_file.read_text(encoding="utf-8")
+    assert (
+        "# - Run with: trend mc run --scenario cost_regime_example --dry-run --n-paths 10"
+        in scenario_text
+    )
 
 
 def test_runner_injects_cash_series_when_override_enabled(monkeypatch: Any) -> None:

--- a/tests/monte_carlo/test_registry.py
+++ b/tests/monte_carlo/test_registry.py
@@ -256,6 +256,12 @@ def test_list_scenarios_filters_by_tags_ignores_case_and_whitespace(
     assert [entry.name for entry in filtered] == ["alpha"]
 
 
+def test_cost_regime_example_discoverable_by_example_and_costs_tags() -> None:
+    for tag in ("example", "costs"):
+        names = {entry.name for entry in list_scenarios(tags=[tag])}
+        assert "cost_regime_example" in names
+
+
 def test_list_scenarios_missing_registry(tmp_path: Path) -> None:
     registry = tmp_path / "missing.yml"
     with pytest.raises(FileNotFoundError, match="Scenario registry"):

--- a/tests/monte_carlo/test_registry.py
+++ b/tests/monte_carlo/test_registry.py
@@ -155,6 +155,11 @@ def test_list_scenarios_filters_by_tags(tmp_path: Path) -> None:
     filtered = list_scenarios(tags=["stress"], registry_path=registry)
     assert [entry.name for entry in filtered] == ["beta"]
 
+    # Also assert the real example scenario can be discovered by both registry tags.
+    for tag in ("example", "costs"):
+        names = {entry.name for entry in list_scenarios(tags=[tag])}
+        assert "cost_regime_example" in names
+
 
 def test_list_scenarios_filters_by_tags_sorted_by_path(tmp_path: Path) -> None:
     scenario_a = tmp_path / "b.yml"


### PR DESCRIPTION
Closes #5169

## Summary
- documents the exact dry-run command on the cost regime example scenario
- adds registry coverage proving `cost_regime_example` is discoverable by both `example` and `costs` tags

## Validation
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run --with pytest-xdist --with pytest-cov pytest tests/monte_carlo/test_costs.py tests/monte_carlo/test_registry.py::test_list_scenarios_filters_by_tags --no-cov` (12 passed, 3 warnings)
