### PR TITLE
Issue #5395: validate regime.threshold for volatility mode

### DIFF
--- a/src/trend_analysis/regimes.py
+++ b/src/trend_analysis/regimes.py
@@ -79,6 +79,12 @@ def normalise_settings(cfg: Mapping[str, Any] | None) -> RegimeSettings:
     lookback = _coerce_positive_int(cfg.get("lookback"), 126)
     smoothing = _coerce_positive_int(cfg.get("smoothing"), 3)
     threshold = _coerce_float(cfg.get("threshold"), 0.0)
+    if method == "volatility" and threshold <= 0:
+        raise ValueError(
+            "regime.threshold must be positive when regime.method is 'volatility' "
+            "(signal = threshold - volatility, and volatility is non-negative, so a "
+            "non-positive threshold collapses the split to all Risk-Off)"
+        )
     neutral_band = abs(_coerce_float(cfg.get("neutral_band"), 0.001))
     min_obs = _coerce_positive_int(cfg.get("min_observations"), 6, minimum=1)
     cache = bool(cfg.get("cache", True))

--- a/src/trend_analysis/regimes.py
+++ b/src/trend_analysis/regimes.py
@@ -79,9 +79,9 @@ def normalise_settings(cfg: Mapping[str, Any] | None) -> RegimeSettings:
     lookback = _coerce_positive_int(cfg.get("lookback"), 126)
     smoothing = _coerce_positive_int(cfg.get("smoothing"), 3)
     threshold = _coerce_float(cfg.get("threshold"), 0.0)
-    if method == "volatility" and threshold <= 0:
+    if enabled and method == "volatility" and (not np.isfinite(threshold) or threshold <= 0):
         raise ValueError(
-            "regime.threshold must be positive when regime.method is 'volatility' "
+            "regime.threshold must be finite and positive when regime.method is 'volatility' "
             "(signal = threshold - volatility, and volatility is non-negative, so a "
             "non-positive threshold collapses the split to all Risk-Off)"
         )

--- a/tests/test_regime_threshold.py
+++ b/tests/test_regime_threshold.py
@@ -1,0 +1,42 @@
+"""Regression tests for A15: volatility-mode regime threshold validation.
+
+In volatility mode the regime signal is ``threshold - volatility`` and realized
+volatility is non-negative, so a non-positive ``regime.threshold`` collapses the
+classification to all Risk-Off. ``normalise_settings`` must reject that config;
+``rolling_return`` mode (the default) is unaffected.
+"""
+
+import pytest
+
+from trend_analysis.regimes import normalise_settings
+
+
+def test_volatility_regime_rejects_zero_threshold() -> None:
+    with pytest.raises(ValueError, match="threshold must be positive"):
+        normalise_settings({"method": "volatility", "threshold": 0.0})
+
+
+def test_volatility_regime_rejects_negative_threshold() -> None:
+    with pytest.raises(ValueError, match="threshold must be positive"):
+        normalise_settings({"method": "volatility", "threshold": -0.1})
+
+
+def test_volatility_alias_rejects_zero_threshold() -> None:
+    # "vol" / "std" normalise to the volatility method and must validate too.
+    for alias in ("vol", "std"):
+        with pytest.raises(ValueError, match="threshold must be positive"):
+            normalise_settings({"method": alias, "threshold": 0.0})
+
+
+def test_rolling_return_regime_allows_zero_threshold() -> None:
+    settings = normalise_settings({"method": "rolling_return", "threshold": 0.0})
+
+    assert settings.method == "rolling_return"
+    assert settings.threshold == 0.0
+
+
+def test_volatility_regime_accepts_positive_threshold() -> None:
+    settings = normalise_settings({"method": "volatility", "threshold": 0.05})
+
+    assert settings.method == "volatility"
+    assert settings.threshold == 0.05

--- a/tests/test_regime_threshold.py
+++ b/tests/test_regime_threshold.py
@@ -12,20 +12,34 @@ from trend_analysis.regimes import normalise_settings
 
 
 def test_volatility_regime_rejects_zero_threshold() -> None:
-    with pytest.raises(ValueError, match="threshold must be positive"):
-        normalise_settings({"method": "volatility", "threshold": 0.0})
+    with pytest.raises(ValueError, match="threshold must be finite and positive"):
+        normalise_settings({"enabled": True, "method": "volatility", "threshold": 0.0})
 
 
 def test_volatility_regime_rejects_negative_threshold() -> None:
-    with pytest.raises(ValueError, match="threshold must be positive"):
-        normalise_settings({"method": "volatility", "threshold": -0.1})
+    with pytest.raises(ValueError, match="threshold must be finite and positive"):
+        normalise_settings({"enabled": True, "method": "volatility", "threshold": -0.1})
 
 
 def test_volatility_alias_rejects_zero_threshold() -> None:
     # "vol" / "std" normalise to the volatility method and must validate too.
     for alias in ("vol", "std"):
