### PR TITLE
Issue #5296: update raise_test_coverage_to_89.md current threshold to 80%

### DIFF
--- a/docs/issues/raise_test_coverage_to_89.md
+++ b/docs/issues/raise_test_coverage_to_89.md
@@ -12,5 +12,5 @@ Once overall test coverage meets or exceeds **89%**, restore the original covera
 - Increase `--cov-fail-under` in CI back to 89% when coverage improves.
 
 ## Reference
-- Current threshold: 74% (temporary)
+- Current threshold: 80% (temporary). Set by `coverage-min: "80"` in `.github/workflows/pr-00-gate.yml` and `coverage-min: '80'` in `.github/workflows/ci.yml`.
 - Target threshold: 89%


### PR DESCRIPTION
Closes #5296.

Updates `docs/issues/raise_test_coverage_to_89.md` so the current-threshold reference matches the live CI configuration.

## Change

- `Current threshold: 74% (temporary)` → `Current threshold: 80% (temporary). Set by coverage-min: "80" in .github/workflows/pr-00-gate.yml and coverage-min: '80' in .github/workflows/ci.yml.`

## Why

`docs/issues/raise_test_coverage_to_89.md` is a current issue-style documentation file used by contributors to understand the coverage-restoration plan. Both `.github/workflows/pr-00-gate.yml` and `.github/workflows/ci.yml` now pass `coverage-min: 80`, but the doc still cited the old `74%` temporary baseline. Contributors using the doc as the current plan would target or explain the wrong baseline.

## Acceptance criteria

- [x] `docs/issues/raise_test_coverage_to_89.md` no longer claims the current temporary threshold is `74%`.
- [x] The document states the current temporary threshold is `80%` and cites the two workflow files that set it.
- [x] `rg "coverage-min: ['\"]80" .github/workflows/pr-00-gate.yml .github/workflows/ci.yml` confirms the cited workflow values (verified against current `phase-3`).

## Non-goals

- No workflow coverage thresholds were changed.
- No new tests were added; this is a doc-only update.
- No unrelated coverage or CI documentation was rewritten.

## Validation

- `rg "74%" docs/issues/raise_test_coverage_to_89.md` returns no matches (verified on branch head).
- `coverage-min: "80"` is present at `.github/workflows/pr-00-gate.yml:71`.
- `coverage-min: '80'` is present at `.github/workflows/ci.yml:30`.

Filed from the documentation drift audit in #5292.
