### PR TITLE
Issue #5291: align docs/api.md endpoints with implemented routes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -85,13 +85,27 @@ instead.
 
 ### Example Request
 
+The `patch` body must match the
+[`ConfigPatch`](../src/trend_analysis/config/patch.py) schema: a list of
+`operations` (each with `op`, `path`, and a `value` for `set`/`append`/`merge`)
+plus a non-empty `summary`. Extra keys at the patch root are rejected. Patches
+that trigger risk flags (constraint removals, leverage increases, validation
+removals, broad-scope edits) or `needs_review` must be sent with
+`confirm_risky: true`.
+
 ```bash
 curl -X POST http://localhost:8000/config/patch/preview \
   -H "Content-Type: application/json" \
   -d '{
-        "config": {},
-        "patch": {"set": {"portfolio.top_n": 10}},
-        "confirm_risky": false
+        "config": {"analysis": {"top_n": 10}},
+        "patch": {
+          "operations": [
+            {"op": "set", "path": "analysis.top_n", "value": 12}
+          ],
+          "summary": "Update selection count to 12.",
+          "needs_review": true
+        },
+        "confirm_risky": true
       }'
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,15 +73,26 @@ uvicorn trend_analysis.api_server:app --host 0.0.0.0 --port 8000
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/health` | GET | Health check |
-| `/analyze` | POST | Run analysis with config |
+| `/` | GET | API metadata (version, links) |
+| `/config/patch` | POST | Apply a config patch with risk confirmation |
+| `/config/patch/preview` | POST | Preview a config patch (returns updated config + diff) |
 | `/docs` | GET | OpenAPI documentation |
