### PR TITLE
Issue #5311: Enrich LangSmith traces for replay and config quality analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ test_output.log
 *.log
 node_modules/
 /.trend_nl_logs/
+artifacts/langsmith/
 
 # auto-generated virtual environments
 .autofix-venv/

--- a/docs/llm_providers.md
+++ b/docs/llm_providers.md
@@ -20,6 +20,20 @@ This guide explains how to configure and use the LLM provider abstraction built 
 5. Validate the provider by running a simple request (or a dry run) before integrating
    it into larger workflows.
 
+## LangSmith Fleet Records
+
+NL config patch and replay calls append sanitized `langsmith-fleet/v1` records for
+the shared fleet dashboard. By default the NDJSON artifact is written to
+`artifacts/langsmith/langsmith-fleet.ndjson`; set `TREND_LANGSMITH_FLEET_PATH` to
+override the path in local runs or CI.
+
+Records include provider/model, temperature, trace URL when available, latency,
+status, replay match state, validation status, config fingerprints, run/request
+IDs, prompt/output hashes, and safe artifact references. They intentionally do
+not include raw prompts, raw model outputs, proprietary datasets, or credentials.
+Missing `LANGSMITH_API_KEY` keeps LangSmith tracing as a no-op while fleet
+records can still be emitted for offline replay and validation checks.
+
 ## Configuration examples
 
 The provider config accepts the following common fields:

--- a/src/trend_analysis/llm/chain.py
+++ b/src/trend_analysis/llm/chain.py
@@ -94,7 +94,9 @@ def _default_variant_patches() -> ConfigPatchVariants:
         variants=[
             ConfigPatchVariant(
                 label=label,
-                patch=ConfigPatch(operations=[], summary=DEFAULT_BLOCK_SUMMARY, risk_flags=[]),
+                patch=ConfigPatch(
+                    operations=[], summary=DEFAULT_BLOCK_SUMMARY, risk_flags=[]
+                ),
             )
             for label in VARIANT_LABELS
         ]
@@ -290,7 +292,9 @@ class _BaseConfigPatchChain:
         supports_attr = getattr(base_llm, "supports_structured_output", None)
         if supports_attr is not None:
             try:
-                supports = supports_attr() if callable(supports_attr) else bool(supports_attr)
+                supports = (
+                    supports_attr() if callable(supports_attr) else bool(supports_attr)
+                )
             except Exception as exc:
                 logger.info(
                     "Structured output availability check failed; falling back to text output: %s",
@@ -304,7 +308,9 @@ class _BaseConfigPatchChain:
         try:
             structured_llm = base_llm.with_structured_output(schema)
         except Exception as exc:
-            logger.info("Structured output unavailable; falling back to text output: %s", exc)
+            logger.info(
+                "Structured output unavailable; falling back to text output: %s", exc
+            )
             return None
         if structured_llm is None:
             return None
@@ -454,6 +460,7 @@ class ConfigPatchChain(_BaseConfigPatchChain):
         trace_url: str | None = None
         patch: ConfigPatch | None = None
         error: str | None = None
+        error_category: str | None = None
 
         config_text = (
             current_config
@@ -487,7 +494,9 @@ class ConfigPatchChain(_BaseConfigPatchChain):
                     "Prompt injection detected (%s); skipping LLM call.",
                     ", ".join(sorted(set(injection_hits))),
                 )
-                patch = ConfigPatch(operations=[], summary=DEFAULT_BLOCK_SUMMARY, risk_flags=[])
+                patch = ConfigPatch(
+                    operations=[], summary=DEFAULT_BLOCK_SUMMARY, risk_flags=[]
+                )
                 return patch
             structured_llm = self._structured_output_llm()
             if structured_llm is not None:
@@ -537,7 +546,9 @@ class ConfigPatchChain(_BaseConfigPatchChain):
                             ) from exc
             else:
 
-                def _response_provider(attempt: int, last_error: Exception | None) -> str:
+                def _response_provider(
+                    attempt: int, last_error: Exception | None
+                ) -> str:
                     nonlocal response_text, trace_url
                     prompt = (
                         prompt_text
@@ -565,7 +576,9 @@ class ConfigPatchChain(_BaseConfigPatchChain):
                     retries=max(1, self.retries + 1),
                     logger=logger,
                 )
-            assert patch is not None  # appease mypy; patch is set unless an exception is raised
+            assert (
+                patch is not None
+            )  # appease mypy; patch is set unless an exception is raised
             schema = self._schema_for_validation(allowed_schema, instruction)
             unknown_keys = flag_unknown_keys(patch, schema, logger=logger)
             self._filter_unknown_keys(patch, unknown_keys)
@@ -573,6 +586,7 @@ class ConfigPatchChain(_BaseConfigPatchChain):
             return patch
         except Exception as exc:
             error = str(exc) or type(exc).__name__
