### PR TITLE
Issue #2933: Select coverage Gate runs with artifacts

### DIFF
--- a/.github/scripts/__tests__/select-coverage-gate-run.test.js
+++ b/.github/scripts/__tests__/select-coverage-gate-run.test.js
@@ -88,6 +88,8 @@ test('selectCoverageGateRun skips newer Gate runs without coverage artifacts', a
 
   assert.equal(selected.run.id, 20);
   assert.deepEqual(selected.artifacts, ['gate-coverage-trend', 'gate-coverage-trend-history']);
+  assert.deepEqual(selected.requiredArtifacts, ['gate-coverage-trend']);
+  assert.deepEqual(selected.skippedRunIds, [30]);
   assert.match(core.infos[0], /Skipping Gate run 30/);
 });
 
@@ -164,5 +166,6 @@ test('selectCoverageGateRun ignores expired coverage artifacts', async () => {
   });
 
   assert.equal(selected.run.id, 43);
+  assert.deepEqual(selected.skippedRunIds, [44]);
   assert.match(core.infos[0], /Skipping Gate run 44/);
 });

--- a/.github/scripts/__tests__/select-coverage-gate-run.test.js
+++ b/.github/scripts/__tests__/select-coverage-gate-run.test.js
@@ -1,0 +1,124 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  selectCoverageGateRun,
+  sortCompletedGateRuns,
+  successfulGateRuns,
+} = require('../select_coverage_gate_run');
+
+function createCore() {
+  return {
+    infos: [],
+    warnings: [],
+    info(message) {
+      this.infos.push(message);
+    },
+    warning(message) {
+      this.warnings.push(message);
+    },
+  };
+}
+
+test('sortCompletedGateRuns orders newest completed runs first', () => {
+  const runs = [
+    { id: 1, status: 'completed', created_at: '2026-01-01T00:00:00Z' },
+    { id: 2, status: 'in_progress', created_at: '2026-01-03T00:00:00Z' },
+    { id: 3, status: 'completed', created_at: '2026-01-02T00:00:00Z' },
+  ];
+
+  assert.deepEqual(
+    sortCompletedGateRuns(runs).map((run) => run.id),
+    [3, 1],
+  );
+});
+
+test('successfulGateRuns keeps success and neutral only', () => {
+  const runs = [
+    { id: 1, status: 'completed', conclusion: 'failure', created_at: '2026-01-03T00:00:00Z' },
+    { id: 2, status: 'completed', conclusion: 'success', created_at: '2026-01-02T00:00:00Z' },
+    { id: 3, status: 'completed', conclusion: 'neutral', created_at: '2026-01-01T00:00:00Z' },
+  ];
+
+  assert.deepEqual(
+    successfulGateRuns(runs).map((run) => run.id),
+    [2, 3],
+  );
+});
+
+test('selectCoverageGateRun skips newer Gate runs without coverage artifacts', async () => {
+  const core = createCore();
+  const artifactByRun = new Map([
+    [30, []],
+    [20, [{ name: 'gate-coverage-trend-history' }, { name: 'gate-coverage-trend' }]],
+  ]);
+  const github = {
+    rest: {
+      actions: {
+        listWorkflowRuns: async () => ({
+          data: {
+            workflow_runs: [
+              {
+                id: 30,
+                status: 'completed',
+                conclusion: 'success',
+                created_at: '2026-02-03T00:00:00Z',
+              },
+              {
+                id: 20,
+                status: 'completed',
+                conclusion: 'success',
+                created_at: '2026-02-02T00:00:00Z',
+              },
+            ],
+          },
+        }),
+        listWorkflowRunArtifacts: async ({ run_id }) => ({
+          data: { artifacts: artifactByRun.get(run_id) || [] },
+        }),
+      },
+    },
+  };
+
+  const selected = await selectCoverageGateRun({
+    github,
+    context: { repo: { owner: 'octo', repo: 'demo' } },
+    core,
+  });
+
+  assert.equal(selected.run.id, 20);
+  assert.deepEqual(selected.artifacts, ['gate-coverage-trend', 'gate-coverage-trend-history']);
+  assert.match(core.infos[0], /Skipping Gate run 30/);
+});
+
+test('selectCoverageGateRun returns null when no run has required coverage artifacts', async () => {
+  const core = createCore();
+  const github = {
+    rest: {
+      actions: {
+        listWorkflowRuns: async () => ({
+          data: {
+            workflow_runs: [
+              {
+                id: 10,
+                status: 'completed',
+                conclusion: 'success',
+                created_at: '2026-02-01T00:00:00Z',
+              },
+            ],
+          },
+        }),
+        listWorkflowRunArtifacts: async () => ({ data: { artifacts: [] } }),
+      },
+    },
+  };
+
+  const selected = await selectCoverageGateRun({
+    github,
+    context: { repo: { owner: 'octo', repo: 'demo' } },
+    core,
+  });
+
+  assert.equal(selected, null);
+  assert.match(core.warnings.at(-1), /No recent Gate workflow run/);
+});

