### PR TITLE
Issue #5397: align regime min observations default

### DIFF
--- a/src/trend_analysis/regimes.py
+++ b/src/trend_analysis/regimes.py
@@ -26,7 +26,7 @@ class RegimeSettings:
     smoothing: int = 3
     threshold: float = 0.0
     neutral_band: float = 0.001
-    min_obs: int = 6
+    min_obs: int = 4
     risk_on_label: str = "Risk-On"
     risk_off_label: str = "Risk-Off"
     default_label: str = "Risk-On"
@@ -86,7 +86,7 @@ def normalise_settings(cfg: Mapping[str, Any] | None) -> RegimeSettings:
             "non-positive threshold collapses the split to all Risk-Off)"
         )
     neutral_band = abs(_coerce_float(cfg.get("neutral_band"), 0.001))
-    min_obs = _coerce_positive_int(cfg.get("min_observations"), 6, minimum=1)
+    min_obs = _coerce_positive_int(cfg.get("min_observations"), 4, minimum=1)
     cache = bool(cfg.get("cache", True))
     annualise_volatility = bool(cfg.get("annualise_volatility", True))
 

--- a/tests/test_regime_min_obs_default.py
+++ b/tests/test_regime_min_obs_default.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+import yaml
+
+from trend_analysis.regimes import RegimeSettings, normalise_settings
+
+
+def test_regime_min_observations_default_matches_shipped_config() -> None:
+    defaults_path = Path("config/defaults.yml")
+    defaults = yaml.safe_load(defaults_path.read_text(encoding="utf-8"))
+    shipped_min_obs = defaults["regime"]["min_observations"]
+
+    assert RegimeSettings().min_obs == shipped_min_obs
+    assert normalise_settings(None).min_obs == shipped_min_obs
+    assert normalise_settings({}).min_obs == shipped_min_obs

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,14 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-06-03T06:40Z - closer lane rebased PR #5450 after regime merges
+
+- Repo/issue/PR: stranske/Trend_Model_Project #5397 / #5450 (`codex/issue-5397-min-obs-default`).
+- Agent: codex closer from neutral Code workspace; selected as a second complex lane after #5449 was advanced and #5393/#5394 were closed on verifier PASS.
+- Conflict evidence: live PR state was `DIRTY` after #5448 and #5449 touched `src/trend_analysis/regimes.py` and `workloop-state.md`.
+- Fix: rebased onto current `origin/phase-3`, kept the min-observation default change and test, and dropped the opener workloop-state churn from the PR branch.
+- Current state: rebase/conflict fix validated locally; after force-with-lease push, fresh GitHub checks should rerun on the rebased branch.
+
 ## 2026-06-03T06:01:06Z - closer lane advanced PR #5448 review fixes
 
 - Repo/issue/PR: stranske/Trend_Model_Project #5395 / #5448 (`claude/issue-5395-regime-threshold-validation`).


### PR DESCRIPTION
Closes #5397

## Summary
- Align the code-only regime min observation default with the shipped config/defaults.yml value of 4.
- Add a regression test that compares RegimeSettings, normalise_settings(None), and normalise_settings({}) against the shipped config value.
- Record opener lane state in workloop-state.md.

## Validation
- python -m pytest tests/test_regime_min_obs_default.py -q
- python -m pytest tests/test_regimes.py::test_normalise_settings_aliases_and_defaults tests/test_regimes_additional.py::test_normalise_settings_default_instance -q
- python -m ruff check src/trend_analysis/regimes.py tests/test_regime_min_obs_default.py
- python -m mypy src/trend_analysis/regimes.py
- git diff --check

## Deliberate-break Gate
- Temporarily set RegimeSettings.min_obs back to 6; tests/test_regime_min_obs_default.py failed with AssertionError: assert 6 == 4; restored the intended default and reran green.