### PR TITLE
Issue #5237: Make Monte Carlo schema example loadable

### DIFF
--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -552,35 +552,37 @@ monte_carlo:
   seed: 12345
   jobs: 8                       # Parallel workers
 
-  # Optional fold configuration
-  folds:
-    enabled: false
-    fold_starts: []
-    calibration_lookback_years: 10
+# Optional fold configuration
+folds:
+  enabled: false
+  fold_starts: []
+  calibration_lookback_years: 10
 
-  # Return generation model
-  return_model:
-    kind: stationary_bootstrap  # stationary_bootstrap | regime_conditioned_bootstrap
-    mean_block_len: 6
-    regime:
-      enabled: true
-      kind: proxy_vol_threshold
-      proxy_column: SPX
-      threshold_percentile: 75
+# Return generation model
+return_model:
+  kind: stationary_bootstrap  # stationary_bootstrap | regime_conditioned_bootstrap
+  mean_block_len: 6
+  regime:
+    enabled: true
+    kind: proxy_vol_threshold
+    proxy_column: SPX
+    threshold_percentile: 75
 
-  # Transaction cost model
-  costs:
-    kind: regime_stochastic
-    calm:
-      trade_cost_bps:
-        dist: lognormal
-        mean: 6
-        sigma: 0.25
-    stress:
-      trade_cost_bps:
-        dist: lognormal
-        mean: 18
-        sigma: 0.35
+# Transaction cost model
+costs:
+  kind: regime_stochastic
+  default_regime: calm
+  calm:
+    trade_cost_bps:
+      dist: lognormal
+      mean: 6
+      sigma: 0.25
+  stress:
+    trade_cost_bps:
+      dist: lognormal
+      mean: 18
+      sigma: 0.35
+    slippage_multiplier: 1.5
 
 # Strategy configurations
 strategy_set:

--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -539,6 +539,32 @@ scenario:
   name: hf_equity_ls_10y
   description: "Equity L/S hedge fund sleeve 10-year forecast"
   version: "1.0"
+  folds:
+    enabled: false
+    fold_starts: []
+    calibration_lookback_years: 10
+  return_model:
+    kind: stationary_bootstrap  # stationary_bootstrap | regime_conditioned_bootstrap
+    mean_block_len: 6
+    regime:
+      enabled: true
+      kind: proxy_vol_threshold
+      proxy_column: SPX
+      threshold_percentile: 75
+  costs:
+    kind: regime_stochastic
+    default_regime: calm
+    calm:
+      trade_cost_bps:
+        dist: lognormal
+        mean: 6
+        sigma: 0.25
+    stress:
+      trade_cost_bps:
+        dist: lognormal
+        mean: 18
+        sigma: 0.35
+      slippage_multiplier: 1.5
 
 # Reference to base pipeline config
 base_config: config/defaults.yml
@@ -551,38 +577,6 @@ monte_carlo:
   frequency: M                  # M | D
   seed: 12345
   jobs: 8                       # Parallel workers
-
-# Optional fold configuration
-folds:
-  enabled: false
-  fold_starts: []
-  calibration_lookback_years: 10
-
-# Return generation model
-return_model:
-  kind: stationary_bootstrap  # stationary_bootstrap | regime_conditioned_bootstrap
-  mean_block_len: 6
-  regime:
-    enabled: true
-    kind: proxy_vol_threshold
-    proxy_column: SPX
-    threshold_percentile: 75
-
-# Transaction cost model
-costs:
-  kind: regime_stochastic
-  default_regime: calm
-  calm:
-    trade_cost_bps:
-      dist: lognormal
-      mean: 6
-      sigma: 0.25
-  stress:
-    trade_cost_bps:
-      dist: lognormal
-      mean: 18
-      sigma: 0.35
-    slippage_multiplier: 1.5
 
 # Strategy configurations
 strategy_set:

