### PR TITLE
Issue #5238: Declare rf override config key

### DIFF
--- a/config.schema.compact.json
+++ b/config.schema.compact.json
@@ -1272,7 +1272,7 @@
         },
         "max_turnover": {
           "default": 1.0,
-          "description": "optional turnover cap (1.0 = no cap)",
+          "description": "optional turnover cap (1.0 = no cap); may be a scalar cap or a regime-to-cap mapping",
           "nl_editable": true,
           "type": [
             "number",

--- a/config.schema.compact.json
+++ b/config.schema.compact.json
@@ -21,6 +21,7 @@
     },
     "export": {
       "directory": "results/",
+      "disable_narrative_generation": false,
       "excel": {
         "autofit_columns": true,
         "conditional_bands": {
@@ -64,6 +65,7 @@
         "information_ratio",
         "max_drawdown"
       ],
+      "rf_override_enabled": false,
       "rf_rate_annual": 0.02,
       "use_continuous": false
     },
@@ -448,6 +450,7 @@
     "export": {
       "default": {
         "directory": "results/",
+        "disable_narrative_generation": false,
         "excel": {
           "autofit_columns": true,
           "conditional_bands": {
@@ -473,6 +476,12 @@
           "description": "Directory to write export outputs.",
           "nl_editable": false,
           "type": "string"
+        },
+        "disable_narrative_generation": {
+          "default": false,
+          "description": "Disable narrative generation in exports.",
+          "nl_editable": true,
+          "type": "boolean"
         },
         "excel": {
           "default": {
@@ -602,6 +611,7 @@
           "information_ratio",
           "max_drawdown"
         ],
+        "rf_override_enabled": false,
         "rf_rate_annual": 0.02,
         "use_continuous": false
       },
@@ -704,6 +714,12 @@
             "null",
             "number"
           ]
+        },
+        "rf_override_enabled": {
+          "default": false,
+          "description": "enable Monte Carlo CASH injection from rf_rate_annual",
+          "nl_editable": true,
+          "type": "boolean"
         },
         "rf_rate_annual": {
           "default": 0.02,
@@ -1256,13 +1272,8 @@
         },
         "max_turnover": {
           "default": 1.0,
-          "description": "optional turnover cap (1.0 = no cap) or mapping of regime names to caps",
+          "description": "optional turnover cap (1.0 = no cap)",
           "nl_editable": true,
-          "additionalProperties": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 2
-          },
           "type": [
             "number",
             "object",

--- a/config.schema.json
+++ b/config.schema.json
@@ -23,6 +23,7 @@
     },
     "export": {
       "directory": "results/",
+      "disable_narrative_generation": false,
       "excel": {
         "autofit_columns": true,
         "conditional_bands": {
@@ -66,6 +67,7 @@
         "information_ratio",
         "max_drawdown"
       ],
+      "rf_override_enabled": false,
       "rf_rate_annual": 0.02,
       "use_continuous": false
     },
@@ -506,6 +508,7 @@
       "constraints": {},
       "default": {
         "directory": "results/",
+        "disable_narrative_generation": false,
         "excel": {
           "autofit_columns": true,
           "conditional_bands": {
@@ -521,8 +524,7 @@
         ],
         "include_figures": false,
         "include_raw_returns": true,
-        "include_vol_adj": true,
-        "disable_narrative_generation": false
+        "include_vol_adj": true
       },
       "description": "Export settings for output artifacts.",
       "nl_editable": true,
@@ -533,6 +535,13 @@
           "description": "Directory to write export outputs.",
           "nl_editable": false,
           "type": "string"
+        },
+        "disable_narrative_generation": {
+          "constraints": {},
+          "default": false,
+          "description": "Disable narrative generation in exports.",
+          "nl_editable": true,
+          "type": "boolean"
         },
         "excel": {
           "additionalProperties": false,
@@ -636,13 +645,6 @@
           "description": "Include volatility-adjusted series in exports.",
           "nl_editable": true,
           "type": "boolean"
-        },
-        "disable_narrative_generation": {
-          "constraints": {},
-          "default": false,
-          "description": "Disable narrative generation in exports.",
-          "nl_editable": true,
-          "type": "boolean"
         }
       },
       "type": "object"
@@ -685,6 +687,7 @@
           "information_ratio",
           "max_drawdown"
         ],
+        "rf_override_enabled": false,
         "rf_rate_annual": 0.02,
         "use_continuous": false
       },
@@ -803,6 +806,13 @@
             "null",
             "number"
           ]
