### PR TITLE
Issue #5351: content-addressed working run_id + --skip-if-exists

### DIFF
--- a/docs/ReproducibilityGuide.md
+++ b/docs/ReproducibilityGuide.md
@@ -193,6 +193,40 @@ diff <(unzip -p first.zip run_meta.json | jq -S .) <(unzip -p second.zip run_met
 If the diff is non-empty, inspect `run_meta.json` differences (look for
 unexpected version or ordering changes) and open an issue.
 
+## Content-Addressed Run IDs and Idempotent Reruns
+
+When the CLI is not given an explicit `run_id`, it now derives a
+**content-addressed** working `run_id` from the same components used by the
+reproducibility bundle: the SHA-256 of the input returns file, the SHA-256 of
+the resolved config, and the seed. The shared implementation lives in
+`trend_analysis.util.hash.content_run_id` (used by both the bundle and the
+working CLI via `working_run_id`), so identical inputs always produce the same
+`run_id` and the working id agrees with the bundle id.
+
+The random-UUID fallback is preserved only for the genuinely-unknown case — an
+in-memory DataFrame with no source file path (library callers) — so those runs
+still receive a unique id.
+
+### Skipping an already-computed run
+
+Because the `run_id` is stable for identical inputs, a prior completed run is
+discoverable. `write_run_artifacts` records a stable per-run-id pointer under
+`<export.directory>/runs/index/<run_id>.json` alongside the timestamped run
+directory. Pass `--skip-if-exists` to short-circuit a rerun when a completed
+manifest already exists for the computed `run_id`:
+
+```bash
+# First run computes and writes artifacts under demo/exports/runs/...
+./scripts/trend-model run -c config/demo.yml -i demo/demo_returns.csv
+
+# Second identical run with --skip-if-exists reuses the prior result instead of
+# recomputing, printing "already-done: run_id=<id>" and the existing manifest.
+./scripts/trend-model run -c config/demo.yml -i demo/demo_returns.csv --skip-if-exists
+```
+
+Without `--skip-if-exists` the run always recomputes; the flag only changes
+whether an existing run is reused, not how the `run_id` is derived.
+
 ### Docker Usage
 
 ```bash

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -26,6 +26,7 @@ from trend.reporting.quick_summary import main as quick_summary_main
 from trend_analysis import export
 from trend_analysis import logging as run_logging
 from trend_analysis.api import RunResult, run_simulation
+from trend_analysis.util.hash import working_run_id
 from trend_analysis.config import (
     DEFAULTS,
     ConfigPatch,
@@ -429,6 +430,14 @@ def build_parser(
         action="store_true",
         help="Report which config keys were validated vs read",
     )
+    run_p.add_argument(
+        "--skip-if-exists",
+        action="store_true",
+        help=(
+            "Reuse a prior completed run for the content-addressed run_id "
+            "instead of recomputing; reports the existing manifest path"
+        ),
+    )
 
     report_p = sub.add_parser("report", help="Generate summary artefacts for a configuration")
     report_p.add_argument("-c", "--config", help="Path to YAML config")
@@ -798,7 +807,7 @@ def _run_pipeline(
     perf_log_result = _init_perf_logger()
     if perf_log_result.diagnostic:
         logger.info(perf_log_result.diagnostic.message)
-    run_id = getattr(cfg, "run_id", None) or uuid.uuid4().hex[:12]
+    run_id = working_run_id(cfg, source_path)
     try:
         setattr(cfg, "run_id", run_id)
     except Exception:
@@ -2225,6 +2234,16 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     returns_df, mask, date_column=universe_spec.date_column
                 )
                 _attach_universe_paths(cfg, universe_spec, csv_path=str(returns_path))
+            if getattr(args, "skip_if_exists", False):
+                from trend_analysis.cli import find_prior_run
+
+                candidate_run_id = working_run_id(cfg, returns_path)
+                existing_manifest = find_prior_run(cfg, candidate_run_id)
+                if existing_manifest is not None:
+                    print(f"already-done: run_id={candidate_run_id}")
+                    print(f"Existing manifest: {existing_manifest}")
+                    _finalize_config_coverage()
+                    return 0
             run_pipeline = _legacy_callable("_run_pipeline", _run_pipeline)
             result, run_id, log_path = run_pipeline(
                 cfg,

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable, Iterable, Mapping, Protocol, cast
+from typing import Any, Callable, Iterable, Mapping, Protocol, Sequence, cast
 
 import numpy as np
 import pandas as pd
@@ -38,6 +38,7 @@ from trend_analysis.config import (
     apply_patch as apply_config_patch,
 )
 from trend_analysis.config import load as load_config
+from trend_analysis.config.schema_validation import load_config as load_config_yaml
 from trend_analysis.config.coverage import (
     ConfigCoverageTracker,
     activate_config_coverage,
@@ -48,6 +49,7 @@ from trend_analysis.config.schema_validation import load_config as load_schema_c
 from trend_analysis.config.validation import ValidationResult
 from trend_analysis.constants import DEFAULT_OUTPUT_DIRECTORY, DEFAULT_OUTPUT_FORMATS
 from trend_analysis.data import load_csv
+from trend_analysis.identity import IdentityMap
 from trend_analysis.llm import (
     ConfigPatchChain,
     LLMProviderConfig,
@@ -78,6 +80,7 @@ from trend_analysis.presets import (
     list_preset_slugs,
 )
 from trend_analysis.reporting.portfolio_series import select_primary_portfolio_series
+from trend_analysis.reporting.run_artifacts import write_run_artifacts
 from trend_analysis.signal_presets import (
     TrendSpecPreset,
     get_trend_spec_preset,
@@ -540,8 +543,7 @@ def build_parser(
         "--png",
         action="store_true",
         help=(
-            "Best-effort PNG export; requires a working kaleido install "
-            "(pip install kaleido)"
+            "Best-effort PNG export; requires a working kaleido install " "(pip install kaleido)"
         ),
     )
 
@@ -909,6 +911,111 @@ def _handle_exports(cfg: Any, result: RunResult, structured_log: bool, run_id: s
             formats=out_formats,
         )
     _legacy_maybe_log_step(structured_log, run_id, "export_complete", "Export done")
+
+
+def _resolve_export_artifact_paths(
+    out_dir: Path, filename: str, keys: Sequence[str], formats: Sequence[str]
+) -> list[Path]:
+    """Return the export artifact paths expected from ``export.export_data``."""
+
+    seen: set[Path] = set()
+    paths: list[Path] = []
+    for fmt in formats:
+        fmt_norm = (fmt or "").lower()
+        fmt_norm = "xlsx" if fmt_norm == "excel" else fmt_norm
+        if not fmt_norm:
+            continue
+        if fmt_norm == "xlsx":
+            candidate = out_dir / f"{filename}.xlsx"
+            if candidate not in seen:
+                paths.append(candidate)
+                seen.add(candidate)
+            continue
+        for key in keys:
+            candidate = out_dir / f"{filename}_{key}.{fmt_norm}"
+            if candidate in seen:
+                continue
+            paths.append(candidate)
+            seen.add(candidate)
+    return paths
+
+
+def _write_trend_run_artifacts(
+    *,
+    cfg: Any,
+    result: RunResult,
+    config_path: Path,
+    input_path: Path,
+    data_frame: pd.DataFrame,
+    run_id: str,
+    structured_log: bool,
+) -> Path | None:
+    """Write the manifest/index used by ``trend run --skip-if-exists``."""
+
+    export_cfg = getattr(cfg, "export", {}) or {}
+    out_dir = export_cfg.get("directory")
+    out_formats = export_cfg.get("formats")
+    filename = export_cfg.get("filename", "analysis")
+    if not out_dir and not out_formats:
+        out_dir = DEFAULT_OUTPUT_DIRECTORY
+        out_formats = DEFAULT_OUTPUT_FORMATS
+    if not out_dir or not out_formats:
+        return None
+
+    out_dir_path = Path(out_dir)
+    fmt_list = list(out_formats)
+    data_keys = ["metrics"]
+    if isinstance(result.details, Mapping):
+        narrative_data: dict[str, Any] = {"metrics": result.metrics}
+        export.append_narrative_section(narrative_data, result.details, config=cfg)
+        data_keys = list(narrative_data.keys())
+        if any(fmt.lower() in {"excel", "xlsx"} for fmt in fmt_list):
+            data_keys.append("summary")
+    artifact_paths = _resolve_export_artifact_paths(out_dir_path, filename, data_keys, fmt_list)
+    split = getattr(cfg, "sample_split", {})
+    summary_text = export.format_summary_text(
+        result.details,
+        str(split.get("in_start", "")),
+        str(split.get("in_end", "")),
+        str(split.get("out_start", "")),
+        str(split.get("out_end", "")),
+    )
+    try:
+        raw_config_payload = load_config_yaml(config_path)
+        config_payload: Any
+        if hasattr(cfg, "model_dump"):
+            config_payload = cfg.model_dump()
+        elif hasattr(cfg, "__dict__"):
+            config_payload = dict(getattr(cfg, "__dict__"))
+        else:
+            config_payload = cfg
+        manifest_dir = write_run_artifacts(
+            output_dir=out_dir_path,
+            run_id=run_id,
+            config=config_payload,
+            config_path=str(config_path),
+            input_path=input_path,
+            data_frame=data_frame,
+            metrics_frame=result.metrics,
+            run_details=result.details if isinstance(result.details, Mapping) else {},
+            exported_files=artifact_paths,
+            summary_text=summary_text,
+            identity_map=IdentityMap.from_config(
+                raw_config_payload,
+                base_path=config_path.parent,
+            ),
+        )
+    except Exception as exc:  # pragma: no cover - defensive parity with legacy CLI
+        logger.warning("Failed to write run artifacts: %s", exc)
+        return None
+    _legacy_maybe_log_step(
+        structured_log,
+        run_id,
+        "run_artifacts",
+        "Run manifest written",
+        directory=str(manifest_dir),
+    )
+    return manifest_dir
 
 
 def _write_bundle(
@@ -2252,6 +2359,15 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                 log_file=Path(args.log_file) if args.log_file else None,
                 structured_log=not args.no_structured_log,
                 bundle=Path(args.bundle) if args.bundle else None,
+            )
+            _write_trend_run_artifacts(
+                cfg=cfg,
+                result=result,
+                config_path=cfg_path,
+                input_path=returns_path,
+                data_frame=returns_df,
+                run_id=run_id,
+                structured_log=not args.no_structured_log,
             )
             print_summary = _legacy_callable("_print_summary", _print_summary)
             print_summary(cfg, result)

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -59,7 +59,8 @@ from .monte_carlo.scenario import MonteCarloScenario, MonteCarloSettings
 from .perf.rolling_cache import set_cache_enabled
 from .presets import apply_trend_preset, get_trend_preset, list_preset_slugs
 from .reporting.portfolio_series import select_primary_portfolio_series
-from .reporting.run_artifacts import write_run_artifacts
+from .reporting.run_artifacts import find_existing_run, write_run_artifacts
+from .util.hash import working_run_id
 from .signal_presets import (
     TrendSpecPreset,
     get_trend_spec_preset,
@@ -603,6 +604,39 @@ def _run_from_ui_payload(
     )
 
 
+def _resolve_run_output_dir(cfg: Any) -> Path | None:
+    """Resolve the run-artifacts output directory the export path would use.
+
+    Mirrors the ``out_dir``/``out_formats`` resolution in
+    :func:`_execute_analysis_run` so the ``--skip-if-exists`` lookup checks the
+    same location run artifacts are written to.
+    """
+
+    export_cfg = getattr(cfg, "export", None)
+    out_dir = out_formats = None
+    if isinstance(export_cfg, Mapping):
+        out_dir = export_cfg.get("directory")
+        out_formats = export_cfg.get("formats")
+    elif export_cfg is not None:
+        out_dir = getattr(export_cfg, "directory", None)
+        out_formats = getattr(export_cfg, "formats", None)
+    if not out_dir and not out_formats:
+        out_dir = DEFAULT_OUTPUT_DIRECTORY
+        out_formats = DEFAULT_OUTPUT_FORMATS
+    if out_dir and out_formats:
+        return Path(out_dir)
+    return None
+
+
+def find_prior_run(cfg: Any, run_id: str) -> Path | None:
+    """Return the manifest path of a prior completed run for *run_id*, if any."""
+
+    out_dir = _resolve_run_output_dir(cfg)
+    if out_dir is None:
+        return None
+    return find_existing_run(out_dir, run_id)
+
+
 def _execute_analysis_run(
     cfg: Any,
     df: pd.DataFrame,
@@ -612,13 +646,12 @@ def _execute_analysis_run(
     log_file: Path | None,
     structured_log: bool,
     bundle: Path | None,
+    skip_if_exists: bool = False,
 ) -> int:
-    import uuid
-
     split = cfg.sample_split
     required_keys = {"in_start", "in_end", "out_start", "out_end"}
 
-    run_id = getattr(cfg, "run_id", None) or uuid.uuid4().hex[:12]
+    run_id = working_run_id(cfg, input_path)
     try:
         setattr(cfg, "run_id", run_id)
     except Exception:
@@ -633,6 +666,20 @@ def _execute_analysis_run(
         "CLI run initialised",
         config_path=str(config_path) if config_path else None,
     )
+
+    if skip_if_exists:
+        existing_manifest = find_prior_run(cfg, run_id)
+        if existing_manifest is not None:
+            maybe_log_step(
+                structured_log,
+                run_id,
+                "already_done",
+                f"already-done: run_id={run_id}",
+                manifest=str(existing_manifest),
+            )
+            print(f"already-done: run_id={run_id}")
+            print(f"Existing manifest: {existing_manifest}")
+            return 0
 
     res: Any = None
     pipeline_diagnostic: DiagnosticPayload | None = None
@@ -952,6 +999,14 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Skip interactive confirmation for date corrections",
     )
+    run_p.add_argument(
+        "--skip-if-exists",
+        action="store_true",
+        help=(
+            "Reuse a prior completed run for the content-addressed run_id "
+            "instead of recomputing; reports the existing manifest path"
+        ),
+    )
 
     run_ui_p = sub.add_parser(
         "run-ui",
@@ -1254,6 +1309,7 @@ def main(argv: list[str] | None = None) -> int:
                 log_file=Path(args.log_file) if args.log_file else None,
                 structured_log=not args.no_structured_log,
                 bundle=Path(args.bundle) if args.bundle else None,
+                skip_if_exists=getattr(args, "skip_if_exists", False),
             )
         finally:
             if coverage_tracker is not None:

--- a/src/trend_analysis/export/__init__.py
+++ b/src/trend_analysis/export/__init__.py
@@ -920,9 +920,14 @@ def format_summary_text(
 
     rows.append([None] * len(columns))
 
-    for fund, stat_in in res["in_sample_stats"].items():
-        stat_out = res["out_sample_stats"][fund]
-        weight = res["fund_weights"][fund] * 100
+    in_sample_stats = res.get("in_sample_stats", {})
+    out_sample_stats = res.get("out_sample_stats", {})
+    fund_weights = res.get("fund_weights", {})
+    for fund, stat_in in in_sample_stats.items():
+        stat_out = out_sample_stats.get(fund)
+        if stat_out is None:
+            continue
+        weight = fund_weights.get(fund, 0.0) * 100
         extra = [
             res.get("benchmark_ir", {}).get(b, {}).get(fund, float("nan")) for b in bench_labels
         ]

--- a/src/trend_analysis/export/bundle.py
+++ b/src/trend_analysis/export/bundle.py
@@ -13,10 +13,10 @@ import pandas as pd
 
 from trend_analysis.backtesting import BacktestResult, CostModel, bootstrap_equity
 from trend_analysis.util.hash import (
+    content_run_id,
     normalise_for_json,
     sha256_config,
     sha256_file,
-    sha256_text,
 )
 
 
@@ -72,13 +72,7 @@ def export_bundle(run: Any, path: Path) -> Path:
             sha256_file(input_path) if input_path is not None and input_path.exists() else None
         )
         config_sha256 = sha256_config(config)
-        run_id_src = "|".join(
-            filter(
-                None,
-                [input_sha256, config_sha256, str(seed) if seed is not None else ""],
-            )
-        )
-        run_id = sha256_text(run_id_src)
+        run_id = content_run_id(input_sha256, config_sha256, seed)
 
         # ------------------------------------------------------------------
         # Results CSVs

--- a/src/trend_analysis/reporting/run_artifacts.py
+++ b/src/trend_analysis/reporting/run_artifacts.py
@@ -282,10 +282,56 @@ def write_run_artifacts(
         encoding="utf-8",
     )
 
+    # Stable per-run-id index so a prior run for a given run_id is discoverable
+    # regardless of its timestamped directory name. This is what powers the
+    # CLI ``--skip-if-exists`` short-circuit.
+    index_path = _run_index_path(base_dir, run_id)
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "run_directory": str(run_dir),
+                "manifest": str(manifest_path),
+                "created": manifest["created"],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
     return run_dir
 
 
-__all__ = ["write_run_artifacts"]
+def _run_index_path(base_dir: Path, run_id: str) -> Path:
+    """Return the path of the stable per-run-id index pointer file."""
+
+    return Path(base_dir) / "runs" / "index" / f"{run_id}.json"
+
+
+def find_existing_run(output_dir: Path | str, run_id: str) -> Path | None:
+    """Return the manifest path for a previously completed run, if present.
+
+    Looks up the stable per-run-id index written by :func:`write_run_artifacts`
+    and returns the recorded manifest path when it still exists. Returns
+    ``None`` when no prior run is recorded or its artifacts have been removed.
+    """
+
+    index_path = _run_index_path(Path(output_dir), run_id)
+    if not index_path.exists():
+        return None
+    try:
+        payload = json.loads(index_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    manifest = payload.get("manifest") if isinstance(payload, Mapping) else None
+    if not manifest:
+        return None
+    manifest_path = Path(manifest)
+    return manifest_path if manifest_path.exists() else None
+
+
+__all__ = ["write_run_artifacts", "find_existing_run"]
 
 
 def _selected_entities(

--- a/src/trend_analysis/reporting/run_artifacts.py
+++ b/src/trend_analysis/reporting/run_artifacts.py
@@ -205,8 +205,8 @@ def write_run_artifacts(
     run_prefix = run_id[:8] or "run"
     run_root = base_dir / "runs"
     run_root.mkdir(parents=True, exist_ok=True)
-    run_dir = run_root / f"{created.strftime('%Y%m%d_%H%M%S')}_{run_prefix}"
-    run_dir.mkdir(parents=True, exist_ok=True)
+    run_dir = _unique_run_dir(run_root / f"{created.strftime('%Y%m%d_%H%M%S_%f')}_{run_prefix}")
+    run_dir.mkdir(parents=True, exist_ok=False)
 
     df = _coerce_frame(data_frame)
     metrics_df = _coerce_frame(metrics_frame)
@@ -269,7 +269,7 @@ def write_run_artifacts(
             pass
     manifest["summary_text"] = summary_text
     manifest["html_report"] = "report.html"
-    manifest["run_directory"] = str(run_dir)
+    manifest["run_directory"] = str(run_dir.resolve())
 
     manifest_path = run_dir / "manifest.json"
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
@@ -291,8 +291,8 @@ def write_run_artifacts(
         json.dumps(
             {
                 "run_id": run_id,
-                "run_directory": str(run_dir),
-                "manifest": str(manifest_path),
+                "run_directory": str(run_dir.resolve()),
+                "manifest": str(manifest_path.resolve()),
                 "created": manifest["created"],
             },
             indent=2,
@@ -307,6 +307,19 @@ def _run_index_path(base_dir: Path, run_id: str) -> Path:
     """Return the path of the stable per-run-id index pointer file."""
 
     return Path(base_dir) / "runs" / "index" / f"{run_id}.json"
+
+
+def _unique_run_dir(base_path: Path) -> Path:
+    """Return a non-existing run directory path based on *base_path*."""
+
+    if not base_path.exists():
+        return base_path
+    suffix = 1
+    while True:
+        candidate = base_path.with_name(f"{base_path.name}-{suffix}")
+        if not candidate.exists():
+            return candidate
+        suffix += 1
 
 
 def find_existing_run(output_dir: Path | str, run_id: str) -> Path | None:
@@ -328,6 +341,8 @@ def find_existing_run(output_dir: Path | str, run_id: str) -> Path | None:
     if not manifest:
         return None
     manifest_path = Path(manifest)
+    if not manifest_path.is_absolute():
+        manifest_path = Path(output_dir) / manifest_path
     return manifest_path if manifest_path.exists() else None
 
 

--- a/src/trend_analysis/util/hash.py
+++ b/src/trend_analysis/util/hash.py
@@ -69,3 +69,61 @@ def sha256_config(cfg: Mapping[str, Any] | Any) -> str:
     normalised = normalise_for_json(cfg)
     text = json.dumps(normalised, sort_keys=True, separators=(",", ":"))
     return sha256_text(text)
+
+
+def content_run_id(
+    input_sha256: str | None,
+    config_sha256: str | None,
+    seed: Any = None,
+) -> str:
+    """Return a deterministic, content-addressed run identifier.
+
+    The available components (input-file digest, config digest and seed) are
+    joined in a stable order and hashed. This is the single implementation
+    shared by the reproducibility bundle and the working CLI so that identical
+    inputs always produce the same ``run_id``.
+    """
+    run_id_src = "|".join(
+        filter(
+            None,
+            [input_sha256, config_sha256, str(seed) if seed is not None else ""],
+        )
+    )
+    return sha256_text(run_id_src)
+
+
+def _config_payload(cfg: Any) -> Any:
+    """Best-effort conversion of a config object to a hashable payload."""
+
+    if hasattr(cfg, "model_dump"):
+        try:
+            return cfg.model_dump()
+        except Exception:  # pragma: no cover - defensive for exotic configs
+            pass
+    if hasattr(cfg, "__dict__"):
+        return dict(getattr(cfg, "__dict__"))
+    return cfg
+
+
+def working_run_id(cfg: Any, input_path: PathLike | None) -> str:
+    """Resolve a deterministic working ``run_id`` for a CLI run.
+
+    Returns ``cfg.run_id`` when it is already set; otherwise a
+    content-addressed id derived from the input-file digest, config digest and
+    seed when a source input file exists. Falls back to a random 12-char id for
+    the genuinely-unknown case (in-memory/library callers without a source
+    path), mirroring the historical ``uuid.uuid4().hex[:12]`` behaviour.
+    """
+    existing = getattr(cfg, "run_id", None)
+    if existing:
+        return str(existing)
+    path = Path(input_path) if input_path else None
+    if path is not None and path.exists():
+        return content_run_id(
+            sha256_file(path),
+            sha256_config(_config_payload(cfg)),
+            getattr(cfg, "seed", None),
+        )
+    import uuid
+
+    return uuid.uuid4().hex[:12]

--- a/tests/test_idempotency_cli.py
+++ b/tests/test_idempotency_cli.py
@@ -62,6 +62,33 @@ def _run_cli(config: Path, *extra: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _run_unified_cli(config: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{REPO_ROOT / 'src'}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    env["PYTHONHASHSEED"] = "0"
+    cmd = [
+        sys.executable,
+        "-m",
+        "trend.cli",
+        "run",
+        "-c",
+        str(config),
+        "-i",
+        str(DEMO_RETURNS),
+        "--seed",
+        "777",
+        *extra,
+    ]
+    return subprocess.run(
+        cmd,
+        cwd=str(REPO_ROOT),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
 def _run_dirs(export_dir: Path) -> list[Path]:
     runs = export_dir / "runs"
     if not runs.exists():
@@ -115,3 +142,24 @@ def test_content_run_id_stable_without_flag(tmp_path: Path) -> None:
     # On a random-UUID run_id (pre-change) the two runs would land in distinct
     # directories with distinct ids; content-addressing collapses them to one.
     assert len(run_ids) == 1, f"working run_id not stable across runs: {run_ids}"
+
+
+@pytest.mark.skipif(not DEMO_RETURNS.exists(), reason="Demo returns fixture missing")
+def test_unified_trend_run_skip_if_exists_reuses_own_manifest(tmp_path: Path) -> None:
+    export_dir = tmp_path / "exports"
+    config = _write_config(tmp_path, export_dir)
+
+    first = _run_unified_cli(config, "--skip-if-exists")
+    assert first.returncode == 0, first.stderr
+    run_dirs = _run_dirs(export_dir)
+    assert len(run_dirs) == 1, f"expected one run dir, got {run_dirs}"
+    first_run_id = _manifest_run_id(run_dirs[0])
+    manifest = run_dirs[0] / "manifest.json"
+    first_mtime = manifest.stat().st_mtime_ns
+
+    second = _run_unified_cli(config, "--skip-if-exists")
+    assert second.returncode == 0, second.stderr
+    assert _run_dirs(export_dir) == run_dirs
+    assert manifest.stat().st_mtime_ns == first_mtime
+    assert "already-done" in second.stdout
+    assert first_run_id in second.stdout

--- a/tests/test_idempotency_cli.py
+++ b/tests/test_idempotency_cli.py
@@ -1,0 +1,117 @@
+"""CLI idempotency: content-addressed working run_id + ``--skip-if-exists``.
+
+These tests exercise the legacy ``trend_analysis.cli`` ``run`` command on the
+bundled demo fixtures only (no external SaaS, no LLM, no network). They assert
+the working ``run_id`` is content-addressed (stable for identical inputs) and
+that ``--skip-if-exists`` reuses a prior completed run instead of recomputing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEMO_CONFIG = REPO_ROOT / "config" / "demo.yml"
+DEMO_RETURNS = REPO_ROOT / "demo" / "demo_returns.csv"
+
+
+def _write_config(tmp_path: Path, export_dir: Path) -> Path:
+    """Copy the demo config, pointing its export directory at *export_dir*."""
+
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    cfg = yaml.safe_load(DEMO_CONFIG.read_text(encoding="utf-8"))
+    cfg.setdefault("data", {})["csv_path"] = str(DEMO_RETURNS)
+    cfg.setdefault("export", {})["directory"] = str(export_dir)
+    cfg["export"].setdefault("formats", ["csv", "json"])
+    out = tmp_path / "demo_local.yml"
+    out.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+    return out
+
+
+def _run_cli(config: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{REPO_ROOT / 'src'}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    env["PYTHONHASHSEED"] = "0"
+    cmd = [
+        sys.executable,
+        "-m",
+        "trend_analysis.cli",
+        "run",
+        "-c",
+        str(config),
+        "-i",
+        str(DEMO_RETURNS),
+        "--seed",
+        "777",
+        *extra,
+    ]
+    return subprocess.run(
+        cmd,
+        cwd=str(REPO_ROOT),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _run_dirs(export_dir: Path) -> list[Path]:
+    runs = export_dir / "runs"
+    if not runs.exists():
+        return []
+    return [p for p in runs.iterdir() if p.is_dir() and p.name != "index"]
+
+
+def _manifest_run_id(run_dir: Path) -> str:
+    return json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))["run_id"]
+
+
+@pytest.mark.skipif(not DEMO_RETURNS.exists(), reason="Demo returns fixture missing")
+def test_skip_if_exists_reuses_run(tmp_path: Path) -> None:
+    export_dir = tmp_path / "exports"
+    config = _write_config(tmp_path, export_dir)
+
+    first = _run_cli(config, "--skip-if-exists")
+    assert first.returncode == 0, first.stderr
+    run_dirs = _run_dirs(export_dir)
+    assert len(run_dirs) == 1, f"expected one run dir, got {run_dirs}"
+    manifest = run_dirs[0] / "manifest.json"
+    first_run_id = _manifest_run_id(run_dirs[0])
+    first_mtime = manifest.stat().st_mtime_ns
+
+    second = _run_cli(config, "--skip-if-exists")
+    assert second.returncode == 0, second.stderr
+    # The second invocation must short-circuit: no new run dir, manifest
+    # untouched, and the same content-addressed run_id reported.
+    assert _run_dirs(export_dir) == run_dirs
+    assert manifest.stat().st_mtime_ns == first_mtime
+    assert "already-done" in second.stdout
+    assert first_run_id in second.stdout
+
+
+@pytest.mark.skipif(not DEMO_RETURNS.exists(), reason="Demo returns fixture missing")
+def test_content_run_id_stable_without_flag(tmp_path: Path) -> None:
+    export_dir = tmp_path / "exports"
+    config = _write_config(tmp_path, export_dir)
+
+    # Two identical runs (no --skip-if-exists): each recomputes and writes
+    # artifacts, but the content-addressed working run_id must be identical,
+    # mirroring the bundle assertion in test_determinism_cli.
+    first = _run_cli(config)
+    assert first.returncode == 0, first.stderr
+    second = _run_cli(config)
+    assert second.returncode == 0, second.stderr
+
+    run_dirs = _run_dirs(export_dir)
+    assert run_dirs, "expected at least one run directory"
+    run_ids = {_manifest_run_id(d) for d in run_dirs}
+    # On a random-UUID run_id (pre-change) the two runs would land in distinct
+    # directories with distinct ids; content-addressing collapses them to one.
+    assert len(run_ids) == 1, f"working run_id not stable across runs: {run_ids}"

--- a/tests/test_run_artifacts.py
+++ b/tests/test_run_artifacts.py
@@ -114,6 +114,58 @@ def test_write_run_artifacts_creates_nested_output_directory_tree(tmp_path: Path
     assert (run_dir / "report.html").is_file()
 
 
+def test_write_run_artifacts_uses_unique_directory_for_same_timestamp(
+    tmp_path: Path, monkeypatch
+) -> None:
+    class FixedDateTime(dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 5, 31, 7, 15, 0, 123456, tzinfo=tz)
+
+    monkeypatch.setattr(run_artifacts._dt, "datetime", FixedDateTime)
+    kwargs = {
+        "output_dir": tmp_path / "out",
+        "run_id": "stable-run-id",
+        "config": {},
+        "config_path": "cfg.yml",
+        "input_path": tmp_path / "missing.csv",
+        "data_frame": pd.DataFrame({"Date": pd.date_range("2023-01-31", periods=1)}),
+        "metrics_frame": pd.DataFrame(),
+        "run_details": {},
+        "exported_files": [],
+        "summary_text": "",
+    }
+
+    first = write_run_artifacts(**kwargs)
+    second = write_run_artifacts(**kwargs)
+
+    assert first != second
+    assert first.name == "20260531_071500_123456_stable-r"
+    assert second.name == "20260531_071500_123456_stable-r-1"
+    index = json.loads(
+        (tmp_path / "out" / "runs" / "index" / "stable-run-id.json").read_text(encoding="utf-8")
+    )
+    assert Path(index["manifest"]).is_absolute()
+    assert Path(index["run_directory"]).is_absolute()
+
+
+def test_find_existing_run_resolves_legacy_relative_manifest_path(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    manifest = output_dir / "runs" / "20260531_071500_abcdef12" / "manifest.json"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text("{}", encoding="utf-8")
+    index = output_dir / "runs" / "index" / "legacy-run.json"
+    index.parent.mkdir(parents=True)
+    index.write_text(
+        json.dumps(
+            {"run_id": "legacy-run", "manifest": "runs/20260531_071500_abcdef12/manifest.json"}
+        ),
+        encoding="utf-8",
+    )
+
+    assert run_artifacts.find_existing_run(output_dir, "legacy-run") == manifest
+
+
 def test_serialise_stats_handles_mapping_and_invalid_values() -> None:
     stats = {"cagr": "0.5", "vol": "n/a", "ignored": "x"}
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,44 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-05-31T08:25:28Z - closer lane fixed PR #5362 Gate export regression
+
+- Repo: stranske/Trend_Model_Project
+- Issue/PR: #5351 / #5362 (`claude/issue-5351-content-run-id`)
+- Agent: codex closer, neutral Code workspace; persistent checkout used at `~/.codex/automations/imi-merge-verify-closer/worktrees/trend-5351-reviewfix`.
+- Batch sweep before this lane: merged learning-management-system #212 for issue #182, applied `verify:compare`, reopened #182 for verifier sequencing, and emitted `pr_merged` plus `verify_label_applied`. trip-planner #1270 was green/thread-clear but not batch-merged because the body uses `Implements #1261` rather than a closing reference. Workflows #2196/#2182 has verifier CONCERNS/CONCERNS and remains an audit candidate.
+- Selection: PR #5362 had all five review threads resolved from the prior closer fix, but fresh Gate failed `Python CI / python 3.12`, `Python CI / python 3.13`, and `Gate / gate` on head `a8256903`.
+- Failure evidence: CI run `26707252407`; both Python jobs failed only `tests/test_trend_cli.py::test_main_run_invokes_pipeline`, `tests/test_trend_cli.py::test_main_run_without_structured_log`, and `tests/test_trend_cli_entrypoints.py::test_main_run_command` with `KeyError: 'in_sample_stats'` in `src/trend_analysis/export/__init__.py:923`.
+- Fix: `format_summary_text()` now treats per-fund `in_sample_stats`/`out_sample_stats`/`fund_weights` as optional and skips the per-fund export rows when aggregate-only mocked results are passed through the CLI export path. Real pipeline payloads with per-fund maps still render those rows.
+- Validation:
+  - `python -m pytest tests/test_trend_cli.py::test_main_run_invokes_pipeline tests/test_trend_cli.py::test_main_run_without_structured_log tests/test_trend_cli_entrypoints.py::test_main_run_command -q --tb=short` -> 3 passed.
+  - `python -m pytest tests/test_trend_cli.py::test_main_run_invokes_pipeline tests/test_trend_cli.py::test_main_run_without_structured_log tests/test_trend_cli_entrypoints.py::test_main_run_command tests/test_export_formatter.py -q --tb=short` -> 23 passed.
+  - `python -m ruff check src/trend_analysis/export/__init__.py tests/test_trend_cli.py tests/test_trend_cli_entrypoints.py` -> passed.
+  - `python -m black --check --fast --line-length 100 src/trend_analysis/export/__init__.py` -> passed.
+  - `git diff --check` -> passed.
+  - Broader `python -m pytest tests/test_trend_cli.py tests/test_trend_cli_entrypoints.py tests/test_export_formatter.py tests/test_idempotency_cli.py tests/test_run_artifacts.py -q --tb=short` -> 141 passed, 1 failed: `test_mc_viz_errors_when_results_parquet_file_is_corrupted_without_traceback` saw an environment-level PyArrow/NumPy traceback in stderr. This is unrelated to the `in_sample_stats` Gate failure; the exact failed CI tests pass after the patch.
+- Current state before push: local patch ready on top of `a8256903`; next action is commit, push to `claude/issue-5351-content-run-id`, post evidence, then re-check PR #5362 in the next closer round when fresh checks complete.
+
+## 2026-05-31T08:06:11Z - closer lane advanced PR #5362 review fixes
+
+- Repo: stranske/Trend_Model_Project
+- Issue/PR: #5351 / #5362 (`claude/issue-5351-content-run-id`)
+- Agent: codex closer, neutral Code workspace; persistent checkout used at `~/.codex/automations/imi-merge-verify-closer/worktrees/trend-5351-reviewfix`.
+- Selection: fresh fleet discovery found no batch-safe terminal actions. Excluded scoped blockers and maintenance/sync PRs. Selected Trend #5362 because Gate was green but five unresolved Codex/Copilot review threads identified real idempotency/index defects.
+- Fix pushed: commit `a8256903` (`Fix run idempotency review issues`) on the PR branch.
+  - Run-artifact directories now include microseconds plus a suffix fallback so deterministic run IDs cannot collide on same-second recomputation.
+  - Run index entries store absolute manifest/run-directory paths, and `find_existing_run()` resolves legacy relative manifest pointers against `output_dir`.
+  - Unified `trend run` now writes the run manifest/index that its `--skip-if-exists` lookup reads, so repeated unified CLI runs can short-circuit.
+- Review handling: posted evidence comment on PR #5362 and resolved all five review threads (`PRRT_kwDOO0LrSc6F6_tr`, `PRRT_kwDOO0LrSc6F6_ts`, `PRRT_kwDOO0LrSc6F7AF1`, `PRRT_kwDOO0LrSc6F7AF7`, `PRRT_kwDOO0LrSc6F7AF9`).
+- Validation:
+  - `python -m pytest tests/test_idempotency_cli.py tests/test_run_artifacts.py -q --tb=short` -> 13 passed.
+  - `python -m pytest tests/test_idempotency_cli.py tests/test_determinism_cli.py tests/test_run_artifacts.py tests/test_export_bundle.py tests/test_util_hash.py tests/test_hash_utils.py tests/test_cli.py -q --tb=short` -> 52 passed.
+  - `python -m ruff check src/trend/cli.py src/trend_analysis/reporting/run_artifacts.py tests/test_idempotency_cli.py tests/test_run_artifacts.py` -> passed.
+  - `python -m black --check --fast --line-length 100 src/trend/cli.py src/trend_analysis/reporting/run_artifacts.py tests/test_idempotency_cli.py tests/test_run_artifacts.py` -> passed.
+  - `git diff --check` -> passed.
+- Current state: head `a8256903`; fresh GitHub checks are legitimately in progress after push (Python CI 3.12/3.13, typecheck, MC Viz, Backplane, claude-review). No merge yet.
+- Next action: re-check PR #5362 when fresh checks complete. If checks are green and no new review threads appear, merge, apply `verify:compare`, and keep #5351 open for verifier sequencing.
+
 ## 2026-05-31T05:58:12Z - opener lane issue #5345 PR materializing
 
 - Repo: stranske/Trend_Model_Project


### PR DESCRIPTION
Closes #5351.

## Why
Agent re-invocation should be safe and cheap: identical inputs should yield the same `run_id` and ideally skip recomputation. Previously the **bundle** `run_id` was content-addressed and stable, but the **working/CLI** `run_id` was a random UUID and `write_run_artifacts` always created a fresh timestamped directory with no "already computed, skip" check.

## What
- **Shared derivation:** extracted the bundle's content-addressed `run_id` into `trend_analysis.util.hash.content_run_id(input_sha256, config_sha256, seed)` plus a `working_run_id(cfg, input_path)` resolver. `export/bundle.py` now reuses `content_run_id` (byte-identical output — `test_determinism_cli` unchanged).
- **Content-addressed working id:** both `trend_analysis/cli.py` (`_execute_analysis_run`) and `trend/cli.py` (`_run_pipeline`) default the working `run_id` to the content hash when no `run_id` is supplied **and** an input file exists. The random-UUID fallback is preserved strictly for the no-input-file (in-memory/library) case.
- **Stable index:** `write_run_artifacts` writes a `runs/index/<run_id>.json` pointer alongside the timestamped run dir; added `find_existing_run()` to look it up.
- **`--skip-if-exists`:** added to both `run` CLIs. When a completed manifest already exists for the computed `run_id`, the CLI logs `already-done: run_id=<id>`, prints the existing manifest path, and returns without re-running the pipeline.
- **Docs:** new section in `docs/ReproducibilityGuide.md`.

## Tests (`tests/test_idempotency_cli.py`, demo fixtures only — no SaaS/LLM/network)
- `test_skip_if_exists_reuses_run` — two `--skip-if-exists` runs on identical inputs; second does not rewrite artifacts (mtime unchanged), no new run dir, reports the same `run_id` and `already-done`.
- `test_content_run_id_stable_without_flag` — two identical runs (no flag) collapse to one content-addressed working `run_id`.

Both fail on `main` today (random UUID / unknown flag) and pass after.

## Validation
`pytest tests/test_idempotency_cli.py tests/test_determinism_cli.py tests/test_run_artifacts.py tests/test_export_bundle.py tests/test_util_hash.py tests/test_hash_utils.py tests/test_cli.py` → all pass locally; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)