### PR TITLE
Issue #5391: render validation page

### DIFF
--- a/streamlit_app/pages/8_Validation.py
+++ b/streamlit_app/pages/8_Validation.py
@@ -20,14 +20,18 @@ import numpy as np
 import pandas as pd
 import streamlit as st
 
-from streamlit_app import state as app_state
-from streamlit_app.components import analysis_runner
-
+# ``st.set_page_config`` must be the first Streamlit command executed on the
+# page. The ``streamlit_app`` imports below pull in ``analysis_runner``, which
+# evaluates an ``@st.cache_data`` decorator at import time, so configure the
+# page before importing them.
 st.set_page_config(
     page_title="Settings Validation",
     page_icon="🔧",
     layout="wide",
 )
+
+from streamlit_app import state as app_state  # noqa: E402
+from streamlit_app.components import analysis_runner  # noqa: E402
 
 # =============================================================================
 # Setting Definitions

--- a/streamlit_app/pages/8_Validation.py
+++ b/streamlit_app/pages/8_Validation.py
@@ -20,7 +20,14 @@ import numpy as np
 import pandas as pd
 import streamlit as st
 
+from streamlit_app import state as app_state
 from streamlit_app.components import analysis_runner
+
+st.set_page_config(
+    page_title="Settings Validation",
+    page_icon="🔧",
+    layout="wide",
+)
 
 # =============================================================================
 # Setting Definitions
@@ -495,7 +502,11 @@ def run_test_analysis(
             model_state=model_state,
             benchmark=None,
         )
-        result = analysis_runner._execute_analysis(payload)
+        result = analysis_runner.run_analysis(
+            payload.returns,
+            payload.model_state,
+            payload.benchmark,
+        )
         return {"status": "success", "result": result}
     except Exception as e:
         return {"status": "error", "error": str(e)}
@@ -526,12 +537,7 @@ def format_value(value: Any) -> str:
 def render_validation_page() -> None:
     """Render the Settings Validation page."""
 
-    st.set_page_config(
-        page_title="Settings Validation",
-        page_icon="🔧",
-        layout="wide",
-    )
-
+    app_state.initialize_session_state()
     st.title("🔧 Settings Validation")
     st.markdown("""
     This page systematically tests each UI setting to verify it's properly
@@ -540,12 +546,10 @@ def render_validation_page() -> None:
     """)
 
     # Check if we have data loaded
-    app_data = st.session_state.get("app_data")
-    if app_data is None or app_data.get("returns") is None:
+    returns, _meta = app_state.get_uploaded_data()
+    if returns is None:
         st.warning("⚠️ Please load data on the Data page first.")
         st.stop()
-
-    returns = app_data["returns"]
 
     # Organize settings by category
     categories = {}
@@ -890,5 +894,14 @@ def render_validation_page() -> None:
             )
 
 
-if __name__ == "__main__":
+def _should_auto_render() -> bool:
+    """Return True when running inside an active Streamlit session."""
+    try:
+        from streamlit.runtime.scriptrunner import get_script_run_ctx
+    except Exception:
+        return False
+    return get_script_run_ctx() is not None
+
+
+if _should_auto_render():
     render_validation_page()

