### PR TITLE
Issue #5350: add data reality manifest projection

### DIFF
--- a/src/trend_analysis/export/run_envelope.py
+++ b/src/trend_analysis/export/run_envelope.py
@@ -73,6 +73,7 @@ class RunEnvelope:
     provenance: dict[str, Any]
     cost_latency: dict[str, Any]
     warnings: list[dict[str, Any]] = field(default_factory=list)
+    data_reality: dict[str, Any] | None = None
     diagnostic: dict[str, Any] | None = None
     actor: str | None = None
     intent: str | None = None
@@ -89,6 +90,7 @@ class RunEnvelope:
             "provenance": self.provenance,
             "cost_latency": self.cost_latency,
             "warnings": self.warnings,
+            "data_reality": self.data_reality,
             "diagnostic": self.diagnostic,
         }
         if self.actor is not None:
@@ -104,7 +106,9 @@ def _serialise_diagnostic(diagnostic: Any) -> dict[str, Any] | None:
     if diagnostic is None:
         return None
     if dataclasses.is_dataclass(diagnostic) and not isinstance(diagnostic, type):
-        return cast("dict[str, Any]", _strict_json_value(dataclasses.asdict(diagnostic)))
+        return cast(
+            "dict[str, Any]", _strict_json_value(dataclasses.asdict(diagnostic))
+        )
     if hasattr(diagnostic, "model_dump"):
         return cast("dict[str, Any]", _strict_json_value(diagnostic.model_dump()))
     if isinstance(diagnostic, dict):
@@ -180,9 +184,13 @@ def to_run_envelope(
         if isinstance(a, dict) and a.get("name") is not None
     ]
 
-    effective_timings = timings if timings is not None else (getattr(result, "timings", None) or {})
+    effective_timings = (
+        timings if timings is not None else (getattr(result, "timings", None) or {})
+    )
     wall_ms = effective_timings.get("wall_ms")
-    cost_latency: dict[str, Any] = {"wall_ms": float(wall_ms) if wall_ms is not None else None}
+    cost_latency: dict[str, Any] = {
+        "wall_ms": float(wall_ms) if wall_ms is not None else None
+    }
     peak_rss_kb = effective_timings.get("peak_rss_kb")
     if peak_rss_kb is not None:
         cost_latency["peak_rss_kb"] = peak_rss_kb
@@ -201,6 +209,14 @@ def to_run_envelope(
         },
         cost_latency=cost_latency,
         warnings=[_strict_json_value(w) for w in effective_warnings],
+        data_reality=cast(
+            "dict[str, Any] | None",
+            (
+                _strict_json_value(manifest.get("data_reality"))
+                if isinstance(manifest.get("data_reality"), dict)
+                else None
+            ),
+        ),
         diagnostic=_serialise_diagnostic(getattr(result, "diagnostic", None)),
         actor=actor,
         intent=intent,
@@ -236,5 +252,7 @@ def write_run_envelope(
     )
     out_path = target_dir / "run_envelope.json"
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(json.dumps(envelope, indent=2, allow_nan=False), encoding="utf-8")
+    out_path.write_text(
+        json.dumps(envelope, indent=2, allow_nan=False), encoding="utf-8"
+    )
     return out_path

--- a/src/trend_analysis/export/run_envelope_schema.json
+++ b/src/trend_analysis/export/run_envelope_schema.json
@@ -73,6 +73,9 @@
         }
       }
     },
+    "data_reality": {
+      "type": ["object", "null"]
+    },
     "diagnostic": {
       "type": ["object", "null"]
     }

--- a/src/trend_analysis/reporting/run_artifacts.py
+++ b/src/trend_analysis/reporting/run_artifacts.py
@@ -12,7 +12,6 @@ from typing import Any, Mapping, Sequence
 
 import pandas as pd
 
-from trend_analysis.diagnostics import PipelineReasonCode
 from trend_analysis.identity import IdentityMap
 from trend_analysis.util.hash import normalise_for_json, sha256_config, sha256_file
 