--- a/.github/scripts/__tests__/select-coverage-gate-run.test.js
+++ b/.github/scripts/__tests__/select-coverage-gate-run.test.js
@@ -122,3 +122,47 @@ test('selectCoverageGateRun returns null when no run has required coverage artif
   assert.equal(selected, null);
   assert.match(core.warnings.at(-1), /No recent Gate workflow run/);
 });
+
+test('selectCoverageGateRun ignores expired coverage artifacts', async () => {
+  const core = createCore();
+  const artifactByRun = new Map([
+    [44, [{ name: 'gate-coverage-trend', expired: true }]],
+    [43, [{ name: 'gate-coverage-trend', expired: false }]],
+  ]);
+  const github = {
+    rest: {
+      actions: {
+        listWorkflowRuns: async () => ({
+          data: {
+            workflow_runs: [
+              {
+                id: 44,
+                status: 'completed',
+                conclusion: 'success',
+                created_at: '2026-03-02T00:00:00Z',
+              },
+              {
+                id: 43,
+                status: 'completed',
+                conclusion: 'success',
+                created_at: '2026-03-01T00:00:00Z',
+              },
+            ],
+          },
+        }),
+        listWorkflowRunArtifacts: async ({ run_id }) => ({
+          data: { artifacts: artifactByRun.get(run_id) || [] },
+        }),
+      },
+    },
+  };
+
+  const selected = await selectCoverageGateRun({
+    github,
+    context: { repo: { owner: 'octo', repo: 'demo' } },
+    core,
+  });
+
+  assert.equal(selected.run.id, 43);
+  assert.match(core.infos[0], /Skipping Gate run 44/);
+});

--- a/.github/scripts/__tests__/select-coverage-gate-run.test.js
+++ b/.github/scripts/__tests__/select-coverage-gate-run.test.js
@@ -2,10 +2,42 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const {
+  listCompletedGateRuns,
   selectCoverageGateRun,
   sortCompletedGateRuns,
   successfulGateRuns,
 } = require('../select_coverage_gate_run');
