### PR TITLE
Document run.monthly_cost config (#5399)

### DIFF
--- a/config.schema.compact.json
+++ b/config.schema.compact.json
@@ -220,6 +220,7 @@
       "deterministic": true,
       "log_file": "logs/phase1.log",
       "log_level": "INFO",
+      "monthly_cost": 0.0,
       "n_jobs": -1
     },
     "sample_split": {
@@ -1194,13 +1195,13 @@
               "default": 0,
               "description": "overrides transaction_cost_bps when provided",
               "nl_editable": true,
-              "type": "integer"
+              "type": "number"
             },
             "slippage_bps": {
               "default": 0,
               "description": "additional penalty applied on turnover",
               "nl_editable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           "type": "object"
@@ -1272,7 +1273,7 @@
         },
         "max_turnover": {
           "default": 1.0,
-          "description": "optional turnover cap (1.0 = no cap); may be a scalar cap or a regime-to-cap mapping",
+          "description": "optional turnover cap (1.0 = no cap)",
           "nl_editable": true,
           "type": [
             "number",
@@ -2028,6 +2029,7 @@
         "deterministic": true,
         "log_file": "logs/phase1.log",
         "log_level": "INFO",
+        "monthly_cost": 0.0,
         "n_jobs": -1
       },
       "description": "Runtime execution settings.",
@@ -2074,6 +2076,12 @@
           "description": "DEBUG | INFO | WARNING | ERROR",
           "nl_editable": true,
           "type": "string"
+        },
+        "monthly_cost": {
+          "default": 0.0,
+          "description": "flat decimal return subtracted from each fund every period",
+          "nl_editable": true,
+          "type": "number"
         },
         "n_jobs": {
           "default": -1,

--- a/config.schema.json
+++ b/config.schema.json
@@ -650,6 +650,65 @@
       },
       "type": "object"
     },