+            error_category = type(exc).__name__
             raise
         finally:
             if log_operation:
@@ -606,7 +620,10 @@ class ConfigPatchChain(_BaseConfigPatchChain):
                     elapsed_ms=elapsed_ms,
                     response_text=response_text,
                     error=error,
-                    validation_status="blocked" if injection_hits else ("error" if error else "ok"),
+                    error_category=error_category,
+                    validation_status=(
+                        "blocked" if injection_hits else ("error" if error else "ok")
+                    ),
                 )
 
 
@@ -659,6 +676,7 @@ class ConfigPatchVariantsChain(_BaseConfigPatchChain):
         trace_url: str | None = None
         variants: ConfigPatchVariants | None = None
         error: str | None = None
+        error_category: str | None = None
 
         config_text = (
             current_config
@@ -743,7 +761,9 @@ class ConfigPatchVariantsChain(_BaseConfigPatchChain):
                             ) from exc
             else:
 
-                def _response_provider(attempt: int, last_error: Exception | None) -> str:
+                def _response_provider(
+                    attempt: int, last_error: Exception | None
+                ) -> str:
                     nonlocal response_text, trace_url
                     prompt = (
                         prompt_text
@@ -779,6 +799,7 @@ class ConfigPatchVariantsChain(_BaseConfigPatchChain):
             return variants
         except Exception as exc:
             error = str(exc) or type(exc).__name__
+            error_category = type(exc).__name__
             raise
         finally:
             if log_operation:
@@ -812,7 +833,10 @@ class ConfigPatchVariantsChain(_BaseConfigPatchChain):
                     elapsed_ms=elapsed_ms,
                     response_text=response_text,
                     error=error,
-                    validation_status="blocked" if injection_hits else ("error" if error else "ok"),
+                    error_category=error_category,
+                    validation_status=(
+                        "blocked" if injection_hits else ("error" if error else "ok")
+                    ),
                 )
 
 
@@ -886,11 +910,14 @@ class ResultSummaryChain:
     ) -> ResultSummaryResponse:
         questions_text = questions
         if metric_entries is not None:
