### PR TITLE
Issue #5344: Internal/on-prem deployment with isolated LLM boundary

### DIFF
--- a/README_APP.md
+++ b/README_APP.md
@@ -42,13 +42,30 @@ Quick setup script (writes the file and locks permissions):
 ```
 ./scripts/setup_streamlit_secrets.sh
 ```
-**Streamlit Cloud (hosted)**
+**Streamlit Cloud (hosted) — synthetic / non-proprietary data only**
   - `OPENAI_API_KEY = "..."`
+  - Streamlit Community Cloud is external SaaS. Do **not** use it for real
+    proprietary returns. For sharing with synthetic data, use the stlite
+    browser demo (issue #5343).
 
 **How Streamlit Cloud differs**
 - Local: you control the environment on your machine.
 - Cloud: Streamlit runs the app on their infrastructure and loads secrets from
   the app settings (not from repo files).
+
+### Proprietary data: internal / on-prem hosting
+
+To run on **real proprietary returns**, host the app inside your perimeter and
+route LLM traffic only through the bundled no-egress proxy. The deterministic
+engine and uploaded data never leave the host; LLM calls go through
+`trend-llm-proxy` pointed at an authorized no-train upstream (an on-prem Ollama
+endpoint keeps prompts in-perimeter too). Set `TREND_LLM_ZONE=disabled` to hide
+all LLM panels in a zone that has no authorized endpoint while still running the
+deterministic engine.
+
+See [`docs/deployment/INTERNAL_HOSTING.md`](docs/deployment/INTERNAL_HOSTING.md)
+for the Docker Compose recipe (`docker compose --profile internal up`) and the
+operator live-verification checklist.
 
 The legacy launcher (`scripts/run_streamlit.sh`) still works, but the packaged
 command keeps the environment consistent across machines and enforces the

--- a/README_APP.md
+++ b/README_APP.md
@@ -60,8 +60,8 @@ route LLM traffic only through the bundled no-egress proxy. The deterministic
 engine and uploaded data never leave the host; LLM calls go through
 `trend-llm-proxy` pointed at an authorized no-train upstream (an on-prem Ollama
 endpoint keeps prompts in-perimeter too). Set `TREND_LLM_ZONE=disabled` to hide
-all LLM panels in a zone that has no authorized endpoint while still running the
-deterministic engine.
+Streamlit LLM entry points in a zone that has no authorized endpoint while still
+running the deterministic engine.
 
 See [`docs/deployment/INTERNAL_HOSTING.md`](docs/deployment/INTERNAL_HOSTING.md)
 for the Docker Compose recipe (`docker compose --profile internal up`) and the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,38 @@ services:
       - "8000:8000"
     volumes:
       - ./data:/app/data
+
+  # --- Internal / on-prem deployment (proprietary data + LLM stay in-perimeter) ---
+  # Start with: docker compose --profile internal up
+  # See docs/deployment/INTERNAL_HOSTING.md for the full recipe and live-verification gate.
+  llm-proxy:
+    image: *trend-image
+    profiles: ["internal"]
+    command: ["trend-llm-proxy", "--host", "0.0.0.0", "--port", "8799"]
+    expose:
+      - "8799"
+    environment:
+      # Operator supplies an authorized no-train upstream at deploy time
+      # (e.g. an on-prem Ollama endpoint for the lowest-egress option).
+      - TS_LLM_PROXY_UPSTREAM=${TS_LLM_PROXY_UPSTREAM:?set TS_LLM_PROXY_UPSTREAM to your authorized no-train endpoint}
+      - TS_LLM_PROXY_TOKEN=${TS_LLM_PROXY_TOKEN:-}
+      - TREND_LLM_API_KEY=${TREND_LLM_API_KEY:-}
+      # Optional data-egress ceiling (bytes); unset means no limit.
+      - TS_LLM_PROXY_MAX_BODY_BYTES=${TS_LLM_PROXY_MAX_BODY_BYTES:-}
+  app-internal:
+    image: *trend-image
+    profiles: ["internal"]
+    # Bind to the loopback interface only by default; change the host portion
+    # to the internal NIC address for LAN-internal access.
+    ports:
+      - "127.0.0.1:8501:8501"
+    environment:
+      # Route all LLM traffic through the in-perimeter proxy, never the public API.
+      - TREND_LLM_BASE_URL=http://llm-proxy:8799/v1
+      # internal_authorized routes via the proxy; disabled hides all LLM panels.
+      - TREND_LLM_ZONE=${TREND_LLM_ZONE:-internal_authorized}
+      - TS_LLM_PROXY_TOKEN=${TS_LLM_PROXY_TOKEN:-}
+    depends_on:
+      - llm-proxy
+    volumes:
+      - ./data:/app/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     environment:
       # Operator supplies an authorized no-train upstream at deploy time
       # (e.g. an on-prem Ollama endpoint for the lowest-egress option).
-      - TS_LLM_PROXY_UPSTREAM=${TS_LLM_PROXY_UPSTREAM:?set TS_LLM_PROXY_UPSTREAM to your authorized no-train endpoint}
+      - TS_LLM_PROXY_UPSTREAM=${TS_LLM_PROXY_UPSTREAM:-}
       - TS_LLM_PROXY_TOKEN=${TS_LLM_PROXY_TOKEN:-}
       - TREND_LLM_API_KEY=${TREND_LLM_API_KEY:-}
       # Optional data-egress ceiling (bytes); unset means no limit.
@@ -47,10 +47,9 @@ services:
     environment:
       # Route all LLM traffic through the in-perimeter proxy, never the public API.
       - TREND_LLM_BASE_URL=http://llm-proxy:8799/v1
-      # internal_authorized routes via the proxy; disabled hides all LLM panels.
+      - TS_LLM_PROXY_URL=http://llm-proxy:8799/v1
+      # internal_authorized routes via the proxy; disabled hides LLM entry points.
       - TREND_LLM_ZONE=${TREND_LLM_ZONE:-internal_authorized}
       - TS_LLM_PROXY_TOKEN=${TS_LLM_PROXY_TOKEN:-}
-    depends_on:
-      - llm-proxy
     volumes:
       - ./data:/app/data

--- a/docs/deployment/INTERNAL_HOSTING.md
+++ b/docs/deployment/INTERNAL_HOSTING.md
@@ -35,8 +35,8 @@ perimeter at all.
   `src/trend_analysis/llm/providers.py` (`base_url` override), so the app talks
   to the proxy instead of the public API.
 - `TREND_LLM_ZONE` switch (new): `internal_authorized` routes via the proxy;
-  `disabled` hides every LLM panel so a zone with no authorized endpoint still
-  runs the deterministic engine.
+  `disabled` hides the Streamlit LLM entry points so a zone with no authorized
+  endpoint still runs the deterministic engine.
 
 ## Run it (Docker Compose)
 
@@ -75,8 +75,9 @@ TREND_LLM_ZONE=disabled docker compose --profile internal up app-internal
 ## What is and isn't sent upstream
 
 - **Sent upstream (only when zone is `internal_authorized`):** the LLM
-  request bodies the app constructs for the Explain Results / LLM Comparison
-  panels, forwarded by `llm-proxy` to `TS_LLM_PROXY_UPSTREAM`.
+  request bodies the app constructs for Explain Results, LLM Comparison,
+  natural-language config edits, and LLM what-if variants, forwarded by
+  `llm-proxy` to `TS_LLM_PROXY_UPSTREAM`.
 - **Never sent:** uploaded returns files, the analysis cache, and the API key
   (the proxy injects the key server-side; the browser and app never hold the
   upstream key when a proxy token is used).
@@ -110,9 +111,8 @@ the acceptance gate for issue #5344.
    proxy URL and make **no direct call** to `api.openai.com` (verify with host
    egress monitoring / firewall logs). Restart the proxy to restore.
 4. **Deterministic features still work with zone `disabled`.** Restart with
-   `TREND_LLM_ZONE=disabled`; confirm the LLM panels are hidden (a single
-   "LLM features are disabled" notice appears) and that analysis runs still
-   complete.
+   `TREND_LLM_ZONE=disabled`; confirm the LLM entry points show disabled-zone
+   notices and that analysis runs still complete.
 
 ## Security notes
 

--- a/docs/deployment/INTERNAL_HOSTING.md
+++ b/docs/deployment/INTERNAL_HOSTING.md
@@ -1,0 +1,124 @@
+# Internal / on-prem hosting for proprietary data
+
+This recipe runs the Trend Model Streamlit app on an **internal host** so that
+proprietary returns and the deterministic engine stay entirely inside the org
+perimeter, while LLM features (which are optional) are routed only through an
+**authorized no-train endpoint** via the bundled proxy. It is the compliant
+alternative to Streamlit Community Cloud, which is external SaaS and therefore
+unsuitable for real proprietary data.
+
+For external sharing with **synthetic** data instead, use the stlite browser
+demo (issue #5343 / `README_APP.md`) — that path never touches real data and is
+out of scope here.
+
+## What stays in-perimeter
+
+| Concern | Where it runs |
+| --- | --- |
+| Deterministic analysis engine + uploaded data | the `app-internal` container, bound to an internal interface |
+| LLM API key | the `llm-proxy` sidecar only (never the browser, never the app env in plain form) |
+| LLM prompt/response traffic | egresses **only** through `llm-proxy` to the operator-supplied upstream |
+
+The only outbound LLM egress is from `llm-proxy` to the upstream you configure.
+Point it at an authorized **no-train** endpoint. An on-prem
+[Ollama](https://ollama.com) server (the `langchain-ollama` extra is already in
+the `[llm]` group) is the lowest-egress option because prompts never leave the
+perimeter at all.
+
+## Components this builds on
+
+- `trend-llm-proxy` console script (`pyproject.toml`) →
+  `src/trend_analysis/llm_proxy/server.py`, an OpenAI-compatible proxy that
+  keeps the API key server-side and binds `0.0.0.0:8799` by default.
+- `TREND_LLM_BASE_URL` plumbing in
+  `streamlit_app/components/llm_settings.py` →
+  `src/trend_analysis/llm/providers.py` (`base_url` override), so the app talks
+  to the proxy instead of the public API.
+- `TREND_LLM_ZONE` switch (new): `internal_authorized` routes via the proxy;
+  `disabled` hides every LLM panel so a zone with no authorized endpoint still
+  runs the deterministic engine.
+
+## Run it (Docker Compose)
+
+The internal services live behind the `internal` compose profile, so the
+default `docker compose up` is unchanged.
+
+```bash
+# 1. Build the image (once).
+docker compose build app
+
+# 2. Set the authorized no-train upstream and (optionally) a proxy token.
+export TS_LLM_PROXY_UPSTREAM="https://your-authorized-no-train-endpoint"   # or http://ollama:11434 for on-prem
+export TS_LLM_PROXY_TOKEN="$(openssl rand -hex 24)"        # optional shared secret
+export TREND_LLM_API_KEY="..."                              # upstream key, stays in the proxy
+# Optional data-egress ceiling (bytes) — bound what can leave the perimeter:
+export TS_LLM_PROXY_MAX_BODY_BYTES=1048576
+
+# 3. Start the internal app + proxy sidecar.
+docker compose --profile internal up app-internal llm-proxy
+```
+
+The app is published on `127.0.0.1:8501` (loopback only) by default. For
+LAN-internal access, change the host portion of the `app-internal` port mapping
+in `docker-compose.yml` to your internal NIC address — never `0.0.0.0` on an
+internet-facing host.
+
+### Running a proprietary zone with no LLM
+
+If a zone has no authorized LLM endpoint, run with the LLM features disabled.
+The deterministic engine is unaffected:
+
+```bash
+TREND_LLM_ZONE=disabled docker compose --profile internal up app-internal
+```
+
+## What is and isn't sent upstream
+
+- **Sent upstream (only when zone is `internal_authorized`):** the LLM
+  request bodies the app constructs for the Explain Results / LLM Comparison
+  panels, forwarded by `llm-proxy` to `TS_LLM_PROXY_UPSTREAM`.
+- **Never sent:** uploaded returns files, the analysis cache, and the API key
+  (the proxy injects the key server-side; the browser and app never hold the
+  upstream key when a proxy token is used).
+- **Bounded:** when `TS_LLM_PROXY_MAX_BODY_BYTES` is set, the proxy rejects any
+  request body larger than that ceiling with HTTP 413 before forwarding, so an
+  oversized payload cannot silently egress. Unset means no limit (default
+  behavior).
+
+> The proxy forwards the request body verbatim within the size ceiling; it does
+> not field-redact prompt contents. Treat prompt construction in the app as the
+> redaction boundary and keep the upstream a no-train endpoint. A richer
+> field-allowlist redaction hook can extend `request_body_within_limit` in
+> `llm_proxy/server.py`.
+
+## Live-verification gate (operator checklist)
+
+Run these on the internal host before declaring the deployment good. This is
+the acceptance gate for issue #5344.
+
+1. **App loads on the internal URL.** Browse to `http://127.0.0.1:8501` (or your
+   internal NIC address) and confirm the Streamlit UI renders.
+   ```bash
+   curl --fail http://127.0.0.1:8501/_stcore/health && echo OK
+   ```
+2. **A real run completes in-perimeter.** Upload a real sample returns CSV and
+   run a single-period analysis; confirm metrics/charts render. No outbound
+   call leaves the host for this step (deterministic engine only).
+3. **LLM fails closed when the proxy is down (zone `internal_authorized`).**
+   Stop `llm-proxy` (`docker compose --profile internal stop llm-proxy`), then
+   trigger an Explain Results / LLM Comparison action. It must error against the
+   proxy URL and make **no direct call** to `api.openai.com` (verify with host
+   egress monitoring / firewall logs). Restart the proxy to restore.
+4. **Deterministic features still work with zone `disabled`.** Restart with
+   `TREND_LLM_ZONE=disabled`; confirm the LLM panels are hidden (a single
+   "LLM features are disabled" notice appears) and that analysis runs still
+   complete.
+
+## Security notes
+
+- The compose config in this repo contains **no public-SaaS hostnames and no
+  embedded real API key**; the LLM upstream and key are operator-supplied at
+  deploy time via environment variables.
+- Set `TS_LLM_PROXY_TOKEN` so only the app (which presents the token) can use
+  the proxy.
+- Keep the app bound to an internal interface; do not expose `8501` publicly.

--- a/src/trend_analysis/llm_proxy/server.py
+++ b/src/trend_analysis/llm_proxy/server.py
@@ -68,6 +68,34 @@ def _resolve_upstream_key() -> str | None:
     )
 
 
+def _max_request_bytes() -> int | None:
+    """Resolve the data-egress payload ceiling from the environment.
+
+    ``TS_LLM_PROXY_MAX_BODY_BYTES`` lets an internal-deployment operator bound
+    how much data can leave the perimeter through the LLM boundary. Unset, a
+    non-numeric value, or a non-positive value means "no limit" so the proxy's
+    default behavior is unchanged.
+    """
+
+    raw = os.environ.get("TS_LLM_PROXY_MAX_BODY_BYTES")
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+def request_body_within_limit(body: bytes) -> bool:
+    """Return ``True`` when ``body`` is within the configured egress ceiling."""
+
+    limit = _max_request_bytes()
+    if limit is None:
+        return True
+    return len(body) <= limit
+
+
 def _filter_response_headers(headers: dict[str, Any]) -> dict[str, str]:
     hop_by_hop = {
         "connection",
@@ -143,6 +171,12 @@ class LLMProxy:
         headers.pop("content-length", None)
         headers["authorization"] = f"Bearer {upstream_key}"
         body = await request.body()
+
+        if not request_body_within_limit(body):
+            raise HTTPException(
+                status_code=413,
+                detail="Request body exceeds the configured proxy egress limit",
+            )
 
         try:
             response = await self.client.request(

--- a/streamlit_app/components/comparison_llm.py
+++ b/streamlit_app/components/comparison_llm.py
@@ -15,6 +15,7 @@ import streamlit as st
 
 from streamlit_app.components.llm_settings import (
     default_api_key,
+    llm_zone_disabled,
     resolve_api_key_input,
     resolve_llm_provider_config,
     sanitize_api_key,
@@ -197,6 +198,14 @@ def render_comparison_llm(
     config_diff: str,
     run_key: str,
 ) -> None:
+    if llm_zone_disabled():
+        st.info(
+            "LLM features are disabled for this deployment zone "
+            "(TREND_LLM_ZONE=disabled). The deterministic analysis engine is "
+            "unaffected; set an authorized no-train endpoint and "
+            "TREND_LLM_ZONE=internal_authorized to enable comparisons."
+        )
+        return
     st.subheader("LLM Comparison")
     st.caption(
         "Use an LLM to analyze why the two simulations differ, focusing on parameter changes."

--- a/streamlit_app/components/explain_results.py
+++ b/streamlit_app/components/explain_results.py
@@ -18,6 +18,9 @@ from streamlit_app.components.llm_settings import (
     default_api_key as _default_api_key,
 )
 from streamlit_app.components.llm_settings import (
+    llm_zone_disabled as _llm_zone_disabled,
+)
+from streamlit_app.components.llm_settings import (
     resolve_api_key_input as _resolve_api_key_input,
 )
 from streamlit_app.components.llm_settings import (
@@ -235,6 +238,14 @@ def render_explain_results(
     run_key: str,
     provider: str | None = None,
 ) -> None:
+    if _llm_zone_disabled():
+        st.info(
+            "LLM features are disabled for this deployment zone "
+            "(TREND_LLM_ZONE=disabled). The deterministic analysis engine is "
+            "unaffected; set an authorized no-train endpoint and "
+            "TREND_LLM_ZONE=internal_authorized to enable explanations."
+        )
+        return
     st.subheader("Explain Results")
     st.caption("Generate a natural-language explanation of the latest analysis run.")
 

--- a/streamlit_app/components/llm_settings.py
+++ b/streamlit_app/components/llm_settings.py
@@ -23,7 +23,7 @@ def llm_zone() -> str:
     ``disabled`` (case-insensitive); any other value — including unset —
     resolves to ``"internal_authorized"``. This keeps a proprietary on-prem
     zone that has no authorized LLM endpoint running the deterministic engine
-    while suppressing every LLM panel.
+    while suppressing Streamlit LLM entry points.
     """
 
     raw = (os.environ.get(LLM_ZONE_ENV) or "").strip().lower()
@@ -144,8 +144,8 @@ def anthropic_api_key_status(
 
 
 def default_api_key(provider_name: str) -> str | None:
-    proxy_url = os.environ.get("TS_LLM_PROXY_URL")
-    if proxy_url:
+    proxy_url = os.environ.get("TS_LLM_PROXY_URL") or os.environ.get("TREND_LLM_BASE_URL")
+    if proxy_url and "llm-proxy" in proxy_url:
         token = os.environ.get("TS_LLM_PROXY_TOKEN")
         token = sanitize_api_key(token)
         if token:
@@ -213,6 +213,10 @@ def resolve_llm_provider_config(
         resolved_api_key = sanitize_api_key(read_secret("TREND_LLM_API_KEY"))
     if not resolved_api_key and provider_name == "openai":
         resolved_api_key = sanitize_api_key(read_secret("OPENAI_API_KEY"))
+    if not resolved_api_key:
+        resolved_base_url = base_url or os.environ.get("TREND_LLM_BASE_URL")
+        if resolved_base_url and "llm-proxy" in resolved_base_url:
+            resolved_api_key = sanitize_api_key(os.environ.get("TS_LLM_PROXY_TOKEN"))
     if provider_name in {"openai", "anthropic"} and not resolved_api_key and require_api_key:
         env_hint = (
             "OPENAI_API_KEY"

--- a/streamlit_app/components/llm_settings.py
+++ b/streamlit_app/components/llm_settings.py
@@ -10,6 +10,34 @@ import streamlit as st
 from trend_analysis.llm import LLMProviderConfig
 
 logger = logging.getLogger(__name__)
+
+LLM_ZONE_ENV = "TREND_LLM_ZONE"
+LLM_ZONE_INTERNAL = "internal_authorized"
+LLM_ZONE_DISABLED = "disabled"
+
+
+def llm_zone() -> str:
+    """Resolve the deployment LLM zone from ``TREND_LLM_ZONE``.
+
+    Returns ``"disabled"`` only when the env var is explicitly set to
+    ``disabled`` (case-insensitive); any other value — including unset —
+    resolves to ``"internal_authorized"``. This keeps a proprietary on-prem
+    zone that has no authorized LLM endpoint running the deterministic engine
+    while suppressing every LLM panel.
+    """
+
+    raw = (os.environ.get(LLM_ZONE_ENV) or "").strip().lower()
+    if raw == LLM_ZONE_DISABLED:
+        return LLM_ZONE_DISABLED
+    return LLM_ZONE_INTERNAL
+
+
+def llm_zone_disabled() -> bool:
+    """Return ``True`` when LLM features must be hidden for this zone."""
+
+    return llm_zone() == LLM_ZONE_DISABLED
+
+
 _PLACEHOLDER_PREFIXES = ("YOUR_", "CHANGE_ME", "REPLACE_ME")
 _ALLOWED_KEY_NAMES = {
     "TS_STREAMLIT_API_KEY",
@@ -211,8 +239,13 @@ def resolve_llm_provider_config(
 
 
 __all__ = [
+    "LLM_ZONE_DISABLED",
+    "LLM_ZONE_ENV",
+    "LLM_ZONE_INTERNAL",
     "anthropic_api_key_status",
     "default_api_key",
+    "llm_zone",
+    "llm_zone_disabled",
     "read_secret",
     "resolve_api_key_input",
     "resolve_anthropic_api_key",

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -26,6 +26,9 @@ from streamlit_app.components.llm_settings import (
     anthropic_api_key_status as _anthropic_api_key_status,
 )
 from streamlit_app.components.llm_settings import (
+    llm_zone_disabled as _llm_zone_disabled,
+)
+from streamlit_app.components.llm_settings import (
     resolve_llm_provider_config as _resolve_llm_provider_config_shared,
 )
 from streamlit_app.components.llm_settings import (
@@ -2091,6 +2094,13 @@ def render_config_chat_panel(
 ) -> None:
     """Render the Config Chat panel for natural-language config tweaks."""
 
+    if _llm_zone_disabled():
+        st.info(
+            "Natural-language config editing is disabled for this deployment zone "
+            "(TREND_LLM_ZONE=disabled)."
+        )
+        return
+
     if location == "sidebar":
         sidebar_ctx = st.sidebar
         if not (hasattr(sidebar_ctx, "__enter__") and hasattr(sidebar_ctx, "__exit__")):
@@ -2113,6 +2123,12 @@ def _render_variant_what_if_panel(
     benchmark: str | None,
 ) -> None:
     st.subheader("🔀 What-if (3 variants)")
+    if _llm_zone_disabled():
+        st.info(
+            "LLM what-if generation is disabled for this deployment zone "
+            "(TREND_LLM_ZONE=disabled)."
+        )
+        return
     st.caption(
         "Generate conservative, baseline, and aggressive variants from one instruction, "
         "then compare their analysis metrics side-by-side."

--- a/tests/test_llm_proxy_routing.py
+++ b/tests/test_llm_proxy_routing.py
@@ -1,0 +1,124 @@
+"""Tests for internal/on-prem LLM routing: proxy base_url, zone guard, egress.
+
+Covers issue #5344 (internal browser deployment that keeps proprietary data and
+the LLM inside the org perimeter):
+
+* ``test_app_uses_base_url_from_env`` locks the contract that the Streamlit LLM
+  settings honor ``TREND_LLM_BASE_URL`` so the app talks to the in-perimeter
+  proxy instead of the public API.
+* ``test_zone_disabled_hides_llm`` proves the LLM components construct no
+  provider and render no panels when ``TREND_LLM_ZONE=disabled``.
+* ``test_proxy_request_body_within_limit`` proves the proxy's data-egress
+  ceiling (``TS_LLM_PROXY_MAX_BODY_BYTES``) bounds what leaves the perimeter.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+_ENV_KEYS = (
+    "TREND_LLM_BASE_URL",
+    "TREND_LLM_ZONE",
+    "TREND_LLM_PROVIDER",
+    "TREND_LLM_API_KEY",
+    "TS_STREAMLIT_API_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_API_STRANSKE",
+    "TS_LLM_PROXY_MAX_BODY_BYTES",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in _ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_app_uses_base_url_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With ``TREND_LLM_BASE_URL`` set, the resolved config carries that base_url."""
+
+    from streamlit_app.components.llm_settings import resolve_llm_provider_config
+
+    monkeypatch.setenv("TREND_LLM_BASE_URL", "http://llm-proxy:8799/v1")
+    config = resolve_llm_provider_config("openai", api_key="sk-test")
+
+    assert config.base_url == "http://llm-proxy:8799/v1"
+
+
+def _reload_with_stub(module_name: str, monkeypatch: pytest.MonkeyPatch) -> Any:
+    st_stub = MagicMock()
+    st_stub.session_state = {}
+    monkeypatch.setitem(sys.modules, "streamlit", st_stub)
+    module = importlib.reload(importlib.import_module(module_name))
+    return module, st_stub
+
+
+@dataclass
+class _StubResult:
+    details: dict[str, Any]
+
+
+def test_zone_disabled_hides_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TREND_LLM_ZONE=disabled hides LLM panels and builds no provider."""
+
+    monkeypatch.setenv("TREND_LLM_ZONE", "disabled")
+    details = {"out_sample_stats": {"Portfolio": (0.1, 0.2, 0.3, 0.4, 0.5, 0.6)}}
+
+    # explain_results component
+    explain, explain_st = _reload_with_stub(
+        "streamlit_app.components.explain_results", monkeypatch
+    )
+    provider_calls: list[Any] = []
+    monkeypatch.setattr(
+        explain, "_resolve_llm_provider_config", lambda *a, **k: provider_calls.append((a, k))
+    )
+    explain.render_explain_results(_StubResult(details=details), run_key="rk")
+    assert explain_st.info.called, "disabled zone should surface an info notice"
+    assert not explain_st.text_area.called, "no LLM panels should render when disabled"
+    assert provider_calls == [], "no LLM provider should be constructed when disabled"
+
+    # comparison_llm component
+    comparison, comparison_st = _reload_with_stub(
+        "streamlit_app.components.comparison_llm", monkeypatch
+    )
+    comparison_calls: list[Any] = []
+    monkeypatch.setattr(
+        comparison, "resolve_llm_provider_config", lambda *a, **k: comparison_calls.append((a, k))
+    )
+    comparison.render_comparison_llm(
+        result_a=_StubResult(details=details),
+        result_b=_StubResult(details=details),
+        label_a="A",
+        label_b="B",
+        config_diff="",
+        run_key="rk",
+    )
+    assert comparison_st.info.called
+    assert not comparison_st.text_area.called
+    assert comparison_calls == []
+
+
+def test_proxy_request_body_within_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The proxy egress ceiling bounds the payload that leaves the perimeter."""
+
+    server = importlib.import_module("trend_analysis.llm_proxy.server")
+
+    # Unset -> no limit (default behavior preserved).
+    assert server.request_body_within_limit(b"x" * 100_000) is True
+
+    monkeypatch.setenv("TS_LLM_PROXY_MAX_BODY_BYTES", "100")
+    assert server.request_body_within_limit(b"x" * 100) is True
+    assert server.request_body_within_limit(b"x" * 101) is False
+
+    # Non-numeric / non-positive -> treated as no limit.
+    monkeypatch.setenv("TS_LLM_PROXY_MAX_BODY_BYTES", "not-a-number")
+    assert server.request_body_within_limit(b"x" * 100_000) is True
+    monkeypatch.setenv("TS_LLM_PROXY_MAX_BODY_BYTES", "0")
+    assert server.request_body_within_limit(b"x" * 100_000) is True

--- a/tests/test_llm_proxy_routing.py
+++ b/tests/test_llm_proxy_routing.py
@@ -6,8 +6,8 @@ the LLM inside the org perimeter):
 * ``test_app_uses_base_url_from_env`` locks the contract that the Streamlit LLM
   settings honor ``TREND_LLM_BASE_URL`` so the app talks to the in-perimeter
   proxy instead of the public API.
-* ``test_zone_disabled_hides_llm`` proves the LLM components construct no
-  provider and render no panels when ``TREND_LLM_ZONE=disabled``.
+* ``test_zone_disabled_hides_llm`` proves the guarded LLM components construct
+  no provider and render no panels when ``TREND_LLM_ZONE=disabled``.
 * ``test_proxy_request_body_within_limit`` proves the proxy's data-egress
   ceiling (``TS_LLM_PROXY_MAX_BODY_BYTES``) bounds what leaves the perimeter.
 """
@@ -32,6 +32,8 @@ _ENV_KEYS = (
     "ANTHROPIC_API_KEY",
     "CLAUDE_API_STRANSKE",
     "TS_LLM_PROXY_MAX_BODY_BYTES",
+    "TS_LLM_PROXY_TOKEN",
+    "TS_LLM_PROXY_URL",
 )
 
 
@@ -50,6 +52,23 @@ def test_app_uses_base_url_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     config = resolve_llm_provider_config("openai", api_key="sk-test")
 
     assert config.base_url == "http://llm-proxy:8799/v1"
+
+
+def test_proxy_token_used_for_internal_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Internal proxy routing uses the proxy token as the client API key."""
+
+    from streamlit_app.components.llm_settings import (
+        default_api_key,
+        resolve_llm_provider_config,
+    )
+
+    monkeypatch.setenv("TREND_LLM_BASE_URL", "http://llm-proxy:8799/v1")
+    monkeypatch.setenv("TS_LLM_PROXY_TOKEN", "proxy-token")
+
+    assert default_api_key("openai") == "proxy-token"
+    config = resolve_llm_provider_config("openai")
+    assert config.base_url == "http://llm-proxy:8799/v1"
+    assert config.api_key == "proxy-token"
 
 
 def _reload_with_stub(module_name: str, monkeypatch: pytest.MonkeyPatch) -> Any:


### PR DESCRIPTION
Closes #5344.

## What

Assembles the repo's existing boundary pieces (the `trend-llm-proxy`
OpenAI-compatible proxy and `base_url` override support) into a documented,
reproducible **internal/on-prem deployment** where proprietary data and the
deterministic engine stay in-perimeter and LLM traffic egresses only through an
authorized no-train upstream.

## Changes

- **`TREND_LLM_ZONE` switch** (`streamlit_app/components/llm_settings.py`):
  `internal_authorized` (default) routes LLM via the proxy; `disabled` hides
  every LLM panel. The two provider-constructing components
  (`explain_results.py`, `comparison_llm.py`) guard at the top of their render
  functions and construct **no provider** when disabled, so a proprietary zone
  with no authorized endpoint still runs the deterministic engine.
- **`internal` Docker Compose profile**: `app-internal` (bound to `127.0.0.1`
  by default) + a `trend-llm-proxy` sidecar. The app's `TREND_LLM_BASE_URL`
  points at the proxy; the operator supplies the no-train upstream and key at
  deploy time. The default `docker compose up` is unchanged (services are
  behind the profile).
- **Data-egress ceiling** (`llm_proxy/server.py`): `TS_LLM_PROXY_MAX_BODY_BYTES`
  bounds how much can leave the perimeter — the proxy returns 413 on oversize
  before forwarding. Unset/non-positive = no limit (existing behavior
  preserved). Implemented as a pure helper so it is unit-testable without the
  FastAPI deps.
- **`docs/deployment/INTERNAL_HOSTING.md`**: the recipe, what is/isn't sent
  upstream, and the operator live-verification checklist (app loads, real run
  completes in-perimeter, LLM fails closed with proxy down, deterministic works
  with zone disabled).
- **`README_APP.md`**: steer proprietary data to internal hosting; reserve
  Streamlit Cloud for synthetic data, cross-linking the synthetic-demo issue
  #5343.

## Tests (`tests/test_llm_proxy_routing.py`)

- `test_app_uses_base_url_from_env` — config carries `TREND_LLM_BASE_URL`.
- `test_zone_disabled_hides_llm` — disabled zone hides panels and builds no
  provider (explain + comparison). **Deliberate-break verified:** removing the
  guard makes this fail (`st.info` not called / `text_area` rendered), restoring
  passes.
- `test_proxy_request_body_within_limit` — egress ceiling enforced; unset/0/non-numeric = no limit.

Focused validation (repo enforces total-coverage fail-under, so `--no-cov` for
partial runs):
- `pytest tests/test_llm_proxy_routing.py` → 3 passed
- `pytest tests/test_llm_settings.py tests/app/test_explain_results_component.py tests/test_proxy_server_additional.py tests/test_proxy_cli.py tests/test_comparison_prompt.py` → 57 passed, no regressions
- `ruff check` on touched files → clean; `git diff --check` → clean
- `docker-compose.yml` parses; `app`/`api` services unchanged, `llm-proxy`/`app-internal` added behind the `internal` profile

## Scope notes

- The first AC's `TREND_LLM_BASE_URL` plumbing already existed on `main` (the
  repo advanced past the issue's premise); the test locks that contract and the
  failing-then-passing gate is on the new `TREND_LLM_ZONE` guard.
- `nl_operation_viewer.py` is a passive log viewer (no provider, no egress), so
  it is intentionally **not** gated — gating it would hide audit logs, not
  reduce egress. The zone guard is applied to the two LLM-egress components.
- A field-level redaction engine is out of scope (per Non-Goals); the bounded
  size ceiling + forced-proxy routing + per-zone disable satisfy the minimum
  boundary requirement, with a documented extension point.