-        with pytest.raises(ValueError, match="threshold must be positive"):
-            normalise_settings({"method": alias, "threshold": 0.0})
+        with pytest.raises(ValueError, match="threshold must be finite and positive"):
+            normalise_settings({"enabled": True, "method": alias, "threshold": 0.0})
+
+
+def test_disabled_volatility_regime_allows_default_threshold() -> None:
+    settings = normalise_settings({"enabled": False, "method": "volatility", "threshold": 0.0})
+
+    assert settings.enabled is False
+    assert settings.method == "volatility"
+    assert settings.threshold == 0.0
+
+
+def test_volatility_regime_rejects_non_finite_threshold() -> None:
+    for threshold in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(ValueError, match="threshold must be finite and positive"):
+            normalise_settings({"enabled": True, "method": "volatility", "threshold": threshold})
 
 
 def test_rolling_return_regime_allows_zero_threshold() -> None:

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,19 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-06-03T06:01:06Z - closer lane advanced PR #5448 review fixes
+
+- Repo/issue/PR: stranske/Trend_Model_Project #5395 / #5448 (`claude/issue-5395-regime-threshold-validation`).
+- Agent: codex closer from neutral Code workspace; selected #5448 as the complex lane after the batch sweep found no safe terminal actions and #5446/#5447 were legitimately waiting on post-merge verifier jobs.
+- Review evidence: GraphQL review-thread audit showed two unresolved threads on head `c65ff5e6`: disabled volatility regimes should not raise before callers honor `regime.enabled: false`, and volatility thresholds should reject NaN/inf as well as non-positive values.
+- Fix: `normalise_settings()` now applies the volatility threshold guard only when regimes are enabled and requires the threshold to be finite and positive. Added regressions for disabled volatility configs and NaN/inf thresholds.
+- Validation:
+  - `PYTHONPATH=src MPLCONFIGDIR=/private/tmp/mplconfig-trend-5448 python -m pytest tests/test_regime_threshold.py -q` -> 7 passed.
+  - `python -m ruff check src/trend_analysis/regimes.py tests/test_regime_threshold.py` -> passed.
+  - `git diff --check` -> passed.
+  - Initial broader regime-suite run hit pre-existing local cache/ABI noise while reading stale `~/.cache/trend_model/rolling` files (`pyarrow` built for NumPy 1.x under local NumPy 2.4.6, then sandbox denied unlink). Rerun with isolated writable cache succeeded: `TREND_ROLLING_CACHE=/Users/teacher/.codex/automations/imi-merge-verify-closer/tmp-cache/trend-5448 PYTHONPATH=src MPLCONFIGDIR=/private/tmp/mplconfig-trend-5448 python -m pytest tests/test_regime_threshold.py tests/test_regimes_additional.py tests/trend_analysis/test_regimes.py tests/test_multi_period_regime_wiring.py -q` -> 65 passed, 16 warnings.
+- Current state before push: local review-fix patch ready on `closer-5448-reviewfix`; next action is race-check remote `origin/claude/issue-5395-regime-threshold-validation`, push to the PR branch, resolve the two review threads, and let fresh GitHub checks rerun.
+
 ## 2026-06-03T04:44:33Z - opener quick-recovery for PR #5444 dependency enforcement
 
 - Repo/issue/PR: stranske/Trend_Model_Project #5392 / #5444 (`codex/issue-5392-deflated-sharpe`).


### PR DESCRIPTION
## Summary

Closes #5395 (A15). In volatility mode the regime signal is `threshold - volatility` and realized volatility is non-negative, so the shipped default `regime.threshold: 0.0` classifies essentially every period as Risk-Off and collapses the regime split. Nothing previously validated this.

`normalise_settings` (`src/trend_analysis/regimes.py`) now raises `ValueError` when `regime.method == "volatility"` and `regime.threshold <= 0` (covering the `vol`/`std` aliases). The default `rolling_return` mode is untouched (non-goal respected), and no shipped config uses volatility mode, so `trend check` on the bundled configs is unaffected.

## Tests

`tests/test_regime_threshold.py`:
- vol-mode rejects zero / negative threshold (+ `vol`/`std` aliases)
- `rolling_return` mode still allows `threshold=0.0`
- vol-mode accepts a positive threshold

## Validation
- `pytest tests/test_regime_threshold.py -q` → 5 passed
- **Deliberate-break gate:** removing the guard makes the 3 vol-mode tests fail (`DID NOT RAISE`); restored → all pass
- `ruff` clean, `mypy` clean on `regimes.py`