### PR TITLE
Issue #5394: warn when single-period run ignores transaction_cost_bps

### DIFF
--- a/src/trend_analysis/api.py
+++ b/src/trend_analysis/api.py
@@ -4,6 +4,7 @@ import logging
 import random
 import sys
 import time
+import warnings
 from collections.abc import Mapping, Sized
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, SupportsInt, cast
@@ -451,6 +452,26 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
             latency_ms=(result.timings or {}).get("wall_ms"),
         )
         return result
+
+    # Single-period path: only ``run.monthly_cost`` and ``portfolio.max_turnover``
+    # affect costs here (see stages/portfolio.py). ``portfolio.transaction_cost_bps``
+    # is a turnover-based lever that is only charged by the multi-period engine, so a
+    # value set on a single-period run is silently ignored. Warn loudly rather than
+    # leaving the no-op undocumented (issue #5394 / A14).
+    portfolio_cfg = getattr(config, "portfolio", {}) or {}
+    try:
+        _tc_bps = float(portfolio_cfg.get("transaction_cost_bps", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        _tc_bps = 0.0
+    if _tc_bps > 0.0:
+        _tc_msg = (
+            "portfolio.transaction_cost_bps=%s is ignored on the single-period analysis "
+            "path; turnover-based transaction costs are only charged by the multi-period "
+            "engine. Single-period runs apply run.monthly_cost and portfolio.max_turnover "
+            "only. Enable multi_period or use run.monthly_cost to model single-period costs."
+        ) % _tc_bps
+        warnings.warn(_tc_msg, UserWarning, stacklevel=2)
+        logger.warning(_tc_msg)
 
     validation_frame = validate_prices_frame(build_validation_frame(returns))
 

--- a/src/trend_analysis/api.py
+++ b/src/trend_analysis/api.py
@@ -453,11 +453,12 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
         )
         return result
 
-    # Single-period path: only ``run.monthly_cost`` and ``portfolio.max_turnover``
-    # affect costs here (see stages/portfolio.py). ``portfolio.transaction_cost_bps``
-    # is a turnover-based lever that is only charged by the multi-period engine, so a
-    # value set on a single-period run is silently ignored. Warn loudly rather than
-    # leaving the no-op undocumented (issue #5394 / A14).
+    # Single-period path: ``run.monthly_cost``, ``portfolio.max_turnover``, and
+    # ``portfolio.lambda_tc`` affect costs/turnover here (see stages/portfolio.py).
+    # ``portfolio.transaction_cost_bps`` is a turnover-based lever that is only
+    # charged by the multi-period engine, so a value set on a single-period run is
+    # silently ignored. Warn loudly rather than leaving the no-op undocumented
+    # (issue #5394 / A14).
     portfolio_cfg = getattr(config, "portfolio", {}) or {}
     try:
         _tc_bps = float(portfolio_cfg.get("transaction_cost_bps", 0.0) or 0.0)
@@ -467,8 +468,9 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
         _tc_msg = (
             "portfolio.transaction_cost_bps=%s is ignored on the single-period analysis "
             "path; turnover-based transaction costs are only charged by the multi-period "
-            "engine. Single-period runs apply run.monthly_cost and portfolio.max_turnover "
-            "only. Enable multi_period or use run.monthly_cost to model single-period costs."
+            "engine. Single-period runs apply run.monthly_cost, portfolio.max_turnover, "
+            "and portfolio.lambda_tc. Enable multi_period or use run.monthly_cost to model "
+            "single-period costs."
         ) % _tc_bps
         warnings.warn(_tc_msg, UserWarning, stacklevel=2)
         logger.warning(_tc_msg)

--- a/tests/test_single_period_costs.py
+++ b/tests/test_single_period_costs.py
@@ -1,0 +1,87 @@
+"""Tests for single-period transaction-cost handling (issue #5394 / A14).
+
+The single-period analysis path only charges ``run.monthly_cost`` (and caps via
+``portfolio.max_turnover``); it never applies ``portfolio.transaction_cost_bps``,
+which is a multi-period-only turnover lever. Setting it on a single-period run is
+therefore a silent no-op. ``run_simulation`` must warn loudly instead.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pandas as pd
+
+from trend_analysis import api
+from trend_analysis.config import Config
+
+
+def _make_df() -> pd.DataFrame:
+    dates = pd.date_range("2020-01-31", periods=6, freq="ME")
+    return pd.DataFrame({"Date": dates, "RF": 0.0, "A": 0.01, "B": 0.012})
+
+
+def _make_single_period_cfg(transaction_cost_bps: float | None) -> Config:
+    portfolio: dict[str, object] = {}
+    if transaction_cost_bps is not None:
+        portfolio["transaction_cost_bps"] = transaction_cost_bps
+    return Config(
+        version="1",
+        data={
+            "risk_free_column": "RF",
+            "allow_risk_free_fallback": False,
+            "date_column": "Date",
+            "frequency": "M",
+        },
+        preprocessing={},
+        vol_adjust={"target_vol": 1.0},
+        sample_split={
+            "in_start": "2020-01",
+            "in_end": "2020-03",
+            "out_start": "2020-04",
+            "out_end": "2020-06",
+        },
+        portfolio=portfolio,
+        metrics={},
+        export={},
+        run={},
+    )
+
+
+def _tc_warnings(records: list[warnings.WarningMessage]) -> list[warnings.WarningMessage]:
+    return [
+        r
+        for r in records
+        if issubclass(r.category, UserWarning)
+        and "transaction_cost_bps" in str(r.message)
+        and "single-period" in str(r.message)
+    ]
+
+
+def test_single_period_warns_when_transaction_cost_bps_set() -> None:
+    """A non-zero ``transaction_cost_bps`` on a single-period run must warn."""
+    df = _make_df()
+    cfg = _make_single_period_cfg(transaction_cost_bps=25.0)
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        api.run_simulation(cfg, df)
+
+    matches = _tc_warnings(records)
+    assert matches, (
+        "expected a UserWarning that single-period transaction_cost_bps is ignored; "
+        f"got categories/messages: {[(type(r.message).__name__, str(r.message)) for r in records]}"
+    )
+    assert "25.0" in str(matches[0].message)
+
+
+def test_single_period_silent_when_transaction_cost_bps_unset() -> None:
+    """No transaction-cost warning when the key is absent (avoid noise)."""
+    df = _make_df()
+    cfg = _make_single_period_cfg(transaction_cost_bps=None)
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        api.run_simulation(cfg, df)
+
+    assert not _tc_warnings(records)

--- a/tests/test_single_period_costs.py
+++ b/tests/test_single_period_costs.py
@@ -1,9 +1,10 @@
 """Tests for single-period transaction-cost handling (issue #5394 / A14).
 
-The single-period analysis path only charges ``run.monthly_cost`` (and caps via
-``portfolio.max_turnover``); it never applies ``portfolio.transaction_cost_bps``,
-which is a multi-period-only turnover lever. Setting it on a single-period run is
-therefore a silent no-op. ``run_simulation`` must warn loudly instead.
+The single-period analysis path charges ``run.monthly_cost`` and still supports
+``portfolio.max_turnover`` / ``portfolio.lambda_tc`` turnover controls; it never
+applies ``portfolio.transaction_cost_bps``, which is a multi-period-only turnover
+lever. Setting it on a single-period run is therefore a silent no-op.
+``run_simulation`` must warn loudly instead.
 """
 
 from __future__ import annotations
@@ -73,6 +74,7 @@ def test_single_period_warns_when_transaction_cost_bps_set() -> None:
         f"got categories/messages: {[(type(r.message).__name__, str(r.message)) for r in records]}"
     )
     assert "25.0" in str(matches[0].message)
+    assert "portfolio.lambda_tc" in str(matches[0].message)
 
 
 def test_single_period_silent_when_transaction_cost_bps_unset() -> None:


### PR DESCRIPTION
Closes #5394

## Summary
The single-period analysis path (`api.run_simulation` → `stages/portfolio.py`) only charges `run.monthly_cost` and caps turnover via `portfolio.max_turnover`. The turnover-based `portfolio.transaction_cost_bps` lever is charged **only** by the multi-period engine (`multi_period/engine.py`), so setting it on a single-period run was a silent no-op.

Per the issue's "apply-vs-document" choice, this takes the **document-loudly** path (the non-goal forbids altering the multi-period cost formula, and single-period has a single allocation so a turnover charge is ambiguous): `run_simulation` now emits a `UserWarning` (and a `logger.warning`) on the single-period path when `portfolio.transaction_cost_bps > 0`, naming the ignored value and the supported single-period cost levers.

## Changes
- `src/trend_analysis/api.py`: warn on the single-period path (after the multi-period delegation) when `transaction_cost_bps > 0`; added `import warnings`.
- `tests/test_single_period_costs.py`: asserts the warning fires when the key is set and stays silent when unset.

## Validation
- `python -m pytest tests/test_single_period_costs.py -q` → 2 passed.
- **Deliberate-break gate:** disabling the `warnings.warn` made `test_single_period_warns_when_transaction_cost_bps_set` FAIL (no UserWarning emitted); reverted after capture.
- `ruff check` clean; `mypy` clean on `api.py`; `git diff --check` clean.

## Tasks / Acceptance
- [x] Decide apply-vs-document → document + warn on single-period when `transaction_cost_bps > 0`.
- [x] `tests/test_single_period_costs.py` asserts the warning is emitted.
- [x] `pytest tests/test_single_period_costs.py -q` passes (non-zero collected).
- [x] Deliberate-break gate verified.