### PR TITLE
fix(config): stop dropping portfolio selection/weighting/constraints on load

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -130,12 +130,15 @@ jobs:
 
       - name: Run config coverage check
         run: |
-          # Note: Threshold set to 72 due to incomplete instrumentation
-          # Only lightweight schema (data.*, portfolio.cost_model.*) is currently tracked
-          # TODO: Reduce threshold as more config sections are instrumented
+          # "Ignored keys" here counts config keys READ during the demo run
+          # (validated-key tracking is not yet wired, so ignored == read count).
+          # Raised 72 -> 80: the config-loader fix (PortfolioSettings extra="allow")
+          # makes the demo honor selection_mode/rank/selector/custom_weights/weighting,
+          # so the engine now legitimately reads ~5 more keys (72 -> 77).
+          # TODO: tighten once validated-key tracking is instrumented.
           python scripts/check_config_coverage.py \
             --config config/demo.yml \
-            --ignored-threshold 72
+            --ignored-threshold 80
 
   summary:
     name: gate-summary

--- a/src/trend_analysis/config/model.py
+++ b/src/trend_analysis/config/model.py
@@ -366,7 +366,13 @@ class PortfolioSettings(BaseModel):
     cooldown_periods: int | None = None
     cooldown_months: int | None = None
 
-    model_config = ConfigDict(extra="ignore")
+    # extra="allow" (not "ignore"): the engine reads many portfolio sub-keys that
+    # are not declared as fields here -- selection_mode, rank, selector,
+    # custom_weights, weighting, weighting_scheme, constraints, robustness,
+    # manual_list, etc. With "ignore" those were SILENTLY DROPPED on load, so
+    # YAML-configured selection/weighting/constraints never reached the engine
+    # (it fell back to selection_mode="all"). "allow" preserves them.
+    model_config = ConfigDict(extra="allow")
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/test_config_portfolio_passthrough.py
+++ b/tests/test_config_portfolio_passthrough.py
@@ -1,0 +1,57 @@
+"""Regression: the config loader must NOT drop portfolio sub-keys.
+
+PortfolioSettings (config/model.py) historically used model_config
+extra="ignore", which silently discarded selection_mode/rank/selector/
+custom_weights/weighting/constraints from any loaded YAML config. The engine
+then fell back to selection_mode="all" and ignored the configured selection,
+weighting, and constraints entirely.
+
+These tests pin the pass-through so the regression cannot recur.
+"""
+
+from __future__ import annotations
+
+from trend_analysis.config import load, load_config
+
+# Keys the engine reads from portfolio but that are not declared fields on
+# PortfolioSettings; all must survive a load.
+_PASSTHROUGH_KEYS = (
+    "selection_mode",
+    "rank",
+    "selector",
+    "custom_weights",
+    "weighting",
+)
+
+
+def test_demo_config_preserves_portfolio_selection_fields():
+    cfg = load("config/demo.yml")
+    portfolio = cfg.portfolio
+    for key in _PASSTHROUGH_KEYS:
+        assert key in portfolio, f"loader dropped portfolio.{key}"
+    assert portfolio.get("selection_mode") == "rank"
+    assert (portfolio.get("rank") or {}).get("n") == 5
+
+
+def test_loader_preserves_arbitrary_portfolio_constraints():
+    """A constraints block (incl. max_weight) must reach the loaded config.
+
+    Built on the valid demo config so all required sections are present; we add a
+    constraints block + weighting_scheme that the loader previously dropped.
+    """
+    from pathlib import Path
+
+    import yaml
+
+    with open("config/demo.yml", encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh)
+    # load_config(dict) resolves csv_path against the repo root, so make it absolute
+    # (demo's "../demo/..." is relative to the config/ dir).
+    raw["data"]["csv_path"] = str((Path("config") / raw["data"]["csv_path"]).resolve())
+    raw["portfolio"]["constraints"] = {"long_only": True, "max_weight": 0.2}
+    raw["portfolio"]["weighting_scheme"] = "risk_parity"
+
+    cfg = load_config(raw)
+    portfolio = cfg.portfolio
+    assert (portfolio.get("constraints") or {}).get("max_weight") == 0.2
+    assert portfolio.get("weighting_scheme") == "risk_parity"


### PR DESCRIPTION
## Problem

`PortfolioSettings` (config/model.py) used `model_config = ConfigDict(extra="ignore")`, which **silently discarded** every portfolio sub-key not declared as a field when loading any YAML/dict config: `selection_mode`, `rank`, `selector`, `custom_weights`, `weighting`, `weighting_scheme`, `constraints` (incl. `max_weight`), `robustness`, `manual_list`, etc.

The engine then fell back to `selection_mode="all"` and ignored the configured selection, weighting, and constraints entirely. Concretely: `config/demo.yml` requests `rank` top-5 but the portfolio held **all 20 funds**, with default weighting and no constraints applied. This affected every config-driven (YAML) run; only values injected via the API/UI patch path took effect.

This was surfaced by the app-baseline-kit pilot's systematic input testing.

## Fix

Switch `PortfolioSettings` to `extra="allow"` so those keys pass through to the engine (which reads them defensively via `.get()`). With the fix, `demo.yml` correctly honors `rank` top-5 (20 → 8 funds held across the rebalance periods), and `constraints.max_weight` / `weighting_scheme` now reach the optimizer.

## Verification

- New `tests/test_config_portfolio_passthrough.py` pins the pass-through (fails on the old `extra="ignore"`, passes now).
- Full suite: **no new failures** — the 23 pre-existing failures (viz/nav-paths/terminal-returns adapters + flaky mc_page) are identical with and without this change (verified by reverting the one-line change and re-running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)