### PR TITLE
Follow-up #5171: document CASH injection policy evidence

### DIFF
--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -322,11 +322,14 @@ Cash Earns = Risk-Free Rate (configurable source)
 
 - Trigger condition (boolean):
   - `inject_cash = bool(metrics.rf_override_enabled)`.
+- `data.risk_free_column` and `data.allow_risk_free_fallback` only choose or discover a risk-free series for metric calculations. They do not bypass the CASH injection gate.
 - Injected CASH rate:
   - If `metrics.rf_override_enabled` is `true`, use `metrics.rf_rate_annual`.
   - Convert to periodic simulation rate with `periods_per_year_from_code(data.frequency)`.
   - Formula: `rf_periodic = (1 + rf_rate_annual) ** (1 / periods_per_year) - 1`.
 - Skip behavior: if `metrics.rf_override_enabled` is disabled, no `CASH` column is injected (even when `data.risk_free_column` or `data.allow_risk_free_fallback` is set).
+- If `metrics.rf_override_enabled` is enabled but risk-free resolution fails, resolves to an unsupported type, or yields a series that cannot align cleanly to the simulated returns, the runner logs one warning and leaves the return frame unchanged.
+- If a `CASH` or legacy `cash` column is already present, the runner preserves it and does not overwrite the existing values.
 
 Example:
 - Config sets `data.frequency: "M"`, `metrics.rf_override_enabled: true`, and `metrics.rf_rate_annual: 0.12`.

--- a/tests/monte_carlo/test_runner.py
+++ b/tests/monte_carlo/test_runner.py
@@ -1837,6 +1837,52 @@ def test_apply_cash_handling_returns_unchanged_when_legacy_lowercase_cash_presen
     pd.testing.assert_frame_equal(injected, returns)
 
 
+def test_issue_5171_cash_policy_gate_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #5171: CASH injection is gated only by metrics.rf_override_enabled."""
+    cfg = _base_config()
+    cfg["data"]["allow_risk_free_fallback"] = True
+    cfg["metrics"] = {
+        "registry": ["sharpe_ratio"],
+        "rf_override_enabled": False,
+        "rf_rate_annual": 0.12,
+    }
+    returns = _returns_without_rf()
+
+    with caplog.at_level(logging.WARNING):
+        skipped = MonteCarloRunner(_scenario("two_layer"), base_config=cfg)._apply_cash_handling(
+            returns
+        )
+
+    assert "CASH" not in skipped.columns
+    assert "gate=false" in caplog.text
+
+    cfg["metrics"]["rf_override_enabled"] = True
+    injected = MonteCarloRunner(_scenario("two_layer"), base_config=cfg)._apply_cash_handling(
+        returns
+    )
+    expected = np.full(len(returns), (1.12 ** (1.0 / 12.0)) - 1.0, dtype=float)
+    np.testing.assert_allclose(injected["CASH"].to_numpy(dtype=float, copy=False), expected)
+
+    existing_cash = returns.copy()
+    existing_cash["CASH"] = 0.0042
+    preserved = MonteCarloRunner(_scenario("two_layer"), base_config=cfg)._apply_cash_handling(
+        existing_cash
+    )
+    pd.testing.assert_frame_equal(preserved, existing_cash)
+
+    monkeypatch.setattr(
+        "trend_analysis.monte_carlo.runner.resolve_risk_free_source",
+        lambda *_args, **_kwargs: RiskFreeResolution(source="bad", risk_free=["bad"]),
+    )
+    unsupported = MonteCarloRunner(_scenario("two_layer"), base_config=cfg)._apply_cash_handling(
+        returns
+    )
+    assert "CASH" not in unsupported.columns
+
+
 def test_apply_cash_handling_skips_when_base_config_invalid(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Follow-up for #5171 and verifier concerns on #5259.

## Summary
- Clarifies that risk-free source settings do not bypass `metrics.rf_override_enabled` for CASH injection.
- Documents skip behavior for failed or unsupported risk-free resolution and preservation of existing CASH columns.
- Adds an issue-specific regression matrix for disabled gate, enabled override, existing CASH preservation, and unsupported risk-free resolution.

## Validation
- `UV_CACHE_DIR=/private/tmp/uv-cache-trend-5171-followup uv run --extra dev python -m pytest tests/monte_carlo/test_runner.py tests/monte_carlo/test_costs.py -q --no-cov`
- `UV_CACHE_DIR=/private/tmp/uv-cache-trend-5171-followup uv run --extra dev ruff check tests/monte_carlo/test_runner.py`

Addresses verifier CONCERNS from #5259; source issue remains open pending follow-up merge and verifier PASS.