-            missing_metrics = detect_unavailable_metric_requests(questions, metric_entries)
+            missing_metrics = detect_unavailable_metric_requests(
+                questions, metric_entries
+            )
             if missing_metrics:
                 missing_text = ", ".join(missing_metrics)
                 response_text = (
-                    "Requested data is unavailable in the analysis output for: " f"{missing_text}."
+                    "Requested data is unavailable in the analysis output for: "
+                    f"{missing_text}."
                 )
                 return ResultSummaryResponse(
                     text=ensure_result_disclaimer(response_text),
@@ -992,20 +1019,27 @@ def _record_config_fleet_event(
     elapsed_ms: float,
     response_text: str | None,
     error: str | None,
+    error_category: str | None,
     validation_status: str,
 ) -> None:
     from trend_analysis.llm.tracing import record_fleet_event, stable_hash
 
-    config_payload = current_config if isinstance(current_config, dict) else {"text": current_config}
+    config_payload = (
+        current_config if isinstance(current_config, dict) else {"text": current_config}
+    )
     record_fleet_event(
         operation=operation,
-        status="error" if error else ("blocked" if validation_status == "blocked" else "success"),
+        status=(
+            "error"
+            if error
+            else ("blocked" if validation_status == "blocked" else "success")
+        ),
         provider=os.environ.get("TREND_LLM_PROVIDER"),
         model=model,
         temperature=temperature,
         trace_url=trace_url,
         latency_ms=round(elapsed_ms, 3),
-        error_category=type(error).__name__ if error else None,
+        error_category=error_category,
         domain={
             "request_id": request_id,
             "dataset_id": stable_hash(config_payload),
@@ -1013,7 +1047,9 @@ def _record_config_fleet_event(
             "scenario_id": _scenario_id(config_payload),
             "config_fingerprint": stable_hash(config_payload),
             "prompt_hash": stable_hash(instruction),
-            "output_hash": stable_hash(response_text) if response_text is not None else None,
+            "output_hash": (
+                stable_hash(response_text) if response_text is not None else None
+            ),
             "replay_diff_summary": None,
             "match_score": None,
             "validation_status": validation_status,

--- a/src/trend_analysis/llm/chain.py
+++ b/src/trend_analysis/llm/chain.py
@@ -595,6 +595,19 @@ class ConfigPatchChain(_BaseConfigPatchChain):
                     trace_url=trace_url,
                 )
                 write_nl_log(entry)
+                _record_config_fleet_event(
+                    operation="nl_to_patch",
+                    request_id=request_id,
+                    current_config=current_config,
+                    instruction=instruction,
+                    model=self.model,
+                    temperature=self.temperature,
+                    trace_url=trace_url,
+                    elapsed_ms=elapsed_ms,
+                    response_text=response_text,
+                    error=error,
+                    validation_status="blocked" if injection_hits else ("error" if error else "ok"),
+                )
 
 
 class ConfigPatchVariantsChain(_BaseConfigPatchChain):
@@ -788,6 +801,19 @@ class ConfigPatchVariantsChain(_BaseConfigPatchChain):
                     trace_url=trace_url,
                 )
                 write_nl_log(entry)
+                _record_config_fleet_event(
+                    operation="nl_to_patch_variants",
+                    request_id=request_id,
+                    current_config=current_config,
+                    instruction=instruction,
+                    model=self.model,
+                    temperature=self.temperature,
+                    trace_url=trace_url,
+                    elapsed_ms=elapsed_ms,
+                    response_text=response_text,
+                    error=error,
+                    validation_status="blocked" if injection_hits else ("error" if error else "ok"),
+                )
 
 
 @dataclass(slots=True)
@@ -952,3 +978,55 @@ def _read_env_float(name: str, *, default: float) -> float:
 def _hash_payload(payload: dict[str, Any]) -> str:
     text = json.dumps(payload, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _record_config_fleet_event(
+    *,
+    operation: str,
+    request_id: str,
+    current_config: str | dict[str, Any],
+    instruction: str,
+    model: str | None,
+    temperature: float,
+    trace_url: str | None,
+    elapsed_ms: float,
+    response_text: str | None,
+    error: str | None,
+    validation_status: str,
+) -> None:
+    from trend_analysis.llm.tracing import record_fleet_event, stable_hash
+
+    config_payload = current_config if isinstance(current_config, dict) else {"text": current_config}
+    record_fleet_event(
+        operation=operation,
+        status="error" if error else ("blocked" if validation_status == "blocked" else "success"),
+        provider=os.environ.get("TREND_LLM_PROVIDER"),
+        model=model,
+        temperature=temperature,
+        trace_url=trace_url,
+        latency_ms=round(elapsed_ms, 3),
+        error_category=type(error).__name__ if error else None,
+        domain={
+            "request_id": request_id,
+            "dataset_id": stable_hash(config_payload),
+            "run_id": request_id,
+            "scenario_id": _scenario_id(config_payload),
+            "config_fingerprint": stable_hash(config_payload),
+            "prompt_hash": stable_hash(instruction),
+            "output_hash": stable_hash(response_text) if response_text is not None else None,
+            "replay_diff_summary": None,
+            "match_score": None,
+            "validation_status": validation_status,
+            "artifact_refs": {"nl_log_request_id": request_id},
+        },
+    )
+
+
+def _scenario_id(config_payload: Any) -> str | None:
+    if not isinstance(config_payload, dict):
+        return None
+    for key in ("scenario", "scenario_id", "name"):
+        value = config_payload.get(key)
+        if isinstance(value, str):
+            return value
+    return None

--- a/src/trend_analysis/llm/replay.py
+++ b/src/trend_analysis/llm/replay.py
@@ -6,6 +6,7 @@ import difflib
 import hashlib
 import logging
 import os
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -58,6 +59,7 @@ def replay_nl_entry(
     model: str | None = None,
     temperature: float | None = None,
 ) -> ReplayResult:
+    started = time.perf_counter()
     prompt_text = render_prompt(entry)
     active_llm = llm or _create_llm_from_env(entry, provider=provider, model=model)
     active_model = model or entry.model_name
@@ -74,6 +76,19 @@ def replay_nl_entry(
     recorded_hash = _hash_text(recorded) if recorded is not None else None
     matches = recorded == output_text if recorded is not None else False
     diff = _diff_outputs(recorded, output_text) if recorded is not None else None
+    _record_replay_fleet_event(
+        entry=entry,
+        provider=provider,
+        model=active_model,
+        temperature=active_temperature,
+        trace_url=trace_url,
+        latency_ms=(time.perf_counter() - started) * 1000,
+        prompt_hash=_hash_text(prompt_text),
+        output_hash=output_hash,
+        recorded_hash=recorded_hash,
+        matches=matches,
+        diff=diff,
+    )
     return ReplayResult(
         prompt=prompt_text,
         prompt_hash=_hash_text(prompt_text),
@@ -147,6 +162,54 @@ def _invoke_llm(
             if trace_url:
                 logger.info("LangSmith trace: %s", trace_url)
     return response_text, trace_url
+
+
+def _record_replay_fleet_event(
+    *,
+    entry: NLOperationLog,
+    provider: str | None,
+    model: str | None,
+    temperature: float,
+    trace_url: str | None,
+    latency_ms: float,
+    prompt_hash: str,
+    output_hash: str,
+    recorded_hash: str | None,
+    matches: bool,
+    diff: str | None,
+) -> None:
+    from trend_analysis.llm.tracing import record_fleet_event, stable_hash
+
+    record_fleet_event(
+        operation="nl-replay",
+        status="success" if matches else "mismatch",
+        provider=provider,
+        model=model,
+        temperature=temperature,
+        trace_url=trace_url,
+        latency_ms=round(latency_ms, 3),
+        error_category=None if matches else "replay_mismatch",
+        domain={
+            "request_id": entry.request_id,
+            "dataset_id": stable_hash(entry.prompt_variables or {}),
+            "run_id": entry.request_id,
+            "config_fingerprint": stable_hash(
+                {
+                    "operation": entry.operation,
+                    "model": model,
+                    "temperature": temperature,
+                    "prompt_variables": entry.prompt_variables,
+                }
+            ),
+            "prompt_hash": prompt_hash,
+            "output_hash": output_hash,
+            "recorded_output_hash": recorded_hash,
+            "replay_diff_summary": stable_hash(diff) if diff else None,
+            "match_score": 1.0 if matches else 0.0,
+            "validation_status": "match" if matches else "mismatch",
+            "artifact_refs": {"nl_log_request_id": entry.request_id},
+        },
+    )
 
 
 def _hash_text(text: str | None) -> str:

--- a/src/trend_analysis/llm/replay.py
+++ b/src/trend_analysis/llm/replay.py
@@ -61,9 +61,14 @@ def replay_nl_entry(
 ) -> ReplayResult:
     started = time.perf_counter()
     prompt_text = render_prompt(entry)
+    active_provider = _normalize_provider(
+        provider or os.environ.get("TREND_LLM_PROVIDER")
+    )
     active_llm = llm or _create_llm_from_env(entry, provider=provider, model=model)
     active_model = model or entry.model_name
-    active_temperature = entry.temperature if temperature is None else float(temperature)
+    active_temperature = (
+        entry.temperature if temperature is None else float(temperature)
+    )
     output_text, trace_url = _invoke_llm(
         prompt_text,
         active_llm,
@@ -78,7 +83,7 @@ def replay_nl_entry(
     diff = _diff_outputs(recorded, output_text) if recorded is not None else None
     _record_replay_fleet_event(
         entry=entry,
-        provider=provider,
+        provider=active_provider,
         model=active_model,
         temperature=active_temperature,
         trace_url=trace_url,
@@ -108,8 +113,12 @@ def _create_llm_from_env(
     provider: str | None = None,
     model: str | None = None,
 ) -> Any:
-    provider_name = _normalize_provider(provider or os.environ.get("TREND_LLM_PROVIDER"))
-    model_name = model or entry.model_name or os.environ.get("TREND_LLM_MODEL", "gpt-4o-mini")
+    provider_name = _normalize_provider(
+        provider or os.environ.get("TREND_LLM_PROVIDER")
+    )
+    model_name = (
+        model or entry.model_name or os.environ.get("TREND_LLM_MODEL", "gpt-4o-mini")
+    )
     config = LLMProviderConfig(provider=provider_name, model=model_name)
     return create_llm(config)
 

--- a/src/trend_analysis/llm/tracing.py
+++ b/src/trend_analysis/llm/tracing.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any, Iterator, Literal
 
 _LANGSMITH_ENABLED: bool | None = None
 _TRUTHY = {"1", "true", "yes", "on"}
+FLEET_SCHEMA_VERSION = "langsmith-fleet/v1"
+FLEET_SOURCE_REPO = "stranske/Trend_Model_Project"
+DEFAULT_FLEET_ARTIFACT_PATH = "artifacts/langsmith/langsmith-fleet.ndjson"
 
 
 def _truthy_env(name: str) -> bool:
@@ -67,6 +74,77 @@ def resolve_trace_url(run: Any) -> str | None:
     return None
 
 
+def stable_hash(value: Any, *, prefix: str = "sha256:") -> str:
+    """Return a deterministic digest for metadata without storing raw content."""
+
+    try:
+        serialized = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    except TypeError:
+        serialized = str(value)
+    return f"{prefix}{hashlib.sha256(serialized.encode('utf-8')).hexdigest()}"
+
+
+def default_fleet_artifact_path() -> Path:
+    return Path(os.environ.get("TREND_LANGSMITH_FLEET_PATH", DEFAULT_FLEET_ARTIFACT_PATH))
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item) for item in value]
+    return str(value)
+
+
+def build_fleet_record(
+    *,
+    operation: str,
+    status: str,
+    provider: str | None = None,
+    model: str | None = None,
+    temperature: float | None = None,
+    trace_url: str | None = None,
+    latency_ms: float | None = None,
+    error_category: str | None = None,
+    domain: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a dashboard-compatible LangSmith fleet record."""
+
+    return {
+        "schema_version": FLEET_SCHEMA_VERSION,
+        "source_repo": FLEET_SOURCE_REPO,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "operation": operation,
+        "status": status,
+        "provider": provider or "unknown",
+        "model": model or "unknown",
+        "temperature": temperature,
+        "trace_url": trace_url,
+        "latency_ms": latency_ms,
+        "error_category": error_category,
+        "domain": _json_safe(domain or {}),
+    }
+
+
+def append_fleet_record(record: dict[str, Any], *, path: str | Path | None = None) -> None:
+    output_path = Path(path) if path is not None else default_fleet_artifact_path()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(_json_safe(record), sort_keys=True, separators=(",", ":"))
+    with output_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{line}\n")
+
+
+def record_fleet_event(**kwargs: Any) -> dict[str, Any]:
+    record = build_fleet_record(**kwargs)
+    try:
+        append_fleet_record(record)
+    except Exception:
+        pass
+    return record
+
+
 @contextmanager
 def langsmith_tracing_context(
     *,
@@ -121,4 +199,14 @@ def langsmith_tracing_context(
                 yield run
 
 
-__all__ = ["langsmith_tracing_context", "maybe_enable_langsmith_tracing", "resolve_trace_url"]
+__all__ = [
+    "FLEET_SCHEMA_VERSION",
+    "append_fleet_record",
+    "build_fleet_record",
+    "default_fleet_artifact_path",
+    "langsmith_tracing_context",
+    "maybe_enable_langsmith_tracing",
+    "record_fleet_event",
+    "resolve_trace_url",
+    "stable_hash",
+]

--- a/src/trend_analysis/llm/tracing.py
+++ b/src/trend_analysis/llm/tracing.py
@@ -136,6 +136,34 @@ def append_fleet_record(record: dict[str, Any], *, path: str | Path | None = Non
         handle.write(f"{line}\n")
 
 
+def iter_fleet_records(
+    *, path: str | Path | None = None, schema_version: str = FLEET_SCHEMA_VERSION
+) -> Iterator[dict[str, Any]]:
+    input_path = Path(path) if path is not None else default_fleet_artifact_path()
+    if not input_path.exists():
+        return
+    with input_path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            payload = line.strip()
+            if not payload:
+                continue
+            try:
+                record = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(record, dict):
+                continue
+            if record.get("schema_version") != schema_version:
+                continue
+            yield record
+
+
+def load_fleet_records(
+    *, path: str | Path | None = None, schema_version: str = FLEET_SCHEMA_VERSION
+) -> list[dict[str, Any]]:
+    return list(iter_fleet_records(path=path, schema_version=schema_version))
+
+
 def record_fleet_event(**kwargs: Any) -> dict[str, Any]:
     record = build_fleet_record(**kwargs)
     try:
@@ -204,7 +232,9 @@ __all__ = [
     "append_fleet_record",
     "build_fleet_record",
     "default_fleet_artifact_path",
+    "iter_fleet_records",
     "langsmith_tracing_context",
+    "load_fleet_records",
     "maybe_enable_langsmith_tracing",
     "record_fleet_event",
     "resolve_trace_url",

--- a/src/trend_analysis/llm/tracing.py
+++ b/src/trend_analysis/llm/tracing.py
@@ -77,15 +77,14 @@ def resolve_trace_url(run: Any) -> str | None:
 def stable_hash(value: Any, *, prefix: str = "sha256:") -> str:
     """Return a deterministic digest for metadata without storing raw content."""
 
-    try:
-        serialized = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
-    except TypeError:
-        serialized = str(value)
+    serialized = json.dumps(_json_safe(value), sort_keys=True, separators=(",", ":"))
     return f"{prefix}{hashlib.sha256(serialized.encode('utf-8')).hexdigest()}"
 
 
 def default_fleet_artifact_path() -> Path:
-    return Path(os.environ.get("TREND_LANGSMITH_FLEET_PATH", DEFAULT_FLEET_ARTIFACT_PATH))
+    return Path(
+        os.environ.get("TREND_LANGSMITH_FLEET_PATH", DEFAULT_FLEET_ARTIFACT_PATH)
+    )
 
 
 def _json_safe(value: Any) -> Any:
@@ -93,7 +92,13 @@ def _json_safe(value: Any) -> Any:
         return value
     if isinstance(value, dict):
         return {str(key): _json_safe(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple, set)):
+    if isinstance(value, (set, frozenset)):
+        items = [_json_safe(item) for item in value]
+        return sorted(
+            items,
+            key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")),
+        )
+    if isinstance(value, (list, tuple)):
         return [_json_safe(item) for item in value]
     return str(value)
 
@@ -128,7 +133,9 @@ def build_fleet_record(
     }
 
 
-def append_fleet_record(record: dict[str, Any], *, path: str | Path | None = None) -> None:
+def append_fleet_record(
+    record: dict[str, Any], *, path: str | Path | None = None
+) -> None:
     output_path = Path(path) if path is not None else default_fleet_artifact_path()
     output_path.parent.mkdir(parents=True, exist_ok=True)
     line = json.dumps(_json_safe(record), sort_keys=True, separators=(",", ":"))
@@ -185,7 +192,9 @@ def langsmith_tracing_context(
 ) -> Iterator[Any]:
     """Provide a LangSmith tracing context and optional run metadata."""
 
-    if os.environ.get("PYTEST_CURRENT_TEST") and not _truthy_env("TREND_LANGSMITH_TRACE_TESTS"):
+    if os.environ.get("PYTEST_CURRENT_TEST") and not _truthy_env(
+        "TREND_LANGSMITH_TRACE_TESTS"
+    ):
         yield None
         return
     if not maybe_enable_langsmith_tracing():

--- a/tests/test_llm_chain_settings.py
+++ b/tests/test_llm_chain_settings.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from trend_analysis.llm.chain import ConfigPatchChain
 from trend_analysis.llm.prompts import build_config_patch_prompt
 
@@ -13,6 +15,22 @@ class DummyLLM:
     def bind(self, **kwargs):
         self.bound = kwargs
         return self
+
+
+class InvokingLLM(DummyLLM):
+    def __call__(self, payload):
+        return self.invoke(payload)
+
+    def invoke(self, _payload):
+        return json.dumps(
+            {
+                "operations": [
+                    {"op": "set", "path": "analysis.top_n", "value": 12},
+                ],
+                "summary": "Update top_n.",
+                "risk_flags": [],
+            }
+        )
 
 
 def test_chain_from_env_uses_temperature_and_model(monkeypatch) -> None:
@@ -31,3 +49,34 @@ def test_chain_from_env_uses_temperature_and_model(monkeypatch) -> None:
 
     chain._bind_llm()
     assert llm.bound == {"temperature": 0.42, "model": "unit-test-model"}
+
+
+def test_config_patch_chain_emits_fleet_record(monkeypatch, tmp_path) -> None:
+    fleet_path = tmp_path / "fleet.ndjson"
+    monkeypatch.setenv("TREND_LANGSMITH_FLEET_PATH", str(fleet_path))
+    monkeypatch.setenv("TREND_LLM_PROVIDER", "openai")
+
+    chain = ConfigPatchChain.from_env(
+        llm=InvokingLLM(),
+        prompt_builder=build_config_patch_prompt,
+        schema={"type": "object"},
+        model="gpt-test",
+    )
+
+    chain.run(
+        current_config={"analysis": {"top_n": 10}, "scenario": "base"},
+        instruction="Set top_n to 12.",
+        request_id="req-chain",
+        log_operation=True,
+    )
+
+    record = json.loads(fleet_path.read_text(encoding="utf-8").splitlines()[0])
+    assert record["schema_version"] == "langsmith-fleet/v1"
+    assert record["operation"] == "nl_to_patch"
+    assert record["status"] == "success"
+    assert record["provider"] == "openai"
+    assert record["model"] == "gpt-test"
+    assert record["domain"]["request_id"] == "req-chain"
+    assert record["domain"]["scenario_id"] == "base"
+    assert record["domain"]["config_fingerprint"].startswith("sha256:")
+    assert "Set top_n" not in json.dumps(record)

--- a/tests/test_llm_chain_settings.py
+++ b/tests/test_llm_chain_settings.py
@@ -33,6 +33,14 @@ class InvokingLLM(DummyLLM):
         )
 
 
+class FailingLLM(DummyLLM):
+    def __call__(self, payload):
+        return self.invoke(payload)
+
+    def invoke(self, _payload):
+        raise RuntimeError("provider unavailable")
+
+
 def test_chain_from_env_uses_temperature_and_model(monkeypatch) -> None:
     monkeypatch.setenv("TREND_LLM_TEMPERATURE", "0.42")
     monkeypatch.setenv("TREND_LLM_MODEL", "unit-test-model")
@@ -80,3 +88,31 @@ def test_config_patch_chain_emits_fleet_record(monkeypatch, tmp_path) -> None:
     assert record["domain"]["scenario_id"] == "base"
     assert record["domain"]["config_fingerprint"].startswith("sha256:")
     assert "Set top_n" not in json.dumps(record)
+
+
+def test_config_patch_chain_preserves_error_category(monkeypatch, tmp_path) -> None:
+    fleet_path = tmp_path / "fleet.ndjson"
+    monkeypatch.setenv("TREND_LANGSMITH_FLEET_PATH", str(fleet_path))
+
+    chain = ConfigPatchChain.from_env(
+        llm=FailingLLM(),
+        prompt_builder=build_config_patch_prompt,
+        schema={"type": "object"},
+        model="gpt-test",
+    )
+
+    try:
+        chain.run(
+            current_config={"analysis": {"top_n": 10}},
+            instruction="Set top_n to 12.",
+            request_id="req-error",
+            log_operation=True,
+        )
+    except RuntimeError:
+        pass
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("expected provider failure")
+
+    record = json.loads(fleet_path.read_text(encoding="utf-8").splitlines()[0])
+    assert record["status"] == "error"
+    assert record["error_category"] == "RuntimeError"

--- a/tests/test_llm_tracing.py
+++ b/tests/test_llm_tracing.py
@@ -6,7 +6,9 @@ import pytest
 
 from trend_analysis.llm import tracing as tracing_module
 from trend_analysis.llm.tracing import (
+    append_fleet_record,
     langsmith_tracing_context,
+    load_fleet_records,
     maybe_enable_langsmith_tracing,
     resolve_trace_url,
 )
@@ -115,3 +117,24 @@ def test_resolve_trace_url_falls_back_to_method() -> None:
             return "https://example.test/run/456"
 
     assert resolve_trace_url(DummyRun()) == "https://example.test/run/456"
+
+
+def test_load_fleet_records_filters_schema_and_invalid_lines(tmp_path) -> None:
+    fleet_path = tmp_path / "fleet.ndjson"
+    append_fleet_record(
+        {
+            "schema_version": "langsmith-fleet/v1",
+            "operation": "nl_to_patch",
+            "status": "success",
+        },
+        path=fleet_path,
+    )
+    with fleet_path.open("a", encoding="utf-8") as handle:
+        handle.write('{"schema_version":"langsmith-fleet/v0","operation":"old"}\n')
+        handle.write("{not-json}\n")
+        handle.write("\n")
+
+    records = load_fleet_records(path=fleet_path)
+
+    assert len(records) == 1
+    assert records[0]["operation"] == "nl_to_patch"

--- a/tests/test_llm_tracing.py
+++ b/tests/test_llm_tracing.py
@@ -11,6 +11,7 @@ from trend_analysis.llm.tracing import (
     load_fleet_records,
     maybe_enable_langsmith_tracing,
     resolve_trace_url,
+    stable_hash,
 )
 
 
@@ -65,7 +66,9 @@ def test_langsmith_tracing_context_invokes_trace(monkeypatch) -> None:
         def __init__(self) -> None:
             self.outputs: dict[str, str] | None = None
 
-        def end(self, *, outputs: dict[str, str] | None = None, error: str | None = None) -> None:
+        def end(
+            self, *, outputs: dict[str, str] | None = None, error: str | None = None
+        ) -> None:
             self.outputs = outputs
             assert error is None
 
@@ -117,6 +120,13 @@ def test_resolve_trace_url_falls_back_to_method() -> None:
             return "https://example.test/run/456"
 
     assert resolve_trace_url(DummyRun()) == "https://example.test/run/456"
+
+
+def test_stable_hash_normalizes_sets_deterministically() -> None:
+    left = {"values": {"beta", "alpha"}, "nested": [{"ids": {3, 1, 2}}]}
+    right = {"nested": [{"ids": {2, 3, 1}}], "values": {"alpha", "beta"}}
+
+    assert stable_hash(left) == stable_hash(right)
 
 
 def test_load_fleet_records_filters_schema_and_invalid_lines(tmp_path) -> None:

--- a/tests/test_nl_replay.py
+++ b/tests/test_nl_replay.py
@@ -117,6 +117,19 @@ def test_replay_nl_entry_emits_fleet_record(monkeypatch, tmp_path) -> None:
     assert "different" not in json.dumps(record)
 
 
+def test_replay_nl_entry_records_resolved_provider(monkeypatch, tmp_path) -> None:
+    entry = _make_entry("req-provider", output="match")
+    fake_llm = FakeLLM("match")
+    fleet_path = tmp_path / "fleet.ndjson"
+    monkeypatch.setenv("TREND_LANGSMITH_FLEET_PATH", str(fleet_path))
+    monkeypatch.setenv("TREND_LLM_PROVIDER", "anthropic")
+
+    replay_nl_entry(entry, llm=fake_llm)
+
+    record = json.loads(fleet_path.read_text(encoding="utf-8").splitlines()[0])
+    assert record["provider"] == "anthropic"
+
+
 def test_replay_nl_entry_logs_langsmith_trace_url(monkeypatch, caplog) -> None:
     entry = _make_entry("req-6", output="match")
     fake_llm = FakeLLM("match")

--- a/tests/test_nl_replay.py
+++ b/tests/test_nl_replay.py
@@ -97,6 +97,26 @@ def test_replay_nl_entry_reports_diff_on_mismatch() -> None:
     assert result.diff.startswith("--- recorded")
 
 
+def test_replay_nl_entry_emits_fleet_record(monkeypatch, tmp_path) -> None:
+    entry = _make_entry("req-fleet", output="match")
+    fake_llm = FakeLLM("different")
+    fleet_path = tmp_path / "fleet.ndjson"
+    monkeypatch.setenv("TREND_LANGSMITH_FLEET_PATH", str(fleet_path))
+
+    replay_nl_entry(entry, llm=fake_llm, provider="openai", model="gpt-test")
+
+    record = json.loads(fleet_path.read_text(encoding="utf-8").splitlines()[0])
+    assert record["schema_version"] == "langsmith-fleet/v1"
+    assert record["operation"] == "nl-replay"
+    assert record["status"] == "mismatch"
+    assert record["provider"] == "openai"
+    assert record["model"] == "gpt-test"
+    assert record["domain"]["request_id"] == "req-fleet"
+    assert record["domain"]["prompt_hash"]
+    assert record["domain"]["output_hash"]
+    assert "different" not in json.dumps(record)
+
+
 def test_replay_nl_entry_logs_langsmith_trace_url(monkeypatch, caplog) -> None:
     entry = _make_entry("req-6", output="match")
     fake_llm = FakeLLM("match")

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -6,13 +6,14 @@
 - Repo: stranske/Trend_Model_Project
 - Issue: #5311 Enrich LangSmith traces for replay and config quality analysis
 - Branch: codex/issue-5311-langsmith-replay-config-quality
+- PR: #5328 https://github.com/stranske/Trend_Model_Project/pull/5328
 - Agent: codex
-- Status: implemented locally; ready to push and open PR
+- Status: PR opened ready-for-review with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns next CI/check follow-up
 - Validation:
   - `python -m pytest tests/test_nl_replay.py tests/test_llm_chain_settings.py --no-cov -q` -> 8 passed
   - `python -m ruff check src/trend_analysis/llm/tracing.py src/trend_analysis/llm/replay.py src/trend_analysis/llm/chain.py tests/test_nl_replay.py tests/test_llm_chain_settings.py` -> passed
   - `python -m mypy src/trend_analysis/llm/tracing.py src/trend_analysis/llm/replay.py src/trend_analysis/llm/chain.py` -> passed
-- Next action: push branch, open non-draft PR with `agent:codex`, `agents:keepalive`, and `autofix`, then emit `pr_opened`.
+- Next action: wait for keepalive.
 
 ## 2026-05-14T06:05:00Z - keepalive lane updated issue #5290
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,19 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-05-24T06:13:51Z - opener lane issue #5311 PR materializing
+
+- Repo: stranske/Trend_Model_Project
+- Issue: #5311 Enrich LangSmith traces for replay and config quality analysis
+- Branch: codex/issue-5311-langsmith-replay-config-quality
+- Agent: codex
+- Status: implemented locally; ready to push and open PR
+- Validation:
+  - `python -m pytest tests/test_nl_replay.py tests/test_llm_chain_settings.py --no-cov -q` -> 8 passed
+  - `python -m ruff check src/trend_analysis/llm/tracing.py src/trend_analysis/llm/replay.py src/trend_analysis/llm/chain.py tests/test_nl_replay.py tests/test_llm_chain_settings.py` -> passed
+  - `python -m mypy src/trend_analysis/llm/tracing.py src/trend_analysis/llm/replay.py src/trend_analysis/llm/chain.py` -> passed
+- Next action: push branch, open non-draft PR with `agent:codex`, `agents:keepalive`, and `autofix`, then emit `pr_opened`.
+
 ## 2026-05-14T06:05:00Z - keepalive lane updated issue #5290
 
 - Automation: `pd-workloop-resume` / `codex` keepalive lane.


### PR DESCRIPTION
Implements #5311

## Summary
- Added `langsmith-fleet/v1` NDJSON record helpers for Trend LLM observability.
- Emit sanitized fleet records from NL config patch and replay paths with config fingerprints, prompt/output hashes, replay match state, validation status, latency, provider/model, and trace URLs when available.
- Documented `TREND_LANGSMITH_FLEET_PATH` and ignored generated LangSmith fleet artifacts.

## Validation
- `python -m pytest tests/test_nl_replay.py tests/test_llm_chain_settings.py --no-cov -q` -> 8 passed
- `python -m ruff check src/trend_analysis/llm/tracing.py src/trend_analysis/llm/replay.py src/trend_analysis/llm/chain.py tests/test_nl_replay.py tests/test_llm_chain_settings.py` -> passed
- `python -m mypy src/trend_analysis/llm/tracing.py src/trend_analysis/llm/replay.py src/trend_analysis/llm/chain.py` -> passed
- `git diff --check` -> passed