### PR TITLE
Issue #5172: Allow optional null scenario sections

### DIFF
--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -549,35 +549,35 @@ monte_carlo:
   seed: 12345
   jobs: 8                       # Parallel workers
 
-  # Optional fold configuration
-  folds:
-    enabled: false
-    fold_starts: []
-    calibration_lookback_years: 10
+# Optional fold configuration
+folds:
+  enabled: false
+  fold_starts: []
+  calibration_lookback_years: 10
 
-  # Return generation model
-  return_model:
-    kind: stationary_bootstrap  # stationary_bootstrap | regime_conditioned_bootstrap
-    mean_block_len: 6
-    regime:
-      enabled: true
-      kind: proxy_vol_threshold
-      proxy_column: SPX
-      threshold_percentile: 75
+# Return generation model
+return_model:
+  kind: stationary_bootstrap  # stationary_bootstrap | regime_conditioned_bootstrap
+  mean_block_len: 6
+  regime:
+    enabled: true
+    kind: proxy_vol_threshold
+    proxy_column: SPX
+    threshold_percentile: 75
 
-  # Transaction cost model
-  costs:
-    kind: regime_stochastic
-    calm:
-      trade_cost_bps:
-        dist: lognormal
-        mean: 6
-        sigma: 0.25
-    stress:
-      trade_cost_bps:
-        dist: lognormal
-        mean: 18
-        sigma: 0.35
+# Transaction cost model
+costs:
+  kind: regime_stochastic
+  calm:
+    trade_cost_bps:
+      dist: lognormal
+      mean: 6
+      sigma: 0.25
+  stress:
+    trade_cost_bps:
+      dist: lognormal
+      mean: 18
+      sigma: 0.35
 
 # Strategy configurations
 strategy_set:

