### PR TITLE
A20 — Consolidate parallelism config keys (#5401)

### DIFF
--- a/config.schema.compact.json
+++ b/config.schema.compact.json
@@ -22,41 +22,14 @@
     "export": {
       "directory": "results/",
       "disable_narrative_generation": false,
-      "excel": {
-        "autofit_columns": true,
-        "conditional_bands": {
-          "enabled": true,
-          "palette": "RdYlGn"
-        },
-        "number_format": "0.00%"
-      },
       "formats": [
         "xlsx",
         "csv",
         "json"
       ],
-      "include_figures": false,
-      "include_raw_returns": true,
-      "include_vol_adj": true
+      "include_figures": false
     },
-    "jobs": -1,
     "metrics": {
-      "alpha_reference": "SP500TR",
-      "bootstrap_ci": {
-        "ci_level": 0.95,
-        "enabled": true,
-        "n_iter": 2000
-      },
-      "compute": [
-        "CAGR",
-        "Volatility",
-        "Sharpe",
-        "Sortino",
-        "Max_Drawdown",
-        "Calmar",
-        "Hit_Rate",
-        "Skew"
-      ],
       "registry": [
         "annual_return",
         "volatility",
@@ -66,8 +39,7 @@
         "max_drawdown"
       ],
       "rf_override_enabled": false,
-      "rf_rate_annual": 0.02,
-      "use_continuous": false
+      "rf_rate_annual": 0.02
     },
     "multi_period": {
       "end": "2024-12",
@@ -216,12 +188,8 @@
       "threshold": 0.0
     },
     "run": {
-      "cache_dir": ".cache/",
-      "deterministic": true,
-      "log_file": "logs/phase1.log",
-      "log_level": "INFO",
-      "monthly_cost": 0.0,
-      "n_jobs": -1
+      "jobs": -1,
+      "monthly_cost": 0.0
     },
     "sample_split": {
       "date": "2017-12-31",
@@ -452,22 +420,12 @@
       "default": {
         "directory": "results/",
         "disable_narrative_generation": false,
-        "excel": {
-          "autofit_columns": true,
-          "conditional_bands": {
-            "enabled": true,
-            "palette": "RdYlGn"
-          },
-          "number_format": "0.00%"
-        },
         "formats": [
           "xlsx",
           "csv",
           "json"
         ],
-        "include_figures": false,
-        "include_raw_returns": true,
-        "include_vol_adj": true
+        "include_figures": false
       },
       "description": "Export settings for output artifacts.",
       "nl_editable": true,
@@ -483,56 +441,6 @@
           "description": "Disable narrative generation in exports.",
           "nl_editable": true,
           "type": "boolean"
-        },
-        "excel": {
-          "default": {
-            "autofit_columns": true,
-            "conditional_bands": {
-              "enabled": true,
-              "palette": "RdYlGn"
-            },
-            "number_format": "0.00%"
-          },
-          "description": "Excel-specific export settings.",
-          "nl_editable": true,
-          "properties": {
-            "autofit_columns": {
-              "default": true,
-              "description": "Auto size Excel columns to fit content.",
-              "nl_editable": true,
-              "type": "boolean"
-            },
-            "conditional_bands": {
-              "default": {
-                "enabled": true,
-                "palette": "RdYlGn"
-              },
-              "description": "Conditional formatting bands for Excel exports.",
-              "nl_editable": true,
-              "properties": {
-                "enabled": {
-                  "default": true,
-                  "description": "Enable conditional formatting bands in Excel.",
-                  "nl_editable": true,
-                  "type": "boolean"
-                },
-                "palette": {
-                  "default": "RdYlGn",
-                  "description": "Color palette name for Excel conditional bands.",
-                  "nl_editable": true,
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "number_format": {
-              "default": "0.00%",
-              "description": "Default numeric format for Excel output.",
-              "nl_editable": true,
-              "type": "string"
-            }
-          },
-          "type": "object"
         },
         "filename": {
           "default": null,
@@ -561,25 +469,13 @@
           "description": "Phase-2",
           "nl_editable": true,
           "type": "boolean"
-        },
-        "include_raw_returns": {
-          "default": true,
-          "description": "Include raw return series in exports.",
-          "nl_editable": true,
-          "type": "boolean"
-        },
-        "include_vol_adj": {
-          "default": true,
-          "description": "Include volatility-adjusted series in exports.",
-          "nl_editable": true,
-          "type": "boolean"
         }
       },
       "type": "object"
     },
     "jobs": {
-      "default": -1,
-      "description": "-1 = use all logical cores",
+      "default": null,
+      "description": "Deprecated top-level alias for run.jobs; ignored when run.jobs is set.",
       "nl_editable": true,
       "type": [
         "integer",
@@ -588,22 +484,6 @@
     },
     "metrics": {
       "default": {
-        "alpha_reference": "SP500TR",
-        "bootstrap_ci": {
-          "ci_level": 0.95,
-          "enabled": true,
-          "n_iter": 2000
-        },
-        "compute": [
-          "CAGR",
-          "Volatility",
-          "Sharpe",
-          "Sortino",
-          "Max_Drawdown",
-          "Calmar",
-          "Hit_Rate",
-          "Skew"
-        ],
         "registry": [
           "annual_return",
           "volatility",
@@ -613,66 +493,11 @@
           "max_drawdown"
         ],
         "rf_override_enabled": false,
-        "rf_rate_annual": 0.02,
-        "use_continuous": false
+        "rf_rate_annual": 0.02
       },
       "description": "Performance metrics configuration.",
       "nl_editable": true,
       "properties": {
-        "alpha_reference": {
-          "default": "SP500TR",
-          "description": "ticker in indices_glob",
-          "nl_editable": true,
-          "type": "string"
-        },
-        "bootstrap_ci": {
-          "default": {
-            "ci_level": 0.95,
-            "enabled": true,
-            "n_iter": 2000
-          },
-          "description": "Bootstrap confidence interval settings.",
-          "nl_editable": true,
-          "properties": {
-            "ci_level": {
-              "default": 0.95,
-              "description": "Bootstrap confidence level.",
-              "nl_editable": true,
-              "type": "number"
-            },
-            "enabled": {
-              "default": true,
-              "description": "Enable bootstrap confidence intervals.",
-              "nl_editable": true,
-              "type": "boolean"
-            },
-            "n_iter": {
-              "default": 2000,
-              "description": "Number of bootstrap iterations.",
-              "nl_editable": true,
-              "type": "integer"
-            }
-          },
-          "type": "object"
-        },
-        "compute": {
-          "default": [
-            "CAGR",
-            "Volatility",
-            "Sharpe",
-            "Sortino",
-            "Max_Drawdown",
-            "Calmar",
-            "Hit_Rate",
-            "Skew"
-          ],
-          "description": "Legacy metrics list for reporting exports.",
-          "items": {
-            "type": "string"
-          },
-          "nl_editable": true,
-          "type": "array"
-        },
         "drawdown": {
           "default": null,
           "description": "Config option for metrics.drawdown.",
@@ -745,12 +570,6 @@
             "null",
             "number"
           ]
-        },
-        "use_continuous": {
-          "default": false,
-          "description": "geometric (default) vs. log",
-          "nl_editable": true,
-          "type": "boolean"
         },
         "volatility": {
           "default": null,
@@ -1877,7 +1696,7 @@
         },
         "steps": {
           "default": null,
-          "description": "Optional list of preprocessing steps to run in order.",
+          "description": "Config option for preprocessing.steps.",
           "nl_editable": true,
           "type": "null"
         },
@@ -2025,22 +1844,12 @@
     },
     "run": {
       "default": {
-        "cache_dir": ".cache/",
-        "deterministic": true,
-        "log_file": "logs/phase1.log",
-        "log_level": "INFO",
-        "monthly_cost": 0.0,
-        "n_jobs": -1
+        "jobs": -1,
+        "monthly_cost": 0.0
       },
       "description": "Runtime execution settings.",
       "nl_editable": true,
       "properties": {
-        "cache_dir": {
-          "default": ".cache/",
-          "description": "Directory for runtime cache.",
-          "nl_editable": true,
-          "type": "string"
-        },
         "checkpoint_dir": {
           "default": null,
           "description": "Directory for saving checkpoints.",
@@ -2050,44 +1859,17 @@
             "string"
           ]
         },
-        "deterministic": {
-          "default": true,
-          "description": "sets NumPy & pandas options",
-          "nl_editable": true,
-          "type": "boolean"
-        },
         "jobs": {
-          "default": null,
-          "description": "Parallel worker count for a run.",
+          "default": -1,
+          "description": "-1 => all CPUs",
           "nl_editable": true,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "log_file": {
-          "default": "logs/phase1.log",
-          "description": "Log file path for runtime logs.",
-          "nl_editable": false,
-          "type": "string"
-        },
-        "log_level": {
-          "default": "INFO",
-          "description": "DEBUG | INFO | WARNING | ERROR",
-          "nl_editable": true,
-          "type": "string"
+          "type": "integer"
         },
         "monthly_cost": {
           "default": 0.0,
           "description": "flat decimal return subtracted from each fund every period",
           "nl_editable": true,
           "type": "number"
-        },
-        "n_jobs": {
-          "default": -1,
-          "description": "1  all CPUs",
-          "nl_editable": true,
-          "type": "integer"
         },
         "name": {
           "default": null,

--- a/config.schema.json
+++ b/config.schema.json
@@ -24,41 +24,14 @@
     "export": {
       "directory": "results/",
       "disable_narrative_generation": false,
-      "excel": {
-        "autofit_columns": true,
-        "conditional_bands": {
-          "enabled": true,
-          "palette": "RdYlGn"
-        },
-        "number_format": "0.00%"
-      },
       "formats": [
         "xlsx",
         "csv",
         "json"
       ],
-      "include_figures": false,
-      "include_raw_returns": true,
-      "include_vol_adj": true
+      "include_figures": false
     },
-    "jobs": -1,
     "metrics": {
-      "alpha_reference": "SP500TR",
-      "bootstrap_ci": {
-        "ci_level": 0.95,
-        "enabled": true,
-        "n_iter": 2000
-      },
-      "compute": [
-        "CAGR",
-        "Volatility",
-        "Sharpe",
-        "Sortino",
-        "Max_Drawdown",
-        "Calmar",
-        "Hit_Rate",
-        "Skew"
-      ],
       "registry": [
         "annual_return",
         "volatility",
@@ -68,8 +41,7 @@
         "max_drawdown"
       ],
       "rf_override_enabled": false,
-      "rf_rate_annual": 0.02,
-      "use_continuous": false
+      "rf_rate_annual": 0.02
     },
     "multi_period": {
       "end": "2024-12",
@@ -218,12 +190,8 @@
       "threshold": 0.0
     },
     "run": {
-      "cache_dir": ".cache/",
-      "deterministic": true,
-      "log_file": "logs/phase1.log",
-      "log_level": "INFO",
-      "monthly_cost": 0.0,
-      "n_jobs": -1
+      "jobs": -1,
+      "monthly_cost": 0.0
     },
     "sample_split": {
       "date": "2017-12-31",
@@ -510,22 +478,12 @@
       "default": {
         "directory": "results/",
         "disable_narrative_generation": false,
-        "excel": {
-          "autofit_columns": true,
-          "conditional_bands": {
-            "enabled": true,
-            "palette": "RdYlGn"
-          },
-          "number_format": "0.00%"
-        },
         "formats": [
           "xlsx",
           "csv",
           "json"
         ],
-        "include_figures": false,
-        "include_raw_returns": true,
-        "include_vol_adj": true
+        "include_figures": false
       },
       "description": "Export settings for output artifacts.",
       "nl_editable": true,
@@ -543,64 +501,6 @@
           "description": "Disable narrative generation in exports.",
           "nl_editable": true,
           "type": "boolean"
-        },
-        "excel": {
-          "additionalProperties": false,
-          "constraints": {},
-          "default": {
-            "autofit_columns": true,
-            "conditional_bands": {
-              "enabled": true,
-              "palette": "RdYlGn"
-            },
-            "number_format": "0.00%"
-          },
-          "description": "Excel-specific export settings.",
-          "nl_editable": true,
-          "properties": {
-            "autofit_columns": {
-              "constraints": {},
-              "default": true,
-              "description": "Auto size Excel columns to fit content.",
-              "nl_editable": true,
-              "type": "boolean"
-            },
-            "conditional_bands": {
-              "additionalProperties": false,
-              "constraints": {},
-              "default": {
-                "enabled": true,
-                "palette": "RdYlGn"
-              },
-              "description": "Conditional formatting bands for Excel exports.",
-              "nl_editable": true,
-              "properties": {
-                "enabled": {
-                  "constraints": {},
-                  "default": true,
-                  "description": "Enable conditional formatting bands in Excel.",
-                  "nl_editable": true,
-                  "type": "boolean"
-                },
-                "palette": {
-                  "constraints": {},
-                  "default": "RdYlGn",
-                  "description": "Color palette name for Excel conditional bands.",
-                  "nl_editable": true,
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "number_format": {
-              "constraints": {},
-              "default": "0.00%",
-              "description": "Default numeric format for Excel output.",
-              "nl_editable": true,
-              "type": "string"
-            }
-          },
-          "type": "object"
         },
         "filename": {
           "constraints": {},
@@ -630,20 +530,6 @@
           "constraints": {},
           "default": false,
           "description": "Phase-2",
-          "nl_editable": true,
-          "type": "boolean"
-        },
-        "include_raw_returns": {
-          "constraints": {},
-          "default": true,
-          "description": "Include raw return series in exports.",
-          "nl_editable": true,
-          "type": "boolean"
-        },
-        "include_vol_adj": {
-          "constraints": {},
-          "default": true,
-          "description": "Include volatility-adjusted series in exports.",
           "nl_editable": true,
           "type": "boolean"
         }
@@ -711,8 +597,8 @@
     },
     "jobs": {
       "constraints": {},
-      "default": -1,
-      "description": "-1 = use all logical cores",
+      "default": null,
+      "description": "Deprecated top-level alias for run.jobs; ignored when run.jobs is set.",
       "nl_editable": true,
       "type": [
         "integer",
@@ -723,22 +609,6 @@
       "additionalProperties": false,
       "constraints": {},
       "default": {
-        "alpha_reference": "SP500TR",
-        "bootstrap_ci": {
-          "ci_level": 0.95,
-          "enabled": true,
-          "n_iter": 2000
-        },
-        "compute": [
-          "CAGR",
-          "Volatility",
-          "Sharpe",
-          "Sortino",
-          "Max_Drawdown",
-          "Calmar",
-          "Hit_Rate",
-          "Skew"
-        ],
         "registry": [
           "annual_return",
           "volatility",
@@ -748,78 +618,11 @@
           "max_drawdown"
         ],
         "rf_override_enabled": false,
-        "rf_rate_annual": 0.02,
-        "use_continuous": false
+        "rf_rate_annual": 0.02
       },
       "description": "Performance metrics configuration.",
       "nl_editable": true,
       "properties": {
-        "alpha_reference": {
-          "constraints": {},
-          "default": "SP500TR",
-          "description": "ticker in indices_glob",
-          "nl_editable": true,
-          "type": "string"
-        },
-        "bootstrap_ci": {
-          "additionalProperties": false,
-          "constraints": {},
-          "default": {
-            "ci_level": 0.95,
-            "enabled": true,
-            "n_iter": 2000
-          },
-          "description": "Bootstrap confidence interval settings.",
-          "nl_editable": true,
-          "properties": {
-            "ci_level": {
-              "constraints": {
-                "maximum": 1,
-                "minimum": 0
-              },
-              "default": 0.95,
-              "description": "Bootstrap confidence level.",
-              "maximum": 1,
-              "minimum": 0,
-              "nl_editable": true,
-              "type": "number"
-            },
-            "enabled": {
-              "constraints": {},
-              "default": true,
-              "description": "Enable bootstrap confidence intervals.",
-              "nl_editable": true,
-              "type": "boolean"
-            },
-            "n_iter": {
-              "constraints": {},
-              "default": 2000,
-              "description": "Number of bootstrap iterations.",
-              "nl_editable": true,
-              "type": "integer"
-            }
-          },
-          "type": "object"
-        },
-        "compute": {
-          "constraints": {},
-          "default": [
-            "CAGR",
-            "Volatility",
-            "Sharpe",
-            "Sortino",
-            "Max_Drawdown",
-            "Calmar",
-            "Hit_Rate",
-            "Skew"
-          ],
-          "description": "Legacy metrics list for reporting exports.",
-          "items": {
-            "type": "string"
-          },
-          "nl_editable": true,
-          "type": "array"
-        },
         "drawdown": {
           "constraints": {},
           "default": null,
@@ -903,13 +706,6 @@
             "null",
             "number"
           ]
-        },
-        "use_continuous": {
-          "constraints": {},
-          "default": false,
-          "description": "geometric (default) vs. log",
-          "nl_editable": true,
-          "type": "boolean"
         },
         "volatility": {
           "constraints": {},
@@ -2326,7 +2122,7 @@
         "steps": {
           "constraints": {},
           "default": null,
-          "description": "Optional list of preprocessing steps to run in order.",
+          "description": "Config option for preprocessing.steps.",
           "nl_editable": true,
           "type": "null"
         },
@@ -2501,23 +2297,12 @@
       "additionalProperties": false,
       "constraints": {},
       "default": {
-        "cache_dir": ".cache/",
-        "deterministic": true,
-        "log_file": "logs/phase1.log",
-        "log_level": "INFO",
-        "monthly_cost": 0.0,
-        "n_jobs": -1
+        "jobs": -1,
+        "monthly_cost": 0.0
       },
       "description": "Runtime execution settings.",
       "nl_editable": true,
       "properties": {
-        "cache_dir": {
-          "constraints": {},
-          "default": ".cache/",
-          "description": "Directory for runtime cache.",
-          "nl_editable": true,
-          "type": "string"
-        },
         "checkpoint_dir": {
           "constraints": {},
           "default": null,
@@ -2528,36 +2313,12 @@
             "string"
           ]
         },
-        "deterministic": {
-          "constraints": {},
-          "default": true,
-          "description": "sets NumPy & pandas options",
-          "nl_editable": true,
-          "type": "boolean"
-        },
         "jobs": {
           "constraints": {},
-          "default": null,
-          "description": "Parallel worker count for a run.",
+          "default": -1,
+          "description": "-1 => all CPUs",
           "nl_editable": true,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "log_file": {
-          "constraints": {},
-          "default": "logs/phase1.log",
-          "description": "Log file path for runtime logs.",
-          "nl_editable": false,
-          "type": "string"
-        },
-        "log_level": {
-          "constraints": {},
-          "default": "INFO",
-          "description": "DEBUG | INFO | WARNING | ERROR",
-          "nl_editable": true,
-          "type": "string"
+          "type": "integer"
         },
         "monthly_cost": {
           "constraints": {},
@@ -2565,13 +2326,6 @@
           "description": "flat decimal return subtracted from each fund every period",
           "nl_editable": true,
           "type": "number"
-        },
-        "n_jobs": {
-          "constraints": {},
-          "default": -1,
-          "description": "1  all CPUs",
-          "nl_editable": true,
-          "type": "integer"
         },
         "name": {
           "constraints": {},

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -176,7 +176,7 @@ performance:
     metrics: false  # scalar metric series memoization (Issue #1156)
 run:
   monthly_cost: 0.0 # flat decimal return subtracted from each fund every period
-  n_jobs: -1 # ‑1 ⇒ all CPUs (parallelism-key consolidation tracked separately in A20 / #5401)
+  jobs: -1 # -1 => all CPUs
 
 
 # ---------------------------------------------------------------------------
@@ -199,5 +199,4 @@ multi_period:
       - [50,  1.00]
       - [100, 0.80]
 checkpoint_dir: "outputs/checkpoints/"
-jobs: -1                  # -1 = use all logical cores
 seed: 42

--- a/config/demo.yml
+++ b/config/demo.yml
@@ -81,7 +81,6 @@ run:
   jobs: 1
   checkpoint_dir: demo/checkpoints
 
-jobs: 1
 checkpoint_dir: demo/checkpoints
 
 multi_period:

--- a/config/robust_demo.yml
+++ b/config/robust_demo.yml
@@ -102,6 +102,6 @@ export:
   formats: ["xlsx", "csv"]
 
 run:
-  n_jobs: 1  # Single-threaded for clearer logging
+  jobs: 1  # Single-threaded for clearer logging
 
 seed: 42

--- a/src/trend_analysis/config/schema_generator.py
+++ b/src/trend_analysis/config/schema_generator.py
@@ -185,9 +185,9 @@ _MANUAL_DESCRIPTIONS: dict[str, str] = {
     "output.path": "Output path or prefix for legacy single-file runners.",
     "run": "Runtime execution settings.",
     "run.seed": "Random seed used for deterministic runs.",
-    "run.jobs": "Parallel worker count for a run.",
+    "run.jobs": "Canonical parallel worker count for a run.",
     "run.checkpoint_dir": "Directory for saving checkpoints.",
-    "jobs": "Legacy top-level worker count override.",
+    "jobs": "Deprecated top-level alias for run.jobs; ignored when run.jobs is set.",
     "checkpoint_dir": "Legacy top-level checkpoint directory override.",
     "multi_period.frequency": "Frequency for multi-period windows.",
     "multi_period.in_sample_len": "Length of the in-sample window.",
@@ -587,6 +587,17 @@ def generate_schema(
             comment_map=comment_map,
             samples=samples,
             model_overrides=model_overrides,
+        )
+    for key in ("jobs",):
+        properties_dict.setdefault(
+            key,
+            build_schema(
+                None,
+                path=[key],
+                comment_map=comment_map,
+                samples=samples,
+                model_overrides=model_overrides,
+            ),
         )
     return schema
 

--- a/src/trend_model/spec.py
+++ b/src/trend_model/spec.py
@@ -113,6 +113,14 @@ def _section_get(section: Mapping[str, Any], key: str, default: Any = None) -> A
     return section.get(key, default)
 
 
+def _resolve_parallel_jobs(cfg: Any, run_cfg: Mapping[str, Any]) -> int | None:
+    """Resolve canonical ``run.jobs`` with top-level ``jobs`` as a legacy alias."""
+
+    run_jobs = _section_get(run_cfg, "jobs", None)
+    value = run_jobs if run_jobs is not None else _cfg_value(cfg, "jobs", None)
+    return _coerce_int(value, default=0) or None
+
+
 def _coerce_int(value: Any, default: int = 0) -> int:
     try:
         return int(value)
@@ -247,7 +255,7 @@ def _build_backtest_spec(cfg: Any, *, base_path: Path | None) -> BacktestSpec:
         regime=_cfg_section(cfg, "regime"),
         metrics=_as_tuple(_section_get(metrics, "registry", ())),
         seed=_coerce_int(_cfg_value(cfg, "seed", _section_get(run_cfg, "seed", 42)), default=42),
-        jobs=_coerce_int(_section_get(run_cfg, "jobs", None), default=0) or None,
+        jobs=_resolve_parallel_jobs(cfg, run_cfg),
         checkpoint_dir=checkpoint,
         export_directory=export_dir,
         export_formats=_as_tuple(_section_get(export_cfg, "formats", ())),

--- a/tests/test_parallelism_keys.py
+++ b/tests/test_parallelism_keys.py
@@ -1,0 +1,50 @@
+"""Regression tests for canonical parallelism config keys."""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import yaml
+
+from trend_analysis.config.schema_generator import generate_schema
+from trend_analysis.config.schema_validation import validate_config_data
+from trend_model.spec import load_run_spec_from_mapping
+
+
+def _defaults_payload() -> dict:
+    payload = yaml.safe_load(Path("config/defaults.yml").read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_run_n_jobs_absent_from_defaults_and_schema() -> None:
+    payload = _defaults_payload()
+    assert "n_jobs" not in payload["run"]
+
+    schema = generate_schema()
+    run_properties = schema["properties"]["run"]["properties"]
+    assert "n_jobs" not in run_properties
+    assert run_properties["jobs"]["type"] == "integer"
+    assert "Deprecated" in schema["properties"]["jobs"]["description"]
+
+    errors = validate_config_data({"run": {"n_jobs": 1}}, schema)
+    assert errors
+    assert any("n_jobs" in error for error in errors)
+
+
+def test_run_jobs_is_canonical_and_top_level_jobs_is_alias() -> None:
+    payload = _defaults_payload()
+    assert "jobs" not in payload
+
+    canonical_payload = copy.deepcopy(payload)
+    canonical_payload["run"]["jobs"] = 3
+    canonical_payload["jobs"] = 7
+    canonical_spec = load_run_spec_from_mapping(canonical_payload, base_path=Path("config"))
+    assert canonical_spec.backtest.jobs == 3
+
+    alias_payload = copy.deepcopy(payload)
+    alias_payload["run"].pop("jobs")
+    alias_payload["jobs"] = 7
+    alias_spec = load_run_spec_from_mapping(alias_payload, base_path=Path("config"))
+    assert alias_spec.backtest.jobs == 7


### PR DESCRIPTION
Closes #5401.

## Summary
- Replace dead run.n_jobs entries with canonical run.jobs in defaults and robust demo config.
- Resolve top-level jobs as a deprecated alias only when run.jobs is absent.
- Regenerate the config schema parallelism surface and add regression coverage for absence plus alias resolution.

## Validation
- PYTHONPATH=src /Users/teacher/Library/CloudStorage/Dropbox/Learning/Code/Trend_Model_Project/.venv/bin/python -m pytest tests/test_parallelism_keys.py tests/test_config_schema_generation.py -q
- PYTHONPATH=src /Users/teacher/Library/CloudStorage/Dropbox/Learning/Code/Trend_Model_Project/.venv/bin/python -m ruff check src/trend_model/spec.py src/trend_analysis/config/schema_generator.py tests/test_parallelism_keys.py
- git diff --check
- jq empty config.schema.json && jq empty config.schema.compact.json
- Deliberate break: temporarily re-added run.n_jobs to config/defaults.yml and confirmed tests/test_parallelism_keys.py failed, then removed it and reran green.