+        },
+        "rf_override_enabled": {
+          "constraints": {},
+          "default": false,
+          "description": "enable Monte Carlo CASH injection from rf_rate_annual",
+          "nl_editable": true,
+          "type": "boolean"
         },
         "rf_rate_annual": {
           "constraints": {
@@ -1436,20 +1446,20 @@
           "type": "array"
         },
         "max_turnover": {
+          "additionalProperties": {
+            "maximum": 2,
+            "minimum": 0,
+            "type": "number"
+          },
           "constraints": {
             "maximum": 2,
             "minimum": 0
           },
           "default": 1.0,
-          "description": "optional turnover cap (1.0 = no cap) or mapping of regime names to caps",
+          "description": "optional turnover cap (1.0 = no cap)",
           "maximum": 2,
           "minimum": 0,
           "nl_editable": true,
-          "additionalProperties": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 2
-          },
           "type": [
             "number",
             "object",

--- a/config.schema.json
+++ b/config.schema.json
@@ -1456,7 +1456,7 @@
             "minimum": 0
           },
           "default": 1.0,
-          "description": "optional turnover cap (1.0 = no cap)",
+          "description": "optional turnover cap (1.0 = no cap); may be a scalar cap or a regime-to-cap mapping",
           "maximum": 2,
           "minimum": 0,
           "nl_editable": true,

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -149,6 +149,7 @@ regime:
 # ----------------------------------------------------------------------
 metrics:
   rf_rate_annual:     0.02            # flat rf or link to series
+  rf_override_enabled: false           # enable Monte Carlo CASH injection from rf_rate_annual
   use_continuous:     false           # geometric (default) vs. log
   alpha_reference:    "SP500TR"       # ticker in indices_glob
   # ---- new vectorised list drives score_frame v2 -----------------

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -1379,6 +1379,16 @@ def _validate_mc_scenario(scenario: MonteCarloScenario) -> list[str]:
 
     base_config = runner.base_config
     base_path = _require_mc_base_config(scenario).parent
+    config_result = validate_config(
+        dict(base_config),
+        base_path=base_path,
+        skip_required_fields=True,
+    )
+    if not config_result.valid:
+        errors.extend(
+            f"base_config: {message}"
+            for message in format_validation_messages(config_result, include_warnings=False)
+        )
 
     return_model = scenario.return_model
     if isinstance(return_model, Mapping):

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -111,7 +111,9 @@ def _maybe_validate_config(
             payload = dict(cfg)
         elif hasattr(cfg, "model_dump"):
             try:
-                payload = cfg.model_dump(exclude_none=True, exclude_unset=True, mode="json")
+                payload = cfg.model_dump(
+                    exclude_none=True, exclude_unset=True, mode="json"
+                )
             except TypeError:
                 try:
                     payload = cfg.model_dump(exclude_none=True, exclude_unset=True)
@@ -154,7 +156,11 @@ def _maybe_track_config_coverage(config_path: Path, input_path: str) -> bool:
         return True
 
     data_section = dict(payload.get("data") or {})
-    if input_path and not data_section.get("csv_path") and not data_section.get("managers_glob"):
+    if (
+        input_path
+        and not data_section.get("csv_path")
+        and not data_section.get("managers_glob")
+    ):
         data_section["csv_path"] = input_path
         payload = dict(payload)
         payload["data"] = data_section
@@ -218,7 +224,9 @@ def _apply_trend_spec_preset(cfg: Any, preset: TrendSpecPreset) -> None:
         object.__setattr__(cfg, "trend_spec_preset", preset.name)
 
 
-def _log_step(run_id: str, event: str, message: str, level: str = "INFO", **fields: Any) -> None:
+def _log_step(
+    run_id: str, event: str, message: str, level: str = "INFO", **fields: Any
+) -> None:
     """Internal indirection for structured logging.
 
     Tests monkeypatch this symbol directly (`_log_step`) rather than the public
@@ -272,7 +280,9 @@ def _extract_cache_stats(payload: object) -> dict[str, int] | None:
     return found[-1] if found else None
 
 
-def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: str) -> pd.DataFrame:
+def _apply_universe_mask(
+    df: pd.DataFrame, mask: pd.DataFrame, *, date_column: str
+) -> pd.DataFrame:
     """Apply a time-varying membership mask to returns data."""
 
     if mask.empty:
@@ -282,7 +292,9 @@ def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: s
     try:
         date_col = lookup[date_column.lower()]
     except KeyError as exc:  # pragma: no cover - defensive guard
-        raise KeyError(f"Date column '{date_column}' is missing from the returns data") from exc
+        raise KeyError(
+            f"Date column '{date_column}' is missing from the returns data"
+        ) from exc
 
     working[date_col] = pd.to_datetime(working[date_col])
     working = working.set_index(date_col)
@@ -297,12 +309,16 @@ def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: s
         )
 
     masked = working.copy()
-    masked.loc[:, aligned_mask.columns] = masked.loc[:, aligned_mask.columns].where(aligned_mask)
+    masked.loc[:, aligned_mask.columns] = masked.loc[:, aligned_mask.columns].where(
+        aligned_mask
+    )
     masked.reset_index(inplace=True)
     return masked
 
 
-def _attach_universe_paths(cfg: Any, spec: NamedUniverse, *, csv_path: str | None) -> None:
+def _attach_universe_paths(
+    cfg: Any, spec: NamedUniverse, *, csv_path: str | None
+) -> None:
     """Persist the selected universe paths onto ``cfg.data`` when possible."""
 
     membership_value = str(spec.membership_path)
@@ -333,7 +349,9 @@ def _attach_universe_paths(cfg: Any, spec: NamedUniverse, *, csv_path: str | Non
         setattr(data_section, "universe_membership_path", membership_value)
     except Exception:
         try:
-            object.__setattr__(data_section, "universe_membership_path", membership_value)
+            object.__setattr__(
+                data_section, "universe_membership_path", membership_value
+            )
         except Exception:
             data_section = None
 
@@ -412,7 +430,9 @@ def check_environment(lock_path: Path | None = None) -> int:
     return 0
 
 
-def maybe_log_step(enabled: bool, run_id: str, event: str, message: str, **fields: Any) -> None:
+def maybe_log_step(
+    enabled: bool, run_id: str, event: str, message: str, **fields: Any
+) -> None:
     """Log a structured step when ``enabled`` is True."""
     if enabled:
         _log_step(run_id, event, message, **fields)
@@ -651,7 +671,9 @@ def _execute_analysis_run(
             if isinstance(bench_map, dict) and bench_map:
                 first_bench = next(iter(bench_map.values()))
                 setattr(run_result, "benchmark", first_bench)
-            weights_user = res.get("weights_user_weight") if isinstance(res, dict) else None
+            weights_user = (
+                res.get("weights_user_weight") if isinstance(res, dict) else None
+            )
             if weights_user is not None:
                 setattr(run_result, "weights", weights_user)
     else:  # pragma: no cover - legacy fallback
@@ -745,7 +767,9 @@ def _execute_analysis_run(
             formats=target_formats,
         )
         data_keys = list(data.keys())
-        artifact_paths = _resolve_artifact_paths(out_dir_path, filename, data_keys, fmt_list)
+        artifact_paths = _resolve_artifact_paths(
+            out_dir_path, filename, data_keys, fmt_list
+        )
         maybe_log_step(
             structured_log,
             run_id,
@@ -777,7 +801,9 @@ def _execute_analysis_run(
                     summary_text=text,
                 )
             except Exception as exc:  # pragma: no cover - defensive guard
-                logging.getLogger(__name__).warning("Failed to write run artifacts: %s", exc)
+                logging.getLogger(__name__).warning(
+                    "Failed to write run artifacts: %s", exc
+                )
             else:
                 maybe_log_step(
                     structured_log,
@@ -828,7 +854,9 @@ def main(argv: list[str] | None = None) -> int:
     """Entry point for the ``trend-model`` command."""
 
     parser = argparse.ArgumentParser(prog="trend-model")
-    parser.add_argument("--check", action="store_true", help="Print environment info and exit")
+    parser.add_argument(
+        "--check", action="store_true", help="Print environment info and exit"
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     sub.add_parser("gui", help="Launch Streamlit interface")
@@ -836,7 +864,9 @@ def main(argv: list[str] | None = None) -> int:
     run_p = sub.add_parser("run", help="Run analysis pipeline")
     run_p.add_argument("-c", "--config", required=True, help="Path to YAML config")
     run_p.add_argument("-i", "--input", required=True, help="Path to returns CSV")
-    run_p.add_argument("--seed", type=int, help="Override random seed (takes precedence)")
+    run_p.add_argument(
+        "--seed", type=int, help="Override random seed (takes precedence)"
+    )
     run_p.add_argument(
         "--bundle",
         nargs="?",
@@ -885,7 +915,9 @@ def main(argv: list[str] | None = None) -> int:
         "run-ui",
         help="Deprecated: use 'run' with Streamlit JSON params",
     )
-    run_ui_p.add_argument("--params", required=True, help="Path to Streamlit JSON params")
+    run_ui_p.add_argument(
+        "--params", required=True, help="Path to Streamlit JSON params"
+    )
     run_ui_p.add_argument("--data", required=True, help="Path to returns CSV or Excel")
     run_ui_p.add_argument(
         "--auto-fix-dates",
@@ -955,7 +987,9 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     mc_run_p = mc_sub.add_parser("run", help="Run Monte Carlo scenarios")
-    mc_run_p.add_argument("--scenario", required=True, help="Scenario name or config path")
+    mc_run_p.add_argument(
+        "--scenario", required=True, help="Scenario name or config path"
+    )
     mc_run_p.add_argument(
         "--data",
         help="CSV/Parquet path for price or returns history (overrides base config)",
@@ -967,7 +1001,9 @@ def main(argv: list[str] | None = None) -> int:
         default=[],
         help="Output formats (csv, json, parquet). Repeatable or comma-separated.",
     )
-    mc_run_p.add_argument("--n-paths", type=int, help="Override number of Monte Carlo paths")
+    mc_run_p.add_argument(
+        "--n-paths", type=int, help="Override number of Monte Carlo paths"
+    )
     mc_run_p.add_argument("--jobs", type=int, help="Override parallel job count")
     mc_run_p.add_argument("--seed", type=int, help="Override Monte Carlo seed")
     mc_run_p.add_argument(
@@ -984,7 +1020,9 @@ def main(argv: list[str] | None = None) -> int:
         "--registry",
         help="Override the scenario registry path",
     )
-    mc_viz_p = mc_sub.add_parser("viz", help="Render Monte Carlo chart artifacts from a bundle")
+    mc_viz_p = mc_sub.add_parser(
+        "viz", help="Render Monte Carlo chart artifacts from a bundle"
+    )
     mc_viz_p.add_argument(
         "--bundle",
         required=True,
@@ -1158,7 +1196,9 @@ def main(argv: list[str] | None = None) -> int:
             universe_spec: NamedUniverse | None = None
             if getattr(args, "universe", None):
                 mask, universe_spec = load_universe(args.universe, prices=df)
-                df = _apply_universe_mask(df, mask, date_column=universe_spec.date_column)
+                df = _apply_universe_mask(
+                    df, mask, date_column=universe_spec.date_column
+                )
             if universe_spec is not None:
                 _attach_universe_paths(cfg, universe_spec, csv_path=args.input)
             return _execute_analysis_run(
@@ -1240,7 +1280,9 @@ def _render_mc_table(entries: Sequence[ScenarioRegistryEntry]) -> str:
     divider = "  ".join("-" * widths[col] for col in columns)
     lines = [header, divider]
     for row in rows:
-        lines.append("  ".join(str(row.get(col, "")).ljust(widths[col]) for col in columns))
+        lines.append(
+            "  ".join(str(row.get(col, "")).ljust(widths[col]) for col in columns)
+        )
     return "\n".join(lines)
 
 
@@ -1250,7 +1292,9 @@ def _resolve_mc_registry_path(raw: str | None) -> Path | None:
     return Path(raw).expanduser().resolve()
 
 
-def _load_mc_scenario_value(raw: str, *, registry_path: Path | None) -> MonteCarloScenario:
+def _load_mc_scenario_value(
+    raw: str, *, registry_path: Path | None
+) -> MonteCarloScenario:
     if not raw:
         raise ValueError("Scenario name is required")
     candidate = Path(raw).expanduser()
@@ -1384,11 +1428,17 @@ def _validate_mc_scenario(scenario: MonteCarloScenario) -> list[str]:
         base_path=base_path,
         skip_required_fields=True,
     )
-    if not config_result.valid:
-        errors.extend(
-            f"base_config: {message}"
-            for message in format_validation_messages(config_result, include_warnings=False)
+    schema_key_errors = [
+        issue
+        for issue in config_result.errors
+        if issue.message.startswith("Unexpected field")
+    ]
+    if schema_key_errors:
+        messages = format_validation_messages(
+            config_result.model_copy(update={"errors": schema_key_errors}),
+            include_warnings=False,
         )
+        errors.extend(f"base_config: {message}" for message in messages)
 
     return_model = scenario.return_model
     if isinstance(return_model, Mapping):
@@ -1400,11 +1450,15 @@ def _validate_mc_scenario(scenario: MonteCarloScenario) -> list[str]:
             "regime_conditioned",
         }
         if kind not in allowed:
-            errors.append(f"return_model.kind must be one of: {', '.join(sorted(allowed))}")
+            errors.append(
+                f"return_model.kind must be one of: {', '.join(sorted(allowed))}"
+            )
 
     outputs = scenario.outputs
     if isinstance(outputs, Mapping):
-        errors.extend(_validate_mc_formats(outputs.get("formats", outputs.get("format"))))
+        errors.extend(
+            _validate_mc_formats(outputs.get("formats", outputs.get("format")))
+        )
 
     try:
         strategies = runner.resolve_strategies()
@@ -1625,7 +1679,11 @@ def _build_mc_progress_callback(
 
 def _validate_mc_viz_output_flags(args: argparse.Namespace) -> None:
     if not any(
-        (getattr(args, "html", False), getattr(args, "json", False), getattr(args, "png", False))
+        (
+            getattr(args, "html", False),
+            getattr(args, "json", False),
+            getattr(args, "png", False),
+        )
     ):
         raise ValueError(
             "The 'mc viz' command requires at least one output flag: --html, --json, or --png"
@@ -1635,7 +1693,9 @@ def _validate_mc_viz_output_flags(args: argparse.Namespace) -> None:
 def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
     suffix = path.suffix.lower()
     if suffix not in {".parquet", ".csv", ".json"}:
-        raise ValueError(f"Unsupported {label} file format '{path.suffix}' for '{path.name}'.")
+        raise ValueError(
+            f"Unsupported {label} file format '{path.suffix}' for '{path.name}'."
+        )
     try:
         if suffix == ".parquet":
             frame = pd.read_parquet(path)
@@ -1653,7 +1713,9 @@ def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
 
 
 def _load_mc_frame(bundle_dir: Path, *, stem: str) -> pd.DataFrame:
-    candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
+    candidates = tuple(
+        bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json")
+    )
     existing = next((candidate for candidate in candidates if candidate.exists()), None)
     if existing is None:
         expected = ", ".join(path.name for path in candidates)
@@ -1671,7 +1733,9 @@ def _load_mc_results_frame(bundle_dir: Path) -> pd.DataFrame:
     return _load_mc_frame(bundle_dir, stem="results")
 
 
-def _load_mc_bundle_frames(bundle: str | os.PathLike[str]) -> tuple[pd.DataFrame, pd.DataFrame]:
+def _load_mc_bundle_frames(
+    bundle: str | os.PathLike[str],
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     bundle_dir = Path(bundle).expanduser().resolve()
     if not bundle_dir.exists():
         raise FileNotFoundError(f"MC bundle directory does not exist: {bundle_dir}")
@@ -1681,7 +1745,9 @@ def _load_mc_bundle_frames(bundle: str | os.PathLike[str]) -> tuple[pd.DataFrame
     missing_inputs: list[str] = []
     expected_by_stem: dict[str, str] = {}
     for stem in required_stems:
-        candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
+        candidates = tuple(
+            bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json")
+        )
         if not any(candidate.exists() for candidate in candidates):
             missing_inputs.append(stem)
             expected_by_stem[stem] = ", ".join(path.name for path in candidates)
@@ -1693,7 +1759,9 @@ def _load_mc_bundle_frames(bundle: str | os.PathLike[str]) -> tuple[pd.DataFrame
                 f"Missing required MC {stem} file in '{bundle_dir}'. Expected one of: {expected}"
             )
         missing_text = ", ".join(missing_inputs)
-        expected_text = "; ".join(f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs)
+        expected_text = "; ".join(
+            f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs
+        )
         raise FileNotFoundError(
             f"Missing required MC input files in '{bundle_dir}': {missing_text}. "
             f"Expected one of each: {expected_text}"
@@ -1710,9 +1778,13 @@ def _load_mc_nav_paths_frame(bundle: str | os.PathLike[str]) -> pd.DataFrame | N
 
 
 def _parse_mc_chart_selection(charts_value: str) -> list[str]:
-    requested = [token.strip().lower() for token in charts_value.split(",") if token.strip()]
+    requested = [
+        token.strip().lower() for token in charts_value.split(",") if token.strip()
+    ]
     if not requested:
-        raise ValueError("The 'mc viz' command requires at least one chart in --charts.")
+        raise ValueError(
+            "The 'mc viz' command requires at least one chart in --charts."
+        )
 
     seen: set[str] = set()
     ordered: list[str] = []
@@ -1782,10 +1854,14 @@ def _build_mc_risk_return_chart(
     from trend_analysis.viz import risk_return
 
     nav_frame = _mc_nav_source_frame(summary_frame, results_frame, nav_paths_frame)
-    returns_frame = nav_frame.pct_change(fill_method=None).replace([np.inf, -np.inf], np.nan)
+    returns_frame = nav_frame.pct_change(fill_method=None).replace(
+        [np.inf, -np.inf], np.nan
+    )
     returns_frame = returns_frame.dropna(how="all")
     if returns_frame.empty:
-        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(how="all")
+        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(
+            how="all"
+        )
     return risk_return.make(returns_frame)
 
 
@@ -1876,7 +1952,9 @@ def _handle_mc_command(args: argparse.Namespace) -> int:
         scenarios: list[MonteCarloScenario] = []
         if scenario_arg:
             try:
-                scenarios = [_load_mc_scenario_value(scenario_arg, registry_path=registry_path)]
+                scenarios = [
+                    _load_mc_scenario_value(scenario_arg, registry_path=registry_path)
+                ]
             except (ValueError, FileNotFoundError, IsADirectoryError) as exc:
                 print(f"Scenario validation failed: {exc}", file=sys.stderr)
                 return 1
@@ -1894,7 +1972,9 @@ def _handle_mc_command(args: argparse.Namespace) -> int:
                 return 2
             for entry in entries:
                 try:
-                    scenarios.append(load_scenario(entry.name, registry_path=registry_path))
+                    scenarios.append(
+                        load_scenario(entry.name, registry_path=registry_path)
+                    )
                 except (ValueError, FileNotFoundError, IsADirectoryError) as exc:
                     print(
                         f"Scenario '{entry.name}' failed to load: {exc}",
@@ -1923,7 +2003,9 @@ def _handle_mc_command(args: argparse.Namespace) -> int:
         registry_path = _resolve_mc_registry_path(getattr(args, "registry", None))
         scenario_arg = getattr(args, "scenario", None) or ""
         try:
-            scenario = _load_mc_scenario_value(scenario_arg, registry_path=registry_path)
+            scenario = _load_mc_scenario_value(
+                scenario_arg, registry_path=registry_path
+            )
         except (ValueError, FileNotFoundError, IsADirectoryError) as exc:
             print(f"Scenario run failed: {exc}", file=sys.stderr)
             return 1

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -111,9 +111,7 @@ def _maybe_validate_config(
             payload = dict(cfg)
         elif hasattr(cfg, "model_dump"):
             try:
-                payload = cfg.model_dump(
-                    exclude_none=True, exclude_unset=True, mode="json"
-                )
+                payload = cfg.model_dump(exclude_none=True, exclude_unset=True, mode="json")
             except TypeError:
                 try:
                     payload = cfg.model_dump(exclude_none=True, exclude_unset=True)
@@ -156,11 +154,7 @@ def _maybe_track_config_coverage(config_path: Path, input_path: str) -> bool:
         return True
 
     data_section = dict(payload.get("data") or {})
-    if (
-        input_path
-        and not data_section.get("csv_path")
-        and not data_section.get("managers_glob")
-    ):
+    if input_path and not data_section.get("csv_path") and not data_section.get("managers_glob"):
         data_section["csv_path"] = input_path
         payload = dict(payload)
         payload["data"] = data_section
@@ -224,9 +218,7 @@ def _apply_trend_spec_preset(cfg: Any, preset: TrendSpecPreset) -> None:
         object.__setattr__(cfg, "trend_spec_preset", preset.name)
 
 
-def _log_step(
-    run_id: str, event: str, message: str, level: str = "INFO", **fields: Any
-) -> None:
+def _log_step(run_id: str, event: str, message: str, level: str = "INFO", **fields: Any) -> None:
     """Internal indirection for structured logging.
 
     Tests monkeypatch this symbol directly (`_log_step`) rather than the public
@@ -280,9 +272,7 @@ def _extract_cache_stats(payload: object) -> dict[str, int] | None:
     return found[-1] if found else None
 
 
-def _apply_universe_mask(
-    df: pd.DataFrame, mask: pd.DataFrame, *, date_column: str
-) -> pd.DataFrame:
+def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: str) -> pd.DataFrame:
     """Apply a time-varying membership mask to returns data."""
 
     if mask.empty:
@@ -292,9 +282,7 @@ def _apply_universe_mask(
     try:
         date_col = lookup[date_column.lower()]
     except KeyError as exc:  # pragma: no cover - defensive guard
-        raise KeyError(
-            f"Date column '{date_column}' is missing from the returns data"
-        ) from exc
+        raise KeyError(f"Date column '{date_column}' is missing from the returns data") from exc
 
     working[date_col] = pd.to_datetime(working[date_col])
     working = working.set_index(date_col)
@@ -309,16 +297,12 @@ def _apply_universe_mask(
         )
 
     masked = working.copy()
-    masked.loc[:, aligned_mask.columns] = masked.loc[:, aligned_mask.columns].where(
-        aligned_mask
-    )
+    masked.loc[:, aligned_mask.columns] = masked.loc[:, aligned_mask.columns].where(aligned_mask)
     masked.reset_index(inplace=True)
     return masked
 
 
-def _attach_universe_paths(
-    cfg: Any, spec: NamedUniverse, *, csv_path: str | None
-) -> None:
+def _attach_universe_paths(cfg: Any, spec: NamedUniverse, *, csv_path: str | None) -> None:
     """Persist the selected universe paths onto ``cfg.data`` when possible."""
 
     membership_value = str(spec.membership_path)
@@ -349,9 +333,7 @@ def _attach_universe_paths(
         setattr(data_section, "universe_membership_path", membership_value)
     except Exception:
         try:
-            object.__setattr__(
-                data_section, "universe_membership_path", membership_value
-            )
+            object.__setattr__(data_section, "universe_membership_path", membership_value)
         except Exception:
             data_section = None
 
@@ -430,9 +412,7 @@ def check_environment(lock_path: Path | None = None) -> int:
     return 0
 
 
-def maybe_log_step(
-    enabled: bool, run_id: str, event: str, message: str, **fields: Any
-) -> None:
+def maybe_log_step(enabled: bool, run_id: str, event: str, message: str, **fields: Any) -> None:
     """Log a structured step when ``enabled`` is True."""
     if enabled:
         _log_step(run_id, event, message, **fields)
@@ -671,9 +651,7 @@ def _execute_analysis_run(
             if isinstance(bench_map, dict) and bench_map:
                 first_bench = next(iter(bench_map.values()))
                 setattr(run_result, "benchmark", first_bench)
-            weights_user = (
-                res.get("weights_user_weight") if isinstance(res, dict) else None
-            )
+            weights_user = res.get("weights_user_weight") if isinstance(res, dict) else None
             if weights_user is not None:
                 setattr(run_result, "weights", weights_user)
     else:  # pragma: no cover - legacy fallback
@@ -767,9 +745,7 @@ def _execute_analysis_run(
             formats=target_formats,
         )
         data_keys = list(data.keys())
-        artifact_paths = _resolve_artifact_paths(
-            out_dir_path, filename, data_keys, fmt_list
-        )
+        artifact_paths = _resolve_artifact_paths(out_dir_path, filename, data_keys, fmt_list)
         maybe_log_step(
             structured_log,
             run_id,
@@ -801,9 +777,7 @@ def _execute_analysis_run(
                     summary_text=text,
                 )
             except Exception as exc:  # pragma: no cover - defensive guard
-                logging.getLogger(__name__).warning(
-                    "Failed to write run artifacts: %s", exc
-                )
+                logging.getLogger(__name__).warning("Failed to write run artifacts: %s", exc)
             else:
                 maybe_log_step(
                     structured_log,
@@ -854,9 +828,7 @@ def main(argv: list[str] | None = None) -> int:
     """Entry point for the ``trend-model`` command."""
 
     parser = argparse.ArgumentParser(prog="trend-model")
-    parser.add_argument(
-        "--check", action="store_true", help="Print environment info and exit"
-    )
+    parser.add_argument("--check", action="store_true", help="Print environment info and exit")
     sub = parser.add_subparsers(dest="command", required=True)
 
     sub.add_parser("gui", help="Launch Streamlit interface")
@@ -864,9 +836,7 @@ def main(argv: list[str] | None = None) -> int:
     run_p = sub.add_parser("run", help="Run analysis pipeline")
     run_p.add_argument("-c", "--config", required=True, help="Path to YAML config")
     run_p.add_argument("-i", "--input", required=True, help="Path to returns CSV")
-    run_p.add_argument(
-        "--seed", type=int, help="Override random seed (takes precedence)"
-    )
+    run_p.add_argument("--seed", type=int, help="Override random seed (takes precedence)")
     run_p.add_argument(
         "--bundle",
         nargs="?",
@@ -915,9 +885,7 @@ def main(argv: list[str] | None = None) -> int:
         "run-ui",
         help="Deprecated: use 'run' with Streamlit JSON params",
     )
-    run_ui_p.add_argument(
-        "--params", required=True, help="Path to Streamlit JSON params"
-    )
+    run_ui_p.add_argument("--params", required=True, help="Path to Streamlit JSON params")
     run_ui_p.add_argument("--data", required=True, help="Path to returns CSV or Excel")
     run_ui_p.add_argument(
         "--auto-fix-dates",
@@ -987,9 +955,7 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     mc_run_p = mc_sub.add_parser("run", help="Run Monte Carlo scenarios")
-    mc_run_p.add_argument(
-        "--scenario", required=True, help="Scenario name or config path"
-    )
+    mc_run_p.add_argument("--scenario", required=True, help="Scenario name or config path")
     mc_run_p.add_argument(
         "--data",
         help="CSV/Parquet path for price or returns history (overrides base config)",
@@ -1001,9 +967,7 @@ def main(argv: list[str] | None = None) -> int:
         default=[],
         help="Output formats (csv, json, parquet). Repeatable or comma-separated.",
     )
-    mc_run_p.add_argument(
-        "--n-paths", type=int, help="Override number of Monte Carlo paths"
-    )
+    mc_run_p.add_argument("--n-paths", type=int, help="Override number of Monte Carlo paths")
     mc_run_p.add_argument("--jobs", type=int, help="Override parallel job count")
     mc_run_p.add_argument("--seed", type=int, help="Override Monte Carlo seed")
     mc_run_p.add_argument(
@@ -1020,9 +984,7 @@ def main(argv: list[str] | None = None) -> int:
         "--registry",
         help="Override the scenario registry path",
     )
-    mc_viz_p = mc_sub.add_parser(
-        "viz", help="Render Monte Carlo chart artifacts from a bundle"
-    )
+    mc_viz_p = mc_sub.add_parser("viz", help="Render Monte Carlo chart artifacts from a bundle")
     mc_viz_p.add_argument(
         "--bundle",
         required=True,
@@ -1196,9 +1158,7 @@ def main(argv: list[str] | None = None) -> int:
             universe_spec: NamedUniverse | None = None
             if getattr(args, "universe", None):
                 mask, universe_spec = load_universe(args.universe, prices=df)
-                df = _apply_universe_mask(
-                    df, mask, date_column=universe_spec.date_column
-                )
+                df = _apply_universe_mask(df, mask, date_column=universe_spec.date_column)
             if universe_spec is not None:
                 _attach_universe_paths(cfg, universe_spec, csv_path=args.input)
             return _execute_analysis_run(
@@ -1280,9 +1240,7 @@ def _render_mc_table(entries: Sequence[ScenarioRegistryEntry]) -> str:
     divider = "  ".join("-" * widths[col] for col in columns)
     lines = [header, divider]
     for row in rows:
-        lines.append(
-            "  ".join(str(row.get(col, "")).ljust(widths[col]) for col in columns)
-        )
+        lines.append("  ".join(str(row.get(col, "")).ljust(widths[col]) for col in columns))
     return "\n".join(lines)
 
 
@@ -1292,9 +1250,7 @@ def _resolve_mc_registry_path(raw: str | None) -> Path | None:
     return Path(raw).expanduser().resolve()
 
 
-def _load_mc_scenario_value(
-    raw: str, *, registry_path: Path | None
-) -> MonteCarloScenario:
+def _load_mc_scenario_value(raw: str, *, registry_path: Path | None) -> MonteCarloScenario:
     if not raw:
         raise ValueError("Scenario name is required")
     candidate = Path(raw).expanduser()
@@ -1429,9 +1385,7 @@ def _validate_mc_scenario(scenario: MonteCarloScenario) -> list[str]:
         skip_required_fields=True,
     )
     schema_key_errors = [
-        issue
-        for issue in config_result.errors
-        if issue.message.startswith("Unexpected field")
+        issue for issue in config_result.errors if issue.message.startswith("Unexpected field")
     ]
     if schema_key_errors:
         messages = format_validation_messages(
@@ -1439,6 +1393,7 @@ def _validate_mc_scenario(scenario: MonteCarloScenario) -> list[str]:
             include_warnings=False,
         )
         errors.extend(f"base_config: {message}" for message in messages)
+        return errors
 
     return_model = scenario.return_model
     if isinstance(return_model, Mapping):
@@ -1450,15 +1405,11 @@ def _validate_mc_scenario(scenario: MonteCarloScenario) -> list[str]:
             "regime_conditioned",
         }
         if kind not in allowed:
-            errors.append(
-                f"return_model.kind must be one of: {', '.join(sorted(allowed))}"
-            )
+            errors.append(f"return_model.kind must be one of: {', '.join(sorted(allowed))}")
 
     outputs = scenario.outputs
     if isinstance(outputs, Mapping):
-        errors.extend(
-            _validate_mc_formats(outputs.get("formats", outputs.get("format")))
-        )
+        errors.extend(_validate_mc_formats(outputs.get("formats", outputs.get("format"))))
 
     try:
         strategies = runner.resolve_strategies()
@@ -1693,9 +1644,7 @@ def _validate_mc_viz_output_flags(args: argparse.Namespace) -> None:
 def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
     suffix = path.suffix.lower()
     if suffix not in {".parquet", ".csv", ".json"}:
-        raise ValueError(
-            f"Unsupported {label} file format '{path.suffix}' for '{path.name}'."
-        )
+        raise ValueError(f"Unsupported {label} file format '{path.suffix}' for '{path.name}'.")
     try:
         if suffix == ".parquet":
             frame = pd.read_parquet(path)
@@ -1713,9 +1662,7 @@ def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
 
 
 def _load_mc_frame(bundle_dir: Path, *, stem: str) -> pd.DataFrame:
-    candidates = tuple(
-        bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json")
-    )
+    candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
     existing = next((candidate for candidate in candidates if candidate.exists()), None)
     if existing is None:
         expected = ", ".join(path.name for path in candidates)
@@ -1745,9 +1692,7 @@ def _load_mc_bundle_frames(
     missing_inputs: list[str] = []
     expected_by_stem: dict[str, str] = {}
     for stem in required_stems:
-        candidates = tuple(
-            bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json")
-        )
+        candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
         if not any(candidate.exists() for candidate in candidates):
             missing_inputs.append(stem)
             expected_by_stem[stem] = ", ".join(path.name for path in candidates)
@@ -1759,9 +1704,7 @@ def _load_mc_bundle_frames(
                 f"Missing required MC {stem} file in '{bundle_dir}'. Expected one of: {expected}"
             )
         missing_text = ", ".join(missing_inputs)
-        expected_text = "; ".join(
-            f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs
-        )
+        expected_text = "; ".join(f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs)
         raise FileNotFoundError(
             f"Missing required MC input files in '{bundle_dir}': {missing_text}. "
             f"Expected one of each: {expected_text}"
@@ -1778,13 +1721,9 @@ def _load_mc_nav_paths_frame(bundle: str | os.PathLike[str]) -> pd.DataFrame | N
 
 
 def _parse_mc_chart_selection(charts_value: str) -> list[str]:
-    requested = [
-        token.strip().lower() for token in charts_value.split(",") if token.strip()
-    ]
+    requested = [token.strip().lower() for token in charts_value.split(",") if token.strip()]
     if not requested:
-        raise ValueError(
-            "The 'mc viz' command requires at least one chart in --charts."
-        )
+        raise ValueError("The 'mc viz' command requires at least one chart in --charts.")
 
     seen: set[str] = set()
     ordered: list[str] = []
@@ -1854,14 +1793,10 @@ def _build_mc_risk_return_chart(
     from trend_analysis.viz import risk_return
 
     nav_frame = _mc_nav_source_frame(summary_frame, results_frame, nav_paths_frame)
-    returns_frame = nav_frame.pct_change(fill_method=None).replace(
-        [np.inf, -np.inf], np.nan
-    )
+    returns_frame = nav_frame.pct_change(fill_method=None).replace([np.inf, -np.inf], np.nan)
     returns_frame = returns_frame.dropna(how="all")
     if returns_frame.empty:
-        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(
-            how="all"
-        )
+        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(how="all")
     return risk_return.make(returns_frame)
 
 
@@ -1952,9 +1887,7 @@ def _handle_mc_command(args: argparse.Namespace) -> int:
         scenarios: list[MonteCarloScenario] = []
         if scenario_arg:
             try:
-                scenarios = [
-                    _load_mc_scenario_value(scenario_arg, registry_path=registry_path)
-                ]
+                scenarios = [_load_mc_scenario_value(scenario_arg, registry_path=registry_path)]
             except (ValueError, FileNotFoundError, IsADirectoryError) as exc:
                 print(f"Scenario validation failed: {exc}", file=sys.stderr)
                 return 1
@@ -1972,9 +1905,7 @@ def _handle_mc_command(args: argparse.Namespace) -> int:
                 return 2
             for entry in entries:
                 try:
-                    scenarios.append(
-                        load_scenario(entry.name, registry_path=registry_path)
-                    )
+                    scenarios.append(load_scenario(entry.name, registry_path=registry_path))
                 except (ValueError, FileNotFoundError, IsADirectoryError) as exc:
                     print(
                         f"Scenario '{entry.name}' failed to load: {exc}",
@@ -2003,9 +1934,7 @@ def _handle_mc_command(args: argparse.Namespace) -> int:
         registry_path = _resolve_mc_registry_path(getattr(args, "registry", None))
         scenario_arg = getattr(args, "scenario", None) or ""
         try:
-            scenario = _load_mc_scenario_value(
-                scenario_arg, registry_path=registry_path
-            )
+            scenario = _load_mc_scenario_value(scenario_arg, registry_path=registry_path)
         except (ValueError, FileNotFoundError, IsADirectoryError) as exc:
             print(f"Scenario run failed: {exc}", file=sys.stderr)
             return 1

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -111,7 +111,9 @@ def _maybe_validate_config(
             payload = dict(cfg)
         elif hasattr(cfg, "model_dump"):
             try:
-                payload = cfg.model_dump(exclude_none=True, exclude_unset=True, mode="json")
+                payload = cfg.model_dump(
+                    exclude_none=True, exclude_unset=True, mode="json"
+                )
             except TypeError:
                 try:
                     payload = cfg.model_dump(exclude_none=True, exclude_unset=True)
@@ -154,7 +156,11 @@ def _maybe_track_config_coverage(config_path: Path, input_path: str) -> bool:
         return True
 
     data_section = dict(payload.get("data") or {})
-    if input_path and not data_section.get("csv_path") and not data_section.get("managers_glob"):
+    if (
+        input_path
+        and not data_section.get("csv_path")
+        and not data_section.get("managers_glob")
+    ):
         data_section["csv_path"] = input_path
         payload = dict(payload)
         payload["data"] = data_section
@@ -218,7 +224,9 @@ def _apply_trend_spec_preset(cfg: Any, preset: TrendSpecPreset) -> None:
         object.__setattr__(cfg, "trend_spec_preset", preset.name)
 
 
-def _log_step(run_id: str, event: str, message: str, level: str = "INFO", **fields: Any) -> None:
+def _log_step(
+    run_id: str, event: str, message: str, level: str = "INFO", **fields: Any
+) -> None:
     """Internal indirection for structured logging.
 
     Tests monkeypatch this symbol directly (`_log_step`) rather than the public
@@ -272,7 +280,9 @@ def _extract_cache_stats(payload: object) -> dict[str, int] | None:
     return found[-1] if found else None
 
 
-def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: str) -> pd.DataFrame:
+def _apply_universe_mask(
+    df: pd.DataFrame, mask: pd.DataFrame, *, date_column: str
+) -> pd.DataFrame:
     """Apply a time-varying membership mask to returns data."""
 
     if mask.empty:
@@ -282,7 +292,9 @@ def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: s
     try:
         date_col = lookup[date_column.lower()]
     except KeyError as exc:  # pragma: no cover - defensive guard
-        raise KeyError(f"Date column '{date_column}' is missing from the returns data") from exc
+        raise KeyError(
+            f"Date column '{date_column}' is missing from the returns data"
+        ) from exc
 
     working[date_col] = pd.to_datetime(working[date_col])
     working = working.set_index(date_col)
@@ -297,12 +309,16 @@ def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: s
         )
 
     masked = working.copy()
-    masked.loc[:, aligned_mask.columns] = masked.loc[:, aligned_mask.columns].where(aligned_mask)
+    masked.loc[:, aligned_mask.columns] = masked.loc[:, aligned_mask.columns].where(
+        aligned_mask
+    )
     masked.reset_index(inplace=True)
     return masked
 
 
-def _attach_universe_paths(cfg: Any, spec: NamedUniverse, *, csv_path: str | None) -> None:
+def _attach_universe_paths(
+    cfg: Any, spec: NamedUniverse, *, csv_path: str | None
+) -> None:
     """Persist the selected universe paths onto ``cfg.data`` when possible."""
 
     membership_value = str(spec.membership_path)
@@ -333,7 +349,9 @@ def _attach_universe_paths(cfg: Any, spec: NamedUniverse, *, csv_path: str | Non
         setattr(data_section, "universe_membership_path", membership_value)
     except Exception:
         try:
-            object.__setattr__(data_section, "universe_membership_path", membership_value)
+            object.__setattr__(
+                data_section, "universe_membership_path", membership_value
+            )
         except Exception:
             data_section = None
 
@@ -412,7 +430,9 @@ def check_environment(lock_path: Path | None = None) -> int:
     return 0
 
 
-def maybe_log_step(enabled: bool, run_id: str, event: str, message: str, **fields: Any) -> None:
+def maybe_log_step(
+    enabled: bool, run_id: str, event: str, message: str, **fields: Any
+) -> None:
     """Log a structured step when ``enabled`` is True."""
     if enabled:
         _log_step(run_id, event, message, **fields)
@@ -651,7 +671,9 @@ def _execute_analysis_run(
             if isinstance(bench_map, dict) and bench_map:
                 first_bench = next(iter(bench_map.values()))
                 setattr(run_result, "benchmark", first_bench)
-            weights_user = res.get("weights_user_weight") if isinstance(res, dict) else None
+            weights_user = (
+                res.get("weights_user_weight") if isinstance(res, dict) else None
+            )
             if weights_user is not None:
                 setattr(run_result, "weights", weights_user)
     else:  # pragma: no cover - legacy fallback
@@ -745,7 +767,9 @@ def _execute_analysis_run(
             formats=target_formats,
         )
         data_keys = list(data.keys())
-        artifact_paths = _resolve_artifact_paths(out_dir_path, filename, data_keys, fmt_list)
+        artifact_paths = _resolve_artifact_paths(
+            out_dir_path, filename, data_keys, fmt_list
+        )
         maybe_log_step(
             structured_log,
             run_id,
@@ -777,7 +801,9 @@ def _execute_analysis_run(
                     summary_text=text,
                 )
             except Exception as exc:  # pragma: no cover - defensive guard
-                logging.getLogger(__name__).warning("Failed to write run artifacts: %s", exc)
+                logging.getLogger(__name__).warning(
+                    "Failed to write run artifacts: %s", exc
+                )
             else:
                 maybe_log_step(
                     structured_log,
@@ -828,7 +854,9 @@ def main(argv: list[str] | None = None) -> int:
     """Entry point for the ``trend-model`` command."""
 
     parser = argparse.ArgumentParser(prog="trend-model")
-    parser.add_argument("--check", action="store_true", help="Print environment info and exit")
+    parser.add_argument(
+        "--check", action="store_true", help="Print environment info and exit"
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     sub.add_parser("gui", help="Launch Streamlit interface")
@@ -836,7 +864,9 @@ def main(argv: list[str] | None = None) -> int:
     run_p = sub.add_parser("run", help="Run analysis pipeline")
     run_p.add_argument("-c", "--config", required=True, help="Path to YAML config")
     run_p.add_argument("-i", "--input", required=True, help="Path to returns CSV")
-    run_p.add_argument("--seed", type=int, help="Override random seed (takes precedence)")
+    run_p.add_argument(
+        "--seed", type=int, help="Override random seed (takes precedence)"
+    )
     run_p.add_argument(
         "--bundle",
         nargs="?",
@@ -885,7 +915,9 @@ def main(argv: list[str] | None = None) -> int:
         "run-ui",
         help="Deprecated: use 'run' with Streamlit JSON params",
     )
-    run_ui_p.add_argument("--params", required=True, help="Path to Streamlit JSON params")
+    run_ui_p.add_argument(
+        "--params", required=True, help="Path to Streamlit JSON params"
+    )
     run_ui_p.add_argument("--data", required=True, help="Path to returns CSV or Excel")
     run_ui_p.add_argument(
         "--auto-fix-dates",
@@ -955,7 +987,9 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     mc_run_p = mc_sub.add_parser("run", help="Run Monte Carlo scenarios")
-    mc_run_p.add_argument("--scenario", required=True, help="Scenario name or config path")
+    mc_run_p.add_argument(
+        "--scenario", required=True, help="Scenario name or config path"
+    )
     mc_run_p.add_argument(
         "--data",
         help="CSV/Parquet path for price or returns history (overrides base config)",
@@ -967,7 +1001,9 @@ def main(argv: list[str] | None = None) -> int:
         default=[],
         help="Output formats (csv, json, parquet). Repeatable or comma-separated.",
     )
-    mc_run_p.add_argument("--n-paths", type=int, help="Override number of Monte Carlo paths")
+    mc_run_p.add_argument(
+        "--n-paths", type=int, help="Override number of Monte Carlo paths"
+    )
     mc_run_p.add_argument("--jobs", type=int, help="Override parallel job count")
     mc_run_p.add_argument("--seed", type=int, help="Override Monte Carlo seed")
     mc_run_p.add_argument(
@@ -984,7 +1020,9 @@ def main(argv: list[str] | None = None) -> int:
         "--registry",
         help="Override the scenario registry path",
     )
-    mc_viz_p = mc_sub.add_parser("viz", help="Render Monte Carlo chart artifacts from a bundle")
+    mc_viz_p = mc_sub.add_parser(
+        "viz", help="Render Monte Carlo chart artifacts from a bundle"
+    )
     mc_viz_p.add_argument(
         "--bundle",
         required=True,
@@ -1158,7 +1196,9 @@ def main(argv: list[str] | None = None) -> int:
             universe_spec: NamedUniverse | None = None
             if getattr(args, "universe", None):
                 mask, universe_spec = load_universe(args.universe, prices=df)
-                df = _apply_universe_mask(df, mask, date_column=universe_spec.date_column)
+                df = _apply_universe_mask(
+                    df, mask, date_column=universe_spec.date_column
+                )
             if universe_spec is not None:
                 _attach_universe_paths(cfg, universe_spec, csv_path=args.input)
             return _execute_analysis_run(
@@ -1240,7 +1280,9 @@ def _render_mc_table(entries: Sequence[ScenarioRegistryEntry]) -> str:
     divider = "  ".join("-" * widths[col] for col in columns)
     lines = [header, divider]
     for row in rows:
-        lines.append("  ".join(str(row.get(col, "")).ljust(widths[col]) for col in columns))
+        lines.append(
+            "  ".join(str(row.get(col, "")).ljust(widths[col]) for col in columns)
+        )
     return "\n".join(lines)
 
 
@@ -1250,7 +1292,9 @@ def _resolve_mc_registry_path(raw: str | None) -> Path | None:
     return Path(raw).expanduser().resolve()
 
 
-def _load_mc_scenario_value(raw: str, *, registry_path: Path | None) -> MonteCarloScenario:
+def _load_mc_scenario_value(
+    raw: str, *, registry_path: Path | None
+) -> MonteCarloScenario:
     if not raw:
         raise ValueError("Scenario name is required")
     candidate = Path(raw).expanduser()
@@ -1385,7 +1429,9 @@ def _validate_mc_scenario(scenario: MonteCarloScenario) -> list[str]:
         skip_required_fields=True,
     )
     schema_key_errors = [
-        issue for issue in config_result.errors if issue.message.startswith("Unexpected field")
+        issue
+        for issue in config_result.errors
+        if issue.message.startswith("Unexpected field")
     ]
     if schema_key_errors:
         messages = format_validation_messages(
@@ -1405,11 +1451,15 @@ def _validate_mc_scenario(scenario: MonteCarloScenario) -> list[str]:
             "regime_conditioned",
         }
         if kind not in allowed:
-            errors.append(f"return_model.kind must be one of: {', '.join(sorted(allowed))}")
+            errors.append(
+                f"return_model.kind must be one of: {', '.join(sorted(allowed))}"
+            )
 
     outputs = scenario.outputs
     if isinstance(outputs, Mapping):
-        errors.extend(_validate_mc_formats(outputs.get("formats", outputs.get("format"))))
+        errors.extend(
+            _validate_mc_formats(outputs.get("formats", outputs.get("format")))
+        )
 
     try:
         strategies = runner.resolve_strategies()
@@ -1644,7 +1694,9 @@ def _validate_mc_viz_output_flags(args: argparse.Namespace) -> None:
 def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
     suffix = path.suffix.lower()
     if suffix not in {".parquet", ".csv", ".json"}:
-        raise ValueError(f"Unsupported {label} file format '{path.suffix}' for '{path.name}'.")
+        raise ValueError(
+            f"Unsupported {label} file format '{path.suffix}' for '{path.name}'."
+        )
     try:
         if suffix == ".parquet":
             frame = pd.read_parquet(path)
@@ -1662,7 +1714,9 @@ def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
 
 
 def _load_mc_frame(bundle_dir: Path, *, stem: str) -> pd.DataFrame:
-    candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
+    candidates = tuple(
+        bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json")
+    )
     existing = next((candidate for candidate in candidates if candidate.exists()), None)
     if existing is None:
         expected = ", ".join(path.name for path in candidates)
@@ -1692,7 +1746,9 @@ def _load_mc_bundle_frames(
     missing_inputs: list[str] = []
     expected_by_stem: dict[str, str] = {}
     for stem in required_stems:
-        candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
+        candidates = tuple(
+            bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json")
+        )
         if not any(candidate.exists() for candidate in candidates):
             missing_inputs.append(stem)
             expected_by_stem[stem] = ", ".join(path.name for path in candidates)
@@ -1704,7 +1760,9 @@ def _load_mc_bundle_frames(
                 f"Missing required MC {stem} file in '{bundle_dir}'. Expected one of: {expected}"
             )
         missing_text = ", ".join(missing_inputs)
-        expected_text = "; ".join(f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs)
+        expected_text = "; ".join(
+            f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs
+        )
         raise FileNotFoundError(
             f"Missing required MC input files in '{bundle_dir}': {missing_text}. "
             f"Expected one of each: {expected_text}"
@@ -1721,9 +1779,13 @@ def _load_mc_nav_paths_frame(bundle: str | os.PathLike[str]) -> pd.DataFrame | N
 
 
 def _parse_mc_chart_selection(charts_value: str) -> list[str]:
-    requested = [token.strip().lower() for token in charts_value.split(",") if token.strip()]
+    requested = [
+        token.strip().lower() for token in charts_value.split(",") if token.strip()
+    ]
     if not requested:
-        raise ValueError("The 'mc viz' command requires at least one chart in --charts.")
+        raise ValueError(
+            "The 'mc viz' command requires at least one chart in --charts."
+        )
 
     seen: set[str] = set()
     ordered: list[str] = []
@@ -1793,10 +1855,14 @@ def _build_mc_risk_return_chart(
     from trend_analysis.viz import risk_return
 
     nav_frame = _mc_nav_source_frame(summary_frame, results_frame, nav_paths_frame)
-    returns_frame = nav_frame.pct_change(fill_method=None).replace([np.inf, -np.inf], np.nan)
+    returns_frame = nav_frame.pct_change(fill_method=None).replace(
+        [np.inf, -np.inf], np.nan
+    )
     returns_frame = returns_frame.dropna(how="all")
     if returns_frame.empty:
-        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(how="all")
+        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(
+            how="all"
+        )
     return risk_return.make(returns_frame)
 
 
@@ -1887,7 +1953,9 @@ def _handle_mc_command(args: argparse.Namespace) -> int:
         scenarios: list[MonteCarloScenario] = []
         if scenario_arg:
             try:
-                scenarios = [_load_mc_scenario_value(scenario_arg, registry_path=registry_path)]
+                scenarios = [
+                    _load_mc_scenario_value(scenario_arg, registry_path=registry_path)
+                ]
             except (ValueError, FileNotFoundError, IsADirectoryError) as exc:
                 print(f"Scenario validation failed: {exc}", file=sys.stderr)
                 return 1
@@ -1905,7 +1973,9 @@ def _handle_mc_command(args: argparse.Namespace) -> int:
                 return 2
             for entry in entries:
                 try:
-                    scenarios.append(load_scenario(entry.name, registry_path=registry_path))
+                    scenarios.append(
+                        load_scenario(entry.name, registry_path=registry_path)
+                    )
                 except (ValueError, FileNotFoundError, IsADirectoryError) as exc:
                     print(
                         f"Scenario '{entry.name}' failed to load: {exc}",
@@ -1934,7 +2004,9 @@ def _handle_mc_command(args: argparse.Namespace) -> int:
         registry_path = _resolve_mc_registry_path(getattr(args, "registry", None))
         scenario_arg = getattr(args, "scenario", None) or ""
         try:
-            scenario = _load_mc_scenario_value(scenario_arg, registry_path=registry_path)
+            scenario = _load_mc_scenario_value(
+                scenario_arg, registry_path=registry_path
+            )
         except (ValueError, FileNotFoundError, IsADirectoryError) as exc:
             print(f"Scenario run failed: {exc}", file=sys.stderr)
             return 1

--- a/src/trend_analysis/config/schema_generator.py
+++ b/src/trend_analysis/config/schema_generator.py
@@ -119,6 +119,7 @@ _MANUAL_DESCRIPTIONS: dict[str, str] = {
     "metrics": "Performance metrics configuration.",
     "metrics.compute": "Legacy metrics list for reporting exports.",
     "metrics.registry": "Metric registry identifiers for score frame.",
+    "metrics.rf_override_enabled": "Enable Monte Carlo CASH injection from rf_rate_annual.",
     "metrics.bootstrap_ci": "Bootstrap confidence interval settings.",
     "metrics.bootstrap_ci.enabled": "Enable bootstrap confidence intervals.",
     "metrics.bootstrap_ci.n_iter": "Number of bootstrap iterations.",

--- a/tests/monte_carlo/test_scenario.py
+++ b/tests/monte_carlo/test_scenario.py
@@ -212,7 +212,12 @@ def test_validate_mc_scenario_reports_misspelled_rf_override(tmp_path: Path) -> 
     scenario = MonteCarloScenario(
         name="typo_scenario",
         base_config=base_path,
-        monte_carlo={"mode": "mixture", "n_paths": 1, "horizon_years": 1.0, "frequency": "M"},
+        monte_carlo={
+            "mode": "mixture",
+            "n_paths": 1,
+            "horizon_years": 1.0,
+            "frequency": "M",
+        },
         return_model={"kind": "stationary_bootstrap"},
         strategy_set={"curated": []},
         raw={"metrics": {"rf_override_enbaled": True}},
@@ -438,7 +443,9 @@ def test_monte_carlo_scenario_missing_mapping_fields_raise_clear_errors() -> Non
         jobs=None,
     )
 
-    with pytest.raises(ValueError, match="return_model must be a mapping \\(null provided\\)"):
+    with pytest.raises(
+        ValueError, match="return_model must be a mapping \\(null provided\\)"
+    ):
         MonteCarloScenario(
             name="missing_mappings",
             description="Missing return_model mapping",

--- a/tests/monte_carlo/test_scenario.py
+++ b/tests/monte_carlo/test_scenario.py
@@ -12,6 +12,7 @@ from trend_analysis.monte_carlo import (
     load_scenario,
 )
 from trend_analysis.monte_carlo.strategy import StrategyVariant
+from trend_analysis.cli import _validate_mc_scenario
 
 
 def _load_example_payload() -> dict:
@@ -191,6 +192,35 @@ outputs:
     assert curated[0].name == "trend_basic"
     assert scenario.folds["n_folds"] == 3
     assert scenario.outputs["directory"] == "outputs/monte_carlo/example"
+
+
+def test_validate_mc_scenario_reports_misspelled_rf_override(tmp_path: Path) -> None:
+    base_config = {
+        "version": "1",
+        "data": {},
+        "preprocessing": {},
+        "vol_adjust": {},
+        "sample_split": {},
+        "portfolio": {},
+        "metrics": {},
+        "benchmarks": {},
+        "export": {},
+        "run": {},
+    }
+    base_path = tmp_path / "base.yml"
+    base_path.write_text(yaml.safe_dump(base_config, sort_keys=False), encoding="utf-8")
+    scenario = MonteCarloScenario(
+        name="typo_scenario",
+        base_config=base_path,
+        monte_carlo={"mode": "mixture", "n_paths": 1, "horizon_years": 1.0, "frequency": "M"},
+        return_model={"kind": "stationary_bootstrap"},
+        strategy_set={"curated": []},
+        raw={"metrics": {"rf_override_enbaled": True}},
+    )
+
+    errors = _validate_mc_scenario(scenario)
+
+    assert any("metrics.rf_override_enbaled" in error for error in errors)
 
 
 def test_monte_carlo_scenario_coerces_curated_variants() -> None:

--- a/tests/monte_carlo/test_scenario.py
+++ b/tests/monte_carlo/test_scenario.py
@@ -226,6 +226,7 @@ def test_validate_mc_scenario_reports_misspelled_rf_override(tmp_path: Path) -> 
     errors = _validate_mc_scenario(scenario)
 
     assert any("metrics.rf_override_enbaled" in error for error in errors)
+    assert not any("Strategy 'base' config invalid" in error for error in errors)
 
 
 def test_monte_carlo_scenario_coerces_curated_variants() -> None:
@@ -443,9 +444,7 @@ def test_monte_carlo_scenario_missing_mapping_fields_raise_clear_errors() -> Non
         jobs=None,
     )
 
-    with pytest.raises(
-        ValueError, match="return_model must be a mapping \\(null provided\\)"
-    ):
+    with pytest.raises(ValueError, match="return_model must be a mapping \\(null provided\\)"):
         MonteCarloScenario(
             name="missing_mappings",
             description="Missing return_model mapping",

--- a/tests/test_cli_mc.py
+++ b/tests/test_cli_mc.py
@@ -100,6 +100,27 @@ monte_carlo:
     assert "base_config" in err
 
 
+def test_mc_validate_reports_misspelled_rf_override_key(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    scenario_path = tmp_path / "invalid_rf_override.yml"
+    _write_scenario(
+        scenario_path,
+        name="invalid_rf_override",
+        extra="""
+metrics:
+  rf_override_enbaled: true
+""".strip(),
+    )
+
+    rc = cli.main(["mc", "validate", str(scenario_path)])
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "base_config" in err
+    assert "metrics.rf_override_enbaled" in err
+
+
 def test_mc_run_overrides_and_manifest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     scenario_path = tmp_path / "scenario.yml"
     data_path = tmp_path / "prices.csv"

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import yaml
 
 from trend_analysis import config
+from trend_analysis.config.validation import validate_config
 
 
 def _write_cfg(
@@ -136,3 +137,22 @@ def test_whitespace_version_rejected(tmp_path: Path) -> None:
     with pytest.raises(ValidationError) as exc_info:
         config.load(str(cfg_file))
     assert "Version field cannot be empty" in str(exc_info.value)
+
+
+def test_validate_config_rejects_misspelled_rf_override_enabled(tmp_path: Path) -> None:
+    payload = {
+        "version": "1",
+        "data": {"csv_path": "data.csv"},
+        "preprocessing": {},
+        "vol_adjust": {},
+        "sample_split": {},
+        "portfolio": {},
+        "metrics": {"rf_override_enbaled": True},
+        "export": {},
+        "run": {},
+    }
+
+    result = validate_config(payload, base_path=tmp_path, skip_required_fields=True)
+
+    assert not result.valid
+    assert any(error.path == "metrics.rf_override_enbaled" for error in result.errors)

--- a/tests/test_config_schema_generation.py
+++ b/tests/test_config_schema_generation.py
@@ -50,7 +50,9 @@ def test_schema_validation_accepts_regime_turnover_caps() -> None:
 
 def test_schema_validation_accepts_rf_override_enabled() -> None:
     schema = generate_schema()
-    metrics_schema = schema["properties"]["metrics"]["properties"]["rf_override_enabled"]
+    metrics_schema = schema["properties"]["metrics"]["properties"][
+        "rf_override_enabled"
+    ]
     assert metrics_schema["type"] == "boolean"
     assert metrics_schema["default"] is False
 
@@ -62,7 +64,9 @@ def test_schema_validation_rejects_misspelled_rf_override_enabled() -> None:
     schema = generate_schema()
     errors = validate_config_data({"metrics": {"rf_override_enbaled": True}}, schema)
     assert errors
-    assert any("metrics" in error and "rf_override_enbaled" in error for error in errors)
+    assert any(
+        "metrics" in error and "rf_override_enbaled" in error for error in errors
+    )
 
 
 def test_schema_validation_rejects_invalid_regime_turnover_caps() -> None:

--- a/tests/test_config_schema_generation.py
+++ b/tests/test_config_schema_generation.py
@@ -48,6 +48,23 @@ def test_schema_validation_accepts_regime_turnover_caps() -> None:
     assert errors == []
 
 
+def test_schema_validation_accepts_rf_override_enabled() -> None:
+    schema = generate_schema()
+    metrics_schema = schema["properties"]["metrics"]["properties"]["rf_override_enabled"]
+    assert metrics_schema["type"] == "boolean"
+    assert metrics_schema["default"] is False
+
+    errors = validate_config_data({"metrics": {"rf_override_enabled": True}}, schema)
+    assert errors == []
+
+
+def test_schema_validation_rejects_misspelled_rf_override_enabled() -> None:
+    schema = generate_schema()
+    errors = validate_config_data({"metrics": {"rf_override_enbaled": True}}, schema)
+    assert errors
+    assert any("metrics" in error and "rf_override_enbaled" in error for error in errors)
+
+
 def test_schema_validation_rejects_invalid_regime_turnover_caps() -> None:
     schema = generate_schema()
     payload = {"portfolio": {"max_turnover": {"risk_on": "fast"}}}


### PR DESCRIPTION
Closes #5238

## Summary
- declare metrics.rf_override_enabled in defaults and regenerated schema artifacts
- add MC base-config validation so trend mc validate reports misspelled metrics.rf_override_* keys
- cover accepted canonical spelling and rejected typo paths in config/schema/MC tests

## Validation
- PYTHONPATH=/private/tmp/trend-issue-5237-pydeps:src pytest tests/test_config_schema_generation.py tests/test_config_load.py tests/monte_carlo/test_costs.py tests/monte_carlo/test_scenario.py -k "rf_override or inject_cash"
- PYTHONPATH=src python -m ruff check src/trend_analysis/config/schema_generator.py src/trend_analysis/cli.py tests/test_config_schema_generation.py tests/test_config_load.py tests/monte_carlo/test_scenario.py
- python YAML parse check for config/defaults.yml
- git diff --check
- closer follow-ups: python -m json.tool config.schema.json; python -m json.tool config.schema.compact.json; required Gate checks green on 2026-05-09