### PR TITLE
Issue #5396: stabilize volatility regime annualization

### DIFF
--- a/src/trend_analysis/regimes.py
+++ b/src/trend_analysis/regimes.py
@@ -216,7 +216,10 @@ def _compute_regime_series(
             periods_per_year=periods,
             annualise=settings.annualise_volatility,
         )
-        signal = settings.threshold - signal
+        threshold = settings.threshold
+        if settings.annualise_volatility and periods and periods > 0:
+            threshold = threshold * float(np.sqrt(periods))
+        signal = threshold - signal
     else:
         signal = _rolling_return_signal(clean, window=window, smoothing=smoothing)
         signal = signal - settings.threshold

--- a/src/trend_analysis/regimes.py
+++ b/src/trend_analysis/regimes.py
@@ -217,16 +217,20 @@ def _compute_regime_series(
             annualise=settings.annualise_volatility,
         )
         threshold = settings.threshold
+        neutral_band = settings.neutral_band
         if settings.annualise_volatility and periods and periods > 0:
-            threshold = threshold * float(np.sqrt(periods))
+            scale = float(np.sqrt(periods))
+            threshold = threshold * scale
+            neutral_band = neutral_band * scale
         signal = threshold - signal
     else:
         signal = _rolling_return_signal(clean, window=window, smoothing=smoothing)
         signal = signal - settings.threshold
+        neutral_band = settings.neutral_band
 
     labels = pd.Series(settings.default_label, index=clean.index, dtype="string")
-    upper = settings.neutral_band
-    lower = -settings.neutral_band
+    upper = neutral_band
+    lower = -neutral_band
     if upper <= 0:
         labels.loc[signal >= 0] = settings.risk_on_label
         labels.loc[signal < 0] = settings.risk_off_label

--- a/tests/soft_coverage/test_regimes_soft.py
+++ b/tests/soft_coverage/test_regimes_soft.py
@@ -108,12 +108,17 @@ def test_compute_regime_series_volatility_and_cache(
 ) -> None:
     dates = _sample_index(6)
     proxy = pd.Series([0.0, 0.01, 0.015, 0.2, 0.18, 0.22], index=dates)
