### PR TITLE
Issue #5290: mark Monte Carlo milestones complete

### DIFF
--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -1,6 +1,6 @@
 # Phase 3: Monte Carlo Framework
 
-> **Status**: Design Complete | Implementation Complete
+> **Status**: Design Complete | Implementation Complete<br>
 > **Target**: Multi-path simulation for portfolio forecasting and risk quantification
 
 ---
@@ -758,7 +758,7 @@ New tab: **Monte Carlo Simulation**
 ### Milestone 2: Return Models
 - [x] Price-path model interface + utilities (`src/trend_analysis/monte_carlo/models/base.py`)
 - [x] Multivariate stationary bootstrap implementation (`src/trend_analysis/monte_carlo/models/bootstrap.py`)
-- [x] Regime labeling + regime-conditioned bootstrap (`src/trend_analysis/monte_carlo/models/bootstrap.py`)
+- [x] Regime labeling + regime-conditioned bootstrap (`src/trend_analysis/monte_carlo/models/regime.py`)
 
 ### Milestone 3: Strategy Sets
 - [x] Strategy variant representation + config merge (`src/trend_analysis/monte_carlo/strategy/variant.py`)

--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -1,6 +1,6 @@
 # Phase 3: Monte Carlo Framework
 
-> **Status**: Design Complete | Implementation Pending  
+> **Status**: Design Complete | Implementation Complete
 > **Target**: Multi-path simulation for portfolio forecasting and risk quantification
 
 ---
@@ -752,34 +752,34 @@ New tab: **Monte Carlo Simulation**
 ## Implementation Milestones
 
 ### Milestone 1: Scenario + Config Foundations
-- [ ] Monte Carlo scenario schema + loader
-- [ ] Scenario library registry + discovery
+- [x] Monte Carlo scenario schema + loader (`src/trend_analysis/monte_carlo/scenario.py`)
+- [x] Scenario library registry + discovery (`src/trend_analysis/monte_carlo/registry.py`)
 
 ### Milestone 2: Return Models
-- [ ] Price-path model interface + utilities
-- [ ] Multivariate stationary bootstrap implementation
-- [ ] Regime labeling + regime-conditioned bootstrap
+- [x] Price-path model interface + utilities (`src/trend_analysis/monte_carlo/models/base.py`)
+- [x] Multivariate stationary bootstrap implementation (`src/trend_analysis/monte_carlo/models/bootstrap.py`)
+- [x] Regime labeling + regime-conditioned bootstrap (`src/trend_analysis/monte_carlo/models/bootstrap.py`)
 
 ### Milestone 3: Strategy Sets
-- [ ] Strategy variant representation + config merge
-- [ ] Sampled strategy generator
-- [ ] Initial curated strategy packs
+- [x] Strategy variant representation + config merge (`src/trend_analysis/monte_carlo/strategy/variant.py`)
+- [x] Sampled strategy generator (`src/trend_analysis/monte_carlo/strategy/sampler.py`)
+- [x] Initial curated strategy packs (`config/scenarios/monte_carlo/strategies/`)
 
 ### Milestone 4: MC Runner + Caching
-- [ ] MonteCarloRunner (two-layer + mixture modes)
-- [ ] Path-context caching (score frames)
-- [ ] Common random numbers support
+- [x] MonteCarloRunner (two-layer + mixture modes) (`src/trend_analysis/monte_carlo/runner.py`)
+- [x] Path-context caching (score frames) (`src/trend_analysis/monte_carlo/runner.py`)
+- [x] Common random numbers support (`src/trend_analysis/monte_carlo/runner.py`)
 
 ### Milestone 5: Costs, Turnover, Cash
-- [ ] Explicit cash handling + RF accrual
-- [ ] Regime-dependent stochastic costs
-- [ ] Turnover constraint variation under MC
+- [x] Explicit cash handling + RF accrual (`src/trend_analysis/monte_carlo/runner.py`)
+- [x] Regime-dependent stochastic costs (`src/trend_analysis/monte_carlo/costs.py`)
+- [x] Turnover constraint variation under MC (`src/trend_analysis/monte_carlo/runner.py`)
 
 ### Milestone 6: Folds + UX
