### PR TITLE
Codex bootstrap for #5265

### DIFF
--- a/agents/codex-5265.md
+++ b/agents/codex-5265.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #5265 -->

--- a/config/scenarios/monte_carlo/cost_regime_example.yml
+++ b/config/scenarios/monte_carlo/cost_regime_example.yml
@@ -36,7 +36,7 @@ costs:
   calm:
     # Baseline all-in trading cost in basis points (bps) in normal markets.
     trade_cost_bps:
-      dist: lognormal
+      kind: lognormal
       mean: 5
       sigma: 0.20
     # Multiplies modeled slippage under calm liquidity conditions.
@@ -44,7 +44,7 @@ costs:
   stress:
     # Elevated all-in trading cost in basis points (bps) during stress regimes.
     trade_cost_bps:
-      dist: lognormal
+      kind: lognormal
       mean: 20
       sigma: 0.35
     # Multiplies modeled slippage when liquidity worsens in stress.

--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -382,12 +382,12 @@ costs:
   default_regime: calm
   calm:
     trade_cost_bps:
-      dist: lognormal
+      kind: lognormal
       mean: 6
       sigma: 0.25
   stress:
     trade_cost_bps:
-      dist: lognormal
+      kind: lognormal
       mean: 18
       sigma: 0.35
     slippage_multiplier: 1.5  # Optional
@@ -398,7 +398,7 @@ costs:
 - Optional slippage multiplier
 - Applied to portfolio turnover
 
-### Backward Compatibility
+## Backward Compatibility
 
 The parser in `src/trend_analysis/monte_carlo/costs.py` still accepts these legacy
 keys and aliases. New scenario files and documentation examples should use the
@@ -572,12 +572,12 @@ scenario:
     default_regime: calm
     calm:
       trade_cost_bps:
-        dist: lognormal
+        kind: lognormal
         mean: 6
         sigma: 0.25
     stress:
       trade_cost_bps:
-        dist: lognormal
+        kind: lognormal
         mean: 18
         sigma: 0.35
       slippage_multiplier: 1.5

--- a/tests/monte_carlo/scenario/test_cost_regime_example_load.py
+++ b/tests/monte_carlo/scenario/test_cost_regime_example_load.py
@@ -6,6 +6,8 @@ from trend_analysis.monte_carlo.registry import load_scenario
 
 
 def test_cost_regime_example_loads_without_exception() -> None:
+    # Repository-supported invocation:
+    # python -m pytest tests/monte_carlo/scenario/test_cost_regime_example_load.py -q --no-cov
     scenario = load_scenario("cost_regime_example")
 
     assert scenario.name == "cost_regime_example"

--- a/tests/monte_carlo/test_monte_carlo_docs_schema.py
+++ b/tests/monte_carlo/test_monte_carlo_docs_schema.py
@@ -67,12 +67,13 @@ def test_monte_carlo_cost_examples_use_canonical_shape() -> None:
             assert "trade_cost_bps" in regime_block
             distribution = regime_block["trade_cost_bps"]
             assert isinstance(distribution, dict)
-            assert {"dist", "mean", "sigma"} <= set(distribution)
+            assert {"kind", "mean", "sigma"} <= set(distribution)
+            assert "dist" not in distribution
 
 
 def test_backward_compatibility_table_lists_legacy_keys_with_statuses() -> None:
     text = DOC_PATH.read_text(encoding="utf-8")
