### PR TITLE
baseline-kit: add no-emit-package (canonical Pattern A, prevent auto-lock URL conflict)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,15 @@
 requires = ["setuptools==82.0.1", "wheel==0.47.0"]
 build-backend = "setuptools.build_meta"
 
+# Do not emit app-baseline-kit into requirements.lock. It is consumed from the
+# Workflows monorepo via an unpinned `@main` git URL (see the dev optional
+# dependencies), so freezing a commit SHA in the lock conflicts with that URL
+# the moment Workflows main advances ("conflicting URLs for package
+# app-baseline-kit" -> uv install aborts). Leaving it unpinned lets the editable
+# project install resolve it from main, with no lock to keep refreshed.
+[tool.uv.pip]
+no-emit-package = ["app-baseline-kit"]
+
 [project]
 name = "trend-model"
 version = "0.1.0"

--- a/requirements.lock
+++ b/requirements.lock
@@ -387,11 +387,16 @@ pyparsing==3.3.2
 pytest==9.0.3
     # via
     #   trend-model (pyproject.toml)
+    #   app-baseline-kit
     #   pytest-cov
+    #   pytest-datadir
+    #   pytest-regressions
     #   pytest-rerunfailures
     #   pytest-xdist
 pytest-cov==7.1.0
     # via trend-model (pyproject.toml)
+pytest-datadir==1.8.0
+    # via pytest-regressions
 pytest-regressions==2.11.0
     # via
     #   trend-model (pyproject.toml)
@@ -417,10 +422,12 @@ pytokens==0.4.1
 pyyaml==6.0.3
     # via
     #   trend-model (pyproject.toml)
+    #   app-baseline-kit
     #   langchain-classic
     #   langchain-community
     #   langchain-core
     #   pre-commit
+    #   pytest-regressions
     #   uvicorn
 referencing==0.37.0
     # via
@@ -568,3 +575,6 @@ yarl==1.23.0
     # via aiohttp
 zstandard==0.25.0
     # via langsmith
+
+# The following packages were excluded from the output:
+# app-baseline-kit


### PR DESCRIPTION
## What

Makes TMP's `app-baseline-kit` dependency fully canonical **Pattern A** by adding a `[tool.uv.pip]` table with `no-emit-package = ["app-baseline-kit"]`.

## Why

`app-baseline-kit` is consumed from the Workflows monorepo via an **unpinned `@main` git URL** in the `dev` optional dependencies:

```
app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit
```

The `dependabot-auto-lock.yml` workflow can regenerate `requirements.lock` and would otherwise freeze a SHA-pinned URL (`app-baseline-kit @ git+...@<sha>`) for this package. The moment Workflows `main` advances past that SHA, `uv pip install` aborts with the "conflicting URLs for package app-baseline-kit" failure class. `no-emit-package` keeps the package out of the lock entirely (resolved instead by the editable project install at install time), eliminating the conflict surface. This mirrors Counter_Risk's canonical pattern.

This is **preventive** — there is no conflict in the current lock today (it carries only `# via app-baseline-kit` comments, no requirement line).

## Changes

- `pyproject.toml`: new `[tool.uv.pip]` table with `no-emit-package = ["app-baseline-kit"]` plus an explanatory comment (mirrors Counter_Risk's comment style), placed right after `[build-system]`.
- `requirements.lock`: regenerated with the documented command:
  ```
  uv pip compile pyproject.toml --extra app --extra llm --extra notebooks --extra dev --universal --output-file requirements.lock
  ```
  Diff is minimal — adds the `# The following packages were excluded from the output:` / `# app-baseline-kit` footer, a few `# via app-baseline-kit` / `# via pytest-regressions` comment lines, and the transitive `pytest-datadir==1.8.0` (a `pytest-regressions` dep). **No existing pins churned**, and **no `app-baseline-kit @ git+...@<sha>` requirement line** is emitted.

## Verification

- Cold resolve in a fresh venv: `uv venv .venv-x && uv pip install --python .venv-x -e ".[dev]"` succeeded with **no "conflicting URLs" error**; `app-baseline-kit==0.2.0` installed (from git@main) and `import baseline_kit` works.
- `pytest tests/test_dependency_version_alignment.py -q` → **1 passed** (it skips direct references, so it remains green).
- `PYTHONHASHSEED=0 pytest tests/baseline -n0 -q` → **43 passed, 5 skipped** (skips are pre-existing report-only/finding markers, not failures).
- `ruff check` / `ruff format --check` on changed files clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)