### PR TITLE
Issue #5401: consolidate parallelism config keys

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -200,7 +200,6 @@ performance:
 run:
   log_level: "INFO" # DEBUG | INFO | WARNING | ERROR
   log_file: "logs/phase1.log"
-  n_jobs: -1 # ‑1 ⇒ all CPUs
   cache_dir: ".cache/"
   deterministic: true # sets NumPy & pandas options
 

--- a/config/robust_demo.yml
+++ b/config/robust_demo.yml
@@ -114,7 +114,7 @@ export:
 run:
   log_level: "DEBUG"  # Enable detailed logging for robustness features
   log_file: "logs/robust_demo.log"
-  n_jobs: 1  # Single-threaded for clearer logging
+  jobs: 1  # Single-threaded for clearer logging
   cache_dir: ".cache/"
   deterministic: true
 

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -749,6 +749,16 @@ REQUIRED_SECTIONS = (
 )
 
 
+def _resolve_deprecated_jobs_alias(data: dict[str, Any]) -> None:
+    """Map legacy top-level jobs into the canonical run.jobs setting."""
+    if "jobs" not in data or data["jobs"] is None:
+        return
+    run_section = data.setdefault("run", {})
+    if not isinstance(run_section, dict):
+        return
+    run_section.setdefault("jobs", data["jobs"])
+
+
 def load_config(cfg: Mapping[str, Any] | str | Path) -> ConfigProtocol:
     """Load configuration from a mapping or file path."""
     if isinstance(cfg, (str, Path)):
@@ -756,6 +766,7 @@ def load_config(cfg: Mapping[str, Any] | str | Path) -> ConfigProtocol:
     if not isinstance(cfg, Mapping):
         raise TypeError("cfg must be a mapping or path")
     cfg_dict = dict(cfg)
+    _resolve_deprecated_jobs_alias(cfg_dict)
     # Early version validation for mapping-based load to surface version
     # errors directly (tests accept ValueError here) regardless of Pydantic.
     if "version" in cfg_dict:
@@ -809,6 +820,8 @@ def load(path: str | Path | None = None) -> ConfigProtocol:
             data = yaml.safe_load(fh)
             if not isinstance(data, dict):
                 raise TypeError("Config file must contain a mapping")
+
+    _resolve_deprecated_jobs_alias(data)
 
     out_cfg = data.pop("output", None)
     if isinstance(out_cfg, dict):

--- a/src/trend_model/spec.py
+++ b/src/trend_model/spec.py
@@ -104,6 +104,14 @@ def _cfg_value(cfg: Any, key: str, default: Any = None) -> Any:
     return getattr(cfg, key, default)
 
 
+def _run_jobs_value(cfg: Any, run_cfg: Mapping[str, Any]) -> Any:
+    """Return canonical run.jobs, falling back to deprecated top-level jobs."""
+    value = _section_get(run_cfg, "jobs", None)
+    if value is not None:
+        return value
+    return _cfg_value(cfg, "jobs", None)
+
+
 def _cfg_section(cfg: Any, key: str) -> Mapping[str, Any]:
     section = _cfg_value(cfg, key, {})
     return _as_mapping(section)
@@ -247,7 +255,7 @@ def _build_backtest_spec(cfg: Any, *, base_path: Path | None) -> BacktestSpec:
         regime=_cfg_section(cfg, "regime"),
         metrics=_as_tuple(_section_get(metrics, "registry", ())),
         seed=_coerce_int(_cfg_value(cfg, "seed", _section_get(run_cfg, "seed", 42)), default=42),
-        jobs=_coerce_int(_section_get(run_cfg, "jobs", None), default=0) or None,
+        jobs=_coerce_int(_run_jobs_value(cfg, run_cfg), default=0) or None,
         checkpoint_dir=checkpoint,
         export_directory=export_dir,
         export_formats=_as_tuple(_section_get(export_cfg, "formats", ())),

--- a/tests/test_parallelism_keys.py
+++ b/tests/test_parallelism_keys.py
@@ -1,0 +1,56 @@
+"""Regression coverage for canonical parallelism config keys."""
+
+from __future__ import annotations
+
+import copy
+
+import yaml
+
+from trend_analysis.config.schema_generator import generate_schema
+from trend_model.spec import load_run_spec_from_mapping
+
+
+def _load_defaults() -> dict:
+    with open("config/defaults.yml", encoding="utf-8") as handle:
+        loaded = yaml.safe_load(handle)
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _config_with_jobs(*, run_jobs: int | None = None, top_level_jobs: int | None = None) -> dict:
+    payload = _load_defaults()
+    payload["run"].pop("jobs", None)
+    payload.pop("jobs", None)
+    if run_jobs is not None:
+        payload["run"]["jobs"] = run_jobs
+    if top_level_jobs is not None:
+        payload["jobs"] = top_level_jobs
+    return payload
+
+
+def test_run_n_jobs_absent_from_defaults_and_schema() -> None:
+    defaults = _load_defaults()
+    assert "n_jobs" not in defaults["run"]
+
+    schema = generate_schema()
+    run_properties = schema["properties"]["run"]["properties"]
+    assert "n_jobs" not in run_properties
+    assert "jobs" in run_properties
+
+
+def test_run_jobs_and_top_level_jobs_alias_resolve_to_same_worker_count() -> None:
+    canonical = load_run_spec_from_mapping(_config_with_jobs(run_jobs=3))
+    legacy_alias = load_run_spec_from_mapping(_config_with_jobs(top_level_jobs=3))
+    both = load_run_spec_from_mapping(_config_with_jobs(run_jobs=3, top_level_jobs=9))
+
+    assert canonical.backtest.jobs == 3
+    assert legacy_alias.backtest.jobs == canonical.backtest.jobs
+    assert both.backtest.jobs == canonical.backtest.jobs
+
+
+def test_top_level_jobs_alias_is_centralized_by_config_loader() -> None:
+    payload = _config_with_jobs(top_level_jobs=2)
+    spec = load_run_spec_from_mapping(copy.deepcopy(payload))
+
+    assert spec.config.jobs == 2
+    assert spec.config.run["jobs"] == 2


### PR DESCRIPTION
Closes #5401

## Summary
- remove the dead `run.n_jobs` key from shipped configs
- map deprecated top-level `jobs` into canonical `run.jobs` in one loader path
- add regression coverage for schema absence and alias resolution

## Validation
- `PYTHONPATH=src python -m pytest tests/test_parallelism_keys.py tests/test_config_schema_generation.py -q`
- `python -m ruff check src/trend_analysis/config/models.py src/trend_model/spec.py tests/test_parallelism_keys.py`
- `git diff --check`
- deliberate-break gate: temporarily re-added `run.n_jobs` to `config/defaults.yml`; `test_run_n_jobs_absent_from_defaults_and_schema` failed as expected, then reverted