-    assert "### Backward Compatibility" in text
+    assert "\n## Backward Compatibility\n" in text
 
     required_rows = {
         "`costs.regimes.<name>`": "`supported`",


### PR DESCRIPTION
### Keepalive: ON
Closes #5265
<!-- meta:issue:5265 -->

### Source Issue #5265: [Follow-up] Remove the extra keepalive status file (docs/keepa (PR #5256)

Base: phase-3
Head: codex/issue-5265

Source: https://github.com/stranske/Trend_Model_Project/issues/5265

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #5256 addressed issue #5168, but verification identified remaining concerns (verdict: **CONCERNS**). This follow-up issue captures the remaining work as concrete, reviewable tasks focused on aligning Monte Carlo documentation and scenario artifacts with the canonical schema, adding executable coverage for scenario loading, and removing unrelated keepalive/status artifacts from the change set.

#### Tasks
### Documentation Updates
- [x] Identify all YAML code blocks in `docs/phase-3/MonteCarlo.md` that contain a `costs:` key and document their current structure in a comment or temporary file
- [x] Remove legacy-only fields from each `costs:` example in `docs/phase-3/MonteCarlo.md` that are not in the canonical schema defined in `src/schemas/monte_carlo.py`
- [x] Update all `costs:` examples in `docs/phase-3/MonteCarlo.md` to use canonical schema key names and nesting structure
- [x] Verify each updated `costs:` example against the canonical Monte Carlo schema definition by running schema validation if available, or by manual comparison with `src/schemas/monte_carlo.py`

### Backward Compatibility Documentation
- [x] Identify all legacy Monte Carlo schema keys and aliases from `config/scenarios/monte_carlo/*.yaml` files and git history of `docs/phase-3/MonteCarlo.md` from the past 3 releases
- [x] Create a `## Backward Compatibility` section in `docs/phase-3/MonteCarlo.md` with the exact heading specified
- [x] Document each legacy key or alias in the Backward Compatibility section with its corresponding status label of `supported` or `deprecated`
- [x] Add examples in the Backward Compatibility section showing how legacy keys map to canonical schema equivalents where applicable

### Scenario Updates
- [x] Update at least one scenario file under `config/scenarios/monte_carlo/` so its `costs:` block uses canonical Monte Carlo schema field names and structure from `src/schemas/monte_carlo.py`

### Test Coverage
- [x] Add an automated integration test under `tests/` that loads the specific updated scenario file from `config/scenarios/monte_carlo/` and asserts that scenario parsing/loading completes without raising an exception
- [x] Identify the current test invocation command that requires the `uv` executable and document its purpose in a code comment
- [x] Determine the repository-supported test runner command from `pyproject.toml` or `Makefile` that should be used instead of `uv`
- [x] Update test helper setup or configuration files to use the repository-supported test command (pytest, make test, etc.)
- [x] Verify the updated test invocation runs successfully in the repository test environment without `uv` by running the test locally

### Cleanup
- [x] Remove `docs/keepalive/PR5168_Status.md` from the change set if present
- [x] Add `.gitignore` rules to exclude `docs/keepalive/` directory or `*_Status.md` files so keepalive/status artifacts are not tracked by the repository

#### Acceptance Criteria
- [x] Every YAML code block in `docs/phase-3/MonteCarlo.md` that contains a top-level `costs:` key uses only keys defined in `src/schemas/monte_carlo.py` and contains no legacy-only aliases or fields not present in that schema definition
- [x] For each `costs:` example in `docs/phase-3/MonteCarlo.md`, the key names and nesting structure exactly match the canonical schema field names and hierarchy defined in `src/schemas/monte_carlo.py`
- [x] `docs/phase-3/MonteCarlo.md` contains a section with the exact heading `## Backward Compatibility`
- [x] The `## Backward Compatibility` section in `docs/phase-3/MonteCarlo.md` lists all legacy keys that appear in any scenario file under `config/scenarios/monte_carlo/` or in git history of `MonteCarlo.md` from the past 3 releases, with status label `supported` or `deprecated` for every listed item
- [x] At least one scenario file under `config/scenarios/monte_carlo/` is modified in this change set so that its `costs:` block uses the canonical Monte Carlo schema field names and structure from `src/schemas/monte_carlo.py`
- [x] A new or updated automated integration test exists under `tests/` that loads the specific updated scenario file from `config/scenarios/monte_carlo/` and the test passes without raising an exception
- [x] The test invocation for the scenario-loading test uses commands documented in `pyproject.toml`, `Makefile`, or `README.md` and does not require the `uv` executable
- [x] Running `pytest tests/` (or the repository-standard test command) executes the new scenario-loading test successfully
- [x] `docs/keepalive/PR5168_Status.md` is not present in the git staging area or committed changes
- [x] `.gitignore` contains an entry that prevents `docs/keepalive/` or `*_Status.md` files from being tracked
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



# Follow-up: Align Monte Carlo Documentation and Scenarios with Canonical Schema

<!-- follow-up-depth: 1 -->

## Why
PR #5256 addressed issue #5168, but verification identified remaining concerns (verdict: **CONCERNS**). This follow-up issue captures the remaining work as concrete, reviewable tasks focused on aligning Monte Carlo documentation and scenario artifacts with the canonical schema, adding executable coverage for scenario loading, and removing unrelated keepalive/status artifacts from the change set.

## Source
- Original PR: #5256
- Parent issue: #5168

## What
Update Monte Carlo documentation examples to match the canonical schema defined in the codebase, add backward compatibility documentation, update at least one scenario artifact to use canonical schema, add automated test coverage for scenario loading, and remove unrelated keepalive artifacts from version control.

The canonical Monte Carlo schema is defined in `src/schemas/monte_carlo.py` (or the equivalent schema definition file in the repository). All `costs:` keys must match fields defined in that file.

## Tasks

### Documentation Updates
- [x] Identify all YAML code blocks in `docs/phase-3/MonteCarlo.md` that contain a `costs:` key and document their current structure in a comment or temporary file
- [x] Remove legacy-only fields from each `costs:` example in `docs/phase-3/MonteCarlo.md` that are not in the canonical schema defined in `src/schemas/monte_carlo.py`
- [x] Update all `costs:` examples in `docs/phase-3/MonteCarlo.md` to use canonical schema key names and nesting structure
- [x] Verify each updated `costs:` example against the canonical Monte Carlo schema definition by running schema validation if available, or by manual comparison with `src/schemas/monte_carlo.py`

### Backward Compatibility Documentation
- [x] Identify all legacy Monte Carlo schema keys and aliases from `config/scenarios/monte_carlo/*.yaml` files and git history of `docs/phase-3/MonteCarlo.md` from the past 3 releases
- [x] Create a `## Backward Compatibility` section in `docs/phase-3/MonteCarlo.md` with the exact heading specified
- [x] Document each legacy key or alias in the Backward Compatibility section with its corresponding status label of `supported` or `deprecated`
- [x] Add examples in the Backward Compatibility section showing how legacy keys map to canonical schema equivalents where applicable

### Scenario Updates
- [x] Update at least one scenario file under `config/scenarios/monte_carlo/` so its `costs:` block uses canonical Monte Carlo schema field names and structure from `src/schemas/monte_carlo.py`

### Test Coverage
- [x] Add an automated integration test under `tests/` that loads the specific updated scenario file from `config/scenarios/monte_carlo/` and asserts that scenario parsing/loading completes without raising an exception
- [x] Identify the current test invocation command that requires the `uv` executable and document its purpose in a code comment
- [x] Determine the repository-supported test runner command from `pyproject.toml` or `Makefile` that should be used instead of `uv`
- [x] Update test helper setup or configuration files to use the repository-supported test command (pytest, make test, etc.)
- [x] Verify the updated test invocation runs successfully in the repository test environment without `uv` by running the test locally

### Cleanup
- [x] Remove `docs/keepalive/PR5168_Status.md` from the change set if present
- [x] Add `.gitignore` rules to exclude `docs/keepalive/` directory or `*_Status.md` files so keepalive/status artifacts are not tracked by the repository

## Acceptance Criteria
- [x] Every YAML code block in `docs/phase-3/MonteCarlo.md` that contains a top-level `costs:` key uses only keys defined in `src/schemas/monte_carlo.py` and contains no legacy-only aliases or fields not present in that schema definition
- [x] For each `costs:` example in `docs/phase-3/MonteCarlo.md`, the key names and nesting structure exactly match the canonical schema field names and hierarchy defined in `src/schemas/monte_carlo.py`
- [x] `docs/phase-3/MonteCarlo.md` contains a section with the exact heading `## Backward Compatibility`
- [x] The `## Backward Compatibility` section in `docs/phase-3/MonteCarlo.md` lists all legacy keys that appear in any scenario file under `config/scenarios/monte_carlo/` or in git history of `MonteCarlo.md` from the past 3 releases, with status label `supported` or `deprecated` for every listed item
- [x] At least one scenario file under `config/scenarios/monte_carlo/` is modified in this change set so that its `costs:` block uses the canonical Monte Carlo schema field names and structure from `src/schemas/monte_carlo.py`
- [x] A new or updated automated integration test exists under `tests/` that loads the specific updated scenario file from `config/scenarios/monte_carlo/` and the test passes without raising an exception
- [x] The test invocation for the scenario-loading test uses commands documented in `pyproject.toml`, `Makefile`, or `README.md` and does not require the `uv` executable
- [x] Running `pytest tests/` (or the repository-standard test command) executes the new scenario-loading test successfully
- [x] `docs/keepalive/PR5168_Status.md` is not present in the git staging area or committed changes
- [x] `.gitignore` contains an entry that prevents `docs/keepalive/` or `*_Status.md` files from being tracked

## Implementation Notes
- Keep the documentation changes focused in `docs/phase-3/MonteCarlo.md`, and make the `costs:` examples directly reviewable against `src/schemas/monte_carlo.py`
- For backward-compatibility documentation, enumerate legacy keys/aliases explicitly from actual scenario files and git history, and apply only the exact labels `supported` or `deprecated`
- Update a real scenario artifact under `config/scenarios/monte_carlo/` rather than relying only on documentation examples
- Prefer an integration-style test under `tests/` that loads the updated scenario through the same parser/loading path used by the application, and fails naturally on parse/load exceptions
- Ensure the test can be run with repository-supported tooling (pytest, make test, etc.) documented in `pyproject.toml`, `Makefile`, or `README.md` without depending on `uv`
- If the repository uses pytest, the test command should be `pytest tests/test_monte_carlo_scenarios.py` or similar
- If the repository uses make, ensure `make test` includes the new scenario-loading test
- Remove unrelated keepalive/status files from the implementation diff by adding appropriate `.gitignore` rules

## Out of Scope
- Review whether changes involving `metrics.rf_override_enabled` and `rf_rate_annual` are behaviorally correct or should be rolled back/documented. This requires domain judgment and is not part of the coding-agent scope for this follow-up.

## Deferred Tasks (Requires Human)
The following items require human judgment or access to resources not available to automated agents:
- Determining the authoritative source of truth if `src/schemas/monte_carlo.py` does not exist or if multiple schema definitions conflict
- Deciding whether legacy keys should be marked `supported` or `deprecated` based on product roadmap and backward compatibility policy
- Verifying that test environment configuration matches CI/CD pipeline requirements if local test execution differs from CI behavior

## Notes

### Background (Previous Attempt Context)
- The automated test command was not verified due to a `uv: command not found` error
- This failed because the current test environment does not have `uv` available, or the command path depends on a context not present in verification
- The solution is to use repository-supported test invocation (pytest, make test, etc.) that works in the available environment, as documented in `pyproject.toml`, `Makefile`, or `README.md`
- If `src/schemas/monte_carlo.py` does not exist, search for schema definitions in `config/schema.yaml`, `src/config/schemas.py`, or similar files and update all references in this issue accordingly



</details>

—
PR created automatically to engage Codex.