+    # threshold is expressed on the effective (periodic) scale; after #5396 the
+    # volatility-mode boundary is invariant to ``annualise_volatility`` because the
+    # threshold is rescaled by sqrt(periods) alongside the annualized vol. 0.05 sits
+    # between the calm windows and the mid-series vol spike so the fixture still
+    # exercises a genuine Risk-On/Risk-Off split under the corrected semantics.
     settings = regimes.RegimeSettings(
         enabled=True,
         method="volatility",
         lookback=2,
         smoothing=1,
-        threshold=0.12,
+        threshold=0.05,
         neutral_band=0.0,
         cache=True,
         annualise_volatility=True,

--- a/tests/test_regime_annualise.py
+++ b/tests/test_regime_annualise.py
@@ -33,3 +33,36 @@ def test_annualise_volatility_keeps_regime_classification_invariant() -> None:
 
     assert {"Risk-On", "Risk-Off"} <= set(non_annualised)
     pd.testing.assert_series_equal(annualised, non_annualised)
+
+
+def test_annualise_volatility_scales_neutral_band_with_signal() -> None:
+    proxy = pd.Series(
+        [0.0, 0.017, 0.017, 0.0, 0.04, -0.04, 0.001, -0.001],
+        index=pd.date_range("2024-01-31", periods=8, freq="ME"),
+    )
+    base_config = {
+        "enabled": True,
+        "method": "volatility",
+        "lookback": 2,
+        "smoothing": 1,
+        "threshold": 0.01,
+        "neutral_band": 0.002,
+        "default_label": "Neutral",
+        "cache": False,
+    }
+
+    non_annualised = compute_regimes(
+        proxy,
+        normalise_settings({**base_config, "annualise_volatility": False}),
+        freq="M",
+        periods_per_year=12,
+    )
+    annualised = compute_regimes(
+        proxy,
+        normalise_settings({**base_config, "annualise_volatility": True}),
+        freq="M",
+        periods_per_year=12,
+    )
+
+    assert "Neutral" in set(non_annualised)
+    pd.testing.assert_series_equal(annualised, non_annualised)

--- a/tests/test_regime_annualise.py
+++ b/tests/test_regime_annualise.py
@@ -1,0 +1,35 @@
+import pandas as pd
+
+from trend_analysis.regimes import compute_regimes, normalise_settings
+
+
+def test_annualise_volatility_keeps_regime_classification_invariant() -> None:
+    proxy = pd.Series(
+        [0.0, 0.0, 0.012, 0.0, 0.04, -0.04, 0.001, -0.001],
+        index=pd.date_range("2024-01-31", periods=8, freq="ME"),
+    )
+    base_config = {
+        "enabled": True,
+        "method": "volatility",
+        "lookback": 2,
+        "smoothing": 1,
+        "threshold": 0.01,
+        "neutral_band": 0.0,
+        "cache": False,
+    }
+
+    non_annualised = compute_regimes(
+        proxy,
+        normalise_settings({**base_config, "annualise_volatility": False}),
+        freq="M",
+        periods_per_year=12,
+    )
+    annualised = compute_regimes(
+        proxy,
+        normalise_settings({**base_config, "annualise_volatility": True}),
+        freq="M",
+        periods_per_year=12,
+    )
+
+    assert {"Risk-On", "Risk-Off"} <= set(non_annualised)
+    pd.testing.assert_series_equal(annualised, non_annualised)

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,14 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-06-03T07:05Z - closer lane rebasing PR #5449 after #5451 merge
+
+- Repo/issue/PR: stranske/Trend_Model_Project #5396 / #5449 (`codex/issue-5396-regime-annualise-volatility`).
+- Agent: codex closer from neutral Code workspace; selected as the complex lane after batch-merging #5451 and leaving #5450/#5397 waiting on post-merge verifier.
+- Conflict evidence: live PR state became `DIRTY` after current `origin/phase-3` moved through adjacent regime PR merges; the rebase conflict was limited to `workloop-state.md`.
+- Fix in progress: preserve the prior #5450 and #5449 workloop evidence while rebasing the annualized-volatility neutral-band fix and regression onto current `origin/phase-3`.
+- Current state: rebase conflict resolved locally; next action is to continue the rebase, validate the focused regime tests/lint/type checks, then force-with-lease push the refreshed PR head.
+
 ## 2026-06-03T06:40Z - closer lane rebased PR #5450 after regime merges
 
 - Repo/issue/PR: stranske/Trend_Model_Project #5397 / #5450 (`codex/issue-5397-min-obs-default`).
@@ -8,6 +16,14 @@
 - Conflict evidence: live PR state was `DIRTY` after #5448 and #5449 touched `src/trend_analysis/regimes.py` and `workloop-state.md`.
 - Fix: rebased onto current `origin/phase-3`, kept the min-observation default change and test, and dropped the opener workloop-state churn from the PR branch.
 - Current state: rebase/conflict fix validated locally; after force-with-lease push, fresh GitHub checks should rerun on the rebased branch.
+
+## 2026-06-03T06:30Z - closer lane advanced PR #5449 review and CI fixes
+
+- Repo/issue/PR: stranske/Trend_Model_Project #5396 / #5449 (`codex/issue-5396-regime-annualise-volatility`).
+- Agent: codex closer from neutral Code workspace; selected after batch-merging #5448 and deferring #5450 on transient `UNKNOWN` mergeability.
+- Review evidence: GraphQL review-thread audit showed two unresolved threads: annualized volatility mode scaled the signal and threshold but not `neutral_band`, and the PR carried an out-of-scope opener workloop log entry.
+- Fix: rebased onto current `origin/phase-3`, dropped the opener workloop churn from the PR branch, and scaled `neutral_band` by `sqrt(periods_per_year)` alongside the volatility threshold when annualization is active. Added a regression with a distinct `Neutral` label proving annualized and non-annualized classification stay invariant around the neutral band.
+- Current state: review fix validated and pushed at `7aeb8124`; review threads are ready to resolve and fresh GitHub checks should rerun on the rebased branch.
 
 ## 2026-06-03T06:01:06Z - closer lane advanced PR #5448 review fixes
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,13 +1,15 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
-## 2026-06-03T07:05Z - closer lane rebasing PR #5449 after #5451 merge
+## 2026-06-03T07:05Z - closer lane rebased PR #5449 after #5451 merge
 
 - Repo/issue/PR: stranske/Trend_Model_Project #5396 / #5449 (`codex/issue-5396-regime-annualise-volatility`).
 - Agent: codex closer from neutral Code workspace; selected as the complex lane after batch-merging #5451 and leaving #5450/#5397 waiting on post-merge verifier.
 - Conflict evidence: live PR state became `DIRTY` after current `origin/phase-3` moved through adjacent regime PR merges; the rebase conflict was limited to `workloop-state.md`.
-- Fix in progress: preserve the prior #5450 and #5449 workloop evidence while rebasing the annualized-volatility neutral-band fix and regression onto current `origin/phase-3`.
-- Current state: rebase conflict resolved locally; next action is to continue the rebase, validate the focused regime tests/lint/type checks, then force-with-lease push the refreshed PR head.
+- Fix: preserved the prior #5450 and #5449 workloop evidence while rebasing the annualized-volatility neutral-band fix and regression onto current `origin/phase-3`.
+- Validation before push: `pytest tests/soft_coverage/test_regimes_soft.py tests/test_regime_annualise.py -q` -> 24 passed; focused `ruff`, focused `mypy`, and `git diff --check` passed.
+- Current state: branch refreshed from old remote head `02da1f42`; PR is mergeable but `UNSTABLE` while fresh Gate/guard/review checks run on the rebased head.
+- Next action: re-check #5449 after fresh checks complete; merge and label `verify:compare` if checks are green and review threads remain resolved, otherwise repair the concrete failing check/thread.
 
 ## 2026-06-03T06:40Z - closer lane rebased PR #5450 after regime merges
 


### PR DESCRIPTION
Closes #5396

## Summary
- Scale the volatility-mode threshold by sqrt(periods_per_year) when the signal is annualized.
- Preserve regime classification when only annualise_volatility changes display scale.
- Add a focused regression covering low, intermediate, and high volatility windows.

## Validation
- python -m pytest tests/test_regime_annualise.py -q
- deliberate-break gate: restoring the old unscaled-threshold comparison fails tests/test_regime_annualise.py
- python -m ruff check src/trend_analysis/regimes.py tests/test_regime_annualise.py
- python -m mypy src/trend_analysis/regimes.py
- git diff --check