+    "identity": {
+      "additionalProperties": false,
+      "constraints": {},
+      "default": null,
+      "description": "Deterministic entity identity aliases for run manifest selected_entities.",
+      "nl_editable": true,
+      "properties": {
+        "entities": {
+          "default": [],
+          "description": "Explicit canonical entities and aliases.",
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "aliases": {
+                "default": [],
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "canonical_id": {
+                "type": "string"
+              },
+              "display_name": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "canonical_id"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "universe": {
+          "description": "Universe file path or paths, resolved relative to the config file.",
+          "type": [
+            "string",
+            "array",
+            "null"
+          ]
+        },
+        "universes": {
+          "description": "Universe file path or paths, resolved relative to the config file.",
+          "type": [
+            "string",
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
     "jobs": {
       "constraints": {},
       "default": -1,

--- a/config.schema.json
+++ b/config.schema.json
@@ -222,6 +222,7 @@
       "deterministic": true,
       "log_file": "logs/phase1.log",
       "log_level": "INFO",
+      "monthly_cost": 0.0,
       "n_jobs": -1
     },
     "sample_split": {
@@ -283,65 +284,6 @@
       "nl_editable": true,
       "type": [
         "string",
-        "null"
-      ]
-    },
-    "identity": {
-      "additionalProperties": false,
-      "constraints": {},
-      "default": null,
-      "description": "Deterministic entity identity aliases for run manifest selected_entities.",
-      "nl_editable": true,
-      "properties": {
-        "entities": {
-          "default": [],
-          "description": "Explicit canonical entities and aliases.",
-          "items": {
-            "additionalProperties": false,
-            "properties": {
-              "aliases": {
-                "default": [],
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "canonical_id": {
-                "type": "string"
-              },
-              "display_name": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "canonical_id"
-            ],
-            "type": "object"
-          },
-          "type": "array"
-        },
-        "universe": {
-          "description": "Universe file path or paths, resolved relative to the config file.",
-          "type": [
-            "string",
-            "array",
-            "null"
-          ]
-        },
-        "universes": {
-          "description": "Universe file path or paths, resolved relative to the config file.",
-          "type": [
-            "string",
-            "array",
-            "null"
-          ]
-        }
-      },
-      "type": [
-        "object",
         "null"
       ]
     },
@@ -1409,18 +1351,24 @@
           "nl_editable": true,
           "properties": {
             "bps_per_trade": {
-              "constraints": {},
+              "constraints": {
+                "minimum": 0
+              },
               "default": 0,
               "description": "overrides transaction_cost_bps when provided",
+              "minimum": 0,
               "nl_editable": true,
-              "type": "integer"
+              "type": "number"
             },
             "slippage_bps": {
-              "constraints": {},
+              "constraints": {
+                "minimum": 0
+              },
               "default": 0,
               "description": "additional penalty applied on turnover",
+              "minimum": 0,
               "nl_editable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           "type": "object"
@@ -1515,7 +1463,7 @@
             "minimum": 0
           },
           "default": 1.0,
-          "description": "optional turnover cap (1.0 = no cap); may be a scalar cap or a regime-to-cap mapping",
+          "description": "optional turnover cap (1.0 = no cap)",
           "maximum": 2,
           "minimum": 0,
           "nl_editable": true,
@@ -2498,6 +2446,7 @@
         "deterministic": true,
         "log_file": "logs/phase1.log",
         "log_level": "INFO",
+        "monthly_cost": 0.0,
         "n_jobs": -1
       },
       "description": "Runtime execution settings.",
@@ -2550,6 +2499,13 @@
           "description": "DEBUG | INFO | WARNING | ERROR",
           "nl_editable": true,
           "type": "string"
+        },
+        "monthly_cost": {
+          "constraints": {},
+          "default": 0.0,
+          "description": "flat decimal return subtracted from each fund every period",
+          "nl_editable": true,
+          "type": "number"
         },
         "n_jobs": {
           "constraints": {},

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -200,6 +200,7 @@ performance:
 run:
   log_level: "INFO" # DEBUG | INFO | WARNING | ERROR
   log_file: "logs/phase1.log"
+  monthly_cost: 0.0 # flat decimal return subtracted from each fund every period
   n_jobs: -1 # ‑1 ⇒ all CPUs
   cache_dir: ".cache/"
   deterministic: true # sets NumPy & pandas options

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -324,6 +324,11 @@ realistic implementation:
 - `portfolio.cost_model.slippage_bps` – optional extra spread per turnover
    event to mimic fill slippage. Defaults to `0`. Positive values reduce the
    first post-rebalance return by the specified number of basis points.
+- `run.monthly_cost` – flat decimal per-period fee subtracted from every fund
+   return before portfolio statistics are calculated. For example, `0.001`
+   subtracts 10 bps from each monthly return. This is not scaled by turnover or
+   exposure; use `portfolio.transaction_cost_bps` / `portfolio.cost_model` for
+   turnover-based trading costs.
 - `portfolio.max_turnover` – soft cap on total turnover (sum of absolute
    weight changes) for a single rebalance expressed as a fraction of gross
    notional. Accepted range is `0.0` to `2.0` where `1.0` effectively means
@@ -334,7 +339,7 @@ Validation rules:
 
 - Negative values for any cost control raises a configuration error.
 - Values are coerced from numeric strings when possible (e.g. `"15"`).
-- Omitting both keys preserves previous behaviour (no costs, no cap).
+- Omitting these keys preserves previous behaviour (no costs, no cap).
 
 Multi‑period runs attach per‑period `turnover` and `transaction_cost` figures
 to each result dictionary. These appear in a separate execution metrics export

--- a/docs/config.md
+++ b/docs/config.md
@@ -56,6 +56,9 @@ model is constructed:
 - `portfolio.transaction_cost_bps` and every linear `cost_model` field (bps per
   trade, slippage, per-trade bps, half-spread) remain non-negative and must
   round-trip unchanged through `CoreConfig.to_payload()` into `TrendConfig`.
+- `run.monthly_cost` is a flat decimal per-period fee. It is subtracted from
+  every fund return before statistics are calculated and is not scaled by
+  turnover or exposure.
 - Relative paths must resolve to the same absolute targets in both layers when
   the same `base_path` is supplied.
 
@@ -117,6 +120,14 @@ output:
   format: excel               # csv, json, excel
   path: outputs/analysis      # Output directory/prefix
   include_raw_metrics: true   # Include detailed metrics
+```
+
+### Run Section
+
+```yaml
+run:
+  monthly_cost: 0.0            # flat decimal per-period fee, e.g. 0.001 = 10 bps
+  n_jobs: -1                   # parallel worker count
 ```
 
 ### Walk-Forward Section

--- a/docs/config.md
+++ b/docs/config.md
@@ -127,7 +127,7 @@ output:
 ```yaml
 run:
   monthly_cost: 0.0            # flat decimal per-period fee, e.g. 0.001 = 10 bps
-  n_jobs: -1                   # parallel worker count
+  jobs: -1                     # parallel worker count
 ```
 
 ### Walk-Forward Section

--- a/tests/test_monthly_cost_documented.py
+++ b/tests/test_monthly_cost_documented.py
@@ -10,6 +10,7 @@ import yaml
 
 from trend_analysis import api
 from trend_analysis.config import Config
+from trend_analysis.config.schema_validation import load_schema, validate_config_data
 
 
 def _make_df() -> pd.DataFrame:
@@ -53,6 +54,23 @@ def test_defaults_document_run_monthly_cost() -> None:
 
     assert "monthly_cost" in defaults["run"]
     assert defaults["run"]["monthly_cost"] == pytest.approx(0.0)
+
+
+def test_schema_accepts_documented_run_monthly_cost() -> None:
+    schema = load_schema()
+
+    assert "monthly_cost" in schema["properties"]["run"]["properties"]
+    assert validate_config_data({"run": {"monthly_cost": 0.001}}, schema) == []
+
+
+def test_run_section_documents_live_jobs_key() -> None:
+    config_doc = Path("docs/config.md").read_text()
+    run_section = config_doc.split("### Run Section", maxsplit=1)[1].split(
+        "### Walk-Forward Section", maxsplit=1
+    )[0]
+
+    assert "jobs: -1" in run_section
+    assert "n_jobs:" not in run_section
 
 
 def test_run_monthly_cost_lowers_net_periodic_returns() -> None:

--- a/tests/test_monthly_cost_documented.py
+++ b/tests/test_monthly_cost_documented.py
@@ -1,0 +1,66 @@
+"""Regression coverage for the documented ``run.monthly_cost`` knob."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import yaml
+
+from trend_analysis import api
+from trend_analysis.config import Config
+
+
+def _make_df() -> pd.DataFrame:
+    dates = pd.date_range("2020-01-31", periods=6, freq="ME")
+    return pd.DataFrame(
+        {
+            "Date": dates,
+            "RF": 0.0,
+            "A": [0.010, 0.013, 0.012, 0.014, 0.011, 0.015],
+            "B": [0.008, 0.010, 0.009, 0.012, 0.010, 0.013],
+        }
+    )
+
+
+def _make_cfg(monthly_cost: float) -> Config:
+    return Config(
+        version="1",
+        data={
+            "risk_free_column": "RF",
+            "allow_risk_free_fallback": False,
+            "date_column": "Date",
+            "frequency": "M",
+        },
+        preprocessing={},
+        vol_adjust={"target_vol": 1.0},
+        sample_split={
+            "in_start": "2020-01",
+            "in_end": "2020-03",
+            "out_start": "2020-04",
+            "out_end": "2020-06",
+        },
+        portfolio={},
+        metrics={},
+        export={},
+        run={"monthly_cost": monthly_cost},
+    )
+
+
+def test_defaults_document_run_monthly_cost() -> None:
+    defaults = yaml.safe_load(Path("config/defaults.yml").read_text())
+
+    assert "monthly_cost" in defaults["run"]
+    assert defaults["run"]["monthly_cost"] == pytest.approx(0.0)
+
+
+def test_run_monthly_cost_lowers_net_periodic_returns() -> None:
+    returns = _make_df()
+    baseline = api.run_simulation(_make_cfg(0.0), returns.copy())
+    charged = api.run_simulation(_make_cfg(0.0025), returns.copy())
+
+    baseline_scaled = baseline.details["out_sample_scaled"][["A", "B"]]
+    charged_scaled = charged.details["out_sample_scaled"][["A", "B"]]
+
+    pd.testing.assert_frame_equal(charged_scaled, baseline_scaled - 0.0025)

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,15 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-06-03T07:31Z - closer lane advanced PR #5452 schema/docs CI and review fixes
+
+- Repo/issue/PR: stranske/Trend_Model_Project #5399 / #5452 (`codex/issue-5399-monthly-cost-doc`).
+- Agent: codex closer from neutral Code workspace; selected as the complex lane after batch-merging #5449, reopening #5396 pending verifier, and closing #5397/#5398 on verifier PASS.
+- Failure/review evidence: live PR state was `UNSTABLE` with failing Python CI 3.12/3.13, and GraphQL showed three unresolved threads: `run.monthly_cost` was added to `config/defaults.yml` but not regenerated into `config.schema.json` / `config.schema.compact.json`, and `docs/config.md` documented inert `run.n_jobs` instead of live `run.jobs`.
+- Fix: regenerated schema artifacts with `scripts/generate_config_schema.py`, updated the Run Section docs example to `jobs`, and added tests proving the checked-in schema accepts `run.monthly_cost` and the docs no longer advertise `run.n_jobs`.
+- Validation before push: `pytest tests/test_monthly_cost_documented.py tests/test_config_schema_generation.py tests/monte_carlo/strategy/test_validation.py -q` -> 35 passed; `scripts/validate_config.py config/defaults.yml` -> valid; focused `ruff` and `git diff --check` passed.
+- Current state: local branch `closer-5452-reviewfix` rebased onto current `origin/phase-3`; next action is race-check, push to `codex/issue-5399-monthly-cost-doc`, resolve the three review threads, and let fresh GitHub checks rerun.
+
 ## 2026-06-03T07:05Z - closer lane rebased PR #5449 after #5451 merge
 
 - Repo/issue/PR: stranske/Trend_Model_Project #5396 / #5449 (`codex/issue-5396-regime-annualise-volatility`).


### PR DESCRIPTION
## Summary
- Add `run.monthly_cost` to `config/defaults.yml` with a zero default.
- Document the knob in the user guide and configuration reference as a flat per-period decimal fee.
- Add regression coverage proving the default remains documented and the runtime fee lowers net fund returns by the configured amount.

## Validation
- `PYTHONPATH=src /Users/teacher/Library/CloudStorage/Dropbox/Learning/Code/Trend_Model_Project/.venv/bin/python -m pytest tests/test_monthly_cost_documented.py -q`
- `PYTHONPATH=src /Users/teacher/Library/CloudStorage/Dropbox/Learning/Code/Trend_Model_Project/.venv/bin/python -m ruff check tests/test_monthly_cost_documented.py`
- `git diff --check`
- Deliberate break: removed the defaults entry and confirmed `test_defaults_document_run_monthly_cost` fails, then restored it.

Closes #5399