### PR TITLE
Codex bootstrap for #5267

### DIFF
--- a/agents/codex-5267.md
+++ b/agents/codex-5267.md
@@ -1,1 +1,0 @@
-<!-- bootstrap for codex on issue #5267 -->

--- a/agents/codex-5267.md
+++ b/agents/codex-5267.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #5267 -->

--- a/config/scenarios/monte_carlo/cost_regime_example.yml
+++ b/config/scenarios/monte_carlo/cost_regime_example.yml
@@ -2,7 +2,7 @@
 # - Demonstrates stochastic calm/stress switching for transaction costs.
 # - Demonstrates regime-specific slippage multipliers.
 # - Intended as a known-good reference for regression tests and CLI examples.
-# - Run with: trend mc run --scenario cost_regime_example --dry-run --n-paths 10
+# - Run with: python -m trend_analysis.cli mc run --scenario cost_regime_example --dry-run --n-paths 10
 scenario:
   name: cost_regime_example
   description: "Example scenario exercising regime-switching costs and slippage."

--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -720,21 +720,21 @@ Rank_12_Equal,max_dd,-0.52,-0.41,-0.35,-0.28,-0.21,-0.15,-0.11,-0.09,-0.06
 
 ```bash
 # List available scenarios
-trend mc list
-trend mc list --tags hedge_fund
+python -m trend_analysis.cli mc list
+python -m trend_analysis.cli mc list --tags hedge_fund
 
 # Validate scenario configuration
-trend mc validate config/scenarios/monte_carlo/hf_equity_ls_10y.yml
+python -m trend_analysis.cli mc validate config/scenarios/monte_carlo/hf_equity_ls_10y.yml
 
 # Run scenario
-trend mc run --scenario hf_equity_ls_10y --out outputs/mc_run_1
-trend mc run --scenario hf_equity_ls_10y --n-paths 500 --jobs 4
+python -m trend_analysis.cli mc run --scenario hf_equity_ls_10y --out outputs/mc_run_1
+python -m trend_analysis.cli mc run --scenario hf_equity_ls_10y --n-paths 500 --jobs 4
 
 # Quick test run
-trend mc run --scenario hf_equity_ls_10y --dry-run --n-paths 10
+python -m trend_analysis.cli mc run --scenario hf_equity_ls_10y --dry-run --n-paths 10
 
 # Cost regime example dry-run (exact command)
-trend mc run --scenario cost_regime_example --dry-run --n-paths 10
+python -m trend_analysis.cli mc run --scenario cost_regime_example --dry-run --n-paths 10
 
 # Export MC charts from an existing bundle
 trend mc viz \

--- a/tests/monte_carlo/test_costs.py
+++ b/tests/monte_carlo/test_costs.py
@@ -187,10 +187,10 @@ def test_runner_integration_records_costs(monkeypatch: Any) -> None:
     transaction_costs = costs["transaction_costs"]
     assert isinstance(transaction_costs, pd.Series)
     assert len(transaction_costs) == 3
+    assert costs["slippage_multiplier"].tolist() == [1.0, 1.8, 1.0]
     cost_bps = pd.Series(costs["cost_bps"], index=transaction_costs.index, dtype=float)
     assert (cost_bps > 0.0).all()
     assert float(cost_bps.iloc[1]) > float(max(cost_bps.iloc[0], cost_bps.iloc[2]))
-    assert costs["slippage_multiplier"].tolist() == [1.0, 1.8, 1.0]
     expected_costs = (
         pd.Series([0.1, 0.2, 0.3], index=transaction_costs.index, name="turnover")
         * (cost_bps / 10000.0)

--- a/tests/monte_carlo/test_costs.py
+++ b/tests/monte_carlo/test_costs.py
@@ -226,7 +226,7 @@ def test_cost_regime_scenario_documents_exact_dry_run_command() -> None:
     scenario_file = Path("config/scenarios/monte_carlo/cost_regime_example.yml")
     scenario_text = scenario_file.read_text(encoding="utf-8")
     assert (
-        "# - Run with: trend mc run --scenario cost_regime_example --dry-run --n-paths 10"
+        "# - Run with: python -m trend_analysis.cli mc run --scenario cost_regime_example --dry-run --n-paths 10"
         in scenario_text
     )
 

--- a/tests/monte_carlo/test_registry.py
+++ b/tests/monte_carlo/test_registry.py
@@ -343,6 +343,8 @@ def test_cost_regime_example_discoverable_by_example_and_cost_tags() -> None:
     for tag in ("example", "cost"):
         names = {entry.name for entry in list_scenarios(tags=[tag])}
         assert "cost_regime_example" in names
+    combined = {entry.name for entry in list_scenarios(tags=["example", "cost"])}
+    assert "cost_regime_example" in combined
 
 
 def test_list_scenarios_missing_registry(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #5267

### Keepalive: OFF
<!-- meta:issue:5267 -->

### Source Issue #5267: [Follow-up] Remove all unrelated changes from the commit – spe (PR #5257)

Base: phase-3
Head: codex/issue-5267

Source: https://github.com/stranske/Trend_Model_Project/issues/5267

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #5257 addressed issue #5169, but verification identified remaining gaps and the verdict was **CONCERNS**. This follow-up isolates the cost-scenario work into a reviewable diff and completes the missing registration, fixture, test, and documentation updates needed for deterministic verification.

#### Tasks
### Scope Cleanup
- [x] Identify all modified files in config/ directory that are not cost-scenario related and revert those changes
- [x] Identify all modified files in src/ directory that are not cost-scenario related and revert those changes
- [x] Identify all modified files in tests/ directory that are not cost-scenario related and revert those changes
- [x] Verify that only the allowed files remain modified after reverting unrelated changes
- [x] Remove the file `docs/keepalive/PR5168_Status.md` from the branch entirely

### Registry Configuration
- [ ] Add the new cost scenario entry to `config/scenarios/monte_carlo/index.yml` with discovery tags `cost` and `example`
- [ ] Create or restore `config/scenarios/monte_carlo/cost_regime_example.yml` with complete regime-stochastic cost scenario definition including all referenced local fixture paths

### Registry Test Implementation
- [x] Check whether a registry-loading test already exists in `tests/**/test_registry.py` for the cost scenario
- [x] Create a new registry-loading test in `tests/**/test_registry.py` if no existing test is found
- [ ] Complete the existing registry-loading test to assert discoverability with `cost` and `example` tags if a partial test exists
- [ ] Verify the registry-loading test loads from the index rather than directly instantiating the scenario file

### Cost Test Implementation
- [x] Check whether a deterministic cost test already exists in `tests/**/test_costs.py`
- [x] Create a new deterministic cost test in `tests/**/test_costs.py` if no existing test is found
- [ ] Add assertions for exact expected slippage output values using local fixtures only
- [ ] Add separate assertions for CASH injection behavior with explicit expected values
- [ ] Add separate assertions for risk-free injection behavior with explicit expected values
- [ ] Verify the test does not depend on network access or non-repository data files

### Documentation
- [ ] Update `docs/**/MonteCarlo.md` to include an exact runnable CLI dry-run command for the cost scenario example that references the registered scenario name

#### Acceptance Criteria
### File Scope
- [ ] The branch modifies only the following files: `config/scenarios/monte_carlo/index.yml`, `config/scenarios/monte_carlo/cost_regime_example.yml`, `tests/**/test_registry.py`, `tests/**/test_costs.py`, `tests/fixtures/**` (cost-related fixtures only), and `docs/**/MonteCarlo.md`
- [ ] No other files in `config/`, `src/`, or `tests/` are modified
- [ ] The file `docs/keepalive/PR5168_Status.md` is absent from the branch diff and is not added or modified

### Registry Configuration
- [ ] `config/scenarios/monte_carlo/index.yml` contains exactly one registry entry for the new cost scenario
- [ ] The registry entry includes discovery tags `cost` and `example`
- [ ] Loading the Monte Carlo registry from `config/scenarios/monte_carlo/index.yml` exposes the new cost scenario as a discoverable scenario record without parse or validation errors
- [ ] Running `python -m yaml.safe_load config/scenarios/monte_carlo/cost_regime_example.yml` completes without exceptions
- [ ] Running the scenario loader's `validate()` method on `config/scenarios/monte_carlo/cost_regime_example.yml` returns success with no validation errors logged
- [ ] `config/scenarios/monte_carlo/cost_regime_example.yml` defines the regime-stochastic cost scenario used by tests and includes all referenced local fixture paths required for deterministic execution

### Test Coverage - Registry
- [ ] A registry test exists in `tests/**/test_registry.py` that loads the Monte Carlo registry index
- [ ] The registry test asserts that the new scenario is discoverable and tagged with both `cost` and `example`
- [ ] The registry test verifies discoverability through the same registry path used by listing/filtering behavior, rather than by directly instantiating the scenario file alone

### Test Coverage - Cost Behavior
- [ ] A deterministic cost test exists in `tests/**/test_costs.py` that executes the cost scenario
- [ ] The deterministic cost test uses only local fixtures under `tests/fixtures/**`
- [ ] The deterministic cost test asserts exact expected slippage output values
- [ ] The deterministic cost test includes separate assertions for CASH injection behavior with explicit expected values
- [ ] The deterministic cost test includes separate assertions for risk-free injection behavior with explicit expected values
- [ ] The deterministic cost test does not depend on network access, live market data, or non-repository data files

### Documentation
- [ ] A Monte Carlo documentation file matching `docs/**/MonteCarlo.md` contains an exact CLI dry-run command for the new cost scenario example
- [ ] The CLI dry-run command text references the registered scenario name so a user can run it without inferring missing arguments
- [ ] The CLI dry-run command exits with status code 0 when executed from the repository root with a clean virtual environment containing `requirements.txt` dependencies
- [ ] The CLI dry-run command produces output to stdout and does not write error messages to stderr or raise unhandled exceptions
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



# Cost Scenario Registration and Testing Follow-up

<!-- follow-up-depth: 1 -->

## Why
PR #5257 addressed issue #5169, but verification identified remaining gaps and the verdict was **CONCERNS**. This follow-up isolates the cost-scenario work into a reviewable diff and completes the missing registration, fixture, test, and documentation updates needed for deterministic verification.

## Source
- Original PR: #5257
- Parent issue: #5169

## Tasks

### Scope Cleanup
- [ ] Identify all modified files in config/ directory that are not cost-scenario related and revert those changes
- [ ] Identify all modified files in src/ directory that are not cost-scenario related and revert those changes
- [ ] Identify all modified files in tests/ directory that are not cost-scenario related and revert those changes
- [ ] Verify that only the allowed files remain modified after reverting unrelated changes
- [ ] Remove the file `docs/keepalive/PR5168_Status.md` from the branch entirely

### Registry Configuration
- [ ] Add the new cost scenario entry to `config/scenarios/monte_carlo/index.yml` with discovery tags `cost` and `example`
- [ ] Create or restore `config/scenarios/monte_carlo/cost_regime_example.yml` with complete regime-stochastic cost scenario definition including all referenced local fixture paths

### Registry Test Implementation
- [ ] Check whether a registry-loading test already exists in `tests/**/test_registry.py` for the cost scenario
- [ ] Create a new registry-loading test in `tests/**/test_registry.py` if no existing test is found
- [ ] Complete the existing registry-loading test to assert discoverability with `cost` and `example` tags if a partial test exists
- [ ] Verify the registry-loading test loads from the index rather than directly instantiating the scenario file

### Cost Test Implementation
- [ ] Check whether a deterministic cost test already exists in `tests/**/test_costs.py`
- [ ] Create a new deterministic cost test in `tests/**/test_costs.py` if no existing test is found
- [ ] Add assertions for exact expected slippage output values using local fixtures only
- [ ] Add separate assertions for CASH injection behavior with explicit expected values
- [ ] Add separate assertions for risk-free injection behavior with explicit expected values
- [ ] Verify the test does not depend on network access or non-repository data files

### Documentation
- [ ] Update `docs/**/MonteCarlo.md` to include an exact runnable CLI dry-run command for the cost scenario example that references the registered scenario name

## Acceptance Criteria

### File Scope
- [ ] The branch modifies only the following files: `config/scenarios/monte_carlo/index.yml`, `config/scenarios/monte_carlo/cost_regime_example.yml`, `tests/**/test_registry.py`, `tests/**/test_costs.py`, `tests/fixtures/**` (cost-related fixtures only), and `docs/**/MonteCarlo.md`
- [ ] No other files in `config/`, `src/`, or `tests/` are modified
- [ ] The file `docs/keepalive/PR5168_Status.md` is absent from the branch diff and is not added or modified

### Registry Configuration
- [ ] `config/scenarios/monte_carlo/index.yml` contains exactly one registry entry for the new cost scenario
- [ ] The registry entry includes discovery tags `cost` and `example`
- [ ] Loading the Monte Carlo registry from `config/scenarios/monte_carlo/index.yml` exposes the new cost scenario as a discoverable scenario record without parse or validation errors
- [ ] Running `python -m yaml.safe_load config/scenarios/monte_carlo/cost_regime_example.yml` completes without exceptions
- [ ] Running the scenario loader's `validate()` method on `config/scenarios/monte_carlo/cost_regime_example.yml` returns success with no validation errors logged
- [ ] `config/scenarios/monte_carlo/cost_regime_example.yml` defines the regime-stochastic cost scenario used by tests and includes all referenced local fixture paths required for deterministic execution

### Test Coverage - Registry
- [ ] A registry test exists in `tests/**/test_registry.py` that loads the Monte Carlo registry index
- [ ] The registry test asserts that the new scenario is discoverable and tagged with both `cost` and `example`
- [ ] The registry test verifies discoverability through the same registry path used by listing/filtering behavior, rather than by directly instantiating the scenario file alone

### Test Coverage - Cost Behavior
- [ ] A deterministic cost test exists in `tests/**/test_costs.py` that executes the cost scenario
- [ ] The deterministic cost test uses only local fixtures under `tests/fixtures/**`
- [ ] The deterministic cost test asserts exact expected slippage output values
- [ ] The deterministic cost test includes separate assertions for CASH injection behavior with explicit expected values
- [ ] The deterministic cost test includes separate assertions for risk-free injection behavior with explicit expected values
- [ ] The deterministic cost test does not depend on network access, live market data, or non-repository data files

### Documentation
- [ ] A Monte Carlo documentation file matching `docs/**/MonteCarlo.md` contains an exact CLI dry-run command for the new cost scenario example
- [ ] The CLI dry-run command text references the registered scenario name so a user can run it without inferring missing arguments
- [ ] The CLI dry-run command exits with status code 0 when executed from the repository root with a clean virtual environment containing `requirements.txt` dependencies
- [ ] The CLI dry-run command produces output to stdout and does not write error messages to stderr or raise unhandled exceptions

## Implementation Notes

**Scope Constraints (Hard Requirements):**
- The branch must modify only: `config/scenarios/monte_carlo/index.yml`, `config/scenarios/monte_carlo/cost_regime_example.yml`, targeted registry/cost tests, supporting local fixtures under `tests/fixtures/**`, and Monte Carlo documentation under `docs/**/MonteCarlo.md`
- Remove `docs/keepalive/PR5168_Status.md` from the branch entirely

**Technical Guidance (Recommendations):**
- The registry change should be explicit in `config/scenarios/monte_carlo/index.yml` and include the discovery tags `cost` and `example`
- Ensure `config/scenarios/monte_carlo/cost_regime_example.yml` is complete and non-truncated so automated tests can load it deterministically
- The registry test should load through the registry index or registry API path used by scenario discovery/listing, not just by loading the scenario file directly
- The deterministic cost test should rely only on repository fixtures and should assert exact expected outputs for slippage plus both CASH and risk-free injection behavior
- The Monte Carlo documentation should include a copy-pastable dry-run CLI command that names the registered scenario explicitly

## Notes

<details>
<summary>Advisory items (non-blocking, informational only)</summary>

- Cannot confirm the exact `12 passed, 3 warnings` test count specified in acceptance criteria without seeing full test implementations
- Cannot verify that `total_cost_drag` assertion is present in `test_costs.py` without full diff
- Cannot verify CASH/risk-free injection behavior is explicitly tested without full diff of `test_runner.py` and `test_scenario.py`

</details>

<details>
<summary>Background (previous attempt context, informational only)</summary>

- Including unrelated schema/CLI changes and an unrelated keepalive/status doc in the same PR failed because it introduced unnecessary risk and made the diff harder to review. Isolate the changes strictly related to the cost scenario—registration, testing, and documentation—in a dedicated branch/PR.
- Truncated diffs for critical test files (`test_costs.py`, `test_registry.py`, `cost_regime_example.yml`) blocked verification because incomplete test code prevents review of required behavior. Ensure the full contents of each test and configuration file are included in the commit.

</details>

## Deferred Tasks (Requires Human)

None - all tasks are actionable by a coding agent.



</details>

—
PR created automatically to engage Codex.