-- [ ] Fold/vintage support
-- [ ] Aggregation outputs + distributions
-- [ ] CLI commands
-- [ ] Streamlit MC tab
+- [x] Fold/vintage support (`src/trend_analysis/monte_carlo/folds.py`)
+- [x] Aggregation outputs + distributions (`src/trend_analysis/monte_carlo/aggregator.py`)
+- [x] CLI commands (`src/trend_analysis/cli.py`)
+- [x] Streamlit MC tab (`streamlit_app/pages/monte_carlo.py`)
 
 ---
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,30 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-05-14T05:55:06Z - opener lane materialized issue #5290
+
+- Automation: `pd-workloop-resume` / `codex` opener lane.
+- Source repo: `stranske/Trend_Model_Project`.
+- Source issue: `#5290` `Mark docs/phase-3/MonteCarlo.md milestones complete: status header and checklist are stale` (`priority:low`, `repo-review-approved`).
+- Selection:
+  - ACTION A succeeded from the neutral Code workspace; cross-lane `active.*` was treated as informational.
+  - Required live priority discovery ran for `priority:high`, `priority:normal`, and `priority:low`.
+  - High-priority queue contained only Workflows `#2073` auth-expiry ops alert, skipped by opener policy.
+  - Normal-priority issues were already linked/in-flight or previously classified satisfied (`Counter_Risk#594` current docs already list the macros); the oldest eligible unlinked issue was low-priority Trend_Model_Project `#5290`.
+  - Initial cap-health at `2026-05-14T05:51:06Z`: `total_opener_owned=4`, `raw_cap_reached=false`, `normal_cap_reached=false`, `non_drainable_cap_blocker=false`.
+  - Infra repair helper removed stale `needs-human` from Pension-Data `#430`, added `agent:retry`, and fresh cap-health at `2026-05-14T05:51:45Z` showed `#430` draining with queued Gate/Gate Followups. Raw cap remained below 5, so opener continued to new issue selection.
+- Implementation worktree: `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/trend-model-5290`, branch `codex/issue-5290-montecarlo-doc-status`, base `origin/phase-3` `b86057ed`.
+- Changes:
+  - `docs/phase-3/MonteCarlo.md`: changed the Phase 3 Monte Carlo status header from `Implementation Pending` to `Implementation Complete`.
+  - Checked all Implementation Milestones and added concise source/config file anchors for each shipped milestone surface.
+- Validation:
+  - `rg -- 'Implementation Pending' docs/phase-3/MonteCarlo.md` -> no matches.
+  - `rg -- '- \[ \]' docs/phase-3/MonteCarlo.md` -> no matches.
+  - `git diff --check` -> passed.
+  - `python -m pytest tests/monte_carlo/ tests/streamlit/ -q --no-cov` initially hit two sandbox cache-write failures under `/Users/teacher/.cache/trend_model/rolling`.
+  - `TREND_ROLLING_CACHE=/Users/teacher/.codex/automations/pd-workloop-resume/cache/trend-model-5290/rolling python -m pytest tests/monte_carlo/ tests/streamlit/ -q --no-cov` -> 630 passed, 197 warnings.
+- Next action: commit, push, open ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; then hand off to keepalive.
+
 ## 2026-05-13T21:50:00Z - opener lane materialized issue #5291
 
 - Automation: `pd-workloop-resume` / `handoff-claude-opener` (claude_code opener lane).

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -25,7 +25,7 @@
   - Normal-priority issues were already linked/in-flight or previously classified satisfied (`Counter_Risk#594` current docs already list the macros); the oldest eligible unlinked issue was low-priority Trend_Model_Project `#5290`.
   - Initial cap-health at `2026-05-14T05:51:06Z`: `total_opener_owned=4`, `raw_cap_reached=false`, `normal_cap_reached=false`, `non_drainable_cap_blocker=false`.
   - Infra repair helper removed stale `needs-human` from Pension-Data `#430`, added `agent:retry`, and fresh cap-health at `2026-05-14T05:51:45Z` showed `#430` draining with queued Gate/Gate Followups. Raw cap remained below 5, so opener continued to new issue selection.
-- Implementation worktree: `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/trend-model-5290`, branch `codex/issue-5290-montecarlo-doc-status`, base `origin/phase-3` `b86057ed`.
+- Implementation worktree: automation-managed `trend-model-5290` worktree, branch `codex/issue-5290-montecarlo-doc-status`, base `origin/phase-3` `b86057ed`.
 - Changes:
   - `docs/phase-3/MonteCarlo.md`: changed the Phase 3 Monte Carlo status header from `Implementation Pending` to `Implementation Complete`.
   - Checked all Implementation Milestones and added concise source/config file anchors for each shipped milestone surface.
@@ -33,8 +33,8 @@
   - `rg -- 'Implementation Pending' docs/phase-3/MonteCarlo.md` -> no matches.
   - `rg -- '- \[ \]' docs/phase-3/MonteCarlo.md` -> no matches.
   - `git diff --check` -> passed.