--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -624,6 +624,11 @@ outputs:
   formats: [parquet, csv]       # Output formats
 ```
 
+`strategy_set`, `outputs`, and `costs` are optional top-level sections. Scenario
+authors may omit them or set them to `null` to document intentional absence; the
+loader treats both forms as absent. Required sections such as `scenario`,
+`base_config`, and `monte_carlo` remain strict and must contain valid values.
+
 ---
 
 ## Output Specifications

--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -627,7 +627,8 @@ outputs:
 `strategy_set`, `outputs`, and `costs` are optional top-level sections. Scenario
 authors may omit them or set them to `null` to document intentional absence; the
 loader treats both forms as absent. Required sections such as `scenario`,
-`base_config`, and `monte_carlo` remain strict and must contain valid values.
+`base_config`, and `monte_carlo` remain strict and must contain valid values
+(`monte_carlo: null` fails validation).
 
 ---
 

--- a/scripts/validate_llm_deps.py
+++ b/scripts/validate_llm_deps.py
@@ -101,9 +101,7 @@ def main() -> int:
                 f"{expected_major}.{expected_minor}.x"
                 for expected_major, expected_minor in expected
             )
-            incompatible_langchain.append(
-                f"{distribution}=={version} (expected {expected_ranges})"
-            )
+            incompatible_langchain.append(f"{distribution}=={version} (expected {expected_ranges})")
 
     if missing_langchain:
         print(

--- a/tests/integration/test_scenario_registration.py
+++ b/tests/integration/test_scenario_registration.py
@@ -66,3 +66,69 @@ def test_registry_includes_new_scenario_and_loads(tmp_path: Path) -> None:
     assert scenario.monte_carlo.frequency == "Q"
     assert scenario.outputs is not None
     assert scenario.outputs["directory"] == f"outputs/monte_carlo/{scenario_name}"
+
+
+@pytest.mark.integration
+def test_registry_scenario_allows_null_optional_sections(tmp_path: Path) -> None:
+    scenario_name = "integration_null_optional"
+    scenario_dir = tmp_path / "config" / "scenarios" / "monte_carlo"
+    scenario_dir.mkdir(parents=True, exist_ok=True)
+
+    registry_path = scenario_dir / "index.yml"
+    scenario_file = scenario_dir / "integration_null_optional.yml"
+    base_config = scenario_dir / "base.yml"
+
+    base_config.write_text("{}", encoding="utf-8")
+    scenario_file.write_text(
+        "scenario:\n"
+        f"  name: {scenario_name}\n"
+        "base_config: base.yml\n"
+        "monte_carlo:\n"
+        "  mode: mixture\n"
+        "  n_paths: 10\n"
+        "  horizon_years: 1.0\n"
+        "  frequency: M\n"
+        "strategy_set: null\n"
+        "outputs: null\n"
+        "costs: null\n",
+        encoding="utf-8",
+    )
+    registry_path.write_text(
+        "scenarios:\n" f"  - name: {scenario_name}\n" "    path: integration_null_optional.yml\n",
+        encoding="utf-8",
+    )
+
+    scenario = load_scenario(scenario_name, registry_path=registry_path)
+    assert scenario.strategy_set is None
+    assert scenario.outputs is None
+    assert scenario.costs is None
+
+
+@pytest.mark.integration
+def test_registry_scenario_rejects_null_required_monte_carlo(tmp_path: Path) -> None:
+    scenario_name = "integration_null_required"
+    scenario_dir = tmp_path / "config" / "scenarios" / "monte_carlo"
+    scenario_dir.mkdir(parents=True, exist_ok=True)
+
+    registry_path = scenario_dir / "index.yml"
+    scenario_file = scenario_dir / "integration_null_required.yml"
+    base_config = scenario_dir / "base.yml"
+
+    base_config.write_text("{}", encoding="utf-8")
+    scenario_file.write_text(
+        "scenario:\n"
+        f"  name: {scenario_name}\n"
+        "base_config: base.yml\n"
+        "monte_carlo: null\n"
+        "strategy_set: null\n"
+        "outputs: null\n"
+        "costs: null\n",
+        encoding="utf-8",
+    )
+    registry_path.write_text(
+        "scenarios:\n" f"  - name: {scenario_name}\n" "    path: integration_null_required.yml\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Scenario config must define monte_carlo"):
+        load_scenario(scenario_name, registry_path=registry_path)

--- a/tests/integration/test_scenario_registration.py
+++ b/tests/integration/test_scenario_registration.py
@@ -132,3 +132,31 @@ def test_registry_scenario_rejects_null_required_monte_carlo(tmp_path: Path) -> 
 
     with pytest.raises(ValueError, match="Scenario config must define monte_carlo"):
         load_scenario(scenario_name, registry_path=registry_path)
+
+
+@pytest.mark.integration
+def test_registry_scenario_rejects_null_required_monte_carlo_without_optional_sections(
+    tmp_path: Path,
+) -> None:
+    scenario_name = "integration_null_required_minimal"
+    scenario_dir = tmp_path / "config" / "scenarios" / "monte_carlo"
+    scenario_dir.mkdir(parents=True, exist_ok=True)
+
+    registry_path = scenario_dir / "index.yml"
+    scenario_file = scenario_dir / "integration_null_required_minimal.yml"
+    base_config = scenario_dir / "base.yml"
+
+    base_config.write_text("{}", encoding="utf-8")
+    scenario_file.write_text(
+        "scenario:\n" f"  name: {scenario_name}\n" "base_config: base.yml\n" "monte_carlo: null\n",
+        encoding="utf-8",
+    )
+    registry_path.write_text(
+        "scenarios:\n"
+        f"  - name: {scenario_name}\n"
+        "    path: integration_null_required_minimal.yml\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Scenario config must define monte_carlo"):
+        load_scenario(scenario_name, registry_path=registry_path)

--- a/tests/monte_carlo/test_registry.py
+++ b/tests/monte_carlo/test_registry.py
@@ -256,39 +256,6 @@ def test_list_scenarios_filters_by_tags_ignores_case_and_whitespace(
     assert [entry.name for entry in filtered] == ["alpha"]
 
 
-def test_load_scenario_treats_null_optional_sections_as_absent(tmp_path: Path) -> None:
-    base_config = tmp_path / "base.yml"
-    base_config.write_text("{}", encoding="utf-8")
-    scenario = tmp_path / "null_optional.yml"
-    scenario.write_text(
-        "scenario:\n"
-        "  name: null_optional\n"
-        "  description: Optional null scenario.\n"
-        '  version: "1.0"\n'
-        "base_config: base.yml\n"
-        "monte_carlo:\n"
-        "  mode: two_layer\n"
-        "  n_paths: 25\n"
-        "  horizon_years: 1.0\n"
-        "  frequency: M\n"
-        "strategy_set: null\n"
-        "outputs: null\n"
-        "costs: null\n",
-        encoding="utf-8",
-    )
-    registry = tmp_path / "index.yml"
-    registry.write_text(
-        "scenarios:\n" "  - name: null_optional\n" "    path: null_optional.yml\n",
-        encoding="utf-8",
-    )
-
-    loaded = load_scenario("null_optional", registry_path=registry)
-
-    assert loaded.strategy_set is None
-    assert loaded.outputs is None
-    assert loaded.costs is None
-
-
 def test_load_scenario_null_optional_sections_match_omitted_sections(tmp_path: Path) -> None:
     base_config = tmp_path / "base.yml"
     base_config.write_text("{}", encoding="utf-8")

--- a/tests/monte_carlo/test_registry.py
+++ b/tests/monte_carlo/test_registry.py
@@ -278,9 +278,7 @@ def test_load_scenario_treats_null_optional_sections_as_absent(tmp_path: Path) -
     )
     registry = tmp_path / "index.yml"
     registry.write_text(
-        "scenarios:\n"
-        "  - name: null_optional\n"
-        "    path: null_optional.yml\n",
+        "scenarios:\n" "  - name: null_optional\n" "    path: null_optional.yml\n",
         encoding="utf-8",
     )
 
@@ -289,6 +287,60 @@ def test_load_scenario_treats_null_optional_sections_as_absent(tmp_path: Path) -
     assert loaded.strategy_set is None
     assert loaded.outputs is None
     assert loaded.costs is None
+
+
+def test_load_scenario_null_optional_sections_match_omitted_sections(tmp_path: Path) -> None:
+    base_config = tmp_path / "base.yml"
+    base_config.write_text("{}", encoding="utf-8")
+
+    scenario_with_nulls = tmp_path / "with_nulls.yml"
+    scenario_with_nulls.write_text(
+        "scenario:\n"
+        "  name: with_nulls\n"
+        "base_config: base.yml\n"
+        "monte_carlo:\n"
+        "  mode: two_layer\n"
+        "  n_paths: 25\n"
+        "  horizon_years: 1.0\n"
+        "  frequency: M\n"
+        "strategy_set: null\n"
+        "outputs: null\n"
+        "costs: null\n",
+        encoding="utf-8",
+    )
+
+    scenario_without_optionals = tmp_path / "without_optionals.yml"
+    scenario_without_optionals.write_text(
+        "scenario:\n"
+        "  name: without_optionals\n"
+        "base_config: base.yml\n"
+        "monte_carlo:\n"
+        "  mode: two_layer\n"
+        "  n_paths: 25\n"
+        "  horizon_years: 1.0\n"
+        "  frequency: M\n",
+        encoding="utf-8",
+    )
+
+    registry = tmp_path / "index.yml"
+    registry.write_text(
+        "scenarios:\n"
+        "  - name: with_nulls\n"
+        "    path: with_nulls.yml\n"
+        "  - name: without_optionals\n"
+        "    path: without_optionals.yml\n",
+        encoding="utf-8",
+    )
+
+    with_nulls = load_scenario("with_nulls", registry_path=registry)
+    without_optionals = load_scenario("without_optionals", registry_path=registry)
+
+    assert with_nulls.strategy_set is None
+    assert with_nulls.outputs is None
+    assert with_nulls.costs is None
+    assert without_optionals.strategy_set is None
+    assert without_optionals.outputs is None
+    assert without_optionals.costs is None
 
 
 def test_load_scenario_rejects_null_required_monte_carlo(tmp_path: Path) -> None:
@@ -307,9 +359,7 @@ def test_load_scenario_rejects_null_required_monte_carlo(tmp_path: Path) -> None
     )
     registry = tmp_path / "index.yml"
     registry.write_text(
-        "scenarios:\n"
-        "  - name: null_required\n"
-        "    path: null_required.yml\n",
+        "scenarios:\n" "  - name: null_required\n" "    path: null_required.yml\n",
         encoding="utf-8",
     )
 

--- a/tests/monte_carlo/test_registry.py
+++ b/tests/monte_carlo/test_registry.py
@@ -256,6 +256,67 @@ def test_list_scenarios_filters_by_tags_ignores_case_and_whitespace(
     assert [entry.name for entry in filtered] == ["alpha"]
 
 
+def test_load_scenario_treats_null_optional_sections_as_absent(tmp_path: Path) -> None:
+    base_config = tmp_path / "base.yml"
+    base_config.write_text("{}", encoding="utf-8")
+    scenario = tmp_path / "null_optional.yml"
+    scenario.write_text(
+        "scenario:\n"
+        "  name: null_optional\n"
+        "  description: Optional null scenario.\n"
+        '  version: "1.0"\n'
+        "base_config: base.yml\n"
+        "monte_carlo:\n"
+        "  mode: two_layer\n"
+        "  n_paths: 25\n"
+        "  horizon_years: 1.0\n"
+        "  frequency: M\n"
+        "strategy_set: null\n"
+        "outputs: null\n"
+        "costs: null\n",
+        encoding="utf-8",
+    )
+    registry = tmp_path / "index.yml"
+    registry.write_text(
+        "scenarios:\n"
+        "  - name: null_optional\n"
+        "    path: null_optional.yml\n",
+        encoding="utf-8",
+    )
+
+    loaded = load_scenario("null_optional", registry_path=registry)
+
+    assert loaded.strategy_set is None
+    assert loaded.outputs is None
+    assert loaded.costs is None
+
+
+def test_load_scenario_rejects_null_required_monte_carlo(tmp_path: Path) -> None:
+    base_config = tmp_path / "base.yml"
+    base_config.write_text("{}", encoding="utf-8")
+    scenario = tmp_path / "null_required.yml"
+    scenario.write_text(
+        "scenario:\n"
+        "  name: null_required\n"
+        "base_config: base.yml\n"
+        "monte_carlo: null\n"
+        "strategy_set: null\n"
+        "outputs: null\n"
+        "costs: null\n",
+        encoding="utf-8",
+    )
+    registry = tmp_path / "index.yml"
+    registry.write_text(
+        "scenarios:\n"
+        "  - name: null_required\n"
+        "    path: null_required.yml\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Scenario config must define monte_carlo"):
+        load_scenario("null_required", registry_path=registry)
+
+
 def test_list_scenarios_missing_registry(tmp_path: Path) -> None:
     registry = tmp_path / "missing.yml"
     with pytest.raises(FileNotFoundError, match="Scenario registry"):


### PR DESCRIPTION
Closes #5172

## Summary
- Adds registry regression coverage that strategy_set, outputs, and costs set to null load as absent optional sections.
- Adds a required-section regression proving monte_carlo: null still fails validation.
- Documents optional-null handling in the Monte Carlo scenario schema notes.

## Validation
- UV_CACHE_DIR=/private/tmp/uv-cache-trend-5172 uv run --extra dev python -m pytest tests/monte_carlo/test_registry.py tests/integration/test_scenario_registration.py -q --no-cov