### PR TITLE
docs: add 2026-06 repo audit artifacts

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -1,0 +1,307 @@
+# Trend Model Project — Whole-Repo Audit
+
+**Status:** COMPLETE — all 7 items + executive summary written and cross-reconciled.
+**Date:** 2026-06-01/02 · **Branch:** phase-3 · **Auditor:** Claude (Opus 4.8)
+
+**Scope:** Core application — `src/trend_analysis/`, `streamlit_app/`, the `trend` CLI, `config/` — plus supporting `scripts/`, `tools/`, `notebooks/`, `demo/`. Excludes `agents/`, `archives/`, `retired/`, and `.github` automation (owned upstream by `stranske/Workflows`).
+
+**Method:** Independent pass (the pre-existing `review-suggested-issues.md` was deliberately *not* used as input). Findings are produced by fan-out agents reading the code with `file:line` evidence, then adversarially verified before inclusion. Severity: **P0** = wrong numbers / correctness · **P1** = misleading or partial · **P2** = hygiene · **info** = note.
+
+---
+
+## Executive summary
+
+The Trend Model Project is a genuinely **differentiated, well-conceived tool**: an integrated, reproducible, allocator-facing *manager-of-managers* pipeline (score → select top-N → weight → vol-target → multi-period walk-forward → regime overlay → reports) that **no single public tool matches end-to-end on manager return series** (§5). Its core financial arithmetic — metrics, volatility scaling, turnover caps, multi-period turnover-cost — is **correctly wired and economically sensible** (§3).
+
+The dominant weakness is **not the math but the configuration contract.** Across the parameter surface:
+
+- **~19 documented config keys are inert no-ops** — declared in `defaults.yml`/schema but never read by the engine (e.g. `metrics.use_continuous`, the whole `metrics.bootstrap_ci.*` and `export.excel.*` blocks, `run.{n_jobs,log_level,cache_dir,deterministic}`, `preprocessing.steps`). Setting them does nothing, silently (§3.3).
+- **A weighting config key silently degrades to equal-weight (YAML/CLI only).** `portfolio.weighting.name` recognizes only `equal`/Bayesian variants; `risk_parity`/`hrp` require a *different* key (`portfolio.weighting_scheme`), and unsupported values fall through to `EqualWeight()` with no error. The shipped `demo.yml` models weighting through exactly the limited key. The **Streamlit GUI is unaffected** (it writes the correct key, §4), but the config-file/CLI path the README leads with is. The advertised "score-proportional" method also appears unreachable from config (§3.6).
+- **`data.frequency` silently coerces everything to monthly** (√12 annualisation regardless of input), **`data.date_column` is ignored on the main load path**, **`data.missing_fill_limit` is a dead alias** shadowing the real key, and **`portfolio.cost_model.*` is dead** on the main pipeline (§3.2, §3.6).
+
+**None of these fail loudly** — the highest-leverage single fix is to make the config *honest*: switch the Pydantic models to `extra="forbid"` (or add a declared-vs-consumed key lint) and unify the duplicated weighting/cost/selection keys behind one validated schema that rejects unsupported values.
+
+**Versus the landscape (§5):** strengths are integration, a real manager-ranking front end, a first-class vol-target step, a turnkey regime overlay, a genuine walk-forward engine, bootstrap robustness, and auditability. Gaps vs. mature tools: general convex-constraint optimization (Riskfolio-Lib/PyPortfolioOpt/skfolio), daily-cadence/order-level backtesting (LEAN/vectorbt/cvxportfolio), non-linear cost modeling (cvxportfolio), factor attribution (Venn/Morningstar), cross-validated tuning (skfolio), and a data universe (the SaaS peers).
+
+**Before presenting to colleagues (§7.2),** the questions that will land first are about *statistical credibility*, not features: selection bias / data-snooping when ranking top-N by Sharpe (deflated Sharpe? holdout?), survivorship & backfill bias in the manager universe, look-ahead in selection/regime fitting, gross-vs-net of fees, and whether out-of-sample gains clear the bootstrap bands over an honest baseline (1/N, equal-weight top-N, SG Trend Index).
+
+**Top recommended actions, in order:** (1) make the config honest (`extra="forbid"` + key lint) and unify weighting/cost/selection keys; (2) fix or hard-reject non-monthly `data.frequency` and the `data.date_column` main-path gap; (3) add the statistical-rigor layer (deflated Sharpe / multiple-testing / OOS significance) — the single biggest credibility upgrade; (4) consolidate the parallel implementations flagged in §1–§2 below.
+
+> Items 1 (quality), 2 (duplication), and 4 (UX) are summarized in §1–§4 below; per the agreed priority they were the lower-priority pass.
+
+---
+
+## 1. Code quality
+
+Overall the core is **competently engineered** — typed, configurable, tested, with sensible module boundaries. The issues below are concentrated in a few oversized modules and in error-handling/test-rigor habits. Findings were adversarially verified where flagged P0/P1.
+
+| Finding | Sev | Evidence | Note |
+|---|---|---|---|
+| **Six CI/autofix *test fixtures* ship inside the production package** | P2 *(verified, ↓ from P1)* | [`_autofix_probe.py`](src/trend_analysis/_autofix_probe.py), `_autofix_violation_case2/3.py`, [`_ci_probe_faults.py`](src/trend_analysis/_ci_probe_faults.py), `automation_multifailure.py`; `pyproject.toml:67` includes `trend_analysis*` with no offsetting exclude | They are self-described autofix fixtures ("not used by production code") yet ship in the wheel as importable `trend_analysis._autofix_*`. `_ci_probe_faults.py` even does runtime work as an import side-effect. **Move to `tests/` fixtures.** |
+| **`engine.run()` is a single ~3,150-line function, ~10 levels of nesting** | **P1 *(verified)*** | [multi_period/engine.py:736](src/trend_analysis/multi_period/engine.py:736) (runs to 3886) | The highest-risk maintainability hotspot in the core. A comment at line 3882 ("was incorrectly outside loop causing only last period kept") records a prior correctness bug *caused by* this structure. Extract per-period setup / weighting / cost / result-assembly stages. |
+| **`cli.main()` ~390-line dispatcher; `_handle_mc_command` ~230 lines; 20+ broad `except Exception`** | P2 | [cli.py:895](src/trend_analysis/cli.py:895), cli.py:1962 | Split per-subcommand handlers so `main()` only parses+dispatches. |
+| **~40 silent `except: …: pass` / swallow blocks** in `src/trend_analysis` | P2 | [monte_carlo/runner.py:1673](src/trend_analysis/monte_carlo/runner.py:1673), runner.py:1770, cli.py:366 | Broad catches in numeric paths mask real defects (e.g. `AttributeError`). Narrow the types and log at debug. |
+| **`_apply_weight_bounds` can return weights not summing to 1.0**; mixes a magic `1e-9` with the named tolerance | P2 | [multi_period/engine.py:342](src/trend_analysis/multi_period/engine.py:342) | If all donors/receivers are saturated, residual is silently left; no warn. Mildly *economic* (weights should sum to 1). |
+| **Module-global mutable cache counters** (`_SELECTOR_CACHE_HITS/MISSES`) | P2 | [core/rank_selection.py:339](src/trend_analysis/core/rank_selection.py:339) | Test-pollution / thread-safety hazard; derive from `_WINDOW_METRIC_CACHE.stats()` instead. |
+| **`_compute_score_frame` swallows config errors → empty frame, silently** | info *(verified ↓ from P2)* | [monte_carlo/runner.py:1196](src/trend_analysis/monte_carlo/runner.py:1196) | At least log the exception before returning empty. |
+| **Tests assert keys exist, not numeric values** | P2 | [tests/backtesting/test_harness.py:133](tests/backtesting/test_harness.py:133), [tests/smoke/test_pipeline_smoke.py:30](tests/smoke/test_pipeline_smoke.py:30) | **This is *why* the §3 wiring issues and divergent metric formulas go unnoticed** — value-level assertions on deterministic fixtures would catch regressions. The single most valuable test-quality upgrade. |
+
+## 2. Duplicative / repetitive code
+
+The codebase has accumulated several **parallel implementations of the same concept**. The dedup agent verified which are genuine redundancy vs. justified separation.
+
+**Genuine consolidation targets (highest value first):**
+
+1. **`backtesting/harness.py` is a second, parallel backtest engine** — high effort, high value. It reimplements `CostModel` ([harness.py:31](src/trend_analysis/backtesting/harness.py:31)), `_rebalance_calendar` (harness.py:533), `_normalise_frequency`/`_infer_periods_per_year` (harness.py:540/555), and its own metrics — **with formulas that diverge from the main pipeline.** This is the structural root of the kind of metric inconsistency that's easy to ship (two code paths computing "the same" Sharpe/Sortino/cost differently). Decide whether the harness is still needed; if so, have it call the main `metrics/`, `cost`, and calendar primitives rather than its own.
+2. **Transaction-cost logic fanned across ≥5 implementations** — medium. `CostModel.apply` (harness), [metrics/turnover.py:39](src/trend_analysis/metrics/turnover.py:39) `turnover_cost`, [rebalancing/strategies.py:199](src/trend_analysis/rebalancing/strategies.py:199) `_calculate_cost`, [monte_carlo/costs.py:172](src/trend_analysis/monte_carlo/costs.py:172), and the inline `period_cost` in the engine. Define the linear turnover-cost primitive **once** and call it everywhere. (Corroborates the §3.6 cost-fragmentation finding.)
+3. **Two parallel weighting config keys** — medium. `portfolio.weighting.name` resolver ([engine.py:1603](src/trend_analysis/multi_period/engine.py:1603)) vs `portfolio.weighting_scheme` resolver (engine.py:1625), chosen between in `_compute_weights`. Unify under one user-facing key whose value space spans *both* the score-based schemes and the risk-based engine names. (See §3.6.)
+4. **`run_analysis.py` vs `run_multi_analysis.py`** share a CLI/export skeleton — medium. Extract the shared argparser/logging/config-load/out-dir boilerplate into one helper. (`pipeline_entrypoints.py` is correctly centralized — leave it.)
+5. **Three parallelism keys** — low. `run.jobs` (live), top-level `jobs` (legacy alias), `run.n_jobs` (**dead**). Keep `run.jobs` canonical, treat `jobs` as a documented deprecated alias resolved in one place, delete `run.n_jobs`.
+
+**Verified *not* duplication (don't merge):**
+
+- **`config/model.py` vs `config/models.py`** — *justified layer separation* (strict Pydantic validator vs. runtime-dict `Config` factory with a fallback-import contract). Verifier downgraded to **info**; the only cleanup is clearer naming to stop the two from being mistaken for each other. *(This corrects an earlier impression in §3.6.)*
+- **`rebalancing.py` (module) vs `rebalancing/` (package)** — an intentional back-compat shim. The actionable item is that the package shadows the module on disk, so `rebalancing.py` is almost certainly **dead** and can be removed.
+
+## 3. Functional & economic correctness — parameter wiring
+
+**Method.** Every user-facing config parameter was inventoried (definition site + every consumption site found via ripgrep), then judged on two axes — *wiring* (does changing it actually change results?) and *economic sensibility* (does the output move in the direction/magnitude a knowledgeable PM would expect?). High-impact findings were then handed to an independent agent told to **refute** them; only findings that survived (or were severity-corrected) are reported. The `portfolio.*` domain (selection/weighting/costs) is being re-run after a stall and will be folded in below.
+
+### 3.1 Scorecard (data / preprocessing / vol_adjust / sample_split / regime / benchmarks / metrics / export / run)
+
+| Domain | Params mapped | Confirmed correct | Dead / not-wired | Economic / wiring concern |
+|---|---|---|---|---|
+| data·preprocessing·vol_adjust·sample_split | 16 | 10 | 2 | 5 |
+| regime·benchmarks·metrics·export·run | 41 | ~17 | ~17 | 7 |
+| portfolio (selection·weighting·costs·rebalance) | ~14 | ~6 | ~2 (`cost_model.*`) | 4 (weighting bifurcation, cost path, single-period costs) |
+
+The single biggest theme: **a large fraction of the advertised config surface is inert.** ~19 documented keys (in `config/defaults.yml`, `demo.yml`, or the generated JSON schema) are *never read by any engine code*. A user who sets them gets silent no-ops. This is the most important correctness/UX risk in the parameter layer — the config file advertises capabilities the engine does not have.
+
+### 3.2 Headline findings (P1, survived adversarial verification)
+
+- **`data.frequency` silently coerces everything to monthly** — *P1, confirmed.* `frequency: D` or `W` only changes an intermediate calendar-alignment cadence; `_prepare_input_data` then unconditionally resamples to month-end (`ME`), and `periods_per_year` is hardcoded to 12 on both the single-period and multi-period paths. So a PM choosing daily expecting √252 annualisation and daily-cadence trend/vol windows actually gets monthly bars with √12 — windows like `window=63` silently change economic meaning. Evidence: [preprocessing.py:450](src/trend_analysis/stages/preprocessing.py:450), [util/frequency.py:110](src/trend_analysis/util/frequency.py:110), [multi_period/engine.py:1230](src/trend_analysis/multi_period/engine.py:1230). **Fix options:** either honor non-monthly cadence end-to-end, or reject non-`M` frequency at validation with a clear message.
+- **`data.date_column` is ignored on the main load path** — *P1, confirmed.* It is honored in walk-forward / Monte-Carlo / validation, but the primary single- and multi-period CSV loader (`load_csv`) has no `date_column` parameter and demands a column literally named `Date`. A user with a `Timestamp` column who correctly sets `data.date_column: Timestamp` passes config validation, then fails at load with a confusing "Missing a Date column." Evidence: [data.py:383](src/trend_analysis/data.py:383), [data.py:26](src/trend_analysis/data.py:26), [run_analysis.py:66](src/trend_analysis/run_analysis.py:66) vs. the working [walk_forward.py:125](src/trend_analysis/walk_forward.py:125).
+- **`data.missing_fill_limit` is a dead alias that shadows the real key** — *P1, confirmed.* It is in the schema description ("Maximum consecutive periods to forward-fill") and in `demo.yml`, but `DataSettings` has no such field (`extra='ignore'` drops it) — the live key is `data.missing_limit`. Copy-paste demo users who tune `missing_fill_limit` get nothing. Evidence: [schema_generator.py:106](src/trend_analysis/config/schema_generator.py:106), [model.py:195](src/trend_analysis/config/model.py:195), [model.py:199](src/trend_analysis/config/model.py:199).
+- **`portfolio.weighting.name` silently degrades to equal-weight for YAML/CLI runs** — *P1 (see §3.6).* This config key recognizes only `equal` and Bayesian variants; `risk_parity`/`hrp` require the *separate* `portfolio.weighting_scheme` key, and unsupported values fall through to `EqualWeight()` with no error. The shipped `demo.yml` models weighting through exactly this limited key. **The Streamlit GUI is unaffected** — it writes the correct `weighting_scheme` key (verified in §4).
+
+### 3.3 Inert / dead config keys (silent no-ops)
+
+These are declared in config/schema but have **zero consumers** in the engine. Each is a UX trap (the app implies a capability it lacks). Verified examples (`run.n_jobs` and `metrics.use_continuous` were independently confirmed dead, severity-corrected to P2):
+
+| Key | Notes |
+|---|---|
+| `metrics.use_continuous` | geometric-vs-log return toggle — no consumer ([defaults.yml:153](config/defaults.yml:153)) |
+| `metrics.alpha_reference` | alpha/beta benchmark ticker — no consumer |
+| `metrics.compute` | a *second* metric list (Title_Case) that is dead; only `metrics.registry` is live, and the two disagree |
+| `metrics.bootstrap_ci.{enabled,n_iter,ci_level}` | CI is actually driven by `portfolio.ci_level`; this block is inert |
+| `export.excel.{autofit_columns,number_format,conditional_bands.*}` | declared but `export_to_excel` never reads them |
+| `export.{include_raw_returns,include_vol_adj,include_figures}` | inclusion not gated on these |
+| `run.{log_level,log_file}` | logging always uses `INFO` and a generated path |
+| `run.n_jobs` | dead; **duplicates** the live top-level `jobs` / `run.jobs` |
+| `run.cache_dir` | cache dir comes from `$TREND_ROLLING_CACHE` / `~/.cache`, not this |
+| `run.deterministic` | determinism is unconditional via `seed`; the toggle does nothing |
+| `preprocessing.steps` | implies a configurable pipeline; sequence is hardcoded |
+
+**Recommended fix pattern:** switch the relevant Pydantic models from `extra='ignore'` to `extra='forbid'` (or add a config-lint pass that diffs declared keys against a registry of consumed keys) so unknown/inert keys fail loudly instead of silently. This single change would have caught most of the above.
+
+### 3.4 Economic-direction & consistency concerns (P2)
+
+- **`vol_adjust.target_vol` leverage is invisible in the weights** — returns are scaled correctly (higher target_vol → higher realised vol/return, the right direction), but the *weights* are renormalised to sum to 1 ([risk.py:291](src/trend_analysis/risk.py:291)), so a PM inspecting the holdings table sees an identical inverse-vol tilt for `target_vol=0.05` and `0.50`. Leverage > 100% gross is never surfaced as exposure. Presentation hazard, not a numeric error.
+- **`regime.threshold=0.0` is degenerate in volatility mode** — `signal = threshold − vol` with non-negative vol means ~every period is classified Risk-Off under shipped defaults; the volatility regime method only works if the user sets a positive vol target, and nothing validates this. Evidence: [regimes.py:213](src/trend_analysis/regimes.py:213). (Verifier corrected to P2 since the default `method` is `rolling_return`, not `volatility`.)
+- **`regime.annualise_volatility`** silently rescales the regime decision boundary by √ppy without rescaling `threshold` — flipping it changes the entire Risk-On/Risk-Off split for a fixed threshold.
+- **`regime.min_observations` default mismatch** — code defaults to 6, `defaults.yml` ships 4 ([regimes.py:83](src/trend_analysis/regimes.py:83) vs [defaults.yml:139](config/defaults.yml:139)).
+- **`metrics.rf_rate_annual` is ignored for ranking** unless `rf_override_enabled=true`; with shipped defaults, fund-selection Sharpe uses rf=0 even though `rf_rate_annual: 0.02` is configured — can subtly change *which funds are selected* vs. user expectation. Evidence: [api.py:462](src/trend_analysis/api.py:462).
+- **`data.frequency` rf de-annualisation mismatch** (*P2, confirmed*) — when `rf_override_enabled` and frequency is non-monthly, the periodic rf is computed with 52/252 but subtracted from the monthly return series, understating the rf deduction (overstating Sharpe). [api.py:467](src/trend_analysis/api.py:467).
+- **`run.monthly_cost` is an undocumented, material cost lever** — widely consumed (subtracted flat from every per-period return: [portfolio.py:571](src/trend_analysis/stages/portfolio.py:571)) but absent from `defaults.yml`. Direction is sensible (higher → lower net return) but it is a flat fee unrelated to turnover/exposure, and being undocumented it hides a meaningful knob.
+- **`sample_split.in_end` boundary convention mismatch** — the ordering validator parses `'2022-12'` as month-*start*; the window slicer resolves it to month-*end* with an inclusive mask. Safe for distinct adjacent months but fragile (two conventions for one field).
+- **Parallelism config is fragmented** across `jobs` (top-level, live), `run.jobs` (live only on the Monte-Carlo CLI path), and `run.n_jobs` (dead) — should be one coherent knob.
+
+### 3.5 What is correctly wired (positive notes)
+
+`vol_adjust.{enabled,target_vol}` return-scaling, `data.{missing_policy,missing_limit,risk_free_column,allow_risk_free_fallback,csv_path}`, `preprocessing.missing_data.{policy,limit}`, `sample_split.in_start`, `regime.{enabled,risk_off_target_vol_multiplier,risk_off_fund_count_multiplier}`, `benchmarks`, `metrics.{registry,rf_override_enabled}`, `export.{directory,formats,disable_narrative_generation}`, and `run.seed` were all confirmed correctly wired with sensible economic behavior.
+
+### 3.6 Portfolio domain (selection / weighting / costs / rebalancing)
+
+_(Audited directly after two workflow attempts on this slice failed — once a stall, once a structured-output miss — so further speculative agent spend wasn't warranted.)_
+
+**Headline — the weighting parameter is the most confusingly-wired knob in the app.** Weighting is controlled by **two different config keys with two different resolvers and two different vocabularies**:
+
+1. `portfolio.weighting.name` (the dict form used in `demo.yml`) is resolved at [multi_period/engine.py:1608](src/trend_analysis/multi_period/engine.py:1608). It recognizes **only** `equal`/`ew`, the Bayesian variants (`score_prop_bayes`/`bayes`/`score_bayes`, `adaptive_bayes`/`adaptive`) — and **everything else silently falls through to `EqualWeight()`** ([engine.py:1622](src/trend_analysis/multi_period/engine.py:1622)).
+2. `portfolio.weighting_scheme` (a separate string key) is resolved at [engine.py:1627](src/trend_analysis/multi_period/engine.py:1627) and handles the risk-based engines: `risk_parity`, `hrp`, `erc`, `robust_mv`, `robust_risk_parity`. A code comment states it *"overrides the legacy `portfolio.weighting` dict config."*
+
+**Scope of the impact (reconciled with the §4 UI review).** The Streamlit GUI is **not** affected: it writes the method to `portfolio.weighting_scheme`, which both engines read correctly. The trap bites **YAML/CLI users** who configure weighting through the dict form the demo models. So this is a config-file footgun, not a broken GUI — important for severity, but still serious for the scripted/CLI workflow the README leads with.
+
+Consequences (P1 for YAML/CLI users; GUI unaffected):
+
+- **`portfolio.weighting.name: risk_parity` silently produces equal weight** (for a config-file/CLI run). To actually get risk parity you must set the *other* key, `portfolio.weighting_scheme: risk_parity`. The shipped `demo.yml` only sets `portfolio.weighting: {name: equal}` — so the natural place a config-file user would change the method is the one that doesn't work for risk-based schemes, and it fails silently rather than erroring.
+- **The advertised "score-proportional" method appears unreachable from config.** `ScorePropSimple` exists at [weighting.py:31](src/trend_analysis/weighting.py:31), but neither resolver maps a config name to it (the `weighting.name` branch only wires the *Bayesian* score variant; `weighting_scheme` only wires risk engines). The README advertises "score-proportional" weighting, but I could find no config string that selects plain `ScorePropSimple`. *(Worth a confirmation pass, but the two resolvers above are the only ones I found.)*
+- This directly answers item 3 for the most important parameter: **changing `portfolio.weighting.name` does NOT reliably change the weighting method, and does not fail loudly when the requested method is unsupported.**
+
+**Transaction costs — fragmented across three implementations, and `cost_model.*` is dead on the main path.**
+
+- The multi-period engine charges `period_cost = period_turnover × ((tc_bps + slippage_bps) / 10000)` ([engine.py:3640](src/trend_analysis/multi_period/engine.py:3640)) — turnover-proportional and economically correct. ✓
+- **But it reads top-level `portfolio.transaction_cost_bps` and `portfolio.slippage_bps`** ([engine.py:1684-1685](src/trend_analysis/multi_period/engine.py:1684)), **not** the validated `portfolio.cost_model.{bps_per_trade, slippage_bps}`. `cost_model` has full validation in both `config/model.py` and `config/models.py` and is in the JSON schema, yet **`cost_model` is never read by the main pipeline** (`rg cost_model` over engine.py / stages/portfolio.py / api.py is empty) — it is consumed only by the separate `backtesting/harness.py`. So a user who configures `portfolio.cost_model` for a normal `trend run` gets no cost effect (P1), and the engine's `portfolio.slippage_bps` is an undocumented top-level key not present in the schema (P2).
+- **Single-period analysis ignores transaction costs entirely.** `stages/portfolio.py` applies the flat `monthly_cost` and the `max_turnover` cap but never `transaction_cost_bps` (no turnover-based cost on the single-period path). So `transaction_cost_bps` is a silent no-op unless you run multi-period. (P2 — arguably defensible since single-period has one allocation, but it is surprising and undocumented.)
+
+**Correctly wired (positive notes).**
+
+- `portfolio.max_turnover` is honored on both paths (turnover cap → trade clipping), with **regime-aware caps** and a `lambda_tc` turnover-damping penalty in multi-period ([engine.py:201](src/trend_analysis/multi_period/engine.py:201), [engine.py:459](src/trend_analysis/multi_period/engine.py:459)). ✓
+- `portfolio.selection_mode` and the selector plugin registry (`rank`, `zscore`) are wired ([api.py:533](src/trend_analysis/api.py:533), [selector.py:9](src/trend_analysis/selector.py:9)). ✓
+- The drop-on-load bug (selection/weighting/constraints lost because they weren't declared model fields) is **fixed** via `extra="allow"` with an explanatory comment ([config/model.py:370-374](src/trend_analysis/config/model.py:370)). ✓
+- `risk_parity` / `hrp` / `erc` / robust engines are real implementations under `weights/` and are reachable via `weighting_scheme`. ✓
+
+**Secondary smell (feeds §1/§2).** Selection is *also* doubly-specified: `demo.yml` carries both a `portfolio.rank` block and a `portfolio.selector` block expressing the same intent (top-5 by Sharpe). The relationship between them is not obvious from config. Combined with the two weighting keys and the parallel `backtesting/harness.py` metrics/cost path (§2), the portfolio layer has accumulated overlapping mechanisms worth consolidating. *(Note: the `config/model.py` vs `config/models.py` split, which initially looked like another duplicate, was verified in §2 to be **justified** layer separation — strict validator vs. runtime-dict factory — not a merge target.)*
+
+### 3.7 Net assessment for item 3
+
+- **Wiring is correct for the *core arithmetic*** — metrics, vol scaling, turnover caps, and multi-period turnover-cost all move output in economically sensible directions.
+- **The dominant problem is the *configuration contract*:** ~19 documented keys are inert no-ops, the headline `weighting.name` knob silently degrades to equal-weight for unsupported values, an advertised method (score-proportional) appears unreachable, `cost_model` is dead on the main path, and several knobs (`frequency`, `date_column`, transaction costs) behave differently than a PM would reasonably expect. None of these fail loudly.
+- **Highest-value single fix:** make the config *honest* — switch the Pydantic models to `extra="forbid"` (or add a lint that diffs declared-vs-consumed keys), and unify the weighting/cost/selection keys behind one validated schema that rejects unsupported values. That converts a class of silent economic-misconfiguration risks into loud, fail-fast errors.
+
+
+## 4. Design & ease of use (UX)
+
+_Static review of the Streamlit app (the live app was **not** launched — see coverage note in the appendix). Pages reviewed: `app.py`, `state.py`, `config_bridge.py`, and `pages/{1_Data, 2_Model, 3_Results, 4_Help, 8_Validation, monte_carlo}.py` plus key components._
+
+**Overall verdict.** A knowledgeable allocator can broadly follow the intended **Data → Model → Results** flow, and those three core pages are visually coherent (consistent emoji-prefixed subheaders, sensible column layouts, `st.metric` summary tiles, tabbed Results). Defaults are mostly reasonable and the **Help page is genuinely good**. But two pages are effectively broken as shipped, the information architecture has a real disconnect at the edges, and the Model page is overwhelming for a first-time user.
+
+**Notable correction to §3.6 (verified in the UI code):** the feared catastrophic "silent equal-weight" trap does **not** manifest in the app. The Model page stores the choice in `model_state['weighting_scheme']`, `analysis_runner` writes it to `portfolio.weighting_scheme` ([analysis_runner.py:337](streamlit_app/components/analysis_runner.py:337)), and **both** the single-period ([api.py:497](src/trend_analysis/api.py:497)) and multi-period ([engine.py:1627](src/trend_analysis/multi_period/engine.py:1627)) engines read that key and dispatch `risk_parity`/`hrp`/`erc`/`robust_*` correctly through the plugin registry. So the GUI route is sound; the `weighting.name` equal-only branch only bites **YAML/CLI** users (and the threshold-hold policy path the UI never enables).
+
+| Page | Issue | Sev |
+|---|---|---|
+| **`8_Validation.py`** | **The page never renders** — unlike every other page it doesn't call its render function (no unconditional call / `_should_auto_render()`); and even if it did, it reads uploaded data from the wrong session key (`st.session_state['app_data']['returns']`, lines 543-548) which no other module writes, so it would `st.stop()`. A **dead/broken page** shipped in the nav. | **P1** |
+| **`monte_carlo.py`** | (a) **IA disconnect** — driven by a separate scenario registry (`list_scenarios`/`load_scenario`) rather than the Data→Model→Results state, so it doesn't consume the model the user just built. (b) **Filename lacks the numeric prefix** every other page uses, so Streamlit orders/labels it inconsistently in the sidebar. | P2 |
+| **`2_Model.py`** | A single **~4,500-line form** exposing dozens of parameters, with internal dev labels leaking to users (`"Fund Holding Rules (Phase 3)"`, `"Hard thresholds (Phase 13)"`). Overwhelming; needs progressive disclosure (basic/advanced) and user-facing language. | P2 |
+| **`2_Model.py`** | **Residual weighting trap:** in multi-period mode, if `create_weight_engine` raises during construction the engine silently sets `use_risk_weighting=False` and falls back to equal weight ([engine.py:1651](src/trend_analysis/multi_period/engine.py:1651), "best-effort only") **without populating `fallback_info`**, so the Results-page fallback banner (3_Results.py:2044) won't fire — the allocator could believe they got risk-parity when they got equal. Surface this fallback. | P2 |
+| **`1_Data.py`** | **Developer diagnostics rendered in the production UI** on every run — an always-visible perf caption (`"Perf: total Xms | render Yms | seed Zms …"`, lines 736-750). Gate behind a debug flag. | P2 |
+| **`app.py`** | **Two parallel preset vocabularies** — the home "Strategy Preset" selector (from `demo_runner.list_presets()`) vs. the model presets elsewhere — create confusion about which presets are authoritative. | P2 |
+| **`1_Data.py`** | **"Apply selection" is an easy-to-miss step** — toggling fund checkboxes updates a live count but only commits to `analysis_fund_columns` on a separate action; users can think they've selected funds when they haven't. | P2 |
+
+**Strengths:** the **Results page** information architecture is strong (clear gating sequence: error-if-no-data → error-if-no-model → prompt-to-run → success banner with period count/date range, then tabbed Summary/Period/Viz/Fund/Export/Compare). The **Help page** with an in-page table of contents is a real asset (minor risk: its anchor links depend on auto-generated header slugs).
+
+**Net for item 4:** intuitive enough for a knowledgeable allocator on the happy path, visually coherent on the three core pages, but let down by (1) a dead Validation page, (2) a disconnected Monte-Carlo page, and (3) an over-dense Model page that exposes internal "Phase N" scaffolding. Fixing those three would materially raise first-use intuitiveness.
+
+## 5. Effectiveness of the approach vs. public alternatives
+
+_Based on primary-source web research across 28 comparable tools in five categories (raw research + verified-vs-codebase synthesis stashed in [reports/audit/landscape_raw.json](reports/audit/landscape_raw.json)). Point-in-time facts (star counts, versions, maintenance status) are flagged as lower-confidence at the end._
+
+### 5.1 Where this app sits
+
+This app is an **integrated, allocator-facing manager-of-managers pipeline**: rank managers by a configurable risk-adjusted score → select top-N → weight → optionally vol-target the book → single/multi-period walk-forward backtest → risk-on/risk-off regime overlay → Excel/CSV/JSON/HTML/PDF reports, built specifically for **monthly trend-following / managed-futures manager returns**. **No single tool in the landscape spans this whole arc on manager returns.** It occupies the gap between two mature clusters:
+
+- **Open-source quant libraries/engines** (powerful *construction* or *backtest*, but instrument/price-centric and missing the manager-ranking front end).
+- **Institutional manager-research SaaS** (rich data + factor attribution, but closed and non-reproducible — you cannot tune or audit the score/selection/cost logic).
+
+### 5.2 Closest analogues, by axis
+
+| Tool | Category | Closest on… | Relative to this app |
+|---|---|---|---|
+| **bt** (pmorissette) | OSS backtest | **Architecture** — `SelectN → WeighEqually/WeighInvVol/WeighERC → TargetVol → RunMonthly` maps ~1:1 onto this app | This app adds: manager *scoring*, Bayesian weighting, a regime overlay, a first-class walk-forward engine, allocator reports. bt adds: nothing this app lacks except a commission callback. |
+| **skfolio** | OSS portfolio opt | **Pipeline shape** — pre-selection → weighting → leakage-safe `WalkForward`/purged CV; sklearn-native | skfolio has far deeper CV/hyperparameter tuning and a general convex constraint layer; this app has the manager front end + vol-target + regimes it lacks. |
+| **Riskfolio-Lib / PyPortfolioOpt** | OSS portfolio opt | **Weighting depth** — 20+ risk measures, full MV/Black-Litterman frontier, turnover/cardinality/tracking-error constraints | This app's weighting is mostly closed-form/heuristic with only min/max bounds — shallow by comparison. |
+| **cvxportfolio** (Boyd) | OSS portfolio opt | **Multi-period + cost realism** — market-impact and holding-cost terms in a convex multi-period objective | This app's cost model is linear bps-on-turnover; cvxportfolio is the gold standard for cost-aware multi-period. |
+| **vectorbt** | OSS backtest | **Robustness throughput** — thousands of parameter combos + walk-forward CV, fast | This app can't sweep/tune at that scale; but it has the construction semantics vectorbt deliberately omits. |
+| **QuantConnect LEAN** | OSS engine | **Construction menu + execution realism** — EqualWeight/MeanVariance/BlackLitterman/RiskParity models, fee+slippage models, daily/tick, live trading | Institutional-heavyweight; overkill for monthly manager selection and built for tradeable securities, not manager returns. |
+| **pysystemtrade / Clenow / PyTrendFollow** | Trend/CTA | **Domain** — systematic futures trend with vol targeting | These build trend signals *from price series*; this app instead *selects among managers* who already run such systems — a complementary layer up. |
+| **SG Trend Index** | Trend/CTA | **Purpose** — a real rules-based, equal-weight, top-N pool of trend CTAs | This app *generalizes* the SG Trend construction to scored ranking + richer weighting; SG Trend is the natural benchmark to regress selected portfolios against. |
+| **Venn / Morningstar Direct / eVestment / PivotalPath / Portfolio Visualizer** | Allocator SaaS | **Evaluate-and-rank front half** + curated universes + factor attribution | None run a *reproducible* rule-based walk-forward selection+weighting+vol-target simulation; this app's auditability and code-control are its edge over them. |
+| **Two Sigma GMM regime (via Venn)** | Regime | **Regime modeling** — probabilistic multi-state GMM on a factor lens | This app's regime overlay is a coarse binary rolling-return/vol threshold by comparison. |
+
+### 5.3 Genuine strengths of this approach
+
+1. **End-to-end integration on manager return series** — the only tool here that bundles score-ranking → top-N → weighting → vol-target → multi-period walk-forward → allocator reports in one pipeline. Every alternative covers only a slice.
+2. **A real manager-ranking/selection front end** keyed to a configurable composite risk-adjusted score — the portfolio-optimization libraries and the trend/CTA tools have *no* first-class ranking/screening step.
+3. **A genuinely competitive weighting *implementation* menu** — `EqualWeight`, `ScorePropSimple`, `ScorePropBayesian`, `AdaptiveBayesWeighting`, `RiskParity`, `ERC`, `HRP`, `RobustMeanVariance`, `RobustRiskParity`. This reaches into skfolio/Riskfolio-Lib/PyPortfolioOpt territory. **⚠️ Caveat (from §3.6): the implementations exist, but the config can't reliably *reach* several of them** — the headline strength is undercut by the wiring bug.
+4. **A first-class, named book-level vol-target step** — bt's `TargetVol` is the only OSS analog; PyPortfolioOpt/Riskfolio-Lib/skfolio/cvxportfolio reach vol targets only indirectly via constraints.
+5. **A turnkey risk-on/risk-off regime overlay** — DIY in every OSS engine here.
+6. **A genuine multi-period walk-forward engine** with in/out-of-sample period generation — bt/backtrader/zipline/PyPortfolioOpt/Riskfolio-Lib have none.
+7. **Statistical robustness present** — circular block-bootstrap equity-curve bands + a reporting CI level — exceeds the ad-hoc robustness of bt/backtrader and the optimizer libraries.
+8. **Reproducible, auditable, config-driven** (with the recent run-envelope/`run_contract` JSON and deterministic identity-map work) — a clear edge over the closed SaaS peers where score/selection/cost logic can't be tuned or audited.
+
+### 5.4 Weaknesses & gaps vs. mature alternatives
+
+1. **Shallow constraint-based optimization** — only min/max weight bounds; no general convex constraint layer (sector/group bounds, cardinality, tracking-error, explicit turnover budget) as in Riskfolio-Lib / PyPortfolioOpt / skfolio.
+2. **Monthly-only cadence** — no daily/intrabar/order-level simulation (LEAN, backtrader, zipline, vectorbt, cvxportfolio all do). Compounded by the §3 finding that `data.frequency` silently coerces to monthly regardless.
+3. **Linear cost model only** — no market-impact, volume-share slippage, holding/financing costs, or per-asset-class fees (cvxportfolio, LEAN, backtrader, pysystemtrade have these).
+4. **No factor attribution / returns decomposition** — can't explain *why* a manager earns its returns or gauge trend purity/replicability (Venn's Two Sigma Factor Lens, Morningstar style analysis, Finominal).
+5. **Single rolling re-fit, not cross-validated tuning** — no purged/combinatorial CV or GridSearch-style hyperparameter selection (skfolio) and no high-throughput sweeps (vectorbt).
+6. **No efficient-frontier MV/Black-Litterman solver** of the depth in PyPortfolioOpt / Riskfolio-Lib / cvxportfolio.
+7. **Coarse binary regime model** vs. probabilistic multi-state GMM/HMM approaches.
+8. **No data universe, no live/broker path, no native CTA peer indices** — you must supply your own manager returns; SaaS peers ship thousands of curated strategies + qualitative DD overlays.
+9. **Maturity/adoption gap** — a single-purpose project vs. battle-tested tools (LEAN, Riskfolio-Lib, PyPortfolioOpt, pysystemtrade, skfolio) and institutional SaaS with analyst overlays.
+
+### 5.5 Caveats (lower-confidence research claims)
+
+Point-in-time figures (star counts; bt v1.2.0; vectorbt OSS v1.0.0; skfolio v0.20.1; etc.) and maintenance-status calls (backtrader "legacy"; PyTrendFollow "unmaintained since 2018"; cvxportfolio "~11 months stale") should be re-verified before publishing a head-to-head. Proprietary methodology details (PivotalPath PQP; Two Sigma's four-regime GMM labels) come partly from trade press. The "bt lacks native Bayesian weighting / WFO" claim — used to credit this app — is consistent with bt's documented Algo set but warrants a docs check before a public comparison.
+
+## 6. Missed opportunities to extend to adjacent problems
+
+The pipeline is **strategy-agnostic on returns** — it operates on a matrix of periodic manager returns and a score. That generality is mostly latent; a handful of modest extensions would let the same engine solve closely related allocator problems:
+
+1. **Generalize beyond trend/managed-futures to any manager universe.** Nothing in the ranking/selection/weighting/regime machinery is trend-specific. Re-framing the docs and presets around "manager-of-managers for *any* strategy bucket" (equity L/S, global macro, multi-strat, credit) is almost free and multiplies the addressable use cases. The only trend-specific assumptions are in the *defaults* (e.g. SPX regime proxy), not the engine.
+2. **Asset-class / index allocation (TAA/SAA).** The same select→weight→vol-target→walk-forward flow applies to ETF or asset-class index returns. A "strategic/tactical asset allocation" preset would reach a much larger audience (the Portfolio Visualizer crowd) with no engine change.
+3. **Benchmark replication / tracking.** Given the SG Trend Index analog, add a "track/replicate this index" objective — select+weight managers to minimize tracking error to a target index. This is a natural, high-value adjacent problem and a direct competitor to commercial CTA-replication analytics (Finominal).
+4. **Fee-structure–aware manager selection.** Manager selection lives or dies on *net*-of-fee returns. Today cost is a flat `monthly_cost` + linear turnover bps. Modeling management + performance fees with hurdles/high-water-marks (a manager-specific concern absent from every generic backtester) would be a differentiator, not just a gap-filler.
+5. **Survivorship/point-in-time universe handling** → unlocks credible historical studies and "as-of" rebalancing (see §7 — this is also a correctness concern).
+6. **Factor attribution as a selection input.** Adding a returns-based factor regression (trend factor, equity beta, carry) would let the tool rank on *trend purity / alpha* rather than raw Sharpe, closing the biggest analytical gap vs. Venn/Morningstar and improving selection quality.
+7. **Scenario / stress testing tied to the regime engine.** The regime overlay already partitions history; exposing "show me performance conditioned on regime X / a user-defined stress window" is a small step from existing code and is exactly what allocators ask for.
+8. **Parameter-sensitivity / robustness surface.** The bootstrap exists; a built-in sweep over `top_n` / `score_by` / `lookback` / rebalance cadence (à la vectorbt) would turn one-off backtests into stability analysis — and would surface the §3 wiring traps loudly.
+
+## 7. Generalizing the model + questions to ask before presenting to colleagues
+
+### 7.1 What it would take to generalize the model
+
+In rough order of leverage:
+
+1. **Honor `data.frequency` end-to-end (precondition for everything else).** The hardcoded monthly resample + `periods_per_year=12` (see §3.2) is the single biggest generalization blocker — daily/weekly manager or asset data is silently downgraded. Thread a real `periods_per_year` from the resolved frequency through `preprocessing`, annualisation, the trend/vol windows, and the multi-period scheduler.
+2. **Make the config contract honest and unified (the §3 fixes).** Switch Pydantic models to `extra="forbid"` (or add a declared-vs-consumed key lint), collapse the two weighting keys (`weighting.name` vs `weighting_scheme`) and the two selection blocks (`rank` vs `selector`) into one validated schema, and wire `cost_model.*`. Until config is trustworthy, no generalization can be relied on.
+3. **Adopt a pluggable optimization backend** (CVXPY / Riskfolio-Lib) behind the weighting interface to add a general convex-constraint layer (sector/group bounds, cardinality, tracking-error, turnover budget) and selectable objectives (MV / Black-Litterman / worst-case). The existing `BaseWeighting`/registry pattern is the right seam for this.
+4. **Pluggable cost models** (linear → market-impact / fee-schedule / financing) behind a `CostModel` interface — and apply them on *both* the single- and multi-period paths (today single-period ignores transaction costs, §3.6).
+5. **Pluggable regime models** — make the current binary threshold one implementation of a `RegimeModel` interface that can also host HMM/GMM/multi-state classifiers.
+6. **Point-in-time / survivorship-safe universe** — represent manager universe membership as-of each rebalance date so backtests can't select managers that didn't yet exist or only survived.
+7. **Statistical-rigor layer** — deflated Sharpe, multiple-testing correction, and out-of-sample significance tests as first-class outputs (see 7.2).
+8. **Daily-cadence + order-aware path** (longer-term) if the tool moves toward tradeable instruments rather than monthly manager returns.
+
+### 7.2 Questions to ask before presenting this to colleagues
+
+These are the diligence questions a quantitatively-sophisticated colleague will ask first. Several are **framed as verification tasks**, not asserted defects — they should be checked against the code/methodology before publishing:
+
+1. **Selection bias / data-snooping (the #1 credibility question).** Ranking top-N managers by Sharpe across a large universe and then reporting that Sharpe *mechanically overstates skill*. Do we correct for multiple testing (e.g. **deflated Sharpe ratio**, Bonferroni/BH), or hold out a true validation set? Without this, an out-of-sample outperformance claim is fragile. *(Note: §3.5 found ranking uses rf=0 by default, which further distorts the Sharpe-based selection.)*
+2. **Survivorship & backfill bias.** Is the manager universe **point-in-time**, or does it include only survivors / backfilled track records? Trend/CTA databases are notorious for both; this can manufacture most of a backtest's edge.
+3. **Look-ahead in selection/weighting.** Is each rebalance's selection and weighting computed **strictly from data available at that date**? The walk-forward engine exists — but confirm the *score* and the *regime threshold* aren't fit on the full sample (the §3.4 regime findings make this worth verifying explicitly).
+4. **Gross vs. net of fees.** Are the input manager returns gross or net? Are management/performance fees modeled? The flat `monthly_cost` is too crude to defend a net-return claim.
+5. **Statistical significance of the result.** The bootstrap CIs exist — are the selected portfolio's out-of-sample gains over the honest baselines (1/N of all managers, equal-weight top-N, SG Trend Index) **outside the confidence bands**, or within noise?
+6. **What is the honest benchmark?** Equal-weight-all vs. equal-weight-top-N vs. a CTA peer index — the choice of baseline can flip the conclusion.
+7. **Parameter stability.** How sensitive are results to `top_n`, `score_by`, `lookback`, and rebalance cadence? A result that only works at one parameter set is overfit.
+8. **Investability / capacity.** Can you actually allocate to the selected managers (minimums, closed funds, liquidity/lockups, subscription-redemption mechanics)? Fund "transaction costs" differ fundamentally from the trading-cost bps model.
+9. **Regime overlay validity.** Given §3.4 (`threshold=0.0` degenerate in vol mode; `annualise_volatility` silently shifts the boundary), is the regime split economically meaningful and out-of-sample, or an artifact of defaults?
+10. **Frequency honesty.** Given §3.2, confirm what cadence the numbers actually reflect before quoting any annualized figure — today daily/weekly inputs are silently monthly with √12 annualisation.
+
+---
+
+## Appendix — methodology & coverage notes
+
+**How this audit was run.** A capacity-aware mix of background multi-agent workflows and direct inspection:
+
+- **Economics/wiring (§3)** — a fan-out workflow inventoried every config parameter (definition + consumption sites) per domain, judged wiring + economic sensibility, then adversarially verified flagged findings. The `portfolio.*` domain failed twice as a workflow (once an agent stall, once a forced-schema miss on `sonnet`), so it was **audited directly** by the lead auditor with targeted reads/greps — slightly less fan-out, but the key claims (weighting bifurcation, cost path, single-period cost gap) were each confirmed against source.
+- **Landscape (§5)** — a research workflow with primary-source-verified summaries across 28 tools in 5 categories, then a synthesis pass. Point-in-time facts flagged in §5.5.
+- **Quality/dedup/UX (§1, §2, §4)** — a workflow with three parallel finders + an adversarial verify pass (one of six verifiers stalled; 5 landed).
+- **Strategy synthesis (§6, §7)** — written directly by the lead auditor, grounded in §3 + §5.
+
+**Independence.** Per the agreed scope, the pre-existing `review-suggested-issues.md` was **not** read or used as input by any agent — this is a fully independent pass.
+
+**Verification discipline.** Findings flagged as wiring bugs / not-wired / economically-questionable / P0-P1 code issues were handed to an independent agent instructed to *refute* them; only confirmed (or severity-corrected) findings are reported. Notable corrections made by verification: several P1s were down-graded to P2/info, the `config/model.py` vs `config/models.py` "duplication" was cleared as justified separation, and the weighting trap was scoped to YAML/CLI (the GUI was verified safe).
+
+**Coverage caveats (what was *not* done):**
+
+1. **UX review is static** — the live Streamlit app was **not** launched. A live click-through is recommended to confirm the §4 findings (esp. the dead Validation page and the Monte-Carlo IA) and to assess responsiveness/visual polish that source can't show.
+2. **Not a line-by-line review.** The repo has ~1,000 `.py` files; this is a *prioritized* audit focused on the core app per the agreed scope (`src/trend_analysis/`, `streamlit_app/`, CLI, `config/`, + supporting `scripts/`/`tools/`). Excluded by agreement: `agents/`, `archives/`, `retired/`, and `.github` automation (owned upstream by `stranske/Workflows`).
+3. **Verify caps (no silent truncation):** economics flagged 30 findings → top 9 verified; quality/dedup → top 6 attempted (5 landed). Unverified findings carry finder-confidence only and are marked as such.
+4. **Medium-confidence items to double-check before acting:** the "`ScorePropSimple` is unreachable from config" claim (only the two engine resolvers were traced); the exact behavior of the `sample_split.in_end` boundary convention in edge cases; and all point-in-time competitive facts in §5.
+
+**Durable evidence artifacts** (raw structured findings, survive independent of this report):
+- [reports/audit/economics_raw.json](reports/audit/economics_raw.json) — full parameter inventory + findings + verdicts (§3 domains 0/2)
+- [reports/audit/landscape_raw.json](reports/audit/landscape_raw.json) — 28-tool research + synthesis (§5)
+- [reports/audit/quality_ux_raw.json](reports/audit/quality_ux_raw.json) — quality/dedup/UX findings + verdicts (§1/§2/§4)
+
+**Suggested next step:** convert the actionable findings into tracked issues (the config-honesty fix, the `data.frequency`/`data.date_column` fixes, the statistical-rigor layer, and the `backtesting/harness.py` consolidation are the highest-leverage). I did not file issues — per the agreed deliverable this is a single consolidated report.

--- a/audit-proposed-issues.md
+++ b/audit-proposed-issues.md
@@ -1,0 +1,67 @@
+# Proposed issues — derived from AUDIT_REPORT.md (independent list)
+
+> Authored from this audit's own findings **before** consulting `review-suggested-issues.md`, to keep the two issue sets independent for comparison. IDs are `A#`. Each maps back to an `AUDIT_REPORT.md` section.
+
+## P1 — correctness, config contract, structure (do first)
+
+| ID | Title | Area | Source |
+|----|-------|------|--------|
+| **A1** | Make the config contract honest: switch Pydantic models to `extra="forbid"` (or add a declared-vs-consumed key lint) so unknown/inert keys fail loudly | config | §3.3 |
+| **A2** | Remove-or-wire the ~19 inert config keys (`metrics.use_continuous`, `metrics.alpha_reference`, `metrics.compute`, `metrics.bootstrap_ci.*`, `export.excel.*`, `export.include_raw_returns/include_vol_adj`, `run.{n_jobs,log_level,log_file,cache_dir,deterministic}`, `preprocessing.steps`) | config | §3.3 |
+| **A3** | `data.frequency` silently coerces all data to monthly (√12 regardless) — honor non-monthly end-to-end or hard-reject with a clear error | engine/data | §3.2 |
+| **A4** | `data.date_column` ignored on the main CSV load path (only walk-forward/MC honor it) | data | §3.2 |
+| **A5** | `data.missing_fill_limit` is a dead alias shadowing the real `data.missing_limit` | config | §3.2 |
+| **A6** | Unify the two weighting keys (`portfolio.weighting.name` vs `weighting_scheme`); reject unsupported values loudly; ensure `ScorePropSimple` is reachable from config | portfolio | §3.6 |
+| **A7** | Consolidate `backtesting/harness.py` parallel engine (own CostModel/calendar/metrics with **divergent formulas**) — reuse main primitives or retire | dedup/metrics | §2 |
+| **A8** | Move the 6 CI/autofix test-fixture modules out of `src/trend_analysis/` (they ship in the wheel) | hygiene/packaging | §1 |
+| **A9** | Refactor `multi_period/engine.py::run()` — a single ~3,150-line, ~10-deep function | complexity | §1 |
+| **A10** | Add **value-level numeric assertions** to tests (harness + smoke tests check keys, not values) — root cause of undetected wiring/metric bugs | testing | §1 |
+| **A11** | Fix the dead `pages/8_Validation.py` (never renders; reads a session key nothing writes) | UX | §4 |
+| **A12** | Add a statistical-rigor layer: deflated Sharpe / multiple-testing correction / OOS significance (biggest pre-presentation credibility upgrade) | methodology | §7.2 |
+
+## P2 — economic-wiring nuances
+
+| ID | Title | Area | Source |
+|----|-------|------|--------|
+| **A13** | `portfolio.cost_model.*` is dead on the main pipeline (engine reads top-level `transaction_cost_bps`/`slippage_bps`) | portfolio/cost | §3.6 |
+| **A14** | Single-period path ignores `transaction_cost_bps` (only `monthly_cost`+turnover cap apply) | portfolio/cost | §3.6 |
+| **A15** | `regime.threshold=0.0` is degenerate in volatility mode (≈all Risk-Off); validate/reject | regime | §3.4 |
+| **A16** | `regime.annualise_volatility` silently rescales the decision boundary by √ppy without rescaling `threshold` | regime | §3.4 |
+| **A17** | `regime.min_observations` default mismatch (code 6 vs `defaults.yml` 4) | regime | §3.4 |
+| **A18** | `metrics.rf_rate_annual` ignored for ranking unless `rf_override_enabled` (ranking Sharpe uses rf=0) | metrics | §3.4 |
+| **A19** | `run.monthly_cost` is an undocumented, material flat cost lever (absent from `defaults.yml`) | cost/docs | §3.4 |
+| **A20** | Consolidate the 3 parallelism keys: `run.jobs` canonical, `jobs` deprecated alias, delete dead `run.n_jobs` | config/dedup | §2 |
+| **A21** | `sample_split.in_end` boundary convention mismatch (validator=month-start, slicer=month-end) | config/validation | §3.4 |
+
+## P2 — code quality & duplication
+
+| ID | Title | Area | Source |
+|----|-------|------|--------|
+| **A22** | Consolidate transaction-cost logic fanned across ≥5 implementations into one primitive | dedup | §2 |
+| **A23** | Extract the shared CLI skeleton from `run_analysis.py` / `run_multi_analysis.py` | dedup | §2 |
+| **A24** | Remove the dead `rebalancing.py` back-compat shim (shadowed by `rebalancing/` package) | dead_code | §2 |
+| **A25** | Refactor `cli.main()`/`_handle_mc_command`; narrow ~40 broad `except: pass`; log swallowed config errors (`_compute_score_frame`) | quality | §1 |
+| **A26** | `_apply_weight_bounds` may not sum to 1.0 (no warn) + mixes magic `1e-9` with named tolerance | quality/economic | §1 |
+| **A27** | Encapsulate module-global mutable cache counters in `rank_selection` | quality | §1 |
+
+## P2 — UX
+
+| ID | Title | Area | Source |
+|----|-------|------|--------|
+| **A28** | Monte-Carlo page: add numeric filename prefix + connect to the Data→Model→Results state | UX | §4 |
+| **A29** | Model page: progressive disclosure + remove internal "Phase N" labels (~4,500-line form) | UX | §4 |
+| **A30** | Surface the multi-period weighting silent-fallback (create_weight_engine failure → equal, `fallback_info` not set) | UX/engine | §4 |
+| **A31** | Gate developer perf diagnostics out of the production UI (`1_Data.py`) | UX | §4 |
+| **A32** | Reconcile the two preset vocabularies (home vs model presets) | UX | §4 |
+| **A33** | Make the "Apply selection" commit step clearer | UX | §4 |
+
+## Strategy epics (items 6–7 — larger than a single PR)
+
+| ID | Title | Area | Source |
+|----|-------|------|--------|
+| **A34** | Survivorship / point-in-time universe handling (as-of membership) | methodology | §7 |
+| **A35** | General convex-constraint optimization backend (CVXPY / Riskfolio-Lib) behind the weighting interface | feature | §7.1 |
+| **A36** | Factor attribution / returns decomposition (trend purity) | feature | §6 |
+| **A37** | Generalize beyond trend (manager-of-managers framing); daily cadence; pluggable cost/regime models; benchmark/peer-index integration | feature/epic | §6, §7.1 |
+
+**Totals:** 12 P1 · 9 P2 (wiring) · 6 P2 (quality/dedup) · 6 P2 (UX) · 4 epics = **37 proposed issues.**

--- a/issue-comparison.html
+++ b/issue-comparison.html
@@ -1,0 +1,372 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Trend Model — Issue Comparison & Selection</title>
+<style>
+  :root{
+    --bg:#0f1419; --panel:#171f2a; --panel2:#1e2836; --line:#2b3949; --txt:#e6edf3; --muted:#9bb0c3;
+    --mine:#4cc2ff; --theirs:#ffb454; --both:#7ee787; --conflict:#ff7b72; --comp:#d2a8ff;
+    --p0:#ff7b72; --p1:#ffb454; --p2:#9bb0c3; --epic:#d2a8ff;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--txt)}
+  header{padding:22px 26px;border-bottom:1px solid var(--line);background:linear-gradient(180deg,#13202e,#0f1419)}
+  h1{margin:0 0 4px;font-size:21px}
+  .sub{color:var(--muted);font-size:13px;max-width:1100px}
+  .wrap{padding:20px 26px;max-width:1500px}
+  .grid{display:grid;gap:16px}
+  .cards{grid-template-columns:repeat(auto-fit,minmax(150px,1fr));margin-bottom:8px}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:14px 16px}
+  .card .n{font-size:26px;font-weight:700}
+  .card .l{color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  .mineC{color:var(--mine)} .theirsC{color:var(--theirs)} .bothC{color:var(--both)}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:18px;margin-bottom:18px}
+  .panel h2{margin:0 0 12px;font-size:16px}
+  .venn{display:flex;align-items:center;gap:24px;flex-wrap:wrap}
+  .vennimg{position:relative;width:330px;height:170px;flex:0 0 auto}
+  .circle{position:absolute;top:10px;width:170px;height:150px;border-radius:50%;display:flex;align-items:center;justify-content:center;flex-direction:column;mix-blend-mode:screen;opacity:.55}
+  .c-mine{left:0;background:var(--mine)} .c-theirs{right:0;background:var(--theirs)}
+  .vlabel{position:absolute;font-weight:700;text-align:center;font-size:13px;color:#04121d}
+  .vl-mine{left:24px;top:74px;width:110px} .vl-both{left:120px;top:78px;width:90px;color:#06210d} .vl-theirs{right:24px;top:74px;width:110px}
+  .legend{font-size:12.5px;color:var(--muted)} .legend b{color:var(--txt)}
+  .bars{display:flex;flex-direction:column;gap:7px;min-width:280px;flex:1}
+  .bar{display:grid;grid-template-columns:140px 1fr 40px;align-items:center;gap:8px;font-size:12.5px}
+  .track{height:14px;background:var(--panel2);border-radius:7px;overflow:hidden;display:flex}
+  .seg{height:100%}
+  .controls{display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-bottom:12px}
+  input[type=search]{background:var(--panel2);border:1px solid var(--line);color:var(--txt);padding:8px 11px;border-radius:8px;min-width:230px}
+  .chip{background:var(--panel2);border:1px solid var(--line);color:var(--muted);padding:6px 11px;border-radius:20px;cursor:pointer;font-size:12.5px;user-select:none}
+  .chip.on{background:var(--mine);color:#04121d;border-color:var(--mine);font-weight:600}
+  .btn{background:var(--panel2);border:1px solid var(--line);color:var(--txt);padding:7px 13px;border-radius:8px;cursor:pointer;font-size:13px}
+  .btn:hover{border-color:var(--mine)}
+  table{width:100%;border-collapse:collapse;font-size:13px}
+  th,td{padding:9px 10px;border-bottom:1px solid var(--line);text-align:left;vertical-align:top}
+  th{position:sticky;top:0;background:var(--panel2);z-index:2;font-size:11.5px;text-transform:uppercase;letter-spacing:.03em;color:var(--muted);cursor:pointer}
+  tr:hover td{background:#19222e}
+  .badge{display:inline-block;padding:2px 8px;border-radius:20px;font-size:11px;font-weight:600;white-space:nowrap}
+  .b-mine{background:rgba(76,194,255,.16);color:var(--mine);border:1px solid rgba(76,194,255,.4)}
+  .b-theirs{background:rgba(255,180,84,.16);color:var(--theirs);border:1px solid rgba(255,180,84,.4)}
+  .b-both{background:rgba(126,231,135,.16);color:var(--both);border:1px solid rgba(126,231,135,.4)}
+  .p{font-weight:700} .p0{color:var(--p0)} .p1{color:var(--p1)} .p2{color:var(--p2)} .pE{color:var(--epic)}
+  .flag{font-size:11px;padding:1px 6px;border-radius:5px;margin-left:5px}
+  .f-conflict{background:rgba(255,123,114,.18);color:var(--conflict);border:1px solid rgba(255,123,114,.4)}
+  .f-comp{background:rgba(210,168,255,.16);color:var(--comp);border:1px solid rgba(210,168,255,.4)}
+  .dupdot{color:var(--theirs);font-weight:700}
+  .note{color:var(--muted);font-size:12px;max-width:430px}
+  .own{font-size:11px;color:var(--conflict)}
+  td.sel{text-align:center;width:34px}
+  input[type=checkbox]{width:16px;height:16px;cursor:pointer;accent-color:var(--both)}
+  .selbar{position:sticky;bottom:0;background:var(--panel2);border-top:1px solid var(--line);padding:12px 26px;display:flex;gap:14px;align-items:center;z-index:5}
+  .selbar .count{font-weight:700;color:var(--both)}
+  .decision{border-left:3px solid var(--conflict);padding:10px 14px;margin:10px 0;background:var(--panel2);border-radius:0 8px 8px 0}
+  .decision h4{margin:0 0 6px;font-size:14px}
+  .decision .factors{font-size:12.5px;color:var(--muted)}
+  details summary{cursor:pointer;font-weight:600;margin:6px 0}
+  .modal{position:fixed;inset:0;background:rgba(0,0,0,.6);display:none;align-items:center;justify-content:center;z-index:10}
+  .modal.on{display:flex}
+  .modal .box{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:18px;width:min(760px,92vw);max-height:84vh;overflow:auto}
+  textarea{width:100%;height:330px;background:var(--bg);color:var(--txt);border:1px solid var(--line);border-radius:8px;padding:10px;font:12px/1.5 ui-monospace,Menlo,monospace}
+  .hl{color:var(--mine)} code{background:var(--panel2);padding:1px 5px;border-radius:4px;font-size:12px}
+  a{color:var(--mine)}
+</style>
+</head>
+<body>
+<header>
+  <h1>Trend Model Project — Two-Review Issue Comparison &amp; Selection</h1>
+  <div class="sub">
+    Cross-comparison of <b class="mineC">this audit's proposed issues</b> (<code>audit-proposed-issues.md</code>, A#)
+    against the <b class="theirsC">iamkayleb parallel review</b> (<code>review-suggested-issues.md</code>, "Issue #") derived from the
+    <code>.docx</code> compendium. <b>Thesis: the two reviews are highly complementary</b> — theirs is line-level
+    correctness + specific copy-paste duplication; mine is behavioral/economic wiring + strategy + UX breadth.
+    Tick the issues you want; use <b>Export selected</b> to copy a filing-ready Markdown list.
+  </div>
+</header>
+
+<div class="wrap">
+
+  <div class="grid cards" id="cards"></div>
+
+  <div class="panel">
+    <h2>Overlap at a glance</h2>
+    <div class="venn">
+      <div class="vennimg">
+        <div class="circle c-mine"></div>
+        <div class="circle c-theirs"></div>
+        <div class="vlabel vl-mine">Mine<br><span id="vmine">35</span> only</div>
+        <div class="vlabel vl-both">Both<br><span id="vboth">2</span></div>
+        <div class="vlabel vl-theirs">Theirs<br><span id="vtheirs">18</span> only</div>
+      </div>
+      <div class="legend">
+        <p style="margin:.2em 0"><b>Direct same-issue overlap: 2</b> — the dead <code>8_Validation.py</code> page and the CI/autofix fixtures in <code>src/</code>.</p>
+        <p style="margin:.2em 0"><b>+ ~5 complementary/adjacent pairs</b> (<span style="color:var(--comp)">🔗</span>) that touch the same area from different angles — e.g. my "consolidate the parallel <code>backtesting/harness.py</code> engine" ↔ their specific <i>Sortino bug</i> + duplicated <code>_infer_periods_per_year</code> inside it.</p>
+        <p style="margin:.2em 0"><b>1 direct conflict</b> (<span style="color:var(--conflict)">⚖</span>) — <code>run_analysis.py</code>/<code>run_multi_analysis.py</code>: I proposed <i>refactor/dedupe</i>; they found them <i>unwired → delete</i>.</p>
+        <p style="margin:.2em 0;color:var(--txt)"><b>≈ 85–90% of each list is unique to it.</b> Filing both, deduped, gives the most complete backlog.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <h2>Where each review is strong (category mix)</h2>
+    <div class="bars" id="catbars"></div>
+    <p class="legend" style="margin-top:10px">Theirs clusters in <b>correctness bugs</b> + <b>duplication/dead-code</b> (its stated "main ask"); mine clusters in <b>config/economic wiring</b>, <b>UX</b>, and <b>methodology/feature</b> (items 5–7) that a syntactic review can't surface.</p>
+  </div>
+
+  <div class="controls">
+    <input type="search" id="q" placeholder="Search title / id / area…"/>
+    <span class="chip on" data-f="src" data-v="all">All sources</span>
+    <span class="chip" data-f="src" data-v="mine">Mine</span>
+    <span class="chip" data-f="src" data-v="theirs">Theirs</span>
+    <span class="chip" data-f="src" data-v="both">Both</span>
+    <span class="chip" data-f="dup" data-v="1">Duplication only ●</span>
+    <span class="chip" data-f="pri" data-v="P0">P0</span>
+    <span class="chip" data-f="pri" data-v="P1">P1</span>
+    <span class="chip" data-f="pri" data-v="P2">P2</span>
+    <span class="chip" data-f="flag" data-v="conflict">⚖ Conflicts</span>
+    <span class="btn" id="selvis">✓ Select all visible</span>
+    <span class="btn" id="clearall">Clear</span>
+  </div>
+
+  <table id="tbl">
+    <thead><tr>
+      <th>✓</th><th data-k="id">ID</th><th data-k="t">Issue</th><th data-k="s">Source</th>
+      <th data-k="p">Pri</th><th data-k="c">Category</th><th data-k="dup">Dup</th><th>Notes / competing-approach factors</th>
+    </tr></thead>
+    <tbody id="rows"></tbody>
+  </table>
+
+  <div class="panel" style="margin-top:20px">
+    <h2>⚖ Competing approaches — factors for the choice</h2>
+
+    <div class="decision">
+      <h4>1. <code>run_analysis.py</code> / <code>run_multi_analysis.py</code> — refactor (mine A23) vs delete (theirs Issue 10)</h4>
+      <div class="factors">
+        <b>Factors:</b> Their review did the wiring check I didn't — they report these modules are <i>not</i> in <code>[project.scripts]</code>, not imported in <code>src/</code>, and only referenced by tests. <b>If that holds, delete &gt; refactor</b> (don't dedupe dead code). My "extract shared CLI skeleton" only applies if the modules are live. <b>Decision rule:</b> verify wiring first; delete if confirmed dead, otherwise apply my skeleton extraction. <b>Lesson adopted:</b> confirm a module is reachable before proposing to refactor it.
+      </div>
+    </div>
+
+    <div class="decision">
+      <h4>2. CLI helper dedup — "8 duplicates" vs "only 3 are real copies" (theirs Issue 9 + Appendix A)</h4>
+      <div class="factors">
+        <b>Factors:</b> Their Appendix A debunks an over-eager dedup: only <code>_apply_trend_spec_preset</code>, <code>_apply_universe_mask</code>, <code>_attach_universe_paths</code> are byte-equivalent; the other five are thin <i>delegators</i> and deduping them mechanically would break working code. <b>Decision rule:</b> dedupe only verified copies; leave delegators. <b>Lesson adopted:</b> my coarser dedup items (A7 harness, A22 cost-primitive) should be split into "verified copy → merge" vs "intentional indirection → leave."
+      </div>
+    </div>
+
+    <div class="decision">
+      <h4>3. Config validation — forbid unknown keys (mine A1) vs run Tier-2 in the bridge (theirs Issue 3)</h4>
+      <div class="factors">
+        <b>Factors:</b> These are <i>complementary, not competing</i>. A1 makes inert/unknown keys fail loudly (<code>extra="forbid"</code>); Issue 3 makes the Streamlit bridge actually run Tier-2 validation so <code>vol_adjust</code>/<code>max_turnover</code>/<code>selection_mode</code> are checked. <b>Decision rule:</b> do <b>both</b> — they close different halves of the same gap. Sequence behind tests (tightening validation may reject configs silently accepted today).
+      </div>
+    </div>
+
+    <div class="decision">
+      <h4>4. "Silent coercion" theme — bfill→ffill (theirs Issue 5) joins frequency→monthly &amp; weighting→equal (mine A3/A6)</h4>
+      <div class="factors">
+        <b>Factors:</b> Three independent instances of the same anti-pattern (a config value silently mapped to something else with no error). <b>Decision rule:</b> adopt a project-wide policy — <i>honor the value or reject it; never silently coerce</i> — and fix all three under one banner. Their Issue 5 is the instance I missed.
+      </div>
+    </div>
+
+    <div class="decision">
+      <h4>5. Consumer-repo ownership (theirs Appendix B) — fix here vs upstream in <code>stranske/Workflows</code></h4>
+      <div class="factors">
+        <b>Factors:</b> Their review flags that <code>tools/*</code>, <code>.github/codex/*</code>, and some <code>scripts/langchain/*</code> are synced from Workflows — fix upstream, not here. My audit scoped these out but didn't add the caveat. <b>Decision rule:</b> before filing any issue touching synced paths (e.g. their Issues 8 &amp; 19), confirm ownership via the sync manifest. <b>Lesson adopted:</b> tag each issue with repo-vs-upstream ownership.
+      </div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <h2>Material each review uniquely contributes (the "missed" question)</h2>
+    <details open><summary>What the iamkayleb review caught that my audit missed (incorporate these)</summary>
+      <ul>
+        <li><b>A wrong-number bug:</b> the <span class="dupdot">Sortino</span> annualization in <code>backtesting/harness</code> (~3.46× too small) — I flagged the harness as a parallel engine with "divergent formulas" but did not pin this specific defect. <b>High value.</b></li>
+        <li><b>Granular, byte-level duplication</b> I didn't enumerate: <code>portfolio_series</code> ×3, <code>_to_nav_wide</code> ×2, <code>_git_hash</code> ×2, <code>_infer_periods_per_year</code> ×2, <code>NAV_PATH_REQUIRED_CHARTS</code> ×2, <code>_init_matplotlib</code>, the LLM-chain ~200-line near-dup, <code>_read_env_float</code> ×2.</li>
+        <li><b>Specific bugs in scripts/state:</b> <code>check_branch.sh</code> syntax error, <code>run_real_model.py</code> <code>.loc</code> KeyError, <code>state.py::_values_equal</code> int/float phantom diffs, <code>missing_policy</code> bfill→ffill coercion.</li>
+        <li><b>Import-time side effects</b> in <code>metrics/__init__.py</code> (monkey-patching <code>builtins</code>); deprecated-shim imports still live in Streamlit; <code>gui/app.py</code> leading-space CSS theme no-op.</li>
+        <li><b>Security/hardening</b> (<code>0.0.0.0</code> bind, injection-guard regex) and a <b>portability/deprecation sweep</b>.</li>
+        <li><b>Discernment discipline</b> (Appendix A) and <b>consumer-repo ownership</b> (Appendix B) — process lessons worth adopting wholesale.</li>
+      </ul>
+    </details>
+    <details open><summary>What my audit caught that their review did not cover</summary>
+      <ul>
+        <li><b>The entire config/economic-wiring layer:</b> ~19 inert config keys, <code>data.frequency</code> monthly coercion, <code>data.date_column</code> main-path gap, <code>data.missing_fill_limit</code> dead alias, the two-weighting-keys bifurcation, <code>cost_model.*</code> dead on the main path, regime degeneracies, rf-ignored-for-ranking, undocumented <code>monthly_cost</code>.</li>
+        <li><b>Structural complexity:</b> the ~3,150-line <code>engine.run()</code> function.</li>
+        <li><b>Items 5–7 entirely:</b> competitive landscape, adjacent-problem extensions, generalization roadmap, and the statistical-rigor / data-snooping / survivorship questions to ask before presenting to colleagues.</li>
+        <li><b>UX breadth:</b> Monte-Carlo IA disconnect, the over-dense Model page, dev diagnostics in the production UI, preset-vocabulary confusion (beyond their dead-Validation-page overlap).</li>
+      </ul>
+    </details>
+  </div>
+
+  <div class="panel" id="propPanel">
+    <h2>Relative proportions</h2>
+    <p class="legend">
+      <b>Their list:</b> 20 filed issues — <b>8 P0 correctness bugs</b>, <b>9 P1 duplication/dead-code</b>, 3 P2 hygiene (+5 deliberately-not-filed in Appendix A). Heavily line-level &amp; syntactic, with precise <code>file:line</code>.<br>
+      <b>My list:</b> 37 issues — dominated by <b>config/economic wiring</b> (≈15), <b>UX</b> (6), <b>methodology/feature epics</b> (5), with fewer specific byte-level duplicates.<br>
+      <b>On duplicative code specifically:</b> theirs is <i>deeper at the function level</i> (specific copies + what <i>not</i> to dedupe); mine is <i>broader at the architectural level</i> (parallel <code>harness</code> engine, transaction-cost primitive fanned across ≥5 sites, duplicate config mechanisms). Forest vs trees — combine for the best dedup backlog.<br>
+      <span id="compendiumNote" style="color:var(--muted)"><b>Compendium completeness check (vs the raw <code>.docx</code>):</b> the source holds <b>~195 distinct actionable findings</b> (~70 bugs, <b>~45 duplication</b>, ~40 quality, ~16 dead-code, plus config/test/perf), but is <b>~80% descriptive documentation / ~20% findings</b> by volume (≈70/30 if de-duplicated — early PRs #8–#29 re-submit the same <code>cli.md</code> brief 14× with incremental growth). <code>review-suggested-issues.md</code> filed only ~20 of those ~195 — a <b>~10% curated distillation</b> (the rest were judged stale, minor, or intentional). Notably, the compendium contains duplication that <i>neither</i> review filed as issues — e.g. <code>_json_default</code> ×4, <code>_load_configuration</code> ×3 (trend/trend_analysis/trend_model), <code>load_csv</code>/<code>load_parquet</code> ~50-line overlap, <code>apply_missing_policy</code> two-contracts, and <code>DataSettings</code>/<code>ValidationError</code> name collisions — candidates for a future pass if you want to go deeper on dedup.</i></span>
+    </p>
+  </div>
+
+</div>
+
+<div class="selbar">
+  <span class="count"><span id="selN">0</span> selected</span>
+  <span class="btn" id="export">⇩ Export selected (Markdown)</span>
+  <span class="legend" style="margin-left:auto">Tip: filter, "Select all visible", then export. Selection persists across filters.</span>
+</div>
+
+<div class="modal" id="modal"><div class="box">
+  <h2 style="margin-top:0">Selected issues — Markdown</h2>
+  <p class="legend">Copy into a tracker, or hand to <code>gh issue create</code>. Sources tagged so you can see provenance.</p>
+  <textarea id="md" readonly></textarea>
+  <div style="margin-top:10px;display:flex;gap:10px">
+    <span class="btn" id="copy">Copy to clipboard</span>
+    <span class="btn" id="closeM">Close</span>
+  </div>
+</div></div>
+
+<script>
+const ISSUES=[
+ // ---- BOTH (direct overlap) ----
+ {id:"A11/T4",t:"Fix the dead 8_Validation.py page (never renders; reads a session key nothing writes)",s:"both",p:"P0",c:"ux",dup:0,own:"repo",flag:"",note:"Direct match. Theirs is more precise (3 compounding defects incl. set_page_config inside the render fn; app stores 'returns_df' not 'app_data'). Adopt their detail."},
+ {id:"A8/T11",t:"Move 6 CI/autofix test-fixture modules out of src/trend_analysis (they ship in the wheel)",s:"both",p:"P1",c:"dead_code",dup:0,own:"repo",flag:"",note:"Direct match. Placement choice: theirs _ci_fixtures/, mine tests/fixtures/. ~5 tests/workflows imports to update."},
+ // ---- THEIRS ----
+ {id:"T1",t:"Sortino annualization bug in backtesting/harness._compute_metrics (~3.46× too small)",s:"theirs",p:"P0",c:"bug",dup:0,own:"repo",flag:"comp",note:"🔗 Complements my A7 (the harness is a parallel engine with divergent formulas). Their specific wrong-number bug is the strongest single catch I missed."},
+ {id:"T2",t:"scripts/check_branch.sh fails bash syntax (duplicate `then`)",s:"theirs",p:"P0",c:"bug",dup:0,own:"repo",flag:"",note:"Dev gate script; add `bash -n scripts/*.sh` lint. Missed by me."},
+ {id:"T3",t:"config/bridge.py::validate_payload only runs Tier-1 validation",s:"theirs",p:"P0",c:"config",dup:0,own:"repo",flag:"comp",note:"🔗 Complements my A1. Do both: run Tier-2 in the bridge AND forbid unknown keys."},
+ {id:"T5",t:"missing_policy bfill/backfill silently coerced to ffill",s:"theirs",p:"P0",c:"bug",dup:0,own:"repo",flag:"comp",note:"🔗 Same silent-coercion anti-pattern as my A3 (freq→monthly) & A6 (weighting→equal). Honor or reject — never coerce."},
+ {id:"T6",t:"scripts/run_real_model.py crashes on RF/portfolio date mismatch (.loc→.reindex)",s:"theirs",p:"P0",c:"bug",dup:0,own:"repo",flag:"",note:"Trivial reindex fix. Missed by me (scripts/)."},
+ {id:"T7",t:"state.py::_values_equal reports phantom int↔float diffs",s:"theirs",p:"P0",c:"bug",dup:0,own:"repo",flag:"",note:"JSON round-trip false 'type changed' diffs. Missed by me."},
+ {id:"T8",t:"scripts/langchain/pr_verifier.py unimportable (missing api_client)",s:"theirs",p:"P0",c:"bug",dup:0,own:"check",flag:"",note:"⚠ Likely Workflows-owned — confirm sync ownership before filing here (their Appendix B)."},
+ {id:"T9",t:"Consolidate the 3 byte-equivalent CLI helpers (NOT the other 5 delegators)",s:"theirs",p:"P1",c:"duplication",dup:1,own:"repo",flag:"",note:"Only _apply_trend_spec_preset/_apply_universe_mask/_attach_universe_paths are real copies. Discernment lesson for my dedup items."},
+ {id:"T10",t:"Remove orphaned/unwired CLI modules + dead stub (run_analysis, run_multi_analysis, src/cli.py, trend_portfolio_app)",s:"theirs",p:"P1",c:"dead_code",dup:0,own:"repo",flag:"conflict",note:"⚖ CONFLICTS with my A23 (refactor). If their wiring analysis holds (only test-imported), DELETE beats refactor. Verify first."},
+ {id:"T12",t:"De-duplicate helpers in export/__init__.py & viz/ (portfolio_series ×3, _to_nav_wide ×2, _git_hash ×2, dead branch, openpyxl pairs)",s:"theirs",p:"P1",c:"duplication",dup:1,own:"repo",flag:"",note:"Granular byte-level copies I did not enumerate (I only flagged export/__init__.py as oversized). High-value dedup."},
+ {id:"T13",t:"De-duplicate trend/mc & reporting helpers (NAV_PATH_REQUIRED_CHARTS ×2, _init_matplotlib)",s:"theirs",p:"P1",c:"duplication",dup:1,own:"repo",flag:"",note:"Missed by me."},
+ {id:"T14",t:"Refactor LLM chain duplication in llm/chain.py (~200-line near-dup run()s, _read_env_float ×2)",s:"theirs",p:"P1",c:"duplication",dup:1,own:"check",flag:"",note:"Missed by me. Confirm llm/* is repo-owned (appears so)."},
+ {id:"T15",t:"Remove import-time side effects in metrics/__init__.py (builtins monkey-patch, synthetic tests.legacy_metrics)",s:"theirs",p:"P1",c:"quality",dup:0,own:"repo",flag:"",note:"Missed by me. Real tech-debt / import-order hazard."},
+ {id:"T16",t:"Hoist duplicated _infer_periods_per_year and reconcile drift (harness vs engine/walkforward)",s:"theirs",p:"P1",c:"duplication",dup:1,own:"repo",flag:"comp",note:"🔗 A specific instance inside my A7 harness-consolidation. The two copies have drifted guards."},
+ {id:"T17",t:"Stop importing deprecated shims from live Streamlit modules (config_bridge, date_correction)",s:"theirs",p:"P1",c:"dead_code",dup:0,own:"repo",flag:"",note:"App emits its own DeprecationWarnings at startup. Missed by me."},
+ {id:"T18",t:"Deprecation & portability sweep (applymap→map, ast.Str, sed -i, echo backticks, $?-after-pipeline)",s:"theirs",p:"P2",c:"quality",dup:0,own:"repo",flag:"",note:"Repo-local .sh items safe to fix here; some review items already fixed (they note it). Missed by me."},
+ {id:"T19",t:"Tighten network-bind (0.0.0.0→127.0.0.1) & injection-guard regex (re.DOTALL)",s:"theirs",p:"P2",c:"security",dup:0,own:"check",flag:"",note:"⚠ injection_guard/llm_proxy may be Workflows-owned. Missed by me."},
+ {id:"T20",t:"Small UI correctness fixes (gui/app.py leading-space CSS theme no-op; ipywidgets unconditional import)",s:"theirs",p:"P2",c:"bug",dup:0,own:"repo",flag:"",note:"Theme toggle silently no-ops. Missed by me."},
+ // ---- MINE ----
+ {id:"A1",t:"Make config honest: extra=\"forbid\" (or declared-vs-consumed key lint) so inert/unknown keys fail loudly",s:"mine",p:"P1",c:"config",dup:0,own:"repo",flag:"comp",note:"🔗 Pairs with their T3 (different half of the same validation gap)."},
+ {id:"A2",t:"Remove-or-wire the ~19 inert config keys (metrics.*, export.excel.*, run.*, preprocessing.steps)",s:"mine",p:"P1",c:"config",dup:0,own:"repo",flag:"",note:"Behavioral finding their syntactic review did not surface. The biggest config-contract issue."},
+ {id:"A3",t:"data.frequency silently coerces all data to monthly (√12 regardless) — honor end-to-end or hard-reject",s:"mine",p:"P1",c:"config",dup:0,own:"repo",flag:"comp",note:"🔗 Silent-coercion theme with their T5."},
+ {id:"A4",t:"data.date_column ignored on the main CSV load path (only walk-forward/MC honor it)",s:"mine",p:"P1",c:"config",dup:0,own:"repo",flag:"",note:"Missed by their review."},
+ {id:"A5",t:"data.missing_fill_limit is a dead alias shadowing the real data.missing_limit",s:"mine",p:"P1",c:"config",dup:0,own:"repo",flag:"",note:"Missed by their review."},
+ {id:"A6",t:"Unify the two weighting keys (weighting.name vs weighting_scheme); reject unsupported values; make ScorePropSimple reachable",s:"mine",p:"P1",c:"config",dup:1,own:"repo",flag:"comp",note:"🔗 Duplicate config mechanism + silent equal-weight fallback (YAML/CLI). Missed by their review."},
+ {id:"A7",t:"Consolidate backtesting/harness.py parallel engine (own CostModel/calendar/metrics, divergent formulas) — reuse or retire",s:"mine",p:"P1",c:"duplication",dup:1,own:"repo",flag:"comp",note:"🔗 The architectural frame around their T1 (Sortino) + T16 (_infer_periods). Forest to their trees."},
+ {id:"A9",t:"Refactor multi_period/engine.py::run() — a single ~3,150-line, ~10-deep function",s:"mine",p:"P1",c:"complexity",dup:0,own:"repo",flag:"",note:"Missed by their review (they focused on duplication, not complexity)."},
+ {id:"A10",t:"Add value-level numeric assertions to tests (harness + smoke tests check keys, not values)",s:"mine",p:"P1",c:"testing",dup:0,own:"repo",flag:"comp",note:"🔗 Both reviews note this; theirs ties it to T1. Make it a cross-cutting test-quality policy."},
+ {id:"A12",t:"Add statistical-rigor layer: deflated Sharpe / multiple-testing / OOS significance",s:"mine",p:"P1",c:"methodology",dup:0,own:"repo",flag:"",note:"Item 7. Biggest pre-presentation credibility upgrade. Out of their scope."},
+ {id:"A13",t:"portfolio.cost_model.* is dead on the main pipeline (engine reads top-level transaction_cost_bps/slippage_bps)",s:"mine",p:"P2",c:"config",dup:0,own:"repo",flag:"",note:"Missed by their review."},
+ {id:"A14",t:"Single-period path ignores transaction_cost_bps (only monthly_cost + turnover cap apply)",s:"mine",p:"P2",c:"config",dup:0,own:"repo",flag:"",note:"Missed by their review."},
+ {id:"A15",t:"regime.threshold=0.0 degenerate in volatility mode (≈all Risk-Off); validate/reject",s:"mine",p:"P2",c:"config",dup:0,own:"repo",flag:"",note:"Missed by their review."},
+ {id:"A16",t:"regime.annualise_volatility silently rescales the decision boundary by √ppy",s:"mine",p:"P2",c:"config",dup:0,own:"repo",flag:"",note:"Missed by their review."},
+ {id:"A17",t:"regime.min_observations default mismatch (code 6 vs defaults.yml 4)",s:"mine",p:"P2",c:"config",dup:0,own:"repo",flag:"",note:"Missed by their review."},
+ {id:"A18",t:"metrics.rf_rate_annual ignored for ranking unless rf_override_enabled (ranking Sharpe uses rf=0)",s:"mine",p:"P2",c:"config",dup:0,own:"repo",flag:"",note:"Affects which funds are selected. Missed by their review."},
+ {id:"A19",t:"run.monthly_cost is an undocumented, material flat cost lever (absent from defaults.yml)",s:"mine",p:"P2",c:"config",dup:0,own:"repo",flag:"",note:"Missed by their review."},
+ {id:"A20",t:"Consolidate the 3 parallelism keys (run.jobs canonical, jobs deprecated alias, delete dead run.n_jobs)",s:"mine",p:"P2",c:"duplication",dup:1,own:"repo",flag:"",note:"Duplicate/dead config mechanism. Missed by their review."},
+ {id:"A21",t:"sample_split.in_end boundary convention mismatch (validator=month-start, slicer=month-end)",s:"mine",p:"P2",c:"config",dup:0,own:"repo",flag:"",note:"Missed by their review."},
+ {id:"A22",t:"Consolidate transaction-cost logic fanned across ≥5 implementations into one primitive",s:"mine",p:"P2",c:"duplication",dup:1,own:"repo",flag:"",note:"Architectural dedup beyond their function-level finds. Apply their discernment (verify copy vs intentional)."},
+ {id:"A23",t:"Extract the shared CLI skeleton from run_analysis.py / run_multi_analysis.py",s:"mine",p:"P2",c:"duplication",dup:1,own:"repo",flag:"conflict",note:"⚖ Superseded-if-dead by their T10. Only valid if the modules are actually wired."},
+ {id:"A24",t:"Remove the dead rebalancing.py back-compat shim (shadowed by rebalancing/ package)",s:"mine",p:"P2",c:"dead_code",dup:0,own:"repo",flag:"",note:"Aligned in spirit with their dead-code cleanup; specific file they didn't list."},
+ {id:"A25",t:"Refactor cli.main()/_handle_mc_command; narrow ~40 broad excepts; log swallowed config errors",s:"mine",p:"P2",c:"quality",dup:0,own:"repo",flag:"",note:"Missed by their review."},
+ {id:"A26",t:"_apply_weight_bounds may not sum to 1.0 (no warn) + mixes magic 1e-9 with named tolerance",s:"mine",p:"P2",c:"quality",dup:0,own:"repo",flag:"",note:"Mildly economic. Missed by their review."},
+ {id:"A27",t:"Encapsulate module-global mutable cache counters in rank_selection",s:"mine",p:"P2",c:"quality",dup:0,own:"repo",flag:"",note:"Test-pollution/thread-safety. Missed by their review."},
+ {id:"A28",t:"Monte-Carlo page: numeric filename prefix + connect to Data→Model→Results state",s:"mine",p:"P2",c:"ux",dup:0,own:"repo",flag:"",note:"UX/IA. Missed by their review."},
+ {id:"A29",t:"Model page: progressive disclosure + remove internal 'Phase N' labels (~4,500-line form)",s:"mine",p:"P2",c:"ux",dup:0,own:"repo",flag:"",note:"Missed by their review."},
+ {id:"A30",t:"Surface the multi-period weighting silent-fallback (create_weight_engine failure → equal, fallback_info unset)",s:"mine",p:"P2",c:"ux",dup:0,own:"repo",flag:"",note:"Missed by their review."},
+ {id:"A31",t:"Gate developer perf diagnostics out of the production UI (1_Data.py)",s:"mine",p:"P2",c:"ux",dup:0,own:"repo",flag:"",note:"Missed by their review."},
+ {id:"A32",t:"Reconcile the two preset vocabularies (home vs model presets)",s:"mine",p:"P2",c:"ux",dup:0,own:"repo",flag:"",note:"Missed by their review."},
+ {id:"A33",t:"Make the 'Apply selection' commit step clearer",s:"mine",p:"P2",c:"ux",dup:0,own:"repo",flag:"",note:"Missed by their review."},
+ {id:"A34",t:"Survivorship / point-in-time universe handling (as-of membership)",s:"mine",p:"P2",c:"methodology",dup:0,own:"repo",flag:"",note:"Item 7. Out of their scope."},
+ {id:"A35",t:"General convex-constraint optimization backend (CVXPY / Riskfolio-Lib) behind the weighting interface",s:"mine",p:"P2",c:"feature",dup:0,own:"repo",flag:"",note:"Item 7.1 epic. Out of their scope."},
+ {id:"A36",t:"Factor attribution / returns decomposition (trend purity)",s:"mine",p:"P2",c:"feature",dup:0,own:"repo",flag:"",note:"Item 6. Out of their scope."},
+ {id:"A37",t:"Generalize beyond trend (manager-of-managers framing); daily cadence; pluggable cost/regime; benchmark indices",s:"mine",p:"P2",c:"feature",dup:0,own:"repo",flag:"",note:"Items 6/7.1 epic. Out of their scope."}
+];
+
+const SRC={mine:"b-mine",theirs:"b-theirs",both:"b-both"};
+const SRCL={mine:"Mine",theirs:"Theirs",both:"Both"};
+const CATC={correctness:"#ff7b72"};
+const sel=new Set();
+let filt={src:"all",dup:null,pri:null,flag:null}, qstr="", sortk=null, sortdir=1;
+
+function passes(it){
+  if(filt.src!=="all" && it.s!==filt.src) return false;
+  if(filt.dup && !it.dup) return false;
+  if(filt.pri && it.p!==filt.pri) return false;
+  if(filt.flag && it.flag!==filt.flag) return false;
+  if(qstr){const h=(it.id+" "+it.t+" "+it.c+" "+it.note).toLowerCase();if(!h.includes(qstr))return false;}
+  return true;
+}
+function render(){
+  let list=ISSUES.filter(passes);
+  if(sortk){list=[...list].sort((a,b)=>String(a[sortk]).localeCompare(String(b[sortk]))*sortdir);}
+  const rows=document.getElementById("rows");
+  rows.innerHTML=list.map(it=>{
+    const pc=it.p==="P0"?"p0":it.p==="P1"?"p1":it.c==="feature"||it.c==="methodology"?"pE":"p2";
+    const fl=it.flag==="conflict"?'<span class="flag f-conflict">⚖ conflict</span>':it.flag==="comp"?'<span class="flag f-comp">🔗 comp</span>':'';
+    return `<tr>
+      <td class="sel"><input type="checkbox" data-id="${it.id}" ${sel.has(it.id)?"checked":""}></td>
+      <td><b>${it.id}</b></td>
+      <td>${it.t}${fl}${it.own==="check"?' <span class="own">⚠ ownership</span>':''}</td>
+      <td><span class="badge ${SRC[it.s]}">${SRCL[it.s]}</span></td>
+      <td class="p ${pc}">${it.p}</td>
+      <td>${it.c}</td>
+      <td style="text-align:center">${it.dup?'<span class="dupdot">●</span>':''}</td>
+      <td class="note">${it.note}</td>
+    </tr>`;
+  }).join("");
+  document.querySelectorAll('#rows input[type=checkbox]').forEach(cb=>cb.onchange=()=>{cb.checked?sel.add(cb.dataset.id):sel.delete(cb.dataset.id);updateSel();});
+  document.getElementById("visN")&&(document.getElementById("visN").textContent=list.length);
+}
+function updateSel(){document.getElementById("selN").textContent=sel.size;}
+function summary(){
+  const by=s=>ISSUES.filter(i=>i.s===s).length;
+  document.getElementById("cards").innerHTML=[
+    ["Total distinct issues",ISSUES.length,""],
+    ["Mine",by("mine"),"mineC"],["Theirs",by("theirs"),"theirsC"],["Both (direct)",by("both"),"bothC"],
+    ["Duplication-tagged",ISSUES.filter(i=>i.dup).length,""],
+    ["P0 / P1",ISSUES.filter(i=>i.p==="P0").length+" / "+ISSUES.filter(i=>i.p==="P1").length,""]
+  ].map(([l,n,c])=>`<div class="card"><div class="n ${c}">${n}</div><div class="l">${l}</div></div>`).join("");
+  document.getElementById("vmine").textContent=by("mine");
+  document.getElementById("vtheirs").textContent=by("theirs");
+  document.getElementById("vboth").textContent=by("both");
+  // category bars (mine vs theirs split)
+  const cats=[...new Set(ISSUES.map(i=>i.c))];
+  document.getElementById("catbars").innerHTML=cats.map(c=>{
+    const m=ISSUES.filter(i=>i.c===c&&(i.s==="mine"||i.s==="both")).length;
+    const t=ISSUES.filter(i=>i.c===c&&(i.s==="theirs"||i.s==="both")).length;
+    const tot=m+t||1;
+    return `<div class="bar"><span>${c}</span><span class="track">
+      <span class="seg" style="width:${m/tot*100}%;background:var(--mine)"></span>
+      <span class="seg" style="width:${t/tot*100}%;background:var(--theirs)"></span>
+    </span><span>${m+t}</span></div>`;
+  }).join("");
+}
+// controls
+document.querySelectorAll(".chip").forEach(ch=>ch.onclick=()=>{
+  const f=ch.dataset.f,v=ch.dataset.v;
+  if(f==="src"){filt.src=v;document.querySelectorAll('.chip[data-f=src]').forEach(c=>c.classList.toggle("on",c===ch));}
+  else{const key=f;filt[key]=filt[key]===v?null:v;ch.classList.toggle("on",filt[key]===v);}
+  render();
+});
+document.getElementById("q").oninput=e=>{qstr=e.target.value.toLowerCase();render();};
+document.getElementById("selvis").onclick=()=>{ISSUES.filter(passes).forEach(i=>sel.add(i.id));render();updateSel();};
+document.getElementById("clearall").onclick=()=>{sel.clear();render();updateSel();};
+document.querySelectorAll("th[data-k]").forEach(th=>th.onclick=()=>{const k=th.dataset.k;sortdir=sortk===k?-sortdir:1;sortk=k;render();});
+document.getElementById("export").onclick=()=>{
+  const chosen=ISSUES.filter(i=>sel.has(i.id));
+  const md=chosen.length? chosen.map(i=>`- [ ] **${i.id}** (${SRCL[i.s]}, ${i.p}${i.dup?", duplication":""}) — ${i.t}`).join("\n")
+    : "_No issues selected._";
+  document.getElementById("md").value=`# Selected issues (${chosen.length})\n\n`+md;
+  document.getElementById("modal").classList.add("on");
+};
+document.getElementById("closeM").onclick=()=>document.getElementById("modal").classList.remove("on");
+document.getElementById("copy").onclick=()=>{const ta=document.getElementById("md");ta.select();document.execCommand("copy");document.getElementById("copy").textContent="Copied!";setTimeout(()=>document.getElementById("copy").textContent="Copy to clipboard",1200);};
+summary();render();updateSel();
+</script>
+</body>
+</html>

--- a/proposed-issues/DECISIONS.md
+++ b/proposed-issues/DECISIONS.md
@@ -1,0 +1,41 @@
+# Final recommendations on the conflicts & competing approaches
+
+_After the follow-on review (wiring + sync-ownership verified against the current `phase-3` checkout)._
+
+## Decision 1 — `run_analysis.py` / `run_multi_analysis.py`: **delete (T10), drop refactor (A23)**
+
+**Verified facts:**
+- `[project.scripts]` maps `trend-analysis`/`trend-multi-analysis` → `trend.compat_entrypoints:trend_analysis/trend_multi_analysis` ([pyproject.toml:56-57](pyproject.toml:56)).
+- `trend/compat_entrypoints.py` does `from trend import cli as trend_cli` and delegates there — it does **not** import or call `trend_analysis.run_analysis` / `run_multi_analysis` ([compat_entrypoints.py:6](src/trend/compat_entrypoints.py:6)).
+- No `src/` production module imports either runner (the many `_run_analysis` hits are the unrelated pipeline function). `run_multi_analysis` is a public lazy submodule ([__init__.py:168](src/trend_analysis/__init__.py:168)) with no production caller; `run_analysis.py` isn't even in the lazy loader.
+- Dependents are ~15 test files + `scripts/run_multi_demo.py`.
+
+**Recommendation: adopt T10 (remove), drop A23 (refactor).** Deduping dead code is wasted effort — my A23 assumed these were live entry points; the wiring check shows they are not. **Caveat:** this is not a one-line delete — it requires migrating the ~15 dependent tests and `run_multi_demo.py` to the public API (`trend_analysis.api` / `trend.cli`) and removing the `_LAZY_SUBMODULES`/`__all__` entry. File as **C1** (below). *(Matches compendium findings #22/#23.)* **Confidence: high** on wiring, **medium** on migration effort.
+
+## Decision 2 — T9 CLI-helper dedup: **scope to the 3 verified copies; verify-before-touch the rest**
+
+**Verified facts:** `_apply_trend_spec_preset`, `_apply_universe_mask`, `_attach_universe_paths` are defined in **both** `src/trend/cli.py` and `src/trend_analysis/cli.py`. `_resolve_returns_path`, `_run_pipeline` (and per the compendium, `_ensure_dataframe`, `_print_summary`, `_write_report_files`) are also present in both but classified as **delegators**. The compendium is internally inconsistent (cli-duplicate-cleanup.md claims "8 duplicates"; resolve-returns-path.md/cli.md call several delegators); `review-suggested-issues.md` Appendix A resolved it: only the 3 are byte-equivalent.
+
+**Recommendation: scope T9 to the 3 named helpers.** Make the issue's **first task** a verification step — diff the function bodies to confirm byte-equivalence of the 3 and confirm the other 5 delegate — then consolidate only confirmed copies. **Lesson adopted:** verify copy-vs-delegator before deduping (applies equally to my A7/A22). **Confidence: high.**
+
+## Decision 3 — A1 + T3 (config validation): **complementary — do both**
+
+`A1` makes inert/unknown keys fail loudly (`extra="forbid"` / declared-vs-consumed lint); `T3` makes `config/bridge.py::validate_payload` actually run Tier-2 `validate_trend_config` so `vol_adjust`/`max_turnover`/`selection_mode` are checked ([bridge.py:68](src/trend_analysis/config/bridge.py:68)). Different halves of the same gap. **Keep as two issues; sequence behind tests** (tightening may reject configs silently accepted today). **Confidence: high.**
+
+## Decision 4 — silent-coercion cluster (A3, A6, T5): **three issues, one banner**
+
+Three instances of the same anti-pattern: `data.frequency`→monthly (A3), `weighting.name`→equal (A6), `missing_policy` bfill→ffill (T5, [util/missing.py:75](src/trend_analysis/util/missing.py:75)). **Keep as separate issues** (distinct sites) **under a shared label** `no-silent-coercion` with a one-line policy: *honor the configured value or reject it — never silently substitute.* **Confidence: high.**
+
+## Decision 5 — ownership (T8, T19, T14): **route synced files upstream**
+
+**Verified against `Workflows/.github/sync-manifest.yml`:** `scripts/langchain/*` **is synced** from Workflows (incl. `pr_verifier.py` line 546, `injection_guard.py` line 519). `src/trend_analysis/{proxy,api_server,llm_proxy,llm}/` are **not** in the manifest → **repo-owned.**
+
+- **T8** (`pr_verifier.py` missing `api_client`): **file UPSTREAM in `stranske/Workflows`** — a local fix is overwritten on next sync. Consumer-side action: add an import smoke test for `scripts/langchain/*` and re-sync once the upstream fix lands.
+- **T19 → SPLIT:** **T19a (repo, here):** network-bind defaults in `api_server/__main__.py`, `proxy/cli.py`, `proxy/server.py`, `llm_proxy/server.py`. **T19b (upstream):** the `injection_guard.py` `re.DOTALL` regex fix.
+- **T14** (`llm/chain.py` dedup): `llm/` is **repo-owned** → fix here. **Confidence: high.**
+
+## New issue from the conflict
+
+- **C1** — Remove orphaned legacy runners `run_analysis.py` / `run_multi_analysis.py`; migrate the ~15 dependent tests + `scripts/run_multi_demo.py` to the public API; drop the `_LAZY_SUBMODULES`/`__all__` entry. (Supersedes A23.)
+
+**Net effect on the issue set:** drop **A23**; add **C1**; split **T19** → **T19a/T19b**; mark **T8** upstream; scope **T9** to 3 + verify-first.

--- a/proposed-issues/T2.md
+++ b/proposed-issues/T2.md
@@ -1,0 +1,27 @@
+## Why
+`scripts/check_branch.sh:222` ends a conditional with a duplicated keyword: `... --cov-branch $XDIST_FLAG" ""; then then`. Running `bash -n scripts/check_branch.sh` exits 2 with `syntax error near unexpected token 'then'`, so the whole script is unparseable and cannot run in `--full` mode. This is a CURRENT break: the script is invoked by `scripts/quality_gate.sh:64` (`./scripts/check_branch.sh --fast --fix`) and by the pre-push hook installed via `scripts/git_hooks.sh:101` (`./scripts/check_branch.sh --fast`), so both the local quality gate and the pre-push hook abort with a bash syntax error before any validation runs.
+
+## Scope
+Covers the single duplicated `then` keyword on `scripts/check_branch.sh:222` and the addition of a `bash -n` parse-check lint step over the repo's shell scripts so a syntax break is caught automatically. Boundaries: this is repo-owned (`scripts/*.sh` is a repo-local script). Only the syntax fix and the new lint step are in scope.
+
+## Non-Goals
+- Scaffold-only or partial completion does NOT count as done: adding a `bash -n` lint step without first fixing line 222 (so the lint step itself would report the existing break) does NOT satisfy this issue; both the fix and a passing lint step are required.
+- Do NOT refactor the surrounding `run_validation` logic, change coverage thresholds (`--cov-fail-under=80`), alter `--fast`/`--full`/`--fix` flag handling, or touch any other `scripts/*.sh` logic beyond what the `bash -n` step needs.
+- Do NOT modify `scripts/quality_gate.sh` or `scripts/git_hooks.sh` behavior beyond confirming they still invoke `check_branch.sh`.
+
+## Tasks
+- [ ] In `scripts/check_branch.sh:222`, change the trailing `; then then` to `; then` (remove the second `then`) on the `run_validation "Test coverage" ...` conditional.
+- [ ] Run `bash -n scripts/check_branch.sh` and confirm it exits 0.
+- [ ] Add a parse-check step that runs `bash -n` over every tracked `scripts/*.sh` file (e.g. a new `scripts/lint_shell.sh` or a step in `ci.yml`) and fails non-zero if any script fails to parse. The step must iterate the files explicitly (e.g. `for f in scripts/*.sh; do bash -n "$f" || exit 1; done`).
+- [ ] Confirm the new parse-check step passes over all current `scripts/*.sh` after the line-222 fix.
+
+## Acceptance Criteria
+- [ ] `bash -n scripts/check_branch.sh; echo $?` prints `0` (currently prints `2` with `syntax error near unexpected token 'then'` at line 222).
+- [ ] The new parse-check step exits 0 when run over the current `scripts/*.sh` set.
+- [ ] Deliberate-break gate: re-introduce a second `then` on `scripts/check_branch.sh:222` (`; then then`), run the new parse-check step, confirm it FAILS (non-zero exit naming `check_branch.sh`), then revert the deliberate break and confirm the step passes again.
+
+## Implementation Notes
+- File is repo-owned: `scripts/*.sh` is a repo-local script per the consumer-repo ownership note; fix here.
+- Confirmed-green reproduction of the CURRENT break: `bash -n scripts/check_branch.sh` → `scripts/check_branch.sh: line 222: syntax error near unexpected token 'then'` and exit code 2.
+- The duplicated keyword is only at line 222; `grep -n "then then" scripts/check_branch.sh` returns exactly that one line.
+- Callers to keep working: `scripts/quality_gate.sh:64`, `scripts/git_hooks.sh:101` (pre-push hook).

--- a/proposed-issues/T5.md
+++ b/proposed-issues/T5.md
@@ -1,0 +1,28 @@
+## Why
+Two layers that both parse the `missing_policy` setting disagree on the same input. `src/trend_analysis/util/missing.py:75` (`_coerce_policy`) maps `{both, bfill, backfill}` → `ffill` and `src/trend_analysis/util/missing.py:77` maps `{zeros, zero_fill, fillzero}` → `zero`, silently accepting undocumented aliases. The io layer, `src/trend_analysis/io/market_data.py:282` (`_normalise_policy_value`), validates against `_VALID_MISSING_POLICIES = {"drop", "ffill", "zero"}` (`market_data.py:59`) and RAISES `ValueError("Unknown missing-data policy 'bfill'...")` on the same input. This is a CURRENT silent-wrong-behavior break: a user who writes `missing_policy: bfill` expecting backward-fill gets forward-fill (the opposite direction) with no warning, and the documented vocabulary is only `drop`/`ffill`/`zero` (`docs/UserGuide.md:79`, `README.md:226`, `docs/config.md:84`). Verified live: `util._coerce_policy("bfill")` → `"ffill"` while `io._normalise_policy_value("bfill")` → `ValueError`.
+
+## Scope
+Covers reconciling `_coerce_policy` in `src/trend_analysis/util/missing.py` with the io layer so the two layers agree on which `missing_policy` strings are valid. Resolution: drop the undocumented coercion aliases (`both`, `bfill`, `backfill`, `zeros`, `zero_fill`, `fillzero`) and raise `ValueError` on them to match `io/market_data.py`, OR (only if backward-fill is genuinely intended as a feature) implement a real `bfill` policy end-to-end in `apply_missing_policy`. The "no-silent-coercion" label applies: no input should map to a different documented policy without an error. Includes a regression test.
+
+## Non-Goals
+- Scaffold-only or partial completion does NOT count as done: editing `_coerce_policy` without updating the existing parametrized test `tests/test_util_missing_additional.py::test_coerce_policy_rejects_unknown` (which currently only checks `"invalid"/""/None`) to also assert the alias behavior does NOT satisfy this issue.
+- If choosing the "raise" resolution, do NOT add a half-feature `bfill` branch that is accepted by `_coerce_policy` but not handled in `apply_missing_policy` (`src/trend_analysis/util/missing.py`) — that would re-create a silent divergence.
+- Do NOT change `io/market_data.py:_normalise_policy_value` or `_VALID_MISSING_POLICIES` — the io layer is the documented contract (`drop`/`ffill`/`zero`); align the util layer TO it, not vice-versa.
+- Do NOT alter the `zero` ↔ documented behavior or the `drop`/`ffill` paths beyond removing the undocumented aliases.
+
+## Tasks
+- [ ] In `src/trend_analysis/util/missing.py`, remove the alias-coercion branches at lines 75 (`{both, bfill, backfill} -> ffill`) and 77 (`{zeros, zero_fill, fillzero} -> zero`) so `_coerce_policy` only accepts `drop`/`ffill`/`zero` (plus empty/None → `drop`), and raises `ValueError` (message matching the existing `"Unsupported missing-data policy"`) on any other string — matching `src/trend_analysis/io/market_data.py:282`.
+- [ ] Add a test to `tests/test_util_missing_additional.py` asserting `_coerce_policy("bfill")`, `_coerce_policy("backfill")`, `_coerce_policy("both")`, and `_coerce_policy("zero_fill")` each raise `ValueError`, AND a cross-layer test asserting that for each of those inputs both `util.missing._coerce_policy` and `io.market_data._normalise_policy_value` raise (i.e. the two layers agree).
+- [ ] Update the existing parametrized test `tests/test_util_missing_additional.py::test_coerce_policy_rejects_unknown` so its expected behavior reflects the new contract (it currently passes only `"invalid"/""/None`).
+- [ ] Run `.venv/bin/python -m pytest tests/test_util_missing_additional.py -q` and confirm green.
+
+## Acceptance Criteria
+- [ ] New test in `tests/test_util_missing_additional.py` asserting `_coerce_policy("bfill")` raises `ValueError` passes (currently it returns `"ffill"`).
+- [ ] Cross-layer test: for input `"bfill"`, both `trend_analysis.util.missing._coerce_policy` and `trend_analysis.io.market_data._normalise_policy_value` raise `ValueError` — confirmed via `.venv/bin/python -m pytest tests/test_util_missing_additional.py -q`.
+- [ ] Deliberate-break gate: after the fix, re-add the line `if value in {"both", "bfill", "backfill"}: value = "ffill"` to `_coerce_policy`, run the new test, confirm it FAILS (the `_coerce_policy("bfill")` raise assertion no longer holds), then revert and confirm green.
+
+## Implementation Notes
+- File is repo-owned: `src/trend_analysis/util/missing.py` and `src/trend_analysis/io/market_data.py` are under `src/trend_analysis/`; fix here.
+- Confirmed-green reproduction of the CURRENT divergence (project venv): `.venv/bin/python -c "import sys; sys.path.insert(0,'src'); from trend_analysis.util.missing import _coerce_policy; from trend_analysis.io.market_data import _normalise_policy_value; print(_coerce_policy('bfill'));"` prints `ffill`, whereas `_normalise_policy_value('bfill')` raises `ValueError: Unknown missing-data policy 'bfill'. Choose one of drop, ffill, zero.`
+- `_coerce_policy` is reached from `_resolve_mapping` (`src/trend_analysis/util/missing.py:100-102`), which feeds `apply_missing_policy` consumed by `src/trend_analysis/stages/preprocessing.py:323,469`. Choosing "raise" keeps all current valid configs working since `drop`/`ffill`/`zero` are untouched.
+- Documented vocabulary to align to: `docs/UserGuide.md:79`, `docs/config.md:84`, `README.md:226` — all list exactly `drop`, `ffill`, `zero`.

--- a/proposed-issues/T6.md
+++ b/proposed-issues/T6.md
@@ -1,0 +1,27 @@
+## Why
+`scripts/run_real_model.py:121` aligns the risk-free series to the stitched out-of-sample portfolio with label-based `.loc`: `rf_aligned = rf_series.loc[portfolio.index] if rf_series is not None else 0.0`. The `portfolio` index is built by concatenating per-period OOS returns (`scripts/run_real_model.py:113` `pd.concat(port_series).sort_index()`), so it can contain dates that fall outside the `Risk-Free Rate` column's range. When that happens `.loc[portfolio.index]` raises `KeyError: "[Timestamp(...)] not in index"` and the script crashes right before computing Sharpe (`scripts/run_real_model.py:123` `sharpe_ratio(portfolio, rf_aligned)`). This is a CURRENT break, reproduced live: `pd.Series([...], index=[Jan,Feb]).loc[pd.Index([Jan,Feb,Mar])]` raises `KeyError`, while `.reindex(...)` returns the same values with `NaN` for the missing date.
+
+## Scope
+Covers replacing the `.loc`-based alignment at `scripts/run_real_model.py:121` with `.reindex(portfolio.index)` and making an explicit, documented decision about how missing risk-free dates are handled (the resulting `NaN`s) before they flow into `sharpe_ratio`. Boundaries: repo-owned script (`scripts/run_real_model.py` is a repo-local script). Only the RF-alignment line and its NaN handling are in scope.
+
+## Non-Goals
+- Scaffold-only or partial completion does NOT count as done: swapping `.loc` for `.reindex` WITHOUT deciding/handling the introduced `NaN`s (so `sharpe_ratio` silently receives NaN and returns NaN) does NOT satisfy this issue — the NaN-handling decision (e.g. `.reindex(portfolio.index).fillna(0.0)` or documented drop) and a test must be present.
+- Do NOT change `src/trend_analysis/metrics/sharpe_ratio` or the `annual_return`/`volatility` calls; only the RF-series alignment in the script.
+- Do NOT alter how `df_all`/`portfolio` are constructed (`scripts/run_real_model.py:39-114`) or the weights/`portfolio_oos_returns.csv` output.
+
+## Tasks
+- [ ] In `scripts/run_real_model.py:121`, replace `rf_series.loc[portfolio.index]` with `rf_series.reindex(portfolio.index)` so out-of-range dates yield `NaN` instead of raising `KeyError`.
+- [ ] Decide and apply NaN handling for the reindexed RF series before it reaches `sharpe_ratio` (`scripts/run_real_model.py:123`): either `.fillna(0.0)` (treat missing RF as 0) or filter `portfolio`/`rf` to the overlapping dates — and add an inline comment stating which was chosen and why.
+- [ ] Add a test (new `tests/test_run_real_model.py` or nearest existing script-test module) that constructs an `rf_series` whose index does NOT cover all of `portfolio.index` and asserts the alignment step returns a series indexed by `portfolio.index` without raising, with the chosen NaN handling applied.
+- [ ] Run `.venv/bin/python -m pytest tests/test_run_real_model.py -q` (or the module the test lands in) and confirm green.
+
+## Acceptance Criteria
+- [ ] A test exists that aligns an `rf_series` missing one or more `portfolio.index` dates and asserts no `KeyError` is raised and the result is indexed by `portfolio.index` — passes via `.venv/bin/python -m pytest tests/test_run_real_model.py -q`.
+- [ ] Running the alignment on an RF series shorter than the portfolio index returns a value (not an exception), and the chosen NaN handling produces a finite Sharpe input (no NaN reaching `sharpe_ratio` if `fillna` was chosen).
+- [ ] Deliberate-break gate: temporarily restore `rf_series.loc[portfolio.index]` at `scripts/run_real_model.py:121`, run the new test, confirm it FAILS with `KeyError`, then revert to `.reindex(...)` and confirm green.
+
+## Implementation Notes
+- File is repo-owned: `scripts/run_real_model.py` is a repo-local script; fix here.
+- Confirmed-green reproduction of the CURRENT break: `rf = pd.Series([0.01,0.02], index=pd.to_datetime(['2020-01-31','2020-02-29'])); port = pd.Series([0.1,0.2,0.3], index=pd.to_datetime(['2020-01-31','2020-02-29','2020-03-31'])); rf.loc[port.index]` raises `KeyError: "[Timestamp('2020-03-31 00:00:00')] not in index"`; `rf.reindex(port.index)` returns `[0.01, 0.02, nan]`.
+- Context: `rf_series = df_all.get("Risk-Free Rate")` (`scripts/run_real_model.py:120`); `portfolio = pd.concat(port_series).sort_index()` (`scripts/run_real_model.py:113`). The `df_all.get(...)` returns `None` when the column is absent, which the existing `if rf_series is not None else 0.0` ternary already handles — keep that branch.
+- Use the project venv (`.venv/bin/python`); the system anaconda Python has a NumPy 1.x/2.x mismatch that emits unrelated import warnings.

--- a/proposed-issues/T7.md
+++ b/proposed-issues/T7.md
@@ -1,0 +1,28 @@
+## Why
+`streamlit_app/state.py:317` runs a strict type check before the numeric tolerance branch: `_values_equal` does `if type(left) is not type(right): return False` (line 317) and only reaches the `numbers.Number` / `math.isclose` branch (lines 319-320) afterward. So `_values_equal(10, 10.0, ...)` returns `False` even though the values are numerically equal. Model states round-trip through JSON via `export_model_state` (`state.py:249`, `json.dumps`) and `import_model_state` (`state.py:263`, `json.loads`), where `10` and `10.0` are both valid JSON numbers, so a value written as int can reload as float (or vice-versa). `diff_model_states` (`state.py:335`) then reports a spurious `changed` diff with `type_changed=True`, which surfaces as a `[type changed]` note in `format_model_state_diff` (`state.py:452`). This is a CURRENT break, reproduced live: `_values_equal(10, 10.0, 1e-9)` → `False`, and `diff_model_states({'k':10}, {'k':10.0})` → `[('k','changed',True)]`.
+
+## Scope
+Covers reordering `_values_equal` in `streamlit_app/state.py` so the `numbers.Number` / `math.isclose` branch (lines 319-320) is evaluated BEFORE the strict `type(left) is not type(right)` comparison (line 317), so two numerically-equal numbers of different concrete types (int vs float) compare equal. Boundaries: repo-owned (`streamlit_app/` is repo-owned). Only `_values_equal` ordering and a regression test are in scope.
+
+## Non-Goals
+- Scaffold-only or partial completion does NOT count as done: moving the numeric branch but leaving the top-level `type(left) is not type(right)` check in `_walk` (`state.py:375`) and the `type_changed=type(left) is not type(right)` flag (`state.py:421`) such that an int↔float still reports `type_changed=True` does NOT satisfy this issue — the phantom diff must disappear for numerically-equal int/float pairs.
+- Do NOT change Mapping/Sequence comparison semantics (lines 322-330) beyond what is required to reach them after the numeric reorder.
+- Do NOT alter `export_model_state`/`import_model_state` JSON handling, or relax type-change reporting for genuinely different types (e.g. `"10"` string vs `10` int must still be reported).
+
+## Tasks
+- [ ] In `streamlit_app/state.py`, reorder `_values_equal` (around lines 316-320) so the `isinstance(left, numbers.Number) and isinstance(right, numbers.Number)` → `math.isclose(...)` branch is checked BEFORE the `type(left) is not type(right): return False` guard, so numerically-equal int/float pairs return `True`.
+- [ ] Verify the `changed`-diff path in `diff_model_states._walk` (`state.py:412` calls `_values_equal`; `state.py:421` sets `type_changed=type(left) is not type(right)`) no longer emits a diff for an int-vs-numerically-equal-float change; if it still flags `type_changed` for equal numbers, guard that flag so numerically-equal numbers are not reported as changed at all.
+- [ ] Add a test to `tests/app/test_streamlit_state.py` asserting `state._values_equal(10, 10.0, 1e-9) is True` and that `state.diff_model_states({'k': 10}, {'k': 10.0})` returns an empty list (no phantom `changed`/`type_changed` diff). Extend `test_diff_model_states_flags_type_changes_and_float_tolerance` (`tests/app/test_streamlit_state.py:322`) or add a sibling test.
+- [ ] Run `.venv/bin/python -m pytest tests/app/test_streamlit_state.py -q` and confirm green.
+
+## Acceptance Criteria
+- [ ] New/updated assertion in `tests/app/test_streamlit_state.py`: `state._values_equal(10, 10.0, 1e-9)` is `True` and `state.diff_model_states({'k': 10}, {'k': 10.0})` returns `[]` — passes via `.venv/bin/python -m pytest tests/app/test_streamlit_state.py -q`.
+- [ ] A genuinely different-type change is still reported: `state.diff_model_states({'k': 10}, {'k': "10"})` still returns one diff (string vs int is a real change) — asserted in the same test module.
+- [ ] Deliberate-break gate: after the fix, re-introduce the early `if type(left) is not type(right): return False` ahead of the numeric branch in `_values_equal`, run the new test, confirm the `_values_equal(10, 10.0)` / empty-diff assertion FAILS, then revert and confirm green.
+
+## Implementation Notes
+- File is repo-owned: `streamlit_app/state.py` is under `streamlit_app/`; fix here.
+- Confirmed-green reproduction of the CURRENT break (project venv): loading `streamlit_app/state.py` and calling `_values_equal(10, 10.0, 1e-9)` returns `False`; `_values_equal(10.0, 10.0, 1e-9)` returns `True`; `diff_model_states({'k':10}, {'k':10.0})` returns `[('k', 'changed', True)]`.
+- `numbers` and `math` are already imported in the module (used at lines 319-320). The fix is purely a branch-ordering change plus the matching `type_changed` guard.
+- Use the project venv (`.venv/bin/python`); the system anaconda Python has a NumPy 1.x/2.x mismatch that prevents importing the module's pandas dependency.
+- The JSON round-trip rationale is grounded in `export_model_state` (`state.py:249`) / `import_model_state` (`state.py:263`); the existing round-trip test is `test_export_import_round_trip_preserves_types` (`tests/app/test_streamlit_state.py:233`).

--- a/review-suggested-issues.md
+++ b/review-suggested-issues.md
@@ -1,0 +1,363 @@
+# Suggested issues from the iamkayleb repo review
+
+Derived from `trend-review-suggested-material-compendium.docx` (iamkayleb's subsystem
+briefs, PRs #8–#53, Jan–May 2026), **after independent verification against the current
+`phase-3` tree** (the review was authored against the `iamkayleb` fork). Each item below was
+confirmed present in this repo with file:line evidence unless noted.
+
+**How to use this file:** each `## Issue` is filing-ready (title = the heading text after the
+number). When you're happy, they can be created on `stranske/Trend_Model_Project` with `gh`.
+Read **Appendix A** (findings deliberately *not* filed) and **Appendix B** (Workflows
+ownership) before working any P0-8 / P2-19 item — some belong upstream, not here.
+
+Priorities: **P0** = correctness bug · **P1** = duplication / dead-code cleanup (the main ask)
+· **P2** = hygiene.
+
+---
+
+## P0 — correctness bugs
+
+### Issue 1 — Fix Sortino annualization in `backtesting/harness._compute_metrics`
+- **Priority:** P0 · **Area:** metrics/backtesting · **Labels:** `bug`, `metrics` · **Source:** PR #42
+
+**Problem.** In `_compute_metrics`, Sharpe is annualized correctly but Sortino is not. The
+downside deviation is annualized on its own line, then divided into the *per-period* mean,
+so the Sortino ratio ends up effectively divided by `√periods_per_year` — about 3.46× too
+small for monthly data. The canonical implementation in
+[`metrics/__init__.py::sortino_ratio`](src/trend_analysis/metrics/__init__.py:253) does it
+correctly (`annual_return / annualized_downside_vol`).
+
+**Evidence.**
+- [src/trend_analysis/backtesting/harness.py:635](src/trend_analysis/backtesting/harness.py:635) `downside_std = downside.std(ddof=0) * np.sqrt(periods_per_year)`
+- [src/trend_analysis/backtesting/harness.py:641](src/trend_analysis/backtesting/harness.py:641) `sortino = active_returns.mean() / downside_std ...`
+- Sharpe one line above multiplies the *whole ratio* by `√ppy`; Sortino is missing that outer factor.
+- `tests/backtesting/test_harness.py` only asserts the `"sortino"` key exists, never its value — which is why this went unnoticed.
+
+**Proposed fix.** Mirror the Sharpe formula: `sortino = active_returns.mean() / downside.std(ddof=0) * np.sqrt(periods_per_year)` (per-period downside std × outer `√ppy`), or build an annualized numerator. Add a numeric assertion to `tests/backtesting/test_harness.py` (cross-check against `metrics.sortino_ratio` on the same series).
+
+**Risk.** Low code change, but it changes a reported metric value — call it out in release notes / changelog.
+
+---
+
+### Issue 2 — `scripts/check_branch.sh` fails bash syntax (duplicate `then`)
+- **Priority:** P0 · **Area:** dev tooling · **Labels:** `bug`, `ci`, `scripts` · **Source:** PR #49
+
+**Problem.** A stray duplicate `then` makes the whole script a syntax error, so the full local
+validation gate and the generated pre-push hook abort immediately.
+
+**Evidence.** [scripts/check_branch.sh:222](scripts/check_branch.sh:222) ends `... $XDIST_FLAG" ""; then then`. `bash -n scripts/check_branch.sh` exits 2: `syntax error near unexpected token 'then'`. Invoked by `quality_gate.sh --full` and the `git_hooks.sh` pre-push hook.
+
+**Proposed fix.** Delete the extra `then`. Add `bash -n` over `scripts/*.sh` to a lint step so this class of breakage is caught in CI.
+
+**Risk.** Trivial. (Repo-local dev script, not synced — safe to fix here.)
+
+---
+
+### Issue 3 — `config/bridge.py::validate_payload` only runs Tier-1 validation
+- **Priority:** P0 · **Area:** config · **Labels:** `bug`, `config` · **Source:** PR #29
+
+**Problem.** `validate_payload` calls Tier-1 `validate_core_config`, which validates only
+`data.*` and `portfolio.cost_model`. `vol_adjust`, `portfolio.rebalance_calendar`,
+`portfolio.max_turnover`, and `portfolio.selection_mode` pass through unchecked — even though
+`build_config_payload` in the same file injects several of them. The Streamlit app accepts and
+forwards those fields silently. **Not fixed by the recent config commits (#5356/#5357).**
+
+**Evidence.** [src/trend_analysis/config/bridge.py:68](src/trend_analysis/config/bridge.py:68) `validate_core_config(payload, ...)`; payload built at [bridge.py:46-57](src/trend_analysis/config/bridge.py:46) injects `rebalance_calendar`/`max_turnover`/`vol_adjust.target_vol`.
+
+**Proposed fix.** Call Tier-2 `validate_trend_config` from `validate_payload` (it covers `vol_adjust` and the `portfolio` minimums), or compose Tier-1 + the missing Tier-2 checks. Add a test that an invalid `target_vol`/`max_turnover` is rejected at the bridge.
+
+**Risk.** Medium — tightening validation may surface configs that were silently accepted before; stage behind tests.
+
+---
+
+### Issue 4 — `pages/8_Validation.py` never renders (three compounding defects)
+- **Priority:** P0 · **Area:** streamlit · **Labels:** `bug`, `streamlit` · **Source:** PR #53
+
+**Problem.** The developer validation page is dead:
+1. Its only render call sits under `if __name__ == "__main__":` — Streamlit imports pages, so it never runs.
+2. Even if fixed, it reads session key `"app_data"`, which is **never written** anywhere in `streamlit_app/`; the app stores returns under `"returns_df"`.
+3. It calls the private `analysis_runner._execute_analysis`, bypassing the public cached `run_analysis`.
+4. `st.set_page_config()` is called *inside* the render function (line ~529), after Streamlit calls have begun — will raise once #1 is fixed.
+
+**Evidence.** [8_Validation.py:893](streamlit_app/pages/8_Validation.py:893), [:543](streamlit_app/pages/8_Validation.py:543), [:498](streamlit_app/pages/8_Validation.py:498); canonical key in [state.py:23](streamlit_app/state.py:23); public API [analysis_runner.py:596](streamlit_app/components/analysis_runner.py:596).
+
+**Proposed fix.** Use the `_should_auto_render()` pattern other pages use; switch to `app_state.get_uploaded_data()` / `"returns_df"`; call public `run_analysis(...)`; hoist `set_page_config` to module top.
+
+**Risk.** Low — page is currently non-functional, so there's nothing to regress.
+
+---
+
+### Issue 5 — `missing_policy: bfill`/`backfill` is silently coerced to `ffill`
+- **Priority:** P0 · **Area:** data/pipeline · **Labels:** `bug`, `data` · **Source:** PR #42
+
+**Problem.** `util/missing.py::_coerce_policy` maps `{"both","bfill","backfill"} → "ffill"`. A user
+configuring backward-fill silently gets forward-fill, with no warning and no real bfill code path.
+The same string raises `ValueError` in `io/market_data.py::_normalise_policy_value`, so the two
+layers disagree on identical input.
+
+**Evidence.** [src/trend_analysis/util/missing.py:75](src/trend_analysis/util/missing.py:75); strict counterpart [io/market_data.py:281](src/trend_analysis/io/market_data.py:281).
+
+**Proposed fix.** Either implement real bfill (`series.bfill(limit=...)`) or raise on `bfill`/`backfill` to match the io layer. Drop the undocumented `both`/`zero_fill` aliases unless they're in the user-facing schema. Add a test.
+
+**Risk.** Low–medium — anyone currently passing `bfill` and tolerating ffill will see behavior change; document it.
+
+---
+
+### Issue 6 — `run_real_model.py` crashes on RF/portfolio date mismatch (`.loc` → `.reindex`)
+- **Priority:** P0 · **Area:** scripts · **Labels:** `bug`, `scripts` · **Source:** PR #50
+
+**Problem.** `rf_series.loc[portfolio.index]` raises `KeyError` whenever the stitched OOS portfolio
+includes a date outside the loaded risk-free range — a realistic backtest configuration.
+
+**Evidence.** [scripts/run_real_model.py:121](scripts/run_real_model.py:121).
+
+**Proposed fix.** `rf_aligned = rf_series.reindex(portfolio.index) if rf_series is not None else 0.0` (NaN-fills missing labels). Decide on NaN handling downstream (fill 0 or forward-fill).
+
+**Risk.** Trivial.
+
+---
+
+### Issue 7 — `state.py::_values_equal` reports phantom `int`↔`float` diffs
+- **Priority:** P0 · **Area:** streamlit · **Labels:** `bug`, `streamlit` · **Source:** PR #52
+
+**Problem.** The `type(left) is not type(right): return False` short-circuit runs before the numeric
+`math.isclose` branch, so `_values_equal(10, 10.0)` returns `False`. Model states round-trip through
+JSON (`export_model_state`/`import_model_state`), where `10` may deserialize as `int` and `10.0` as
+`float`; comparing a fresh state to an imported one reports spurious `"10 → 10.0 [type changed]"`.
+
+**Evidence.** [streamlit_app/state.py:317](streamlit_app/state.py:317).
+
+**Proposed fix.** Check the numeric (`numbers.Number`) `isclose` branch before the strict type comparison.
+
+**Risk.** Low.
+
+---
+
+### Issue 8 — `scripts/langchain/pr_verifier.py` is unimportable (missing `api_client`)
+- **Priority:** P0 · **Area:** agent intake · **Labels:** `bug`, `needs-ownership-check` · **Source:** PR #51
+- **⚠ Check Workflows ownership first (Appendix B). Likely fixed upstream, not here.**
+
+**Problem.** `from scripts import api_client` references a module that does not exist anywhere in the
+repo, so `import scripts.langchain.pr_verifier` raises `ImportError` at load; the `create_issue`
+call site is unreachable.
+
+**Evidence.** [scripts/langchain/pr_verifier.py:26](scripts/langchain/pr_verifier.py:26) and `:681`; `find . -name 'api_client*'` → nothing.
+
+**Proposed fix.** If `scripts/langchain/*` is synced from `stranske/Workflows`, `api_client.py` was probably never synced to this consumer — fix by adding it to the sync manifest / syncing it, **not** by writing a local module. Otherwise, restore/author `scripts/api_client.py`. Add an import smoke test for `scripts/langchain/*`.
+
+**Risk.** Depends on routing — confirm ownership before touching.
+
+---
+
+## P1 — duplication & dead-code cleanup (the core focus)
+
+### Issue 9 — Consolidate the 3 truly copy-pasted CLI helpers
+- **Priority:** P1 · **Area:** cli · **Labels:** `refactor`, `duplication` · **Source:** PR #28 (reframed)
+
+**Problem.** `trend/cli.py` and `trend_analysis/cli.py` contain three **byte-equivalent**
+reimplementations: `_apply_trend_spec_preset`, `_apply_universe_mask`, `_attach_universe_paths`.
+**Important:** the other five "duplicates" the review listed are already thin delegators, and the
+`_load_configuration`/`_json_default` "copies" are delegators or genuinely different helpers — **do
+not** dedupe those mechanically.
+
+**Evidence.** Real copies: [trend/cli.py:134/163/193](src/trend/cli.py:134) vs [trend_analysis/cli.py:199/284/320](src/trend_analysis/cli.py:199). (Delegators to leave alone: `_resolve_returns_path`, `_ensure_dataframe`, `_run_pipeline`, `_print_summary`, `_write_report_files`.)
+
+**Proposed fix.** Move the three into a shared module (e.g. a `trend_analysis` util or `trend.cli`) and have the other side import them, matching the existing delegator pattern.
+
+**Risk.** Low if scoped to the 3 confirmed copies and covered by existing CLI tests.
+
+---
+
+### Issue 10 — Remove orphaned/unwired CLI modules and dead stub
+- **Priority:** P1 · **Area:** cli/packaging · **Labels:** `cleanup`, `dead-code` · **Source:** PR #33, #38
+
+**Problem.** Several modules are not wired and not used in production:
+- `src/trend_analysis/run_analysis.py` — own argparse `main()`, not in `[project.scripts]`, not imported in `src/`, not in the lazy loader (only `tests/test_constants.py`).
+- `src/trend_analysis/run_multi_analysis.py` — registered in `_LAZY_SUBMODULES` but no production caller.
+- `src/cli.py` — `cv`/`report` subcommands, not in `[project.scripts]`, only test-imported; relies on `src/__init__.py` making `src` importable.
+- `src/trend_portfolio_app/__init__.py` — empty compat stub (`__all__ = []`), no production callers.
+
+**Proposed fix.** Delete `run_analysis.py` and `run_multi_analysis.py` (+ remove their `_LAZY_SUBMODULES`/`__all__` entries). Either wire `src/cli.py` as a real entry point or move it under `scripts/`; drop the `src/__init__.py` marker if no other `src.*` imports remain. Delete `trend_portfolio_app/` (update the handful of tests referencing it).
+
+**Risk.** Low — confirm no `[project.scripts]`/import references before each deletion; some tests import these and will need updating.
+
+---
+
+### Issue 11 — Move CI-fixture files out of the production `trend_analysis` namespace
+- **Priority:** P1 · **Area:** packaging/CI · **Labels:** `cleanup`, `ci` · **Source:** PR #33
+
+**Problem.** Six intentional-violation CI fixtures live inside production source
+`src/trend_analysis/`: `_autofix_probe.py`, `_autofix_trigger_sample.py`,
+`_autofix_violation_case2.py`, `_autofix_violation_case3.py`, `_ci_probe_faults.py`,
+`automation_multifailure.py`. They pollute the public namespace and IDE autocomplete.
+
+**Proposed fix.** Move to `src/trend_analysis/_ci_fixtures/` (or `tests/fixtures/`) and update the ~5 `tests/workflows/` imports. No production code imports them, so low risk.
+
+**Risk.** Low.
+
+---
+
+### Issue 12 — De-duplicate helpers in `export/__init__.py` and `viz/`
+- **Priority:** P1 · **Area:** reporting/export/viz · **Labels:** `refactor`, `duplication` · **Source:** PR #43
+
+**Problem / checklist (all verified):**
+- `portfolio_series` defined **3× byte-identical** at [export/__init__.py:593/873/1366](src/trend_analysis/export/__init__.py:593) → extract one `_weighted_sum`.
+- `_to_nav_wide` **2× byte-identical** in [viz/charts/rolling_panel.py:34](src/trend_analysis/viz/charts/rolling_panel.py:34) and `seasonality_heatmap.py` → import from `viz/adapters.py` (`_paths_to_wide_nav`).
+- `_git_hash` **2×** with divergent `except` — [export/bundle.py:23](src/trend_analysis/export/bundle.py:23) (specific) vs [reporting/run_artifacts.py:28](src/trend_analysis/reporting/run_artifacts.py:28) (bare `Exception`) → hoist to `util/`, keep the specific catch.
+- Dead `if proxy is not None: pass` at [export/__init__.py:1109](src/trend_analysis/export/__init__.py:1109) → delete.
+- Two redundant openpyxl proxy/adapter class pairs (`_Openpyxl*Proxy` vs `_Openpyxl*Adapter`) → collapse to one.
+- (Related notes) inconsistent bare `[]` vs `.get()` result-dict access in `_build_summary_formatter`/`format_summary_text` → use `.get(...)` like `summary_frame_from_result`.
+
+**Proposed fix.** One PR with the checklist above; behavior-preserving.
+
+**Risk.** Low–medium — `export/__init__.py` is 2,051 lines; lean on existing export tests and add a couple for the consolidated helpers.
+
+---
+
+### Issue 13 — De-duplicate `trend/mc` and reporting helpers
+- **Priority:** P1 · **Area:** mc/reporting · **Labels:** `refactor`, `duplication` · **Source:** PR #39
+
+**Problem.** `NAV_PATH_REQUIRED_CHARTS` is defined in both [mc/charts.py:6](src/trend/mc/charts.py:6)
+(which even exports it) and [mc/viz.py:16](src/trend/mc/viz.py:16) — they can drift. `_init_matplotlib`
+is near-duplicated (differs by 2 rcParams) across [reporting/quick_summary.py:31](src/trend/reporting/quick_summary.py:31)
+and [reporting/unified.py:27](src/trend/reporting/unified.py:27).
+
+**Proposed fix.** `viz.py` imports the constant from `charts.py`; extract a single `_init_matplotlib` into `reporting/_matplotlib.py` (reconcile the rcParam superset).
+
+**Risk.** Low.
+
+---
+
+### Issue 14 — Refactor LLM chain duplication in `llm/chain.py`
+- **Priority:** P1 · **Area:** llm · **Labels:** `refactor`, `duplication` · **Source:** PR #44
+- **⚠ Confirm `src/trend_analysis/llm/*` is repo-owned (it appears to be — package code, not `tools/`).**
+
+**Problem.** `ConfigPatchChain.run()` and `ConfigPatchVariantsChain.run()` are ~200 lines of
+near-identical logic (prompt build → injection check → structured/text select → retry loop →
+schema validate → `finally` logging); both already share `_BaseConfigPatchChain`. `ResultSummaryChain`
+is a separate `@dataclass` that re-implements `_bind_llm`/`_invoke_llm`. `_read_env_float` is defined
+identically in `chain.py` and `result_feedback.py`.
+
+**Evidence.** [chain.py:443](src/trend_analysis/llm/chain.py:443), [chain.py:659](src/trend_analysis/llm/chain.py:659), `ResultSummaryChain` at `:852`; `_read_env_float` at [chain.py:997](src/trend_analysis/llm/chain.py:997) and [result_feedback.py:95](src/trend_analysis/llm/result_feedback.py:95).
+
+**Proposed fix.** Extract a `_BaseConfigPatchChain._run_chain(prompt_builder, parser, ...)`; make the two `run()`s thin wrappers; let `ResultSummaryChain` reuse shared binding; hoist `_read_env_float` to a small `llm/_env.py`.
+
+**Risk.** Medium — central LLM path; cover with the existing chain tests and add retry/injection regression cases.
+
+---
+
+### Issue 15 — Remove import-time side effects in `metrics/__init__.py`
+- **Priority:** P1 · **Area:** metrics · **Labels:** `refactor`, `tech-debt` · **Source:** PR #41
+
+**Problem.** Importing the metrics package monkey-patches `builtins` (`annualize_return`,
+`annualize_volatility`) and registers a synthetic `tests.legacy_metrics` via
+`sys.modules.setdefault` that collides with the real `tests/legacy_metrics.py` (resolution depends on
+import order). The 439-line `__init__.py` mixes registry, metric impls, and these side effects.
+
+**Evidence.** [metrics/__init__.py:431](src/trend_analysis/metrics/__init__.py:431) (builtins) and `:426` (`tests.legacy_metrics`).
+
+**Proposed fix.** Drop the `builtins` patch (expose back-compat via an explicit module if still needed); pick one `tests.legacy_metrics` (keep the real file, drop the synthetic registration). Optionally split into `metrics/registry.py` + `metrics/core.py` + thin `__init__.py`.
+
+**Risk.** Medium — verify the two `test_metric_vectorise*` tests still resolve `tests.legacy_metrics` correctly.
+
+---
+
+### Issue 16 — Hoist duplicated `_infer_periods_per_year` and reconcile drift
+- **Priority:** P1 · **Area:** util · **Labels:** `refactor`, `duplication` · **Source:** PR #42
+
+**Problem.** Defined in both [backtesting/harness.py:555](src/trend_analysis/backtesting/harness.py:555)
+(ends `return max(1, approx)`) and [engine/walkforward.py:110](src/trend_analysis/engine/walkforward.py:110)
+(has a `median_days <= 0` guard, lacks the `max(1, approx)` floor). The drift is a latent
+behavioral divergence.
+
+**Proposed fix.** Move to `util/frequency.py`, import from both, keep both guards (the `median_days <= 0` check *and* the `max(1, approx)` floor).
+
+**Risk.** Low.
+
+---
+
+### Issue 17 — Stop importing deprecated shims from live Streamlit modules
+- **Priority:** P1 · **Area:** streamlit · **Labels:** `cleanup`, `tech-debt` · **Source:** PR #52
+
+**Problem.** `streamlit_app/config_bridge.py` and `components/date_correction.py` warn on import and
+tell callers to use `trend_analysis.*`, but `guardrails.py`, `csv_validation.py`, and `pages/1_Data.py`
+still import the shims — so the app emits its own `DeprecationWarning`s at startup. `analysis_runner.py`
+already uses the canonical path, confirming it's a missed find-and-replace.
+
+**Evidence.** [guardrails.py:22](streamlit_app/components/guardrails.py:22), [csv_validation.py:18](streamlit_app/components/csv_validation.py:18); canonical [analysis_runner.py:14](streamlit_app/components/analysis_runner.py:14).
+
+**Proposed fix.** Repoint the three importers at `trend_analysis.config.bridge` / `trend_analysis.io.date_correction`, then delete the shims (or keep them only if external callers depend on them).
+
+**Risk.** Low.
+
+---
+
+## P2 — hygiene (group as you see fit)
+
+### Issue 18 — Deprecation & portability sweep
+- **Priority:** P2 · **Area:** mixed · **Labels:** `cleanup`, `deprecation` · **Source:** PR #50, #53, #49
+
+- `DataFrame.applymap` → `.map` at [3_Results.py:1370](streamlit_app/pages/3_Results.py:1370) (deprecated pandas 2.1).
+- Dead `ast.Str`/`ast.Str.s` branch in `scripts/evaluate_settings_effectiveness.py` (~L141-146).
+- `sed -i .bak` GNU/BSD portability in [scripts/test-release.sh:36](scripts/test-release.sh:36) (use `sed -i.bak` or a Python one-liner).
+- Literal backticks from single-quoted `echo` in [scripts/open_pr_from_issue.sh:53](scripts/open_pr_from_issue.sh:53)/`:59` (PR body code fence renders broken).
+- `$?`-after-pipeline in [scripts/quick_check.sh:23](scripts/quick_check.sh:23) (warning branch unreachable without `pipefail`).
+
+**Note.** `datetime.utcnow()` items the review listed in `tools/coverage_guard.py` are **already fixed** in this tree — skip. The repo-local `scripts/*.sh` items above are safe to fix here.
+
+**Risk.** Low; mostly one-liners.
+
+---
+
+### Issue 19 — Tighten network-bind and injection defaults
+- **Priority:** P2 · **Area:** security · **Labels:** `security`, `hardening` · **Source:** PR #44, #47, #51
+- **⚠ `injection_guard` and the `llm_proxy`/`tools` pieces may be Workflows-owned — see Appendix B.**
+
+- Default host `0.0.0.0` → `127.0.0.1` for [api_server/__main__.py:7](src/trend_analysis/api_server/__main__.py:7), [proxy/cli.py:30](src/trend_analysis/proxy/cli.py:30), [proxy/server.py:237](src/trend_analysis/proxy/server.py:237), and `llm_proxy/server.py` (carries the upstream API key). Require an explicit `--host 0.0.0.0` for external reachability.
+- `scripts/langchain/injection_guard.py` regex uses `re.IGNORECASE` but not `re.DOTALL`, so a newline between trigger words bypasses detection — add `re.DOTALL` (or `[\s\S]`). *(Likely Workflows-owned.)*
+
+**Risk.** Low; behavioral default change — note in docs. Confirm ownership for the langchain piece.
+
+---
+
+### Issue 20 — Small UI correctness fixes
+- **Priority:** P2 · **Area:** gui/ui · **Labels:** `bug`, `ui` · **Source:** PR #47
+
+- Leading-space CSS property name in [gui/app.py:807](src/trend_analysis/gui/app.py:807) — `' --trend-theme'` should be `'--trend-theme'`; the theme toggle silently no-ops. Remove the leading space (and the pointless implicit string concat that hid it).
+- [ui/rank_widgets.py:6](src/trend_analysis/ui/rank_widgets.py:6) imports `ipywidgets` unconditionally while `gui/app.py` treats it as optional — make the import lazy (inside `build_ui()`) so the module is importable in headless/CI environments.
+
+**Risk.** Low.
+
+---
+
+## Appendix A — findings deliberately NOT filed
+
+- **`llm/schema.py` "bare import" (PR #44/#45 #1) — WRONG.** `from utils.paths import proj_path` is
+  the codebase-wide standard; `trend_analysis.utils.paths` does not exist, so the recommended fix would
+  break the import. Do not action.
+- **`coverage_guard.py` return-0-on-error and `datetime.utcnow()` (PR #48 #1/#2) — STALE.** Already fixed
+  in this tree.
+- **"8 duplicate CLI functions" / `_load_configuration` ×3 / `_json_default` ×4 (PR #28) — OVERSTATED.**
+  Only the 3 helpers in Issue 9 are real copies; the rest are delegators or genuinely different. Acting
+  literally would break working code.
+- The review's many self-labeled "Notes (not actionable)" and "No issues (clean files)" entries are
+  correctly low-priority and are not filed here; several were good *non*-actions (three-tier config,
+  `CashPolicy` shim, `pipeline._run_analysis` patch target, `walk_forward` vs `walkforward` scopes).
+
+## Appendix B — Workflows ownership (read before P0-8, P2-19, and any `tools/` work)
+
+This is a **consumer repo**; per `CLAUDE.md`, `tools/*`, `.github/codex/*`, and synced scripts are
+owned by `stranske/Workflows` and managed via `.github/sync-manifest.yml`. Verified-synced files among
+the findings: `tools/coverage_guard.py`, `tools/langchain_client.py`, `tools/post_ci_summary.py`,
+`tools/llm_provider.py`, `tools/enforce_gate_branch_protection.py`. `scripts/langchain/*` (incl.
+`pr_verifier.py`, `injection_guard.py`, `structured_output.py`) is agent-intake infra and **may** be
+synced too. **For anything synced, fix upstream in Workflows and re-sync — not here.** The repo-local
+`scripts/*.sh` dev/release helpers and everything under `src/trend_analysis/`, `src/trend/`,
+`streamlit_app/` are this repo's to fix.
+
+## Appendix C — process feedback for the reviewer (not code)
+
+- The compendium's Source Index shows ~12 "Exact duplicate of PR #X" resubmissions of the same briefs —
+  ironic given the subject, and worth squashing in future deliverables.
+- Early PRs (#8–#26) carried frequent typos and were descriptive walkthroughs rather than findings;
+  quality climbs sharply from PR #33 on. The reviewer clearly grew into the work.


### PR DESCRIPTION
## Summary

Adds the working artifacts produced by the 2026-06-01/02 whole-repo audit, which until now lived only as untracked files in the working tree.

| File | Purpose |
|------|---------|
| `AUDIT_REPORT.md` | Full audit findings (headline: config-contract issues — inert keys, weighting bifurcation, frequency coercion) |
| `audit-proposed-issues.md` | Candidate issues derived from the audit |
| `review-suggested-issues.md` | Review-suggested issue list |
| `issue-comparison.html` | Side-by-side comparison view of proposed vs. existing issues |
| `proposed-issues/` | Per-issue drafts (T2, T5, T6, T7) + `DECISIONS.md` |

No tracked source files are modified — this is purely additive documentation.

## Notes

These are point-in-time audit outputs. If the team would rather keep transient audit artifacts out of the repo, this PR can be closed without merging instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)