@@ -91,9 +90,14 @@ def _data_window(df: pd.DataFrame) -> dict[str, Any]:
 
 
 def _metadata_attr(df: pd.DataFrame, name: str, default: Any = None) -> Any:
-    metadata = df.attrs.get("market_data", {}).get("metadata")
+    market_data = df.attrs.get("market_data", {})
+    metadata = market_data.get("metadata") if isinstance(market_data, Mapping) else None
+    if isinstance(metadata, Mapping) and name in metadata:
+        return metadata[name]
     if metadata is not None and hasattr(metadata, name):
         return getattr(metadata, name)
+    if isinstance(market_data, Mapping) and name in market_data:
+        return market_data[name]
     attr_name = f"market_data_{name}"
     return df.attrs.get(attr_name, default)
 
@@ -121,12 +125,13 @@ def _data_reality(df: pd.DataFrame) -> dict[str, Any]:
     instruments: list[dict[str, Any]] = []
     for column in instrument_cols:
         label = str(column)
-        missing_count = int(pd.to_numeric(df[column], errors="coerce").isna().sum())
         fill_details = filled.get(label)
         if fill_details is not None:
+            missing_count = int(fill_details.get("count") or 0)
             disposition = "filled"
             reason = fill_details.get("method") or "missing_policy_filled"
         else:
+            missing_count = int(df[column].isna().sum())
             disposition = "kept"
             reason = "complete" if missing_count == 0 else "missing_values_present"
         instruments.append(
@@ -142,7 +147,7 @@ def _data_reality(df: pd.DataFrame) -> dict[str, Any]:
         {
             "label": label,
             "disposition": "dropped",
-            "reason": PipelineReasonCode.NO_VALUE_COLUMNS.value,
+            "reason": "missing_policy_dropped",
         }
         for label in dropped_labels
     ]

--- a/src/trend_analysis/reporting/run_artifacts.py
+++ b/src/trend_analysis/reporting/run_artifacts.py
@@ -112,15 +112,23 @@ def _serialise_fill_details(value: Any) -> dict[str, Any]:
     return {str(k): v for k, v in raw.items() if v is not None}
 
 
+def _coerce_label_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return {str(label): details for label, details in value.items()}
+    return {}
+
+
+def _coerce_label_list(value: Any) -> list[str]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [str(label) for label in value]
+    return []
+
+
 def _data_reality(df: pd.DataFrame) -> dict[str, Any]:
     instrument_cols = [c for c in df.columns if str(c).lower() != "date"]
-    filled_raw = _metadata_attr(df, "missing_policy_filled", {}) or {}
-    dropped_raw = _metadata_attr(df, "missing_policy_dropped", []) or []
-    filled = {
-        str(label): _serialise_fill_details(details)
-        for label, details in dict(filled_raw).items()
-    }
-    dropped_labels = [str(label) for label in dropped_raw]
+    filled_raw = _coerce_label_mapping(_metadata_attr(df, "missing_policy_filled", {}) or {})
+    dropped_labels = _coerce_label_list(_metadata_attr(df, "missing_policy_dropped", []) or [])
+    filled = {str(label): _serialise_fill_details(details) for label, details in filled_raw.items()}
 
     instruments: list[dict[str, Any]] = []
     for column in instrument_cols:
@@ -318,18 +326,14 @@ def write_run_artifacts(
         )
 
     selected = details.get("selected_funds")
-    if isinstance(selected, Sequence) and not isinstance(
-        selected, (str, bytes, bytearray)
-    ):
+    if isinstance(selected, Sequence) and not isinstance(selected, (str, bytes, bytearray)):
         selected_list = list(selected)
     elif selected is None:
         selected_list = []
     else:
         selected_list = [selected]
     resolver = identity_map or (
-        IdentityMap.from_config(config)
-        if isinstance(config, Mapping)
-        else IdentityMap()
+        IdentityMap.from_config(config) if isinstance(config, Mapping) else IdentityMap()
     )
     selected_entities = _selected_entities(selected_list, resolver)
 
