### PR TITLE
docs: fix broken README `trend report` example (#5346)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ trend run -c config/demo.yml --returns data/returns.csv
 # Use a preset strategy
 trend run -c config/demo.yml --returns data/returns.csv --preset conservative
 
-# Generate a report from previous results
-trend report --last-run demo/portfolio_test_results/last_run_results.json
+# Generate a unified HTML report from a config and returns
+trend report -c config/demo.yml -i demo/demo_returns.csv --output report.html
 
 # Run stress test scenarios
 trend stress -c config/demo.yml


### PR DESCRIPTION
## Summary

Fixes the broken `trend report` example in `README.md` (Closes #5346).

The example told users to run `trend report --last-run demo/portfolio_test_results/last_run_results.json`, but the `report` subparser has **no `--last-run` flag** and `last_run_results.json` exists nowhere — a new user's first copy-paste fails immediately.

## Change

`README.md:131-132` — replaced the broken example with a verified-working invocation matching the real parser (`src/trend/cli.py:445-478`):

```bash
trend report -c config/demo.yml -i demo/demo_returns.csv --output report.html
```

## Verification (acceptance criteria)

- ✅ Corrected command runs against bundled demo data and writes an HTML report — confirmed on `phase-3`: `trend report -c config/demo.yml -i demo/demo_returns.csv --output /tmp/rep.html` → `Report written: /tmp/rep.html` (5,624-byte HTML file).
- ✅ `grep -rn 'last-run\|last_run_results' README.md README_APP.md docs/` returns nothing.

## Scope / Non-Goals

- Doc-only fix; no new `--last-run` feature added (per issue non-goals).
- The optional doc-lint CI step is left out as explicitly optional; both hard acceptance criteria are satisfied by the doc correction.

Closes #5346