--- a/tests/app/test_validation_page_renders.py
+++ b/tests/app/test_validation_page_renders.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+from typing import Any, Callable
+
+import pandas as pd
+import pytest
+
+
+class RecordingSessionState(dict[str, Any]):
+    def __init__(self) -> None:
+        super().__init__()
+        self.get_keys: list[str] = []
+
+    def get(self, key: str, default: Any = None) -> Any:
+        self.get_keys.append(key)
+        return super().get(key, default)
+
+
+class DummyStreamlit:
+    class _Context:
+        def __init__(self, parent: "DummyStreamlit") -> None:
+            self._parent = parent
+
+        def __enter__(self) -> "DummyStreamlit":
+            return self._parent
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._parent, name)
+
+    def __init__(self) -> None:
+        self.session_state = RecordingSessionState()
+        self.page_config_calls: list[dict[str, Any]] = []
+        self.title_calls: list[str] = []
+        self.warning_messages: list[str] = []
+        self.stop_called = False
+        self.sidebar = DummyStreamlit._Context(self)
+
+    def set_page_config(self, **kwargs: Any) -> None:
+        self.page_config_calls.append(kwargs)
+
+    def title(self, text: str) -> None:
+        self.title_calls.append(text)
+
+    def warning(self, message: str) -> None:
+        self.warning_messages.append(message)
+
+    def stop(self) -> None:
+        self.stop_called = True
+        raise AssertionError("validation page should not stop when returns_df exists")
+
+    def selectbox(self, *args: Any, **kwargs: Any) -> Any:
+        options = kwargs.get("options") or args[1]
+        return options[0]
+
+    def columns(self, spec: int | list[int]) -> list["DummyStreamlit._Context"]:
+        count = spec if isinstance(spec, int) else len(spec)
+        return [DummyStreamlit._Context(self) for _ in range(count)]
+
+    def expander(self, *args: Any, **kwargs: Any) -> "DummyStreamlit._Context":
+        return DummyStreamlit._Context(self)
+
+    def button(self, *args: Any, **kwargs: Any) -> bool:
+        return False
+
+    def cache_data(self, *args: Any, **kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            return func
+
+        return decorator
+
+    def markdown(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def header(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def subheader(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def code(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+def _install_streamlit_stub(
+    monkeypatch: pytest.MonkeyPatch,
+    stub: DummyStreamlit,
+    *,
+    active_context: bool,
+) -> ModuleType:
+    module = ModuleType("streamlit")
+    module.__path__ = []  # mark as package so streamlit.runtime imports resolve
+
+    for attr in (
+        "set_page_config",
+        "title",
+        "warning",
+        "stop",
+        "selectbox",
+        "columns",
+        "expander",
+        "button",
+        "cache_data",
+        "markdown",
+        "header",
+        "subheader",
+        "code",
+    ):
+        setattr(module, attr, getattr(stub, attr))
+    module.session_state = stub.session_state
+    module.sidebar = stub.sidebar
+
+    runtime = ModuleType("streamlit.runtime")
+    scriptrunner = ModuleType("streamlit.runtime.scriptrunner")
+    scriptrunner.get_script_run_ctx = lambda: object() if active_context else None
+
+    monkeypatch.setitem(sys.modules, "streamlit", module)
+    monkeypatch.setitem(sys.modules, "streamlit.runtime", runtime)
+    monkeypatch.setitem(sys.modules, "streamlit.runtime.scriptrunner", scriptrunner)
+    return module
+
+
+def _reload_validation_page(monkeypatch: pytest.MonkeyPatch, streamlit_module: ModuleType):
+    from streamlit_app import state as app_state
+
+    monkeypatch.setattr(app_state, "st", streamlit_module)
+    sys.modules.pop("streamlit_app.pages.8_Validation", None)
+    importlib.invalidate_caches()
+    return importlib.import_module("streamlit_app.pages.8_Validation")
+
+
+def test_validation_page_auto_renders_with_uploaded_returns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = DummyStreamlit()
+    stub.session_state.update(
+        {
+            "returns_df": pd.DataFrame(
+                {"FundA": [0.01, -0.02], "FundB": [0.03, 0.01]},
+                index=pd.date_range("2024-01-31", periods=2, freq="ME"),
+            ),
+            "schema_meta": {"validation": {"issues": [], "warnings": []}},
+            "upload_status": "success",
+        }
+    )
+    streamlit_module = _install_streamlit_stub(
+        monkeypatch,
+        stub,
+        active_context=True,
+    )
+
+    _reload_validation_page(monkeypatch, streamlit_module)
+
+    assert stub.page_config_calls
+    assert any("Settings Validation" in call for call in stub.title_calls)
+    assert "returns_df" in stub.session_state.get_keys
+    assert "app_data" not in stub.session_state.get_keys
+    assert not any("Please load data" in message for message in stub.warning_messages)
+    assert not stub.stop_called
+
+
+def test_run_test_analysis_uses_public_analysis_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = DummyStreamlit()
+    streamlit_module = _install_streamlit_stub(
+        monkeypatch,
+        stub,
+        active_context=False,
+    )
+    page = _reload_validation_page(monkeypatch, streamlit_module)
+
+    calls: list[tuple[pd.DataFrame, dict[str, Any], str | None]] = []
+
+    def fake_run_analysis(
+        returns: pd.DataFrame,
+        model_state: dict[str, Any],
+        benchmark: str | None,
+    ) -> str:
+        calls.append((returns, model_state, benchmark))
+        return "analysis-result"
+
+    monkeypatch.setattr(page.analysis_runner, "run_analysis", fake_run_analysis)
+    monkeypatch.setattr(
+        page.analysis_runner,
+        "_execute_analysis",
+        lambda *_args, **_kwargs: pytest.fail("private analysis API should not be used"),
+    )
+
+    returns = pd.DataFrame({"FundA": [0.01, 0.02]})
+    model_state = {"selection_count": 1}
+
+    result = page.run_test_analysis(returns, model_state)
+
+    assert result == {"status": "success", "result": "analysis-result"}
+    assert calls == [(returns, model_state, None)]

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,15 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-06-03T04:03:37Z - opener lane issue #5391 PR opened
+
+- Repo/issue/PR: stranske/Trend_Model_Project #5391 / #5443.
+- Branch: `codex/issue-5391-validation-page`; head commit `377a6ef1` opened ready-for-review against `phase-3`.
+- PR routing: labels `agent:codex`, `agents:keepalive`, and `autofix`; `codex-automation` label was unavailable in this repo.
+- Relay: `pr_opened active.source_repo=stranske/Trend_Model_Project active.source_issue=5391 active.source_pr=5443 active.next_action=wait_for_keepalive`.
+- Post-open cap health at 2026-06-03T04:03:17Z: total opener-owned PRs 2, raw cap false, #5443 state `draining` with active Gate evidence after latest branch update; #5440 remains `runner-failed` / scoped-blocked on #5389 owner strict-key decision.
+- Next action: keepalive owns CI/check follow-up for PR #5443; opener can continue selecting future unlinked issues while cap remains below 5.
+
 ## 2026-06-03T04:01:25Z - opener lane issue #5391 PR materializing
 
 - Repo/issue: stranske/Trend_Model_Project #5391 `A11 - Fix the dead pages/8_Validation.py`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,32 +1,6 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
-## 2026-06-03T04:03:37Z - opener lane issue #5391 PR opened
-
-- Repo/issue/PR: stranske/Trend_Model_Project #5391 / #5443.
-- Branch: `codex/issue-5391-validation-page`; head commit `377a6ef1` opened ready-for-review against `phase-3`.
-- PR routing: labels `agent:codex`, `agents:keepalive`, and `autofix`; `codex-automation` label was unavailable in this repo.
-- Relay: `pr_opened active.source_repo=stranske/Trend_Model_Project active.source_issue=5391 active.source_pr=5443 active.next_action=wait_for_keepalive`.
-- Post-open cap health at 2026-06-03T04:03:17Z: total opener-owned PRs 2, raw cap false, #5443 state `draining` with active Gate evidence after latest branch update; #5440 remains `runner-failed` / scoped-blocked on #5389 owner strict-key decision.
-- Next action: keepalive owns CI/check follow-up for PR #5443; opener can continue selecting future unlinked issues while cap remains below 5.
-
-## 2026-06-03T04:01:25Z - opener lane issue #5391 PR materializing
-
-- Repo/issue: stranske/Trend_Model_Project #5391 `A11 - Fix the dead pages/8_Validation.py`.
-- Branch: `codex/issue-5391-validation-page`.
-- Agent: codex opener from neutral Code workspace; raw opener cap below 5, #5442 already merged by closer, #5440 remains scoped-blocked on #5389 strict-key owner decision. Selected #5391 as the highest-priority/oldest unlinked implementation candidate outside scoped blockers.
-- Implementation:
-  - Moved Validation page `set_page_config` to module top level and replaced the `__main__` guard with the active Streamlit `_should_auto_render()` pattern used by other pages.
-  - Switched page data loading from stale `st.session_state["app_data"]` to `app_state.get_uploaded_data()` / `returns_df`.
-  - Replaced private `analysis_runner._execute_analysis(...)` usage with public cached `analysis_runner.run_analysis(...)`.
-  - Added `tests/app/test_validation_page_renders.py` to prove auto-render invokes the page under an active Streamlit context, reads `returns_df`, does not read `app_data`, and uses the public analysis API.
-- Validation:
-  - `PYTHONPATH=src python -m pytest tests/app/test_validation_page_renders.py -q` -> 2 passed, 1 deprecation warning.
-  - Deliberate-break gate: temporarily restored the bad `app_data` read; the new test failed because the page stopped despite `returns_df` being present; reverted before commit.
-  - `python -m ruff check streamlit_app/pages/8_Validation.py tests/app/test_validation_page_renders.py` -> passed.
-  - `git diff --check` -> passed.
-- Current state: changes ready to commit/push and open ready-for-review PR for #5391; keepalive owns post-open CI/check follow-up.
-
 ## 2026-06-01T07:00:12Z - closer lane addressed PR #5374 review blockers
 
 - Repo/issue/PR: stranske/Trend_Model_Project #5343 / #5374 (`claude/issue-5343-stlite-demo`).

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,23 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-06-03T04:01:25Z - opener lane issue #5391 PR materializing
+
+- Repo/issue: stranske/Trend_Model_Project #5391 `A11 - Fix the dead pages/8_Validation.py`.
+- Branch: `codex/issue-5391-validation-page`.
+- Agent: codex opener from neutral Code workspace; raw opener cap below 5, #5442 already merged by closer, #5440 remains scoped-blocked on #5389 strict-key owner decision. Selected #5391 as the highest-priority/oldest unlinked implementation candidate outside scoped blockers.
+- Implementation:
+  - Moved Validation page `set_page_config` to module top level and replaced the `__main__` guard with the active Streamlit `_should_auto_render()` pattern used by other pages.
+  - Switched page data loading from stale `st.session_state["app_data"]` to `app_state.get_uploaded_data()` / `returns_df`.
+  - Replaced private `analysis_runner._execute_analysis(...)` usage with public cached `analysis_runner.run_analysis(...)`.
+  - Added `tests/app/test_validation_page_renders.py` to prove auto-render invokes the page under an active Streamlit context, reads `returns_df`, does not read `app_data`, and uses the public analysis API.
+- Validation:
+  - `PYTHONPATH=src python -m pytest tests/app/test_validation_page_renders.py -q` -> 2 passed, 1 deprecation warning.
+  - Deliberate-break gate: temporarily restored the bad `app_data` read; the new test failed because the page stopped despite `returns_df` being present; reverted before commit.
+  - `python -m ruff check streamlit_app/pages/8_Validation.py tests/app/test_validation_page_renders.py` -> passed.
+  - `git diff --check` -> passed.
+- Current state: changes ready to commit/push and open ready-for-review PR for #5391; keepalive owns post-open CI/check follow-up.
+
 ## 2026-06-01T07:00:12Z - closer lane addressed PR #5374 review blockers
 
 - Repo/issue/PR: stranske/Trend_Model_Project #5343 / #5374 (`claude/issue-5343-stlite-demo`).


### PR DESCRIPTION
Closes #5391

## Summary
- auto-render the Validation page under active Streamlit sessions instead of the dead __main__ guard
- read uploaded data through app_state.get_uploaded_data() / returns_df and move set_page_config to module top level
- use the public cached analysis_runner.run_analysis API instead of _execute_analysis
- add an app regression test for auto-render, returns_df state access, and public analysis API usage

## Validation
- PYTHONPATH=src python -m pytest tests/app/test_validation_page_renders.py -q
- deliberate-break gate: temporarily restored the app_data read and confirmed the new test fails, then reverted
- python -m ruff check streamlit_app/pages/8_Validation.py tests/app/test_validation_page_renders.py
- git diff --check

## Live note
- The regression test exercises the page render path with loaded returns_df data under an active Streamlit context; keepalive owns fresh browser/CI follow-up after PR open.