@@ -343,8 +347,7 @@ def write_run_artifacts(
         "git_hash": _git_hash(),
         "data_window": _data_window(df),
         "data_reality": _data_reality(df),
-        "metrics": _serialise_stats(details.get("out_ew_stats"))
-        or _summarise_metrics(metrics_df),
+        "metrics": _serialise_stats(details.get("out_ew_stats")) or _summarise_metrics(metrics_df),
         "metrics_overview": _summarise_metrics(metrics_df),
         "selected_funds": selected_list,
         "selected_entities": selected_entities,
@@ -363,16 +366,12 @@ def write_run_artifacts(
 
     manifest_path = run_dir / "manifest.json"
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
-    manifest_path.write_text(
-        json.dumps(normalise_for_json(manifest), indent=2), encoding="utf-8"
-    )
+    manifest_path.write_text(json.dumps(normalise_for_json(manifest), indent=2), encoding="utf-8")
 
     html_path = run_dir / "report.html"
     html_path.parent.mkdir(parents=True, exist_ok=True)
     html_path.write_text(
-        _render_html(
-            run_id=run_id, created=created, manifest=manifest, summary_text=summary_text
-        ),
+        _render_html(run_id=run_id, created=created, manifest=manifest, summary_text=summary_text),
         encoding="utf-8",
     )
 

--- a/src/trend_analysis/reporting/run_artifacts.py
+++ b/src/trend_analysis/reporting/run_artifacts.py
@@ -12,6 +12,7 @@ from typing import Any, Mapping, Sequence
 
 import pandas as pd
 
+from trend_analysis.diagnostics import PipelineReasonCode
 from trend_analysis.identity import IdentityMap
 from trend_analysis.util.hash import normalise_for_json, sha256_config, sha256_file
 
@@ -87,6 +88,84 @@ def _data_window(df: pd.DataFrame) -> dict[str, Any]:
     instrument_cols = [c for c in df.columns if str(c).lower() != "date"]
     summary["instrument_count"] = len(instrument_cols)
     return summary
+
+
+def _metadata_attr(df: pd.DataFrame, name: str, default: Any = None) -> Any:
+    metadata = df.attrs.get("market_data", {}).get("metadata")
+    if metadata is not None and hasattr(metadata, name):
+        return getattr(metadata, name)
+    attr_name = f"market_data_{name}"
+    return df.attrs.get(attr_name, default)
+
+
+def _serialise_fill_details(value: Any) -> dict[str, Any]:
+    if hasattr(value, "model_dump"):
+        raw = value.model_dump()
+    elif isinstance(value, Mapping):
+        raw = dict(value)
+    else:
+        raw = {"method": str(value)}
+    return {str(k): v for k, v in raw.items() if v is not None}
+
+
+def _data_reality(df: pd.DataFrame) -> dict[str, Any]:
+    instrument_cols = [c for c in df.columns if str(c).lower() != "date"]
+    filled_raw = _metadata_attr(df, "missing_policy_filled", {}) or {}
+    dropped_raw = _metadata_attr(df, "missing_policy_dropped", []) or []
+    filled = {
+        str(label): _serialise_fill_details(details)
+        for label, details in dict(filled_raw).items()
+    }
+    dropped_labels = [str(label) for label in dropped_raw]
+
+    instruments: list[dict[str, Any]] = []
+    for column in instrument_cols:
+        label = str(column)
+        missing_count = int(pd.to_numeric(df[column], errors="coerce").isna().sum())
+        fill_details = filled.get(label)
+        if fill_details is not None:
+            disposition = "filled"
+            reason = fill_details.get("method") or "missing_policy_filled"
+        else:
+            disposition = "kept"
+            reason = "complete" if missing_count == 0 else "missing_values_present"
+        instruments.append(
+            {
+                "label": label,
+                "missing_count": missing_count,
+                "disposition": disposition,
+                "reason": str(reason),
+            }
+        )
+
+    dropped = [
+        {
+            "label": label,
+            "disposition": "dropped",
+            "reason": PipelineReasonCode.NO_VALUE_COLUMNS.value,
+        }
+        for label in dropped_labels
+    ]
+
+    return {
+        "policy": _metadata_attr(df, "missing_policy"),
+        "policy_limit": _metadata_attr(df, "missing_policy_limit"),
+        "policy_summary": _metadata_attr(df, "missing_policy_summary"),
+        "frequency_missing_periods": _metadata_attr(df, "frequency_missing_periods", 0),
+        "frequency_max_gap_periods": _metadata_attr(df, "frequency_max_gap_periods", 0),
+        "instruments": instruments,
+        "filled": [
+            {
+                "label": label,
+                "disposition": "filled",
+                "reason": str(details.get("method") or "missing_policy_filled"),
+                **details,
+            }
+            for label, details in filled.items()
+        ],
+        "dropped": dropped,
+        "unknown": [],
+    }
 
 
 def _summarise_metrics(df: pd.DataFrame) -> dict[str, float]:
@@ -234,14 +313,18 @@ def write_run_artifacts(
         )
 
     selected = details.get("selected_funds")
-    if isinstance(selected, Sequence) and not isinstance(selected, (str, bytes, bytearray)):
+    if isinstance(selected, Sequence) and not isinstance(
+        selected, (str, bytes, bytearray)
+    ):
         selected_list = list(selected)
     elif selected is None:
         selected_list = []
     else:
         selected_list = [selected]
     resolver = identity_map or (
-        IdentityMap.from_config(config) if isinstance(config, Mapping) else IdentityMap()
+        IdentityMap.from_config(config)
+        if isinstance(config, Mapping)
+        else IdentityMap()
     )
     selected_entities = _selected_entities(selected_list, resolver)
 
@@ -254,7 +337,9 @@ def write_run_artifacts(
         "config_sha256": sha256_config(config),
         "git_hash": _git_hash(),
         "data_window": _data_window(df),
-        "metrics": _serialise_stats(details.get("out_ew_stats")) or _summarise_metrics(metrics_df),
+        "data_reality": _data_reality(df),
+        "metrics": _serialise_stats(details.get("out_ew_stats"))
+        or _summarise_metrics(metrics_df),
         "metrics_overview": _summarise_metrics(metrics_df),
         "selected_funds": selected_list,
         "selected_entities": selected_entities,
@@ -273,12 +358,16 @@ def write_run_artifacts(
 
     manifest_path = run_dir / "manifest.json"
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
-    manifest_path.write_text(json.dumps(normalise_for_json(manifest), indent=2), encoding="utf-8")
+    manifest_path.write_text(
+        json.dumps(normalise_for_json(manifest), indent=2), encoding="utf-8"
+    )
 
     html_path = run_dir / "report.html"
     html_path.parent.mkdir(parents=True, exist_ok=True)
     html_path.write_text(
-        _render_html(run_id=run_id, created=created, manifest=manifest, summary_text=summary_text),
+        _render_html(
+            run_id=run_id, created=created, manifest=manifest, summary_text=summary_text
+        ),
         encoding="utf-8",
     )
 

--- a/src/trend_analysis/reporting/run_artifacts.py
+++ b/src/trend_analysis/reporting/run_artifacts.py
@@ -126,20 +126,38 @@ def _coerce_label_list(value: Any) -> list[str]:
 
 def _data_reality(df: pd.DataFrame) -> dict[str, Any]:
     instrument_cols = [c for c in df.columns if str(c).lower() != "date"]
-    filled_raw = _coerce_label_mapping(_metadata_attr(df, "missing_policy_filled", {}) or {})
-    dropped_labels = _coerce_label_list(_metadata_attr(df, "missing_policy_dropped", []) or [])
-    filled = {str(label): _serialise_fill_details(details) for label, details in filled_raw.items()}
+    instrument_lookup = {str(column): column for column in instrument_cols}
+    filled_raw = _coerce_label_mapping(
+        _metadata_attr(df, "missing_policy_filled", {}) or {}
+    )
+    dropped_labels = _coerce_label_list(
+        _metadata_attr(df, "missing_policy_dropped", []) or []
+    )
+    dropped_set = set(dropped_labels)
+    filled = {
+        str(label): _serialise_fill_details(details)
+        for label, details in filled_raw.items()
+    }
 
     instruments: list[dict[str, Any]] = []
-    for column in instrument_cols:
-        label = str(column)
+    labels_in_order = list(instrument_lookup.keys())
+    for dropped_label in dropped_labels:
+        if dropped_label not in instrument_lookup:
+            labels_in_order.append(dropped_label)
+
+    for label in labels_in_order:
+        column = instrument_lookup.get(label)
         fill_details = filled.get(label)
         if fill_details is not None:
             missing_count = int(fill_details.get("count") or 0)
             disposition = "filled"
             reason = fill_details.get("method") or "missing_policy_filled"
+        elif label in dropped_set:
+            missing_count = int(df[column].isna().sum()) if column is not None else 0
+            disposition = "dropped"
+            reason = "missing_policy_dropped"
         else:
-            missing_count = int(df[column].isna().sum())
+            missing_count = int(df[column].isna().sum()) if column is not None else 0
             disposition = "kept"
             reason = "complete" if missing_count == 0 else "missing_values_present"
         instruments.append(
@@ -326,14 +344,18 @@ def write_run_artifacts(
         )
 
     selected = details.get("selected_funds")
-    if isinstance(selected, Sequence) and not isinstance(selected, (str, bytes, bytearray)):
+    if isinstance(selected, Sequence) and not isinstance(
+        selected, (str, bytes, bytearray)
+    ):
         selected_list = list(selected)
     elif selected is None:
         selected_list = []
     else:
         selected_list = [selected]
     resolver = identity_map or (
-        IdentityMap.from_config(config) if isinstance(config, Mapping) else IdentityMap()
+        IdentityMap.from_config(config)
+        if isinstance(config, Mapping)
+        else IdentityMap()
     )
     selected_entities = _selected_entities(selected_list, resolver)
 
@@ -347,7 +369,8 @@ def write_run_artifacts(
         "git_hash": _git_hash(),
         "data_window": _data_window(df),
         "data_reality": _data_reality(df),
-        "metrics": _serialise_stats(details.get("out_ew_stats")) or _summarise_metrics(metrics_df),
+        "metrics": _serialise_stats(details.get("out_ew_stats"))
+        or _summarise_metrics(metrics_df),
         "metrics_overview": _summarise_metrics(metrics_df),
         "selected_funds": selected_list,
         "selected_entities": selected_entities,
@@ -366,12 +389,16 @@ def write_run_artifacts(
 
     manifest_path = run_dir / "manifest.json"
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
-    manifest_path.write_text(json.dumps(normalise_for_json(manifest), indent=2), encoding="utf-8")
+    manifest_path.write_text(
+        json.dumps(normalise_for_json(manifest), indent=2), encoding="utf-8"
+    )
 
     html_path = run_dir / "report.html"
     html_path.parent.mkdir(parents=True, exist_ok=True)
     html_path.write_text(
-        _render_html(run_id=run_id, created=created, manifest=manifest, summary_text=summary_text),
+        _render_html(
+            run_id=run_id, created=created, manifest=manifest, summary_text=summary_text
+        ),
         encoding="utf-8",
     )
 

--- a/tests/test_data_reality_manifest.py
+++ b/tests/test_data_reality_manifest.py
@@ -103,6 +103,40 @@ def test_all_good_run_emits_empty_lists(tmp_path: Path) -> None:
     assert reality["instruments"][0]["disposition"] == "kept"
 
 
+def test_dropped_instrument_is_projected_with_dropped_disposition(
+    tmp_path: Path,
+) -> None:
+    frame = pd.DataFrame(
+        {
+            "Date": pd.date_range("2021-01-31", periods=3, freq="ME"),
+            "Mgr_A": [0.01, 0.03, 0.02],
+        }
+    )
+    frame.attrs["market_data_missing_policy"] = "drop"
+    frame.attrs["market_data"] = {
+        "metadata": {
+            "missing_policy_dropped": ["Mgr_B"],
+        }
+    }
+
+    manifest = _write_manifest(tmp_path, frame)
+
+    reality = manifest["data_reality"]
+    dropped_item = next(
+        item for item in reality["instruments"] if item["label"] == "Mgr_B"
+    )
+    assert dropped_item["disposition"] == "dropped"
+    assert dropped_item["reason"] == "missing_policy_dropped"
+    assert dropped_item["missing_count"] == 0
+    assert reality["dropped"] == [
+        {
+            "label": "Mgr_B",
+            "disposition": "dropped",
+            "reason": "missing_policy_dropped",
+        }
+    ]
+
+
 def test_demo_fixture_manifest_records_configured_missing_policy(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_data_reality_manifest.py
+++ b/tests/test_data_reality_manifest.py
@@ -111,7 +111,9 @@ def test_demo_fixture_manifest_records_configured_missing_policy(
         str(repo_root / "demo" / "demo_returns.csv"),
         missing_policy="drop",
         missing_limit=None,
+        errors="raise",
     )
+    assert frame is not None
 
     manifest = _write_manifest(tmp_path, frame)
 

--- a/tests/test_data_reality_manifest.py
+++ b/tests/test_data_reality_manifest.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from trend_analysis.data import load_csv
+from trend_analysis.export.run_envelope import to_run_envelope
+from trend_analysis.io.market_data import MissingPolicyFillDetails
+from trend_analysis.reporting.run_artifacts import write_run_artifacts
+
+
+class _Result:
+    seed = 42
+    timings = {"wall_ms": 1.0}
+    warnings: list[dict[str, object]] = []
+    environment: dict[str, object] = {}
+    diagnostic = None
+
+
+def _write_manifest(tmp_path: Path, frame: pd.DataFrame) -> dict[str, object]:
+    input_path = tmp_path / "returns.csv"
+    input_path.write_text("Date,A\n2021-01-31,0.01\n", encoding="utf-8")
+    run_dir = write_run_artifacts(
+        output_dir=tmp_path / "out",
+        run_id="data-reality",
+        config={"data": {"missing_policy": "ffill"}},
+        config_path="config.yml",
+        input_path=input_path,
+        data_frame=frame,
+        metrics_frame=pd.DataFrame(),
+        run_details={},
+        exported_files=[],
+        summary_text="",
+    )
+    return json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+
+
+def test_partial_missing_instrument_recorded(tmp_path: Path) -> None:
+    frame = pd.DataFrame(
+        {
+            "Date": pd.date_range("2021-01-31", periods=3, freq="ME"),
+            "Mgr_A": [0.01, None, 0.03],
+            "Mgr_B": [0.02, 0.02, 0.01],
+        }
+    )
+    frame.attrs["market_data_missing_policy"] = "ffill"
+    frame.attrs["market_data_missing_policy_limit"] = 2
+    frame.attrs["market_data_missing_policy_summary"] = "ffill applied to Mgr_A"
+    frame.attrs["market_data_frequency_missing_periods"] = 1
+    frame.attrs["market_data_frequency_max_gap_periods"] = 1
+    frame.attrs["market_data"] = {
+        "metadata": type(
+            "Metadata",
+            (),
+            {
+                "missing_policy_filled": {
+                    "Mgr_A": MissingPolicyFillDetails(method="ffill", count=1)
+                },
+                "missing_policy_dropped": [],
+            },
+        )()
+    }
+
+    manifest = _write_manifest(tmp_path, frame)
+
+    reality = manifest["data_reality"]
+    assert reality["policy"] == "ffill"
+    assert reality["policy_limit"] == 2
+    assert reality["frequency_missing_periods"] == 1
+    mgr_a = next(item for item in reality["instruments"] if item["label"] == "Mgr_A")
+    assert mgr_a["missing_count"] == 1
+    assert mgr_a["disposition"] == "filled"
+    assert reality["filled"] == [
+        {
+            "label": "Mgr_A",
+            "disposition": "filled",
+            "reason": "ffill",
+            "method": "ffill",
+            "count": 1,
+        }
+    ]
+
+
+def test_all_good_run_emits_empty_lists(tmp_path: Path) -> None:
+    frame = pd.DataFrame(
+        {
+            "Date": pd.date_range("2021-01-31", periods=2, freq="ME"),
+            "Mgr_A": [0.01, 0.03],
+        }
+    )
+    frame.attrs["market_data_missing_policy"] = "drop"
+    frame.attrs["market_data_missing_policy_summary"] = "no missing values"
+
+    manifest = _write_manifest(tmp_path, frame)
+
+    reality = manifest["data_reality"]
+    assert reality["policy"] == "drop"
+    assert reality["filled"] == []
+    assert reality["dropped"] == []
+    assert reality["unknown"] == []
+    assert reality["instruments"][0]["disposition"] == "kept"
+
+
+def test_demo_fixture_manifest_records_configured_missing_policy(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    frame = load_csv(
+        str(repo_root / "demo" / "demo_returns.csv"),
+        missing_policy="drop",
+        missing_limit=None,
+    )
+
+    manifest = _write_manifest(tmp_path, frame)
+
+    reality = manifest["data_reality"]
+    assert reality["policy"] == "drop"
+    assert "instruments" in reality
+    assert len(reality["instruments"]) > 1
+
+
+def test_run_envelope_projects_manifest_data_reality(tmp_path: Path) -> None:
+    frame = pd.DataFrame(
+        {
+            "Date": pd.date_range("2021-01-31", periods=2, freq="ME"),
+            "Mgr_A": [0.01, 0.03],
+        }
+    )
+    frame.attrs["market_data_missing_policy"] = "zero"
+    manifest = _write_manifest(tmp_path, frame)
+    manifest_path = Path(manifest["run_directory"]) / "manifest.json"
+
+    envelope = to_run_envelope(_Result(), config={}, manifest_path=manifest_path)
+
+    assert envelope["data_reality"]["policy"] == "zero"

--- a/tests/test_run_artifacts.py
+++ b/tests/test_run_artifacts.py
@@ -194,3 +194,17 @@ def test_coerce_frame_gracefully_handles_unexpected_input() -> None:
 
     assert isinstance(result, pd.DataFrame)
     assert result.empty
+
+
+def test_data_reality_tolerates_non_mapping_fill_metadata() -> None:
+    df = pd.DataFrame({"Date": pd.date_range("2021-01-31", periods=2, freq="ME"), "A": [0.1, 0.2]})
+    df.attrs["market_data_missing_policy"] = "ffill"
+    df.attrs["market_data_missing_policy_filled"] = "unexpected-shape"
+    df.attrs["market_data_missing_policy_dropped"] = "not-a-list"
+
+    reality = run_artifacts._data_reality(df)
+
+    assert reality["policy"] == "ffill"
+    assert reality["filled"] == []
+    assert reality["dropped"] == []
+    assert reality["unknown"] == []

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -40,6 +40,7 @@
 - Repo: stranske/Trend_Model_Project
 - Issue: #5350 `Promote missingness into the run manifest as a first-class data_reality block (data_reality_layer)`
 - Branch: codex/issue-5350-data-reality
+- PR: #5360 https://github.com/stranske/Trend_Model_Project/pull/5360
 - Agent: codex
 - Selection:
   - Opener cap-health showed raw cap below 5. Existing opener PRs were classified before selection: Trend #5359 active-moving, Trend #5353 scoped product/CI blocker, TPP #1133 repaired by dispatching Gate Followups, and PAEM #1847 scoped as a non-registry branch/routing human blocker.
@@ -53,7 +54,15 @@
   - `python -m ruff check src/trend_analysis/reporting/run_artifacts.py src/trend_analysis/export/run_envelope.py tests/test_data_reality_manifest.py tests/test_run_artifacts.py tests/test_run_envelope_schema.py` -> passed.
   - `python -m black --check --fast src/trend_analysis/reporting/run_artifacts.py src/trend_analysis/export/run_envelope.py tests/test_data_reality_manifest.py` -> passed.
   - `git diff --check` -> passed.
-- Next action: commit, push, open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`.
+- PR status: opened ready-for-review (`isDraft=false`) against `phase-3` with labels `agent:codex`, `agents:keepalive`, `autofix`, `priority:normal`, and `repo-review-approved`.
+- Post-open cap/health:
+  - Raw opener cap reached: `total_opener_owned=5`, `raw_cap_reached=true`.
+  - PR #5360 is `draining` with a queued Gate run after latest branch update.
+  - Non-drainable scoped blockers remain: PAEM #1847 non-registry `feat/app-baseline-kit` routing/human confirmation blocker; Trend #5353 product/CI decision blocker; TPP #1133 still helper-reported infra-stalled after accepted Gate Followups dispatch.
+- Relay:
+  - `issue_created active.source_repo=stranske/Trend_Model_Project active.source_issue=5350`
+  - `pr_opened active.source_pr=5360 active.next_action=wait_for_keepalive`
+- Next action: keepalive owns CI/check follow-up for PR #5360; closer/workflow-health should drain cap pressure on the existing non-drainable PRs.
 
 ## 2026-05-25T15:01:13Z - opener lane issue #2933 PR materializing
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -35,6 +35,26 @@
   - Trend PR #5353 remains the known scoped product/CI blocker on #5343: owner decision needed on no-LLM demo CI scope vs langchain pinning before a safe fix.
 - Next action: keepalive owns CI/check follow-up for PR #5359; closer/workflow-health owns #5353 product-blocker disposition after an owner decision.
 
+## 2026-05-31T06:09:00Z - opener lane issue #5350 PR materializing
+
+- Repo: stranske/Trend_Model_Project
+- Issue: #5350 `Promote missingness into the run manifest as a first-class data_reality block (data_reality_layer)`
+- Branch: codex/issue-5350-data-reality
+- Agent: codex
+- Selection:
+  - Opener cap-health showed raw cap below 5. Existing opener PRs were classified before selection: Trend #5359 active-moving, Trend #5353 scoped product/CI blocker, TPP #1133 repaired by dispatching Gate Followups, and PAEM #1847 scoped as a non-registry branch/routing human blocker.
+  - High-priority candidates were linked, merged-awaiting-verifier, or scoped-blocked. Older normal candidates #1833/#1837/#1128 were merged, #1129 and #5345 were linked to open PRs, and #5350 had no all-state linked PR.
+- Changes:
+  - Added `data_reality` manifest projection in `run_artifacts.py`, sourced from existing market-data frame attrs/metadata.
+  - Added run-envelope pass-through for manifest `data_reality`.
+  - Added focused tests covering partial missingness, all-good empty lists, demo fixture policy projection, and run-envelope projection.
+- Validation:
+  - `python -m pytest tests/test_data_reality_manifest.py tests/test_run_artifacts.py tests/test_run_envelope_schema.py -q` -> 18 passed.
+  - `python -m ruff check src/trend_analysis/reporting/run_artifacts.py src/trend_analysis/export/run_envelope.py tests/test_data_reality_manifest.py tests/test_run_artifacts.py tests/test_run_envelope_schema.py` -> passed.
+  - `python -m black --check --fast src/trend_analysis/reporting/run_artifacts.py src/trend_analysis/export/run_envelope.py tests/test_data_reality_manifest.py` -> passed.
+  - `git diff --check` -> passed.
+- Next action: commit, push, open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`.
+
 ## 2026-05-25T15:01:13Z - opener lane issue #2933 PR materializing
 
 - Repo: stranske/Trend_Model_Project


### PR DESCRIPTION
Implements #5350

## Summary
- add a `data_reality` block to run manifests from existing market-data attrs/metadata
- include policy, frequency gap metadata, instrument missing counts, filled/dropped dispositions, and empty lists for clean runs
- pass manifest `data_reality` through to `run_envelope.json`

## Validation
- `python -m pytest tests/test_data_reality_manifest.py tests/test_run_artifacts.py tests/test_run_envelope_schema.py -q`
- `python -m ruff check src/trend_analysis/reporting/run_artifacts.py src/trend_analysis/export/run_envelope.py tests/test_data_reality_manifest.py tests/test_run_artifacts.py tests/test_run_envelope_schema.py`
- `python -m black --check --fast src/trend_analysis/reporting/run_artifacts.py src/trend_analysis/export/run_envelope.py tests/test_data_reality_manifest.py`
- `git diff --check`