+
+function createPaginatedListWorkflowRuns(pages) {
+  let callCount = 0;
+  return async () => {
+    const page = pages[callCount] || { data: { workflow_runs: [] } };
+    callCount += 1;
+    return page;
+  };
+}
+
+function createPaginateIterator(pages) {
+  return {
+    iterator(_method, _params) {
+      let index = 0;
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              if (index >= pages.length) {
+                return { value: undefined, done: true };
+              }
+              const value = pages[index];
+              index += 1;
+              return { value, done: false };
+            },
+          };
+        },
+      };
+    },
+  };
+}
 
 function createCore() {
   return {
@@ -168,4 +200,148 @@ test('selectCoverageGateRun ignores expired coverage artifacts', async () => {
   assert.equal(selected.run.id, 43);
   assert.deepEqual(selected.skippedRunIds, [44]);
   assert.match(core.infos[0], /Skipping Gate run 44/);
+});
+
+test('selectCoverageGateRun paginates across pages when only an older run has coverage artifacts', async () => {
+  const core = createCore();
+  const pages = [
+    {
+      data: {
+        workflow_runs: Array.from({ length: 3 }, (_, idx) => ({
+          id: 200 + idx,
+          status: 'completed',
+          conclusion: 'success',
+          created_at: `2026-04-${String(20 - idx).padStart(2, '0')}T00:00:00Z`,
+        })),
+      },
+    },
+    {
+      data: {
+        workflow_runs: [
+          {
+            id: 150,
+            status: 'completed',
+            conclusion: 'success',
+            created_at: '2026-04-10T00:00:00Z',
+          },
+        ],
+      },
+    },
+  ];
+  const artifactByRun = new Map([
+    [150, [{ name: 'gate-coverage-trend' }]],
+  ]);
+  const github = {
+    paginate: createPaginateIterator(pages),
+    rest: {
+      actions: {
+        listWorkflowRuns: createPaginatedListWorkflowRuns(pages),
+        listWorkflowRunArtifacts: async ({ run_id }) => ({
+          data: { artifacts: artifactByRun.get(run_id) || [] },
+        }),
+      },
+    },
+  };
+
+  const selected = await selectCoverageGateRun({
+    github,
+    context: { repo: { owner: 'octo', repo: 'demo' } },
+    core,
+  });
+
+  assert.equal(selected.run.id, 150);
+  assert.deepEqual(selected.skippedRunIds, [200, 201, 202]);
+});
+
+test('selectCoverageGateRun honors maxPages cap when walking pages', async () => {
+  const core = createCore();
+  const pages = [
+    {
+      data: {
+        workflow_runs: [
+          {
+            id: 301,
+            status: 'completed',
+            conclusion: 'success',
+            created_at: '2026-04-05T00:00:00Z',
+          },
+        ],
+      },
+    },
+    {
+      data: {
+        workflow_runs: [
+          {
+            id: 302,
+            status: 'completed',
+            conclusion: 'success',
+            created_at: '2026-04-04T00:00:00Z',
+          },
+        ],
+      },
+    },
+    {
+      data: {
+        workflow_runs: [
+          {
+            id: 303,
+            status: 'completed',
+            conclusion: 'success',
+            created_at: '2026-04-03T00:00:00Z',
+          },
+        ],
+      },
+    },
+  ];
+  const github = {
+    paginate: createPaginateIterator(pages),
+    rest: {
+      actions: {
+        listWorkflowRuns: createPaginatedListWorkflowRuns(pages),
+        listWorkflowRunArtifacts: async () => ({ data: { artifacts: [] } }),
+      },
+    },
+  };
+
+  const selected = await selectCoverageGateRun({
+    github,
+    context: { repo: { owner: 'octo', repo: 'demo' } },
+    core,
+    maxPages: 2,
+  });
+
+  assert.equal(selected, null);
+  assert.deepEqual(core.warnings.at(-1).match(/required coverage artifact/) !== null, true);
+});
+
+test('listCompletedGateRuns falls back to a single page when paginate.iterator is absent', async () => {
+  const runs = [
+    {
+      id: 1,
+      status: 'completed',
+      conclusion: 'success',
+      created_at: '2026-04-01T00:00:00Z',
+    },
+  ];
+  const github = {
+    rest: {
+      actions: {
+        listWorkflowRuns: async () => ({ data: { workflow_runs: runs } }),
+      },
+    },
+  };
+
+  const result = await listCompletedGateRuns({
+    github,
+    owner: 'octo',
+    repo: 'demo',
+    workflowId: '.github/workflows/pr-00-gate.yml',
+    perPage: 100,
+    maxPages: 5,
+  });
+
+  assert.deepEqual(
+    result.map((run) => run.id),
+    [1],
+  );
 });

--- a/.github/scripts/select_coverage_gate_run.js
+++ b/.github/scripts/select_coverage_gate_run.js
@@ -66,6 +66,8 @@ async function selectCoverageGateRun({
     return null;
   }
 
+  const skippedRunIds = [];
+
   for (const run of candidates) {
     let artifacts = [];
     try {
@@ -77,8 +79,14 @@ async function selectCoverageGateRun({
     const names = artifactNames(artifacts);
     const missing = requiredArtifacts.filter((name) => !names.has(name));
     if (!missing.length) {
-      return { run, artifacts: [...names].sort() };
+      return {
+        run,
+        artifacts: [...names].sort(),
+        requiredArtifacts: [...requiredArtifacts],
+        skippedRunIds,
+      };
     }
+    skippedRunIds.push(run.id);
     core?.info?.(
       `Skipping Gate run ${run.id}: missing coverage artifact(s): ${missing.join(', ')}`,
     );

--- a/.github/scripts/select_coverage_gate_run.js
+++ b/.github/scripts/select_coverage_gate_run.js
@@ -2,6 +2,8 @@
 
 const DEFAULT_ARTIFACT_NAMES = ['gate-coverage-trend'];
 const DEFAULT_WORKFLOW_ID = '.github/workflows/pr-00-gate.yml';
+const DEFAULT_PER_PAGE = 100;
+const DEFAULT_MAX_PAGES = 5;
 
 function runStartedAt(run) {
   return new Date(run?.run_started_at || run?.created_at || 0).getTime();
@@ -42,23 +44,58 @@ async function listArtifactsForRun({ github, owner, repo, runId }) {
   return response?.data?.artifacts || [];
 }
 
+async function listCompletedGateRuns({
+  github,
+  owner,
+  repo,
+  workflowId,
+  perPage,
+  maxPages,
+}) {
+  const params = {
+    owner,
+    repo,
+    workflow_id: workflowId,
+    status: 'completed',
+    per_page: perPage,
+  };
+  const listRuns = github.rest.actions.listWorkflowRuns;
+  const iterator = github.paginate?.iterator;
+  if (typeof iterator === 'function') {
+    const collected = [];
+    let pagesFetched = 0;
+    for await (const response of iterator.call(github.paginate, listRuns, params)) {
+      const pageRuns = response?.data?.workflow_runs || [];
+      collected.push(...pageRuns);
+      pagesFetched += 1;
+      if (maxPages && pagesFetched >= maxPages) {
+        break;
+      }
+    }
+    return collected;
+  }
+  const response = await listRuns(params);
+  return response?.data?.workflow_runs || [];
+}
+
 async function selectCoverageGateRun({
   github,
   context,
   core,
   workflowId = DEFAULT_WORKFLOW_ID,
   requiredArtifacts = DEFAULT_ARTIFACT_NAMES,
-  perPage = 50,
+  perPage = DEFAULT_PER_PAGE,
+  maxPages = DEFAULT_MAX_PAGES,
 } = {}) {
   const { owner, repo } = context.repo;
-  const response = await github.rest.actions.listWorkflowRuns({
+  const runs = await listCompletedGateRuns({
+    github,
     owner,
     repo,
-    workflow_id: workflowId,
-    status: 'completed',
-    per_page: perPage,
+    workflowId,
+    perPage,
+    maxPages,
   });
-  const runs = response?.data?.workflow_runs || [];
   const candidates = successfulGateRuns(runs);
 
   if (!candidates.length) {
@@ -101,6 +138,7 @@ async function selectCoverageGateRun({
 module.exports = {
   artifactNames,
   listArtifactsForRun,
+  listCompletedGateRuns,
   selectCoverageGateRun,
   sortCompletedGateRuns,
   successfulGateRuns,

--- a/.github/scripts/select_coverage_gate_run.js
+++ b/.github/scripts/select_coverage_gate_run.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const DEFAULT_ARTIFACT_NAMES = ['gate-coverage-trend'];
+const DEFAULT_WORKFLOW_ID = '.github/workflows/pr-00-gate.yml';
+
+function runStartedAt(run) {
+  return new Date(run?.run_started_at || run?.created_at || 0).getTime();
+}
+
+function sortCompletedGateRuns(runs) {
+  return [...(runs || [])]
+    .filter((run) => run && run.status === 'completed')
+    .sort((a, b) => runStartedAt(b) - runStartedAt(a));
+}
+
+function successfulGateRuns(runs) {
+  const allowed = new Set(['success', 'neutral']);
+  return sortCompletedGateRuns(runs).filter((run) => allowed.has(run.conclusion || ''));
+}
+
+function artifactNames(artifacts) {
+  return new Set(
+    (artifacts || [])
+      .map((artifact) => String(artifact?.name || '').trim())
+      .filter(Boolean),
+  );
+}
+
+async function listArtifactsForRun({ github, owner, repo, runId }) {
+  const params = {
+    owner,
+    repo,
+    run_id: runId,
+    per_page: 100,
+  };
+  const listArtifacts = github.rest.actions.listWorkflowRunArtifacts;
+  if (typeof github.paginate === 'function') {
+    return github.paginate(listArtifacts, params);
+  }
+  const response = await listArtifacts(params);
+  return response?.data?.artifacts || [];
+}
+
+async function selectCoverageGateRun({
+  github,
+  context,
+  core,
+  workflowId = DEFAULT_WORKFLOW_ID,
+  requiredArtifacts = DEFAULT_ARTIFACT_NAMES,
+  perPage = 50,
+} = {}) {
+  const { owner, repo } = context.repo;
+  const response = await github.rest.actions.listWorkflowRuns({
+    owner,
+    repo,
+    workflow_id: workflowId,
+    status: 'completed',
+    per_page: perPage,
+  });
+  const runs = response?.data?.workflow_runs || [];
+  const candidates = successfulGateRuns(runs);
+
+  if (!candidates.length) {
+    core?.warning?.('No successful or neutral Gate workflow runs found.');
+    return null;
+  }
+
+  for (const run of candidates) {
+    let artifacts = [];
+    try {
+      artifacts = await listArtifactsForRun({ github, owner, repo, runId: run.id });
+    } catch (error) {
+      core?.warning?.(`Unable to inspect artifacts for Gate run ${run.id}: ${error.message}`);
+      continue;
+    }
+    const names = artifactNames(artifacts);
+    const missing = requiredArtifacts.filter((name) => !names.has(name));
+    if (!missing.length) {
+      return { run, artifacts: [...names].sort() };
+    }
+    core?.info?.(
+      `Skipping Gate run ${run.id}: missing coverage artifact(s): ${missing.join(', ')}`,
+    );
+  }
+
+  core?.warning?.(
+    `No recent Gate workflow run published required coverage artifact(s): ${requiredArtifacts.join(', ')}`,
+  );
+  return null;
+}
+
+module.exports = {
+  artifactNames,
+  listArtifactsForRun,
+  selectCoverageGateRun,
+  sortCompletedGateRuns,
+  successfulGateRuns,
+};

--- a/.github/scripts/select_coverage_gate_run.js
+++ b/.github/scripts/select_coverage_gate_run.js
@@ -21,6 +21,7 @@ function successfulGateRuns(runs) {
 function artifactNames(artifacts) {
   return new Set(
     (artifacts || [])
+      .filter((artifact) => artifact && artifact.expired !== true)
       .map((artifact) => String(artifact?.name || '').trim())
       .filter(Boolean),
   );

--- a/.github/workflows/maint-coverage-guard.yml
+++ b/.github/workflows/maint-coverage-guard.yml
@@ -125,46 +125,19 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { owner, repo } = context.repo;
             const workflowId = '.github/workflows/pr-00-gate.yml';
-            const fs = require('fs');
-            const retryHelperPath = './.github/scripts/github-api-with-retry.js';
-            const retryHelpers = fs.existsSync(retryHelperPath)
-              ? require(retryHelperPath)
-              : {
-                  withRetry: (fn) => fn(),
-                  paginateWithRetry: (githubInstance, method, params) =>
-                    githubInstance.paginate(method, params),
-                };
-            const { paginateWithRetry } = retryHelpers;
-
-            const runs = await paginateWithRetry(
-              github, github.rest.actions.listWorkflowRuns,
-              {
-                owner,
-                repo,
-                workflow_id: workflowId,
-                status: 'completed',
-                per_page: 50,
-              },
-            );
-
-            if (!runs.length) {
-              core.warning('No Gate workflow runs found.');
-              core.setOutput('run_id', '');
-              return;
-            }
-
-            runs.sort(
-              (a, b) =>
-                new Date(b.run_started_at || b.created_at || 0) -
-                new Date(a.run_started_at || a.created_at || 0),
-            );
-            const candidate =
-              runs.find((run) => ['success', 'neutral'].includes(run.conclusion || '')) || runs[0];
+            const { selectCoverageGateRun } = require('./.github/scripts/select_coverage_gate_run');
+            const selected = await selectCoverageGateRun({
+              github,
+              context,
+              core,
+              workflowId,
+              requiredArtifacts: ['gate-coverage-trend'],
+            });
+            const candidate = selected?.run;
 
             if (!candidate) {
-              core.warning('Unable to locate a completed Gate workflow run.');
+              core.warning('Unable to locate a completed Gate workflow run with coverage artifacts.');
               core.setOutput('run_id', '');
               return;
             }
@@ -173,7 +146,8 @@ jobs:
             core.setOutput('run_number', String(candidate.run_number || ''));
             core.setOutput('run_url', candidate.html_url || '');
             const url = candidate.html_url || 'no url';
-            core.notice(`Using Gate workflow run ${candidate.id} (${url})`);
+            const artifacts = selected.artifacts.join(', ') || 'none';
+            core.notice(`Using Gate workflow run ${candidate.id} (${url}); artifacts: ${artifacts}`);
 
       - name: Download coverage trend artifact
         if: ${{ steps.discover.outputs.run_id }}

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,32 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-05-25T15:01:13Z - opener lane issue #2933 PR materializing
+
+- Repo: stranske/Trend_Model_Project
+- Issue: #2933 `[coverage] baseline breach`
+- Branch: codex/issue-2933-coverage-guard-artifacts
+- PR: #5333 https://github.com/stranske/Trend_Model_Project/pull/5333
+- Agent: codex
+- Selection:
+  - Opener cap-health reported `total_opener_owned=0`, so cap was not blocking.
+  - All-open liveness found Trend_Model_Project #2933 as the oldest non-generated open supported issue after priority LMS issues were accounted for as merged-awaiting-verifier or scoped dependency blockers.
+  - Latest coverage guard runs were green but left #2933 open; run `26390421210` selected Gate run `26387928708`, which had no coverage artifacts, then exited `No coverage trend payload found; skipping coverage guard update`.
+  - A newer search found Gate run `26356812365` with `gate-coverage-trend` and `gate-coverage-trend-history` artifacts, so the guard's Gate-run selection was the repo-local defect.
+- Changes:
+  - Added `.github/scripts/select_coverage_gate_run.js` to choose the newest successful/neutral Gate run that actually published required coverage artifacts.
+  - Added Node tests for completed-run ordering, success/neutral filtering, artifact-backed selection, and no-artifact fallback.
+  - Updated `.github/workflows/maint-coverage-guard.yml` to use the helper before downloading coverage artifacts.
+- Validation:
+  - `node --test .github/scripts/__tests__/select-coverage-gate-run.test.js` -> 4 passed.
+  - `node --check .github/scripts/select_coverage_gate_run.js` -> passed.
+  - Workflow reference smoke check for `selectCoverageGateRun`, `gate-coverage-trend`, and the artifact-missing warning -> passed.
+  - `git diff --check` -> passed.
+- PR status: opened ready-for-review (`isDraft=false`) with labels `agent:codex`, `agents:keepalive`, and `autofix`.
+- Relay:
+  - `pr_opened active.source_repo=stranske/Trend_Model_Project active.source_issue=2933 active.source_pr=5333 active.next_action=wait_for_keepalive`
+- Next action: keepalive owns CI/check follow-up. Initial Gate run `26406953602` was superseded/cancelled almost immediately after PR creation, so the next run should be evaluated by keepalive rather than blocking opener.
+
 ## 2026-05-24T06:13:51Z - opener lane issue #5311 PR materializing
 
 - Repo: stranske/Trend_Model_Project


### PR DESCRIPTION
Closes #2933

## Summary
- Add a tested coverage Gate-run selector that skips successful Gate runs without coverage artifacts.
- Route the coverage guard workflow through the selector before downloading trend/history artifacts.
- Record the opener handoff state for this repo-local coverage guard fix.

## Validation
- node --test .github/scripts/__tests__/select-coverage-gate-run.test.js
- node --check .github/scripts/select_coverage_gate_run.js
- workflow reference smoke check for selector and artifact warning
- git diff --check

## Handoff
Keepalive owns CI/check follow-up after PR creation. The coverage guard should select a Gate run with gate-coverage-trend artifacts, allowing the stale coverage issue to be updated or closed on its next run.