--- a/src/trend_analysis/monte_carlo/registry.py
+++ b/src/trend_analysis/monte_carlo/registry.py
@@ -376,18 +376,20 @@ def _parse_scenario(
 
     def _from_top_or_scenario(key: str) -> object:
         top_has = key in raw and raw.get(key) is not None
-        scenario_has = (
-            scenario_map is not None and key in scenario_map and scenario_map.get(key) is not None
-        )
-        if top_has and scenario_has and raw.get(key) != scenario_map.get(key):
+        scenario_value: object | None = None
+        scenario_has = False
+        if scenario_map is not None and key in scenario_map:
+            scenario_value = scenario_map.get(key)
+            scenario_has = scenario_value is not None
+        if top_has and scenario_has and raw.get(key) != scenario_value:
             raise ValueError(
                 f"Scenario config has conflicting '{key}' values between scenario block "
                 f"and top-level in '{source_path}'"
             )
         if top_has:
             return raw.get(key)
-        if scenario_has and scenario_map is not None:
-            return scenario_map.get(key)
+        if scenario_has:
+            return scenario_value
         return None
 
     base_config_value = raw.get("base_config")

--- a/src/trend_analysis/monte_carlo/registry.py
+++ b/src/trend_analysis/monte_carlo/registry.py
@@ -369,6 +369,26 @@ def _parse_scenario(
     scenario_name, description, version = _extract_scenario_metadata(
         name, raw, source_path=source_path
     )
+    scenario_block = raw.get("scenario")
+    scenario_map: Mapping[str, object] | None = None
+    if scenario_block is not None:
+        scenario_map = _ensure_mapping(scenario_block, label="Scenario config 'scenario'")
+
+    def _from_top_or_scenario(key: str) -> object:
+        top_has = key in raw and raw.get(key) is not None
+        scenario_has = (
+            scenario_map is not None and key in scenario_map and scenario_map.get(key) is not None
+        )
+        if top_has and scenario_has and raw.get(key) != scenario_map.get(key):
+            raise ValueError(
+                f"Scenario config has conflicting '{key}' values between scenario block "
+                f"and top-level in '{source_path}'"
+            )
+        if top_has:
+            return raw.get(key)
+        if scenario_has and scenario_map is not None:
+            return scenario_map.get(key)
+        return None
 
     base_config_value = raw.get("base_config")
     if not base_config_value:
@@ -409,8 +429,9 @@ def _parse_scenario(
         outputs = _ensure_mapping(raw.get("outputs"), label="Scenario config 'outputs'")
 
     costs = None
-    if "costs" in raw and raw.get("costs") is not None:
-        costs = _ensure_mapping(raw.get("costs"), label="Scenario config 'costs'")
+    costs_value = _from_top_or_scenario("costs")
+    if costs_value is not None:
+        costs = _ensure_mapping(costs_value, label="Scenario config 'costs'")
 
     enable_fold_runs = raw.get("enable_fold_runs", _MISSING)
 
@@ -429,11 +450,21 @@ def _parse_scenario(
     if enable_fold_runs is not _MISSING:
         scenario_kwargs["enable_fold_runs"] = enable_fold_runs
 
-    folds_value = _optional_mapping(raw, key="folds", scenario_name=scenario_name)
+    folds_raw = dict(raw)
+    folds_source = _from_top_or_scenario("folds")
+    if folds_source is not None:
+        folds_raw["folds"] = folds_source
+    folds_value = _optional_mapping(folds_raw, key="folds", scenario_name=scenario_name)
     if folds_value is not None:
         scenario_kwargs["folds"] = folds_value
 
-    return_model_value = _optional_mapping(raw, key="return_model", scenario_name=scenario_name)
+    return_model_raw = dict(raw)
+    return_model_source = _from_top_or_scenario("return_model")
+    if return_model_source is not None:
+        return_model_raw["return_model"] = return_model_source
+    return_model_value = _optional_mapping(
+        return_model_raw, key="return_model", scenario_name=scenario_name
+    )
     if return_model_value is not None:
         scenario_kwargs["return_model"] = return_model_value
 

--- a/tests/monte_carlo/test_scenario.py
+++ b/tests/monte_carlo/test_scenario.py
@@ -226,6 +226,12 @@ outputs:
 def test_complete_schema_markdown_example_loads_through_registry(tmp_path: Path) -> None:
     payload = _extract_complete_schema_payload()
 
+    scenario_meta = payload.get("scenario")
+    assert isinstance(scenario_meta, dict)
+    assert "folds" in scenario_meta
+    assert "return_model" in scenario_meta
+    assert "costs" in scenario_meta
+
     monte_carlo = payload["monte_carlo"]
     assert isinstance(monte_carlo, dict)
     assert "folds" not in monte_carlo

--- a/tests/monte_carlo/test_scenario.py
+++ b/tests/monte_carlo/test_scenario.py
@@ -25,6 +25,36 @@ def _load_example_payload() -> dict:
     return payload
 
 
+def _extract_complete_schema_payload() -> dict:
+    root = Path(__file__).resolve().parents[2]
+    docs_path = root / "docs" / "phase-3" / "MonteCarlo.md"
+    lines = docs_path.read_text(encoding="utf-8").splitlines()
+
+    in_section = False
+    in_fence = False
+    yaml_lines: list[str] = []
+    for line in lines:
+        if line == "### Complete Scenario Schema":
+            in_section = True
+            continue
+        if not in_section:
+            continue
+        if line.startswith("### "):
+            break
+        if line == "```yaml" and not in_fence:
+            in_fence = True
+            continue
+        if line == "```" and in_fence:
+            break
+        if in_fence:
+            yaml_lines.append(line)
+
+    assert yaml_lines, "Complete Scenario Schema YAML block was not found"
+    payload = yaml.safe_load("\n".join(yaml_lines))
+    assert isinstance(payload, dict)
+    return payload
+
+
 def test_monte_carlo_settings_validates_and_normalizes() -> None:
     settings = MonteCarloSettings(
         mode="Two_Layer",
@@ -191,6 +221,48 @@ outputs:
     assert curated[0].name == "trend_basic"
     assert scenario.folds["n_folds"] == 3
     assert scenario.outputs["directory"] == "outputs/monte_carlo/example"
+
+
+def test_complete_schema_markdown_example_loads_through_registry(tmp_path: Path) -> None:
+    payload = _extract_complete_schema_payload()
+
+    monte_carlo = payload["monte_carlo"]
+    assert isinstance(monte_carlo, dict)
+    assert "folds" not in monte_carlo
+    assert "return_model" not in monte_carlo
+    assert "costs" not in monte_carlo
+
+    scenario_path = tmp_path / "hf_equity_ls_10y.yml"
+    scenario_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    registry_path = tmp_path / "index.yml"
+    registry_path.write_text(
+        yaml.safe_dump(
+            {
+                "scenarios": [
+                    {
+                        "name": "hf_equity_ls_10y",
+                        "path": str(scenario_path),
+                    }
+                ]
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    scenario = load_scenario("hf_equity_ls_10y", registry_path=registry_path)
+
+    assert scenario.name == "hf_equity_ls_10y"
+    assert scenario.monte_carlo.mode == "two_layer"
+    assert scenario.monte_carlo.n_paths == 2000
+    assert scenario.folds is not None
+    assert scenario.folds["enabled"] is False
+    assert scenario.return_model is not None
+    assert scenario.return_model["kind"] == "stationary_bootstrap"
+    assert scenario.costs is not None
+    assert scenario.costs["kind"] == "regime_stochastic"
+    assert scenario.outputs is not None
+    assert scenario.outputs["formats"] == ["parquet", "csv"]
 
 
 def test_monte_carlo_scenario_coerces_curated_variants() -> None:


### PR DESCRIPTION
Implements #5237.

## Summary
- Move the Complete Scenario Schema folds, return_model, and costs sections to the top level accepted by the Monte Carlo scenario parser.
- Add a regression that extracts that Markdown YAML fence and loads it through a temporary scenario registry.

## Validation
- PYTHONPATH=/private/tmp/trend-issue-5237-pydeps:src pytest tests/monte_carlo/test_scenario.py tests/monte_carlo/test_example_config.py
- python -m ruff check docs/phase-3/MonteCarlo.md tests/monte_carlo/test_scenario.py
- rg -n "^  (folds|return_model|costs):" docs/phase-3/MonteCarlo.md
- git diff --check