+
+The REST surface is scoped to config-patch preview and apply. Running an
+analysis is not exposed over HTTP — use the [`trend-run`](CLI.md) CLI
+(`trend-run -c <config>`) or the Python API at the top of this document
+instead.
 
 ### Example Request
 
 ```bash
-curl -X POST http://localhost:8000/analyze \
+curl -X POST http://localhost:8000/config/patch/preview \
   -H "Content-Type: application/json" \
-  -d '{"config_path": "config/demo.yml"}'
+  -d '{
+        "config": {},
+        "patch": {"set": {"portfolio.top_n": 10}},
+        "confirm_risky": false
+      }'
 ```
 
 ## CLI Interface

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,0 +1,31 @@
+# stranske/Trend_Model_Project
+# Workloop State
+
+## 2026-05-13T21:50:00Z - opener lane materialized issue #5291
+
+- Automation: `pd-workloop-resume` / `handoff-claude-opener` (claude_code opener lane).
+- Source repo: `stranske/Trend_Model_Project`.
+- Source issue: `#5291` `REST API /analyze endpoint documented in docs/api.md but not registered in api_server` (`priority:normal`, `repo-review-approved`).
+- Selection:
+  - ACTION A succeeded from the neutral Code workspace.
+  - Cross-lane single-slot `active.source_repo=stranske/Manager-Database active.source_pr=1033 active.next_action=wait_for_verifier` treated as informational only; opener ran full discovery per read-order rule.
+  - Raw `gh search prs --owner stranske --author claude --state open` and `--author codex` both returned `[]`.
+  - `opener-cap-health.py --json`: `total_opener_owned=4`, `raw_cap_reached=false`, `normal_cap_reached=false`, `non_drainable_cap_blocker=false`. Items: Pension-Data #424, Pension-Data #427, Portable-Alpha-Extension-Model #1787, Travel-Plan-Permission #1085 -- all `runner-failed` with `agent:retry` already applied (closer/workflow-health territory, not opener-actionable).
+  - `opener-repair-infra-stalls.py --json` -> 0 repairs (all `runner-failed` skipped as not repairable by opener); post-repair cap-health unchanged.
+  - Fleet discovery: `priority:high` -> only `Workflows#2073` credential ops alert (SKIP). `priority:normal` ordered by `createdAt asc`; `Manager-Database#1032` was already merged in PR #1033 (closer/verifier owns the open-issue-without-close-ref), `Pension-Data#423`, `Pension-Data#425`, `Portable-Alpha-Extension-Model#1786`, and `Travel-Plan-Permission#1084` already linked to open opener-owned PRs. `Counter_Risk#594` was already satisfied on `origin/main` per prior rounds. `Pension-Data#426` was skipped as `repo-review-meta-audit`. Next eligible bounded item: `Trend_Model_Project#5291`.
+- Implementation (clean clone `/tmp/trend-issue-5291-claude-1778708766` because the Dropbox-backed `Trend_Model_Project` checkout has a pre-existing `.gitignore` local modification that must be preserved). Branch `claude/issue-5291-rest-api-doc-drift` from `origin/phase-3` `5b008a4`.
+- Resolution path: B (docs aligned to actual implementation), per the issue's "Why" -- the REST surface's real role is config-patch preview, and `_risky_change_guard` whitelists only `/config/patch*`.
+- Changes:
+  - `docs/api.md`: replaced the stale `POST /analyze` row in the endpoint table with the four routes the FastAPI server actually registers (`GET /health`, `GET /`, `POST /config/patch`, `POST /config/patch/preview`) plus `GET /docs`; replaced the `/analyze` curl example with a working `POST /config/patch/preview` example matching `ConfigPatchRequest`; added a note steering readers to the `trend-run` CLI / Python API for analysis runs.
+- Validation:
+  - `rg '/analyze' docs/api.md` -> no matches.
+  - `rg '/analyze' docs/` (recursive) -> no matches anywhere in `docs/`.
+  - `python -m pytest tests/test_api_server.py -q --no-cov` -> 51 passed.
+  - Cross-referenced new table against `app.add_api_route` / `@app.post` calls at `src/trend_analysis/api_server/__init__.py:148-166`.
+  - `git diff --check` -> passed.
+- Commit: `b5a1324c` (`Issue #5291: align docs/api.md endpoints with implemented routes`).
+- PR: [stranske/Trend_Model_Project#5293](https://github.com/stranske/Trend_Model_Project/pull/5293), opened ready-for-review (`isDraft=false`) with labels `agent:claude`, `agents:keepalive`, `autofix`; branch `claude/issue-5291-rest-api-doc-drift`.
+- Relay:
+  - `pr_opened active.source_repo=stranske/Trend_Model_Project active.source_issue=5291 active.source_pr=5293 active.next_action=wait_for_keepalive`
+- Cap after open: 5/5 opener-owned PRs (Pension-Data #424, Pension-Data #427, Portable-Alpha-Extension-Model #1787, Travel-Plan-Permission #1085, Trend_Model_Project #5293). Raw cap reached.
+- Next action: keepalive owns CI/check follow-up for PR `#5293`. Closer/workflow-health needs to drain at least one PR before the next opener tick can open a sixth.


### PR DESCRIPTION
## Summary

Resolves issue #5291 via path B (docs-aligned to actual implementation).

- Replaces the stale `POST /analyze` row in the REST API endpoint table with the four routes the FastAPI server in `src/trend_analysis/api_server/__init__.py` actually registers: `GET /health`, `GET /`, `POST /config/patch`, `POST /config/patch/preview`, plus `GET /docs`.
- Replaces the `/analyze` curl example with a working `POST /config/patch/preview` example matching the `ConfigPatchRequest` schema.
- Adds a note clarifying that analysis runs are exposed via the [`trend-run`](../docs/CLI.md) CLI / Python API, not REST.

Path B was selected per the issue's "Why" — the REST surface's real role is config-patch preview, not analysis execution; the `_risky_change_guard` middleware also only whitelists the `/config/patch*` paths, confirming the intent.

## Files changed

- `docs/api.md`: endpoint table + curl example + CLI-routing note in the REST API section.

## Validation

- `rg '/analyze' docs/api.md` -> no matches (acceptance criterion).
- `rg '/analyze' docs/` (recursive) -> no remaining doc references.
- Cross-referenced the new table against `app.add_api_route` / `@app.post` calls at `src/trend_analysis/api_server/__init__.py:148-166`.
- `python -m pytest tests/test_api_server.py -q --no-cov` -> 51 passed, 0 failed (no test changes; docs-only PR).

## Non-goals respected

- No changes to `/config/patch`, `/config/patch/preview`, `ConfigPatchRequest`, or `_risky_change_guard`.
- No new `/analyze` route (would have required pipeline plumbing the issue explicitly says is out of scope for both paths).
- No edits to `docs/phase-3/MonteCarlo.md` (tracked in its own issue).
