### PR TITLE
Declare pyarrow as an explicit base dependency for parquet MC bundles (#5347)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "pandas==3.0.3",
     "pandera==0.31.1",
     "plotly==6.7.0",
+    "pyarrow==23.0.1",
     "pydantic==2.13.4",
     "requests==2.34.2",
     "scipy==1.17.1",

--- a/requirements.lock
+++ b/requirements.lock
@@ -349,7 +349,9 @@ ptyprocess==0.7.0 ; sys_platform != 'emscripten' and sys_platform != 'win32'
 pure-eval==0.2.3
     # via stack-data
 pyarrow==23.0.1
-    # via streamlit
+    # via
+    #   trend-model (pyproject.toml)
+    #   streamlit
 pycodestyle==2.14.0
     # via flake8
 pydantic==2.13.4

--- a/tests/integration/test_mc_bundle_parquet.py
+++ b/tests/integration/test_mc_bundle_parquet.py
@@ -1,0 +1,63 @@
+"""Parquet-path integration gate for the MC bundle loaders.
+
+Issue #5347: ``pyarrow`` is required to read the parquet MC bundles
+(``summary.parquet``, ``results.parquet``, ``nav_paths.parquet``) shipped in
+``tests/fixtures/mc_bundle`` and consumed by ``trend mc viz``. Before pyarrow
+became an explicit ``[project].dependencies`` entry it was only present
+transitively via Streamlit, so a base ``pip install -e .`` (no ``[app]``) could
+not read these fixtures at all.
+
+The existing ``tests/integration/test_mc_viz.py`` drives the CLI end-to-end;
+this module adds an in-process gate that loads the parquet fixture directly
+through the production loaders, so the parquet code path is exercised even when
+the heavier CLI/PNG plumbing is unavailable. It fails in a base-deps-only
+environment without pyarrow and passes once pyarrow is installed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from trend.mc.io import load_nav_paths_frame
+from trend.mc.viz import _load_mc_bundle_frames
+
+pytestmark = [pytest.mark.integration, pytest.mark.mc_viz_integration]
+
+
+def _fixture_bundle_dir() -> Path:
+    return Path(__file__).resolve().parents[1] / "fixtures" / "mc_bundle"
+
+
+def test_pyarrow_is_importable() -> None:
+    """pyarrow must be importable for the parquet bundle path to work."""
+    import pyarrow
+
+    assert pyarrow.__version__
+
+
+def test_mc_bundle_summary_and_results_parquet_load() -> None:
+    """summary.parquet and results.parquet load into non-empty DataFrames."""
+    bundle_dir = _fixture_bundle_dir()
+    assert (bundle_dir / "summary.parquet").is_file()
+    assert (bundle_dir / "results.parquet").is_file()
+
+    summary, results = _load_mc_bundle_frames(bundle_dir)
+
+    assert isinstance(summary, pd.DataFrame)
+    assert isinstance(results, pd.DataFrame)
+    assert not summary.empty
+    assert not results.empty
+
+
+def test_mc_bundle_nav_paths_parquet_loads() -> None:
+    """nav_paths.parquet loads into a non-empty DataFrame via the io loader."""
+    bundle_dir = _fixture_bundle_dir()
+    assert (bundle_dir / "nav_paths.parquet").is_file()
+
+    nav_paths = load_nav_paths_frame(bundle_dir)
+
+    assert isinstance(nav_paths, pd.DataFrame)
+    assert not nav_paths.empty

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,15 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-05-31T16:53:37Z - opener (claude_code) materialized PR for #5347 (pyarrow base dep)
+
+- Repo: stranske/Trend_Model_Project
+- Issue/PR: #5347 -> new PR (branch `claude/issue-5347-pyarrow-dep`, base `phase-3`)
+- Agent: claude_code opener, neutral Code workspace; isolated worktree at `~/.codex/automations/pd-workloop-resume/worktrees/trend-5347-pyarrow-dep`.
+- Change: declared `pyarrow==23.0.1` in `[project].dependencies` (was only transitive via streamlit, absent from base `pip install -e .`); surgically updated `requirements.lock` so pyarrow is now sourced from `trend-model (pyproject.toml)` (version already pinned, no churn); added `tests/integration/test_mc_bundle_parquet.py` (integration + mc_viz_integration) exercising the parquet bundle loaders on `tests/fixtures/mc_bundle`.
+- Validation: built isolated `/tmp/trend5347-venv` (numpy 2.4.6 / pandas 3.0.3 / pyarrow 23.0.1 / pytest 9.0.3 / pytest-xdist 3.8.0); new test passes 3/3. Lock kept surgical to avoid uv-version drift (`>=3.12` project; full `uv pip compile` emitted spurious `<3.12` marker lines + header path pollution).
+- Next action: ready-for-review PR labeled `agent:claude`/`agents:keepalive`/`autofix`; keepalive owns CI from here.
+
 ## 2026-05-31T08:25:28Z - closer lane fixed PR #5362 Gate export regression
 
 - Repo: stranske/Trend_Model_Project

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,15 +1,6 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
-## 2026-05-31T16:53:37Z - opener (claude_code) materialized PR for #5347 (pyarrow base dep)
-
-- Repo: stranske/Trend_Model_Project
-- Issue/PR: #5347 -> new PR (branch `claude/issue-5347-pyarrow-dep`, base `phase-3`)
-- Agent: claude_code opener, neutral Code workspace; isolated worktree at `~/.codex/automations/pd-workloop-resume/worktrees/trend-5347-pyarrow-dep`.
-- Change: declared `pyarrow==23.0.1` in `[project].dependencies` (was only transitive via streamlit, absent from base `pip install -e .`); surgically updated `requirements.lock` so pyarrow is now sourced from `trend-model (pyproject.toml)` (version already pinned, no churn); added `tests/integration/test_mc_bundle_parquet.py` (integration + mc_viz_integration) exercising the parquet bundle loaders on `tests/fixtures/mc_bundle`.
-- Validation: built isolated `/tmp/trend5347-venv` (numpy 2.4.6 / pandas 3.0.3 / pyarrow 23.0.1 / pytest 9.0.3 / pytest-xdist 3.8.0); new test passes 3/3. Lock kept surgical to avoid uv-version drift (`>=3.12` project; full `uv pip compile` emitted spurious `<3.12` marker lines + header path pollution).
-- Next action: ready-for-review PR labeled `agent:claude`/`agents:keepalive`/`autofix`; keepalive owns CI from here.
-
 ## 2026-05-31T08:25:28Z - closer lane fixed PR #5362 Gate export regression
 
 - Repo: stranske/Trend_Model_Project


### PR DESCRIPTION
## Why

`pyarrow` is required to read the parquet Monte Carlo bundles — `src/trend/mc/io.py` (`_read_nav_paths_parquet`) and `src/trend/mc/viz.py` (`_load_mc_bundle_frames`) call `pd.read_parquet` — and to load the shipped fixture `tests/fixtures/mc_bundle/` (`summary.parquet`, `results.parquet`, `nav_paths.parquet`). But `pyarrow` was only present transitively via Streamlit (`requirements.lock` `pyarrow==23.0.1`) and absent from `[project].dependencies` and every extra. A base `pip install -e .` (no `[app]`) yields no pyarrow, so `trend mc viz --bundle tests/fixtures/mc_bundle …` and the README's parquet example fail.

Closes #5347.

## What

- **`pyproject.toml`**: add `pyarrow==23.0.1` (matching the lock pin) to `[project].dependencies` so parquet support is guaranteed wherever MC bundles are used, not incidental via `[app]`.
- **`requirements.lock`**: pyarrow is now sourced from `trend-model (pyproject.toml)` (in addition to `streamlit`). The version was already pinned at `23.0.1`, so this is a surgical `# via` annotation update — both files agree. A full `uv pip compile` run was deliberately *not* committed: on this `requires-python >=3.12` project the available uv emits spurious `<3.12`/`<=3.11` universal-marker lines (ipython/psutil/tomli) and rewrites the header path, which is uv-version drift unrelated to this change. `make lock` can fully regenerate when a lock refresh is intended.
- **`tests/integration/test_mc_bundle_parquet.py`** (new, `integration` + `mc_viz_integration`): loads `summary.parquet`/`results.parquet` via the production `_load_mc_bundle_frames` loader and `nav_paths.parquet` via `load_nav_paths_frame`, and asserts pyarrow is importable. This adds the parquet-fixture path alongside the existing CLI coverage in `tests/integration/test_mc_viz.py`; it fails in a base-deps-only env without pyarrow and passes once pyarrow is installed.

## Validation

Built an isolated venv (`numpy==2.4.6`, `pandas==3.0.3`, `pyarrow==23.0.1`, `pytest==9.0.3`, `pytest-xdist==3.8.0`) and ran the new test:

```
tests/integration/test_mc_bundle_parquet.py ...  [100%]
3 passed
```

## Acceptance criteria

- [x] `pyarrow` appears under `[project].dependencies` in `pyproject.toml`, and `requirements.lock` shows it sourced from the project.
- [x] Parquet-fixture path encoded as an `integration`-marked test (`tests/fixtures/mc_bundle` loaded through the production loaders).

## Non-goals (respected)

- Bundle format unchanged (still parquet).
- `pyproject.toml` and `requirements.lock` kept in agreement.