-  - `python -m pytest tests/monte_carlo/ tests/streamlit/ -q --no-cov` initially hit two sandbox cache-write failures under `/Users/teacher/.cache/trend_model/rolling`.
-  - `TREND_ROLLING_CACHE=/Users/teacher/.codex/automations/pd-workloop-resume/cache/trend-model-5290/rolling python -m pytest tests/monte_carlo/ tests/streamlit/ -q --no-cov` -> 630 passed, 197 warnings.
+  - `python -m pytest tests/monte_carlo/ tests/streamlit/ -q --no-cov` initially hit two sandbox cache-write failures under the default user cache path.
+  - `TREND_ROLLING_CACHE=<automation-cache>/trend-model-5290/rolling python -m pytest tests/monte_carlo/ tests/streamlit/ -q --no-cov` -> 630 passed, 197 warnings.
 - Commit: `38b59dbb` (`Issue #5290: mark Monte Carlo milestones complete`).
 - PR: [stranske/Trend_Model_Project#5294](https://github.com/stranske/Trend_Model_Project/pull/5294), opened ready-for-review (`isDraft=false`) with labels `agent:codex`, `agents:keepalive`, and `autofix`; branch `codex/issue-5290-montecarlo-doc-status`.
 - Relay:

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,18 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-05-14T06:05:00Z - keepalive lane updated issue #5290
+
+- Automation: `pd-workloop-resume` / `codex` keepalive lane.
+- Source repo: `stranske/Trend_Model_Project`.
+- Source issue: `#5290` `Mark docs/phase-3/MonteCarlo.md milestones complete: status header and checklist are stale`.
+- Keepalive verification:
+  - `docs/phase-3/MonteCarlo.md` already shows `> **Status**: Design Complete | Implementation Complete`.
+  - Implementation milestones are fully checked and include shipped source/config anchors.
+  - `rg -- 'Implementation Pending' docs/phase-3/MonteCarlo.md` -> no matches.
+  - `rg -- '- \[ \]' docs/phase-3/MonteCarlo.md` -> no matches.
+- Next action: no further document edits required for `#5290`; proceed with normal keepalive handoff/PR status workflow.
+
 ## 2026-05-14T05:55:06Z - opener lane materialized issue #5290
 
 - Automation: `pd-workloop-resume` / `codex` opener lane.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -23,7 +23,15 @@
   - `git diff --check` -> passed.
   - `python -m pytest tests/monte_carlo/ tests/streamlit/ -q --no-cov` initially hit two sandbox cache-write failures under `/Users/teacher/.cache/trend_model/rolling`.
   - `TREND_ROLLING_CACHE=/Users/teacher/.codex/automations/pd-workloop-resume/cache/trend-model-5290/rolling python -m pytest tests/monte_carlo/ tests/streamlit/ -q --no-cov` -> 630 passed, 197 warnings.
-- Next action: commit, push, open ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; then hand off to keepalive.
+- Commit: `38b59dbb` (`Issue #5290: mark Monte Carlo milestones complete`).
+- PR: [stranske/Trend_Model_Project#5294](https://github.com/stranske/Trend_Model_Project/pull/5294), opened ready-for-review (`isDraft=false`) with labels `agent:codex`, `agents:keepalive`, and `autofix`; branch `codex/issue-5290-montecarlo-doc-status`.
+- Relay:
+  - `pr_opened active.source_repo=stranske/Trend_Model_Project active.source_issue=5290 active.source_pr=5294 active.next_action=wait_for_keepalive`
+- Post-open cap/health:
+  - Raw opener cap reached: `total_opener_owned=5`, `raw_cap_reached=true`.
+  - PR `#5294` had fresh Gate and Agents Gate Followups runs queued/in progress after initial cancelled superseded runs, so it is actively moving.
+  - Existing cap blocker: `Pension-Data#427` remains outside opener quick-recovery scope. Audit at `2026-05-14T05:58:06Z` found green checks but `mergeStateStatus=BEHIND` and a durable closer comment documenting four product-decision review threads; next owner is closer/human disposition, not opener branch-local recovery.
+- Next action: keepalive owns CI/check follow-up for PR `#5294`; closer/workflow-health needs to drain at least one cap PR before opener can open another issue.
 
 ## 2026-05-13T21:50:00Z - opener lane materialized issue #5291
 


### PR DESCRIPTION
Closes #5290

## Summary
- Update the Phase 3 Monte Carlo status header to Implementation Complete
- Mark the implementation milestones complete and add source/config anchors for the shipped surfaces
- Record opener lane state in workloop-state.md

## Validation
- rg -- 'Implementation Pending' docs/phase-3/MonteCarlo.md\n- rg -- '- \\[ \\]' docs/phase-3/MonteCarlo.md\n- git diff --check HEAD~1..HEAD\n- TREND_ROLLING_CACHE=/Users/teacher/.codex/automations/pd-workloop-resume/cache/trend-model-5290/rolling python -m pytest tests/monte_carlo/ tests/streamlit/ -q --no-cov (630 passed, 197 warnings)\n\nNote: the first pytest run without TREND_ROLLING_CACHE failed two tests because the macOS sandbox could not write to /Users/teacher/.cache/trend_model/rolling; rerunning with the cache inside the automation workspace passed.