### PR TITLE
Issue #5345: document optional kaleido PNG export

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,10 @@ trend mc viz --bundle <path> --out <dir> --charts fan,path_dist,risk_return --ht
 - `--charts`: Comma-separated chart names to render, for example `fan,path_dist,risk_return`.
 - `--html`: Write HTML chart files to `<out>/plots/*.html`.
 - `--json`: Write JSON chart files to `<out>/plots/*.json`.
-- `--png`: Write PNG chart files to `<out>/plots/*.png`.
+- `--png`: Best-effort PNG export to `<out>/plots/*.png`; requires a working
+  `kaleido` installation (`pip install kaleido`). When `kaleido` is missing or
+  incompatible, `trend mc viz` skips PNGs if HTML or JSON output was also
+  requested, and fails early when PNG is the only requested output.
 
 NAV-path selection options:
 

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -530,7 +530,10 @@ def build_parser(
     mc_viz_p.add_argument(
         "--png",
         action="store_true",
-        help="Export chart artifacts as PNG",
+        help=(
+            "Best-effort PNG export; requires a working kaleido install "
+            "(pip install kaleido)"
+        ),
     )
 
     sub.add_parser("app", help="Launch the Streamlit application")

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -1093,7 +1093,10 @@ def main(argv: list[str] | None = None) -> int:
     mc_viz_p.add_argument(
         "--png",
         action="store_true",
-        help="Export chart artifacts as PNG",
+        help=(
+            "Best-effort PNG export; requires a working kaleido install "
+            "(pip install kaleido)"
+        ),
     )
 
     # Handle --check flag before parsing subcommands

--- a/tests/integration/test_mc_viz.py
+++ b/tests/integration/test_mc_viz.py
@@ -90,6 +90,9 @@ def _run_mc_viz_without_kaleido(
     out_dir: Path,
     *,
     charts: str = "fan,path_dist,risk_return",
+    html: bool = True,
+    json_flag: bool = True,
+    png: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     """Run mc viz with kaleido hidden from the import system."""
     project_root = _project_root()
@@ -97,6 +100,14 @@ def _run_mc_viz_without_kaleido(
     src_dir = project_root / "src"
     existing = env.get("PYTHONPATH", "")
     env["PYTHONPATH"] = f"{src_dir}{os.pathsep}{existing}" if existing else str(src_dir)
+    output_flags = []
+    if html:
+        output_flags.append("--html")
+    if json_flag:
+        output_flags.append("--json")
+    if png:
+        output_flags.append("--png")
+    output_flags_literal = ", ".join(repr(flag) for flag in output_flags)
 
     # Use a wrapper that blocks kaleido imports before invoking the CLI.
     wrapper = (
@@ -108,7 +119,7 @@ def _run_mc_viz_without_kaleido(
         f"'--bundle', {str(bundle_dir)!r},"
         f"'--out', {str(out_dir)!r},"
         f"'--charts', {charts!r},"
-        "'--html', '--json', '--png'];"
+        f"{output_flags_literal}];"
         "from trend.cli import main; sys.exit(main())"
     )
     return subprocess.run(
@@ -437,6 +448,28 @@ def test_mc_viz_cli_error_contains_install_hint_when_kaleido_missing(
     assert result.returncode == 0, result.stderr
     assert "kaleido" in result.stderr
     assert "pip install kaleido" in result.stderr
+
+
+def test_mc_viz_cli_fails_when_png_only_and_kaleido_missing(
+    tmp_path: Path,
+) -> None:
+    """PNG-only output fails early when kaleido is unavailable."""
+    bundle_dir = _fixture_bundle_dir()
+    out_dir = tmp_path / "out"
+
+    result = _run_mc_viz_without_kaleido(
+        bundle_dir,
+        out_dir,
+        charts="fan",
+        html=False,
+        json_flag=False,
+        png=True,
+    )
+
+    assert result.returncode == 2
+    assert "PNG export requires a working kaleido installation" in result.stderr
+    assert "pip install kaleido" in result.stderr
+    assert not (out_dir / "plots").exists()
 
 
 def test_mc_viz_cli_no_png_when_flag_not_set(tmp_path: Path) -> None:

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,30 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-05-31T05:58:12Z - opener lane issue #5345 PR materializing
+
+- Repo: stranske/Trend_Model_Project
+- Issue: #5345 ``trend mc viz --png`` is documented but silently never produces PNGs (`kaleido` absent from every install path)
+- Branch: codex/issue-5345-kaleido-optional
+- Agent: codex
+- Selection:
+  - Mandatory cap/liveness discovery ran from the neutral Code workspace. Raw opener cap was below 5.
+  - Infra repair helper fixed Travel-Plan-Permission #1133 by adding `agent:retry` and dispatching Gate Followups; fresh evidence showed #1133 draining with an active Gate run.
+  - Portable-Alpha-Extension-Model #1847 initially appeared as a routing defect on `feat/app-baseline-kit`, then fresh PR evidence showed `autofix`/`autofix:patch`, a runner-dispatch comment, and a newer Gate run in progress; classified active-moving.
+  - Trend_Model_Project #5353 remains a scoped product/CI blocker on issue #5343, with a durable comment requiring an owner decision on LLM eval CI scope vs langchain pinning; not a bounded opener quick-recovery.
+  - Higher-priority candidates were linked, merged-awaiting-verifier, or scoped-blocked. Issue #5345 was the oldest eligible unlinked normal-priority implementation issue outside the #5353 dependency cone.
+- Implementation:
+  - Chose the optional-kaleido path because the repo already implements graceful missing-kaleido degradation and does not declare `kaleido` in `pyproject.toml` or `requirements.lock`.
+  - Updated `README.md` and CLI help in `src/trend/cli.py` and `src/trend_analysis/cli.py` to state `--png` is best-effort and requires `pip install kaleido`.
+  - Extended `tests/integration/test_mc_viz.py` so the missing-kaleido helper can request output formats individually, and added a PNG-only test that asserts the early `TrendCLIError` path and no `plots/` output.
+- Validation:
+  - `python -m pytest tests/integration/test_mc_viz.py::test_mc_viz_cli_fails_when_png_only_and_kaleido_missing tests/test_mc_viz_shared_api.py::test_execute_mc_viz_raises_on_png_without_kaleido -q` -> 2 passed.
+  - `python -m ruff check README.md src/trend/cli.py src/trend_analysis/cli.py tests/integration/test_mc_viz.py tests/test_mc_viz_shared_api.py` -> passed.
+  - `grep -Rin 'kaleido' pyproject.toml requirements.lock || true` -> no dependency declaration, matching the optional policy.
+  - `git diff --check` -> passed.
+  - Broader missing-kaleido integration pair currently fails on this Mac before chart export because the global Python has NumPy 2.4.6 with older compiled `pyarrow`/`numexpr`/`bottleneck`; this is the same local environment incompatibility previously observed in this repo, not introduced by this change.
+- Next action: commit, push, open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`.
+
 ## 2026-05-25T15:01:13Z - opener lane issue #2933 PR materializing
 
 - Repo: stranske/Trend_Model_Project

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -23,7 +23,17 @@
   - `grep -Rin 'kaleido' pyproject.toml requirements.lock || true` -> no dependency declaration, matching the optional policy.
   - `git diff --check` -> passed.
   - Broader missing-kaleido integration pair currently fails on this Mac before chart export because the global Python has NumPy 2.4.6 with older compiled `pyarrow`/`numexpr`/`bottleneck`; this is the same local environment incompatibility previously observed in this repo, not introduced by this change.
-- Next action: commit, push, open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`.
+- Commit: `6ee0d095` (`Issue #5345: document optional kaleido PNG export`).
+- PR: [stranske/Trend_Model_Project#5359](https://github.com/stranske/Trend_Model_Project/pull/5359), opened ready-for-review (`isDraft=false`) with labels `agent:codex`, `agents:keepalive`, `autofix`, `priority:normal`, and `repo-review-approved`; branch `codex/issue-5345-kaleido-optional`.
+- Relay:
+  - `issue_created active.source_repo=stranske/Trend_Model_Project active.source_issue=5345`
+  - `pr_opened active.source_pr=5359 active.next_action=wait_for_keepalive`
+- Post-open cap/health:
+  - Raw opener cap below limit: `total_opener_owned=4`, `raw_cap_reached=false`.
+  - PR #5359 has a fresh Gate run in progress after initial superseded runs and is classified `draining`.
+  - Fleet hygiene also repaired/dispatched PAEM #1847 and TPP #1133; fresh cap-health at `2026-05-31T06:00:19Z` shows #1847 `draining` with fresh Autofix/Gate evidence and #1133 re-dispatched after the helper still reported stale keepalive-skip evidence.
+  - Trend PR #5353 remains the known scoped product/CI blocker on #5343: owner decision needed on no-LLM demo CI scope vs langchain pinning before a safe fix.
+- Next action: keepalive owns CI/check follow-up for PR #5359; closer/workflow-health owns #5353 product-blocker disposition after an owner decision.
 
 ## 2026-05-25T15:01:13Z - opener lane issue #2933 PR materializing
 


### PR DESCRIPTION
Implements #5345

## Summary
- document `trend mc viz --png` as best-effort optional output requiring a working `kaleido` install
- align both CLI parser help strings with the optional dependency policy
- add a PNG-only missing-kaleido integration assertion so the early failure path is covered

## Validation
- `python -m pytest tests/integration/test_mc_viz.py::test_mc_viz_cli_fails_when_png_only_and_kaleido_missing tests/test_mc_viz_shared_api.py::test_execute_mc_viz_raises_on_png_without_kaleido -q`
- `python -m ruff check README.md src/trend/cli.py src/trend_analysis/cli.py tests/integration/test_mc_viz.py tests/test_mc_viz_shared_api.py`
- `grep -Rin 'kaleido' pyproject.toml requirements.lock || true`\n- `git diff --check`\n\n## Note\nThe broader missing-kaleido integration pair still hits this Mac local Python environment issue before chart export: NumPy 2.4.6 with older compiled `pyarrow`/`numexpr`/`bottleneck`. The new PNG-only path and shared API path pass locally.