### PR TITLE
Issue #5348: Emit a single replayable run-envelope JSON (run_contract)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ results/
 !/.github/config/required-contexts.json
 !perf/perf_baseline.json
 !src/trend_analysis/export/manifest_schema.json
+!src/trend_analysis/export/run_envelope_schema.json
 !tests/fixtures/config_patch_structured.json
 !tests/fixtures/keepalive/*.json
 !tests/fixtures/keepalive_post_work/*.json

--- a/src/trend_analysis/api.py
+++ b/src/trend_analysis/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import random
 import sys
+import time
 from collections.abc import Mapping, Sized
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, SupportsInt, cast
@@ -34,6 +35,7 @@ from .pipeline import (
     _run_analysis_with_diagnostics,
 )
 from .risk import periods_per_year_from_code
+from .util.hash import normalise_for_json as _normalise_for_json
 from .util.risk_free import resolve_risk_free_settings
 from .util.weights import normalize_weights
 from .weights.robust_config import weight_engine_params_from_robustness
@@ -127,6 +129,12 @@ class RunResult:
     # Multi-period specific fields
     period_results: list[dict[str, Any]] | None = None
     period_count: int = 0
+    # Wall-clock timing of the pipeline dispatch (e.g. ``{"wall_ms": 12.3}``).
+    # Optional/``None``-defaulted so existing positional constructors stay valid.
+    timings: dict[str, float] | None = None
+    # Structured warnings collected during the run (e.g. weight-engine
+    # fallback, missing-data policy). Each entry carries at least a ``code``.
+    warnings: list[dict[str, Any]] | None = None
 
 
 def _run_multi_period_simulation(
@@ -159,6 +167,7 @@ def _run_multi_period_simulation(
     run_id = getattr(config, "run_id", None) or "api_multi_run"
     _log_step(run_id, "multi_period_start", "Starting multi-period simulation")
 
+    _dispatch_start = time.perf_counter()
     try:
         period_results = run_multi_period(config, returns)
     except Exception as exc:
@@ -168,7 +177,9 @@ def _run_multi_period_simulation(
             details={"error": str(exc)},
             seed=seed,
             environment=env,
+            timings={"wall_ms": (time.perf_counter() - _dispatch_start) * 1000.0},
         )
+    timings: dict[str, float] = {"wall_ms": (time.perf_counter() - _dispatch_start) * 1000.0}
 
     if not period_results:
         logger.warning("Multi-period simulation returned no results")
@@ -177,6 +188,7 @@ def _run_multi_period_simulation(
             details={},
             seed=seed,
             environment=env,
+            timings=timings,
         )
 
     _log_step(
@@ -239,6 +251,7 @@ def _run_multi_period_simulation(
         portfolio=portfolio_series,
         period_results=period_results,
         period_count=len(period_results),
+        timings=timings,
     )
 
     if structured is not None:
@@ -506,6 +519,7 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
     _log_step(run_id, "analysis_start", "_run_analysis dispatch")
     resolved_split = _resolve_sample_split(returns, split)
 
+    _dispatch_start = time.perf_counter()
     pipeline_output = _run_analysis(
         returns,
         resolved_split["in_start"],
@@ -541,6 +555,7 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
         risk_free_override=risk_free_override,
         weight_engine_params=weight_engine_params,
     )
+    timings: dict[str, float] = {"wall_ms": (time.perf_counter() - _dispatch_start) * 1000.0}
     diag_hint = cast(DiagnosticPayload | None, getattr(pipeline_output, "diagnostic", None))
     try:
         payload, diag = coerce_pipeline_result(pipeline_output)
@@ -549,7 +564,7 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
             "Unexpected pipeline result type (%s); returning empty payload",
             exc,
         )
-        return RunResult(pd.DataFrame(), {}, seed, env, diagnostic=diag_hint)
+        return RunResult(pd.DataFrame(), {}, seed, env, diagnostic=diag_hint, timings=timings)
     if payload is None:
         # Prefer NO_FUNDS_SELECTED when the input has no investable fund columns
         # (e.g. Date + RF only), even if the configured split yields an empty
@@ -578,7 +593,7 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
             )
         else:
             logger.warning("run_simulation produced no result (unknown reason)")
-        return RunResult(pd.DataFrame(), {}, seed, env, diagnostic=diag)
+        return RunResult(pd.DataFrame(), {}, seed, env, diagnostic=diag, timings=timings)
     res_dict = cast(dict[str, Any], payload)
     if isinstance(res_dict, dict):
         _attach_reporting_metadata(res_dict, config)
@@ -598,6 +613,9 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
             {k: v for k, v in ir_map.items() if k not in {"equal_weight", "user_weight"}}
         )
 
+    # Collect structured warnings rather than only logging them, so they can be
+    # surfaced in the replayable run envelope (see export/run_envelope.py).
+    collected_warnings: list[dict[str, Any]] = []
     fallback_raw = res_dict.get("weight_engine_fallback")
     fallback_info: dict[str, Any] | None = fallback_raw if isinstance(fallback_raw, dict) else None
     if fallback_info:
@@ -608,6 +626,25 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
             fallback_info.get("safe_mode"),
             fallback_info.get("condition_number"),
             fallback_info.get("condition_threshold"),
+        )
+        collected_warnings.append(
+            {
+                "code": "weight_engine_fallback",
+                "engine": fallback_info.get("engine"),
+                "safe_mode": fallback_info.get("safe_mode"),
+                "condition_number": fallback_info.get("condition_number"),
+                "condition_threshold": fallback_info.get("condition_threshold"),
+            }
+        )
+    # Fold in the missing-data policy summary recorded on the returns frame at
+    # ingestion (``data.py``: ``market_data_missing_policy_summary``) when present.
+    try:
+        policy_summary = returns.attrs.get("market_data_missing_policy_summary")
+    except AttributeError:  # pragma: no cover - defensive (non-frame input)
+        policy_summary = None
+    if policy_summary:
+        collected_warnings.append(
+            {"code": "missing_data_policy", "summary": _normalise_for_json(policy_summary)}
         )
     # Granular logging (best-effort; keys may vary by configuration)
     try:  # pragma: no cover - observational logging
@@ -707,6 +744,8 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
         fallback_info=fallback_info,
         analysis=structured,
         diagnostic=diag,
+        timings=timings,
+        warnings=collected_warnings,
     )
 
     if structured is not None:

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -822,7 +822,7 @@ def _execute_analysis_run(
                     if envelope_result is None:  # pragma: no cover - legacy path
                         envelope_result = _RR(
                             metrics_df,
-                            res if isinstance(res, dict) else {},
+                            dict(res) if isinstance(res, Mapping) else {},
                             run_seed,
                             {
                                 "python": sys.version.split()[0],

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -812,6 +812,42 @@ def _execute_analysis_run(
                     "Run manifest written",
                     directory=str(manifest_dir),
                 )
+                # Emit the single replayable run-envelope JSON that references
+                # (does not duplicate) the manifest just written.
+                try:
+                    from .api import RunResult as _RR
+                    from .export.run_envelope import write_run_envelope
+
+                    envelope_result = locals().get("run_result")
+                    if envelope_result is None:  # pragma: no cover - legacy path
+                        envelope_result = _RR(
+                            metrics_df,
+                            res if isinstance(res, dict) else {},
+                            run_seed,
+                            {
+                                "python": sys.version.split()[0],
+                                "numpy": np.__version__,
+                                "pandas": pd.__version__,
+                            },
+                        )
+                    envelope_path = write_run_envelope(
+                        envelope_result,
+                        config=config_payload,
+                        manifest_path=manifest_dir / "manifest.json",
+                        run_dir=manifest_dir,
+                    )
+                except Exception as exc:  # pragma: no cover - defensive guard
+                    logging.getLogger(__name__).warning(
+                        "Failed to write run envelope: %s", exc
+                    )
+                else:
+                    maybe_log_step(
+                        structured_log,
+                        run_id,
+                        "run_envelope",
+                        "Run envelope written",
+                        path=str(envelope_path),
+                    )
 
     if bundle:
         from .api import RunResult as _RR

--- a/src/trend_analysis/export/run_envelope.py
+++ b/src/trend_analysis/export/run_envelope.py
@@ -1,0 +1,208 @@
+"""Build and write the single replayable run-envelope JSON (``run_contract``).
+
+The *run envelope* is an export-time projection that ties together the data
+already produced by a run into one independently re-runnable JSON object:
+who/what/why (``actor``/``intent``), validated input hashes, named outputs (a
+reference to the existing artifact ``manifest.json`` rather than a duplicate),
+collected ``warnings``, ``cost_latency``, ``provenance`` and the run
+``diagnostic``.
+
+It deliberately **references** the existing
+:func:`trend_analysis.reporting.run_artifacts.write_run_artifacts` manifest and
+does not replace :class:`trend_analysis.api.RunResult` or either existing
+manifest. See ``run_envelope_schema.json`` for the validated shape.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from trend_analysis.util.hash import normalise_for_json, sha256_config, sha256_text
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from trend_analysis.api import RunResult
+
+SCHEMA_VERSION = "trend.run_envelope/1"
+
+
+@dataclass
+class RunEnvelope:
+    """In-memory representation of the run envelope.
+
+    Mirrors the JSON shape validated by ``run_envelope_schema.json``. Use
+    :func:`to_run_envelope` to build the serialisable ``dict`` from a
+    :class:`~trend_analysis.api.RunResult`.
+    """
+
+    run_id: str
+    inputs: dict[str, Any]
+    outputs: dict[str, Any]
+    provenance: dict[str, Any]
+    cost_latency: dict[str, Any]
+    warnings: list[dict[str, Any]] = field(default_factory=list)
+    diagnostic: dict[str, Any] | None = None
+    actor: str | None = None
+    intent: str | None = None
+    schema_version: str = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-friendly envelope mapping (omitting empty actor/intent)."""
+
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "run_id": self.run_id,
+            "inputs": self.inputs,
+            "outputs": self.outputs,
+            "provenance": self.provenance,
+            "cost_latency": self.cost_latency,
+            "warnings": self.warnings,
+            "diagnostic": self.diagnostic,
+        }
+        if self.actor is not None:
+            payload["actor"] = self.actor
+        if self.intent is not None:
+            payload["intent"] = self.intent
+        return payload
+
+
+def _serialise_diagnostic(diagnostic: Any) -> dict[str, Any] | None:
+    """Return a JSON-friendly projection of a ``DiagnosticPayload`` (or ``None``)."""
+
+    if diagnostic is None:
+        return None
+    if dataclasses.is_dataclass(diagnostic) and not isinstance(diagnostic, type):
+        return cast("dict[str, Any]", normalise_for_json(dataclasses.asdict(diagnostic)))
+    if hasattr(diagnostic, "model_dump"):
+        return cast("dict[str, Any]", normalise_for_json(diagnostic.model_dump()))
+    if isinstance(diagnostic, dict):
+        return cast("dict[str, Any]", normalise_for_json(diagnostic))
+    return {"message": str(diagnostic)}
+
+
+def _load_manifest(manifest_path: Path) -> dict[str, Any]:
+    try:
+        with open(manifest_path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):  # pragma: no cover - defensive
+        return {}
+
+
+def to_run_envelope(
+    result: RunResult,
+    *,
+    config: Any,
+    manifest_path: Path | str,
+    timings: dict[str, float] | None = None,
+    warnings: list[dict[str, Any]] | None = None,
+    actor: str | None = None,
+    intent: str | None = None,
+) -> dict[str, Any]:
+    """Build the run-envelope ``dict`` for *result*, cross-linking the manifest.
+
+    Parameters
+    ----------
+    result:
+        The :class:`~trend_analysis.api.RunResult` from :func:`run_simulation`.
+    config:
+        The configuration object/mapping (hashed via :func:`sha256_config`).
+    manifest_path:
+        Path to the existing ``manifest.json`` produced by
+        :func:`write_run_artifacts`; the envelope references it and reuses its
+        ``input_sha256``/``git_hash``/artifact names rather than duplicating them.
+    timings:
+        Optional timing mapping (e.g. ``{"wall_ms": 12.3}``). Falls back to
+        ``result.timings`` when omitted.
+    warnings:
+        Optional structured warnings. Falls back to ``result.warnings`` when
+        omitted.
+    actor, intent:
+        Optional caller-supplied provenance describing who ran it and why.
+    """
+
+    manifest_path = Path(manifest_path)
+    manifest = _load_manifest(manifest_path)
+
+    config_sha256 = sha256_config(config)
+    input_sha256 = manifest.get("input_sha256")
+    seed = getattr(result, "seed", None)
+
+    # Content-addressed run_id, identical scheme to export/bundle.py:75-81.
+    run_id_src = "|".join(
+        part
+        for part in (
+            input_sha256 if isinstance(input_sha256, str) else None,
+            config_sha256,
+            str(seed) if seed is not None else "",
+        )
+        if part
+    )
+    run_id = sha256_text(run_id_src)
+
+    artifacts = manifest.get("artifacts", [])
+    artifact_names = [
+        a.get("name")
+        for a in artifacts
+        if isinstance(a, dict) and a.get("name") is not None
+    ]
+
+    effective_timings = timings if timings is not None else (getattr(result, "timings", None) or {})
+    wall_ms = effective_timings.get("wall_ms")
+    cost_latency: dict[str, Any] = {"wall_ms": float(wall_ms) if wall_ms is not None else None}
+    peak_rss_kb = effective_timings.get("peak_rss_kb")
+    if peak_rss_kb is not None:
+        cost_latency["peak_rss_kb"] = peak_rss_kb
+
+    effective_warnings = (
+        warnings if warnings is not None else (getattr(result, "warnings", None) or [])
+    )
+
+    envelope = RunEnvelope(
+        run_id=run_id,
+        inputs={"config_sha256": config_sha256, "input_sha256": input_sha256},
+        outputs={"manifest": manifest_path.name, "artifacts": artifact_names},
+        provenance={
+            "git_hash": manifest.get("git_hash"),
+            "environment": normalise_for_json(getattr(result, "environment", {}) or {}),
+        },
+        cost_latency=cost_latency,
+        warnings=[normalise_for_json(w) for w in effective_warnings],
+        diagnostic=_serialise_diagnostic(getattr(result, "diagnostic", None)),
+        actor=actor,
+        intent=intent,
+    )
+    return envelope.to_dict()
+
+
+def write_run_envelope(
+    result: RunResult,
+    *,
+    config: Any,
+    manifest_path: Path | str,
+    run_dir: Path | str | None = None,
+    timings: dict[str, float] | None = None,
+    warnings: list[dict[str, Any]] | None = None,
+    actor: str | None = None,
+    intent: str | None = None,
+) -> Path:
+    """Write ``run_envelope.json`` next to the manifest and return its path."""
+
+    manifest_path = Path(manifest_path)
+    target_dir = Path(run_dir) if run_dir is not None else manifest_path.parent
+    envelope = to_run_envelope(
+        result,
+        config=config,
+        manifest_path=manifest_path,
+        timings=timings,
+        warnings=warnings,
+        actor=actor,
+        intent=intent,
+    )
+    out_path = target_dir / "run_envelope.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(envelope, indent=2), encoding="utf-8")
+    return out_path

--- a/src/trend_analysis/export/run_envelope.py
+++ b/src/trend_analysis/export/run_envelope.py
@@ -17,9 +17,11 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import math
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Mapping, cast
 
 from trend_analysis.util.hash import normalise_for_json, sha256_config, sha256_text
 
@@ -27,6 +29,33 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from trend_analysis.api import RunResult
 
 SCHEMA_VERSION = "trend.run_envelope/1"
+
+
+def _strict_json_value(value: Any) -> Any:
+    """Return a JSON value that can be written with ``allow_nan=False``."""
+
+    normalised = normalise_for_json(value)
+    if isinstance(normalised, Mapping):
+        return {k: _strict_json_value(v) for k, v in normalised.items()}
+    if isinstance(normalised, list):
+        return [_strict_json_value(item) for item in normalised]
+    if isinstance(normalised, tuple):
+        return [_strict_json_value(item) for item in normalised]
+    if isinstance(normalised, float) and not math.isfinite(normalised):
+        if math.isnan(normalised):
+            return "NaN"
+        return "Infinity" if normalised > 0 else "-Infinity"
+    return normalised
+
+
+def _manifest_reference(manifest_path: Path, target_dir: Path) -> str:
+    """Return the manifest path as it should appear inside the envelope."""
+
+    try:
+        relative = Path(os.path.relpath(manifest_path, start=target_dir))
+    except ValueError:  # pragma: no cover - different drives on Windows
+        return str(manifest_path)
+    return relative.as_posix()
 
 
 @dataclass
@@ -75,21 +104,20 @@ def _serialise_diagnostic(diagnostic: Any) -> dict[str, Any] | None:
     if diagnostic is None:
         return None
     if dataclasses.is_dataclass(diagnostic) and not isinstance(diagnostic, type):
-        return cast("dict[str, Any]", normalise_for_json(dataclasses.asdict(diagnostic)))
+        return cast("dict[str, Any]", _strict_json_value(dataclasses.asdict(diagnostic)))
     if hasattr(diagnostic, "model_dump"):
-        return cast("dict[str, Any]", normalise_for_json(diagnostic.model_dump()))
+        return cast("dict[str, Any]", _strict_json_value(diagnostic.model_dump()))
     if isinstance(diagnostic, dict):
-        return cast("dict[str, Any]", normalise_for_json(diagnostic))
+        return cast("dict[str, Any]", _strict_json_value(diagnostic))
     return {"message": str(diagnostic)}
 
 
 def _load_manifest(manifest_path: Path) -> dict[str, Any]:
-    try:
-        with open(manifest_path, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-        return data if isinstance(data, dict) else {}
-    except (OSError, ValueError):  # pragma: no cover - defensive
-        return {}
+    with open(manifest_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f"manifest must be a JSON object: {manifest_path}")
+    return data
 
 
 def to_run_envelope(
@@ -101,6 +129,7 @@ def to_run_envelope(
     warnings: list[dict[str, Any]] | None = None,
     actor: str | None = None,
     intent: str | None = None,
+    manifest_reference: str | None = None,
 ) -> dict[str, Any]:
     """Build the run-envelope ``dict`` for *result*, cross-linking the manifest.
 
@@ -126,6 +155,7 @@ def to_run_envelope(
 
     manifest_path = Path(manifest_path)
     manifest = _load_manifest(manifest_path)
+    manifest_ref = manifest_reference or manifest_path.name
 
     config_sha256 = sha256_config(config)
     input_sha256 = manifest.get("input_sha256")
@@ -164,13 +194,13 @@ def to_run_envelope(
     envelope = RunEnvelope(
         run_id=run_id,
         inputs={"config_sha256": config_sha256, "input_sha256": input_sha256},
-        outputs={"manifest": manifest_path.name, "artifacts": artifact_names},
+        outputs={"manifest": manifest_ref, "artifacts": artifact_names},
         provenance={
             "git_hash": manifest.get("git_hash"),
-            "environment": normalise_for_json(getattr(result, "environment", {}) or {}),
+            "environment": _strict_json_value(getattr(result, "environment", {}) or {}),
         },
         cost_latency=cost_latency,
-        warnings=[normalise_for_json(w) for w in effective_warnings],
+        warnings=[_strict_json_value(w) for w in effective_warnings],
         diagnostic=_serialise_diagnostic(getattr(result, "diagnostic", None)),
         actor=actor,
         intent=intent,
@@ -193,6 +223,7 @@ def write_run_envelope(
 
     manifest_path = Path(manifest_path)
     target_dir = Path(run_dir) if run_dir is not None else manifest_path.parent
+    manifest_ref = _manifest_reference(manifest_path, target_dir)
     envelope = to_run_envelope(
         result,
         config=config,
@@ -201,8 +232,9 @@ def write_run_envelope(
         warnings=warnings,
         actor=actor,
         intent=intent,
+        manifest_reference=manifest_ref,
     )
     out_path = target_dir / "run_envelope.json"
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(json.dumps(envelope, indent=2), encoding="utf-8")
+    out_path.write_text(json.dumps(envelope, indent=2, allow_nan=False), encoding="utf-8")
     return out_path

--- a/src/trend_analysis/export/run_envelope_schema.json
+++ b/src/trend_analysis/export/run_envelope_schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://trend-analysis.example.com/schema/run_envelope.json",
+  "title": "Trend Analysis Run Envelope",
+  "type": "object",
+  "required": [
+    "run_id",
+    "inputs",
+    "outputs",
+    "provenance",
+    "cost_latency",
+    "warnings",
+    "diagnostic"
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$"
+    }
+  },
+  "properties": {
+    "schema_version": {"type": ["string", "null"]},
+    "run_id": {"$ref": "#/$defs/sha256"},
+    "actor": {"type": ["string", "null"]},
+    "intent": {"type": ["string", "null"]},
+    "inputs": {
+      "type": "object",
+      "required": ["config_sha256"],
+      "properties": {
+        "config_sha256": {"$ref": "#/$defs/sha256"},
+        "input_sha256": {
+          "anyOf": [
+            {"type": "null"},
+            {"$ref": "#/$defs/sha256"}
+          ]
+        }
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "required": ["manifest"],
+      "properties": {
+        "manifest": {"type": "string"},
+        "artifacts": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["git_hash", "environment"],
+      "properties": {
+        "git_hash": {"type": ["string", "null"]},
+        "environment": {"type": "object"}
+      }
+    },
+    "cost_latency": {
+      "type": "object",
+      "required": ["wall_ms"],
+      "properties": {
+        "wall_ms": {"type": ["number", "null"]},
+        "peak_rss_kb": {"type": ["number", "null"]}
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["code"],
+        "properties": {
+          "code": {"type": "string"}
+        }
+      }
+    },
+    "diagnostic": {
+      "type": ["object", "null"]
+    }
+  },
+  "additionalProperties": true
+}

--- a/tests/test_run_envelope_schema.py
+++ b/tests/test_run_envelope_schema.py
@@ -165,3 +165,56 @@ def test_run_envelope_cost_latency_and_fallback_warning(tmp_path: Path) -> None:
 
     codes = {w.get("code") for w in envelope["warnings"]}
     assert "weight_engine_fallback" in codes
+
+
+def test_run_envelope_writes_strict_json_for_non_finite_warning(tmp_path: Path) -> None:
+    """Non-finite diagnostic values are preserved without invalid JSON tokens."""
+
+    cfg = _make_robust_cfg()
+    result = api.run_simulation(cfg, _make_ill_conditioned_df())
+    result.warnings = [{"code": "condition", "condition_number": float("inf")}]
+
+    config_payload = dict(vars(cfg)) if not hasattr(cfg, "model_dump") else cfg.model_dump()
+    manifest_path = _write_manifest(tmp_path, config=config_payload)
+    out_path = write_run_envelope(result, config=config_payload, manifest_path=manifest_path)
+    raw = out_path.read_text(encoding="utf-8")
+
+    assert "Infinity" in raw
+    assert '"condition_number": "Infinity"' in raw
+    jsonschema.validate(json.loads(raw), _schema())
+
+
+def test_run_envelope_fails_fast_for_bad_manifest(tmp_path: Path) -> None:
+    """A missing or corrupted manifest must not produce a partial envelope."""
+
+    cfg = _make_robust_cfg()
+    result = api.run_simulation(cfg, _make_ill_conditioned_df())
+
+    with pytest.raises(FileNotFoundError):
+        to_run_envelope(result, config=cfg, manifest_path=tmp_path / "missing.json")
+
+    bad_manifest = tmp_path / "bad-manifest.json"
+    bad_manifest.write_text("[1, 2, 3]", encoding="utf-8")
+    with pytest.raises(ValueError, match="manifest must be a JSON object"):
+        to_run_envelope(result, config=cfg, manifest_path=bad_manifest)
+
+
+def test_run_envelope_manifest_reference_is_relative_to_run_dir(tmp_path: Path) -> None:
+    """A non-adjacent run_dir keeps a valid cross-link to the manifest."""
+
+    cfg = _make_robust_cfg()
+    result = api.run_simulation(cfg, _make_ill_conditioned_df())
+    config_payload = dict(vars(cfg)) if not hasattr(cfg, "model_dump") else cfg.model_dump()
+    manifest_path = _write_manifest(tmp_path, config=config_payload)
+    envelope_dir = tmp_path / "envelopes"
+
+    out_path = write_run_envelope(
+        result,
+        config=config_payload,
+        manifest_path=manifest_path,
+        run_dir=envelope_dir,
+    )
+    envelope = json.loads(out_path.read_text(encoding="utf-8"))
+
+    assert envelope["outputs"]["manifest"] == "../runs/20200101_000000_demoabcd/manifest.json"
+    assert (out_path.parent / envelope["outputs"]["manifest"]).resolve() == manifest_path.resolve()

--- a/tests/test_run_envelope_schema.py
+++ b/tests/test_run_envelope_schema.py
@@ -1,0 +1,167 @@
+"""Validate the single replayable run-envelope JSON (``run_contract``).
+
+These tests build a :class:`~trend_analysis.api.RunResult` via
+:func:`run_simulation` and project it into ``run_envelope.json`` through
+:func:`trend_analysis.export.run_envelope.to_run_envelope`, then assert the
+result conforms to ``run_envelope_schema.json`` and that cost/latency and
+structured warnings are populated. They fail on ``main`` today because no such
+module/schema/function exists.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import numpy as np
+import pandas as pd
+import pytest
+
+from trend_analysis import api
+from trend_analysis.config import Config, load_config
+from trend_analysis.export.run_envelope import to_run_envelope, write_run_envelope
+from trend_analysis.util.hash import sha256_config
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEMO_CONFIG = REPO_ROOT / "config" / "demo.yml"
+DEMO_RETURNS = REPO_ROOT / "demo" / "demo_returns.csv"
+
+SCHEMA_PATH = (
+    REPO_ROOT / "src" / "trend_analysis" / "export" / "run_envelope_schema.json"
+)
+
+
+def _schema() -> dict:
+    assert SCHEMA_PATH.exists(), f"Schema file missing: {SCHEMA_PATH}"
+    with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _write_manifest(tmp_path: Path, *, config) -> Path:
+    """Write a minimal manifest.json mirroring write_run_artifacts' shape."""
+
+    run_dir = tmp_path / "runs" / "20200101_000000_demoabcd"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "schema_version": "trend.run_artifacts/1",
+        "run_id": "demoabcd",
+        "config_sha256": sha256_config(config),
+        # 64-hex placeholder input hash so the envelope run_id is content-addressed.
+        "input_sha256": "a" * 64,
+        "git_hash": "abc1234",
+        "artifacts": [
+            {"name": "summary.csv", "sha256": "b" * 64, "size": 10},
+            {"name": "report.html", "sha256": "c" * 64, "size": 20},
+        ],
+    }
+    manifest_path = run_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return manifest_path
+
+
+def _make_ill_conditioned_df() -> pd.DataFrame:
+    dates = pd.date_range("2020-01-31", periods=8, freq="ME")
+    base = np.array([0.01, 0.011, 0.009, 0.012, 0.0105, 0.0115, 0.0095, 0.0108])
+    jitter = np.array([1e-4, -1e-4, 5e-5, -5e-5, 8e-5, -8e-5, 6e-5, -6e-5])
+    return pd.DataFrame(
+        {"Date": dates, "RF": 0.0, "A": base, "B": base + jitter, "C": base * 0.2 + 0.001}
+    )
+
+
+def _make_robust_cfg() -> Config:
+    return Config(
+        version="1",
+        data={
+            "risk_free_column": "RF",
+            "allow_risk_free_fallback": False,
+            "date_column": "Date",
+            "frequency": "M",
+        },
+        preprocessing={},
+        vol_adjust={"target_vol": 1.0},
+        sample_split={
+            "in_start": "2020-01",
+            "in_end": "2020-06",
+            "out_start": "2020-07",
+            "out_end": "2020-08",
+        },
+        portfolio={
+            "weighting_scheme": "robust_mv",
+            "robustness": {
+                "shrinkage": {"enabled": False},
+                "condition_check": {
+                    "enabled": True,
+                    "threshold": 1.0,
+                    "safe_mode": "risk_parity",
+                    "diagonal_loading_factor": 1.0e-6,
+                },
+            },
+        },
+        metrics={},
+        export={},
+        run={},
+    )
+
+
+def test_run_envelope_conforms_to_schema(tmp_path: Path) -> None:
+    """run_simulation on the demo fixtures -> run_envelope.json -> schema valid."""
+
+    if not DEMO_CONFIG.exists() or not DEMO_RETURNS.exists():  # pragma: no cover
+        pytest.skip("Demo fixtures missing")
+
+    cfg = load_config(str(DEMO_CONFIG))
+    returns = pd.read_csv(DEMO_RETURNS)
+    result = api.run_simulation(cfg, returns)
+
+    config_payload = cfg.model_dump() if hasattr(cfg, "model_dump") else dict(vars(cfg))
+    manifest_path = _write_manifest(tmp_path, config=config_payload)
+
+    out_path = write_run_envelope(
+        result,
+        config=config_payload,
+        manifest_path=manifest_path,
+        actor="ci",
+        intent="schema-conformance",
+    )
+    assert out_path.exists()
+    envelope = json.loads(out_path.read_text(encoding="utf-8"))
+
+    jsonschema.validate(envelope, _schema())
+
+    # The envelope references (does not duplicate) the manifest.
+    assert envelope["outputs"]["manifest"] == "manifest.json"
+    assert "summary.csv" in envelope["outputs"]["artifacts"]
+    assert envelope["inputs"]["config_sha256"] == sha256_config(config_payload)
+
+
+def test_run_envelope_missing_required_fails(tmp_path: Path) -> None:
+    """Removing a required field should trigger schema validation failure."""
+
+    cfg = _make_robust_cfg()
+    result = api.run_simulation(cfg, _make_ill_conditioned_df())
+    config_payload = dict(vars(cfg)) if not hasattr(cfg, "model_dump") else cfg.model_dump()
+    manifest_path = _write_manifest(tmp_path, config=config_payload)
+    envelope = to_run_envelope(result, config=config_payload, manifest_path=manifest_path)
+
+    envelope.pop("run_id")
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(envelope, _schema())
+
+
+def test_run_envelope_cost_latency_and_fallback_warning(tmp_path: Path) -> None:
+    """wall_ms is a positive float and the weight-engine fallback is captured."""
+
+    cfg = _make_robust_cfg()
+    result = api.run_simulation(cfg, _make_ill_conditioned_df())
+
+    config_payload = dict(vars(cfg)) if not hasattr(cfg, "model_dump") else cfg.model_dump()
+    manifest_path = _write_manifest(tmp_path, config=config_payload)
+    envelope = to_run_envelope(result, config=config_payload, manifest_path=manifest_path)
+
+    wall_ms = envelope["cost_latency"]["wall_ms"]
+    assert isinstance(wall_ms, float)
+    assert wall_ms > 0.0
+
+    codes = {w.get("code") for w in envelope["warnings"]}
+    assert "weight_engine_fallback" in codes


### PR DESCRIPTION
Closes #5348.

## What

Adds a single replayable **run-envelope JSON** (`run_contract`) produced on the CLI export path. The envelope **references** the existing artifact `manifest.json` rather than duplicating it, and adds the fields the backplane `run_contract` standard requires.

## Changes

- **`src/trend_analysis/export/run_envelope.py`** (new): `RunEnvelope` dataclass + `to_run_envelope(result, *, config, manifest_path, timings=None, warnings=None, actor=None, intent=None)` serializer (reuses `sha256_config`/`normalise_for_json` from `util/hash.py`; content-addressed `run_id` via `sha256_text("input_sha256|config_sha256|seed")`, matching `bundle.py:75-81`) + `write_run_envelope(...)` writer.
- **`src/trend_analysis/export/run_envelope_schema.json`** (new, draft 2020-12): `required: [run_id, inputs, outputs, provenance, cost_latency, warnings, diagnostic]`, modeled on `manifest_schema.json`.
- **`src/trend_analysis/api.py`**: add optional, `None`-defaulted `timings` and `warnings` fields to `RunResult` (existing positional constructors stay valid); wrap the pipeline dispatch with `time.perf_counter()` in both single- and multi-period paths; collect the weight-engine fallback and the missing-data policy summary (`market_data_missing_policy_summary`) as structured `{"code": ...}` warnings instead of only logging.
- **`src/trend_analysis/cli.py`**: write `run_envelope.json` right after the existing `write_run_artifacts(...)` call, passing the returned `run_dir`/`manifest.json` so `outputs.manifest` cross-links it.
- **`tests/test_run_envelope_schema.py`** (new).
- **`.gitignore`**: negate the repo-wide `*.json` ignore for the new schema (same pattern as `manifest_schema.json`).

## Non-goals honored

`RunResult` and both existing manifests are unchanged; no new numeric computation; no run DB/server/index. The envelope is the deterministic core's output — no LLM narrative embedded.

## Tests

- `tests/test_run_envelope_schema.py::test_run_envelope_conforms_to_schema` — runs `run_simulation` on `config/demo.yml` + `demo/demo_returns.csv`, writes `run_envelope.json`, `jsonschema.validate`s it (fails on `main`: no module/schema exists).
- `test_run_envelope_missing_required_fails` — dropping `run_id` raises `ValidationError`.
- `test_run_envelope_cost_latency_and_fallback_warning` — `cost_latency.wall_ms` is a positive float and the weight-engine fallback yields a `code == "weight_engine_fallback"` warning.
- `tests/test_determinism_cli.py` still passes unchanged (envelope addition does not perturb bundle `run_id` determinism).

All green locally: new file 3/3; `test_api_run_simulation.py` 10/10; `test_export_manifest_schema.py`; `test_determinism_cli.py` 2/2; `test_streamlit_smoke_ci.py`. `ruff` + `mypy` clean on changed source.

## Live-verification / replay smoke step

Run entirely locally (deterministic core, no SaaS, no LLM):

```
python -m trend_analysis.cli run -c config/demo.yml -i demo/demo_returns.csv --seed 777
# -> demo/exports/runs/<ts>/run_envelope.json
```

Observed envelope (abridged):

```json
{
  "schema_version": "trend.run_envelope/1",
  "run_id": "9434a31d76be4bf7aa2f7727ef9d05d054ebf6163e64aa4212beef8e3f5ea68c",
  "inputs": {"config_sha256": "42021ce2...", "input_sha256": "3034f70c..."},
  "outputs": {"manifest": "manifest.json", "artifacts": ["analysis_metrics.csv", "..."]},
  "provenance": {"git_hash": "3a918f9...", "environment": {"python": "3.12.2", "numpy": "...", "pandas": "..."}},
  "cost_latency": {"wall_ms": 432.66},
  "warnings": [],
  "diagnostic": null
}
```

Re-running the same command reproduces a **byte-identical `run_id`** (`9434a31d76be4bf7...`), confirming the envelope is content-addressed off the referenced `config_sha256`/`input_sha256` and replayable.
