### PR TITLE
A21 — Unify sample_split boundary convention (validator vs slicer) (#5402)

### DIFF
--- a/src/trend_analysis/config/validation.py
+++ b/src/trend_analysis/config/validation.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from trend_analysis.config.model import validate_trend_config
 from trend_analysis.config.models import Config
 from trend_analysis.config.schema_validation import load_schema
+from trend_analysis.time_utils import resolve_period_bound
 from utils.paths import proj_path
 
 _PATH_PATTERN = re.compile(r"^([A-Za-z0-9_.\[\]-]+)(:|\s+)(.+)$")
@@ -520,12 +521,17 @@ def _check_date_ranges(config: Mapping[str, Any], errors: list[ValidationError])
     if not all(key in split for key in required):
         return
 
+    # Resolve each label to the same instant the window slicer uses
+    # (stages/preprocessing.py): start labels -> month start, end labels ->
+    # month end. Resolving uniformly to month start here would let the
+    # validator and slicer disagree on what an `*_end` label denotes.
+    bound_roles = {"in_start": "start", "in_end": "end", "out_start": "start", "out_end": "end"}
     parsed: dict[str, pd.Timestamp] = {}
     invalid_fields: set[str] = set()
     for key in required:
         raw = split.get(key)
         try:
-            parsed[key] = pd.to_datetime(raw)
+            parsed[key] = resolve_period_bound(raw, bound=bound_roles[key])
         except Exception:
             issue = ValidationError(
                 path=f"sample_split.{key}",

--- a/src/trend_analysis/stages/preprocessing.py
+++ b/src/trend_analysis/stages/preprocessing.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from ..diagnostics import PipelineReasonCode, PipelineResult, pipeline_failure
 from ..risk import periods_per_year_from_code
-from ..time_utils import align_calendar
+from ..time_utils import align_calendar, resolve_period_bound
 from ..timefreq import MONTHLY_DATE_FREQ
 from ..util.frequency import FrequencySummary, detect_frequency
 from ..util.missing import MissingPolicyResult, apply_missing_policy
@@ -330,24 +330,15 @@ def _build_sample_windows(
             return reindexed
         return reindexed
 
-    def _is_month_label(label: str) -> bool:
-        text = str(label).strip()
-        return len(text) == 7 and text.count("-") == 1
-
     def _resolve_bound(label: str, *, bound: str) -> pd.Timestamp:
         text = str(label).strip()
         if not text:
             raise ValueError("Period label must be non-empty")
         try:
-            if _is_month_label(text):
-                period = pd.Period(text, freq="M")
-                ts = period.start_time if bound == "start" else period.end_time
-            else:
-                ts = pd.to_datetime(text)
+            return resolve_period_bound(text, bound=bound)
         except Exception as exc:  # pragma: no cover - defensive
             msg = f"Failed to parse period label '{label}': {exc}"
             raise ValueError(msg) from exc
-        return pd.Timestamp(ts).normalize()
 
     in_sdate = _resolve_bound(in_start, bound="start")
     in_edate = _resolve_bound(in_end, bound="end")

--- a/src/trend_analysis/time_utils.py
+++ b/src/trend_analysis/time_utils.py
@@ -12,6 +12,39 @@ DEFAULT_FREQUENCY = "B"
 DEFAULT_CALENDAR = "simple"
 
 
+def is_month_label(label: str) -> bool:
+    """Return ``True`` for a bare month label of the form ``YYYY-MM``."""
+    text = str(label).strip()
+    return len(text) == 7 and text.count("-") == 1
+
+
+def resolve_period_bound(label: object, *, bound: str) -> pd.Timestamp:
+    """Resolve a sample-split boundary label to a single timestamp.
+
+    A boundary label denotes one instant everywhere it is used. For a bare
+    month label (``YYYY-MM``) the instant depends on which side of a window it
+    bounds: ``bound="start"`` resolves to the month start and ``bound="end"``
+    resolves to the month end. Finer-grained labels are parsed directly. The
+    result is normalised to midnight so it matches the inclusive ``<=`` mask the
+    window slicer applies.
+
+    Both the ordering validator (``config/validation.py``) and the window
+    slicer (``stages/preprocessing.py``) resolve boundaries through this helper
+    so a given label means the same instant in validation and slicing.
+    """
+    if bound not in ("start", "end"):
+        raise ValueError(f"bound must be 'start' or 'end', got {bound!r}")
+    text = str(label).strip()
+    if not text:
+        raise ValueError("Period label must be non-empty")
+    if is_month_label(text):
+        period = pd.Period(text, freq="M")
+        ts = period.start_time if bound == "start" else period.end_time
+    else:
+        ts = pd.to_datetime(text)
+    return pd.Timestamp(ts).normalize()
+
+
 def _normalise_calendar_name(calendar_name: str | None) -> str:
     cal = (calendar_name or DEFAULT_CALENDAR).lower()
     if cal not in {"simple", "nyse", "us"}:
@@ -223,4 +256,4 @@ def align_calendar(
     return aligned
 
 
-__all__ = ["align_calendar"]
+__all__ = ["align_calendar", "is_month_label", "resolve_period_bound"]

--- a/tests/test_sample_split_boundary.py
+++ b/tests/test_sample_split_boundary.py
@@ -1,0 +1,96 @@
+"""A21 (#5402): validator and window slicer must agree on boundary instants.
+
+The ordering validator (`config/validation.py`) used to parse every
+``sample_split`` label with ``pd.to_datetime`` -> month **start**, while the
+window slicer (`stages/preprocessing.py`) resolves ``*_end`` labels via
+``pd.Period.end_time`` -> month **end**. A month-granularity ``in_end`` therefore
+denoted a different instant in validation than in slicing. Both paths now route
+through :func:`trend_analysis.time_utils.resolve_period_bound`, so a given label
+means one instant everywhere.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from trend_analysis.config.validation import validate_config
+from trend_analysis.time_utils import resolve_period_bound
+
+
+def _base_config(tmp_path: Path) -> dict[str, Any]:
+    csv_path = tmp_path / "returns.csv"
+    csv_path.write_text("Date,A,B\n2020-01-31,0.0,0.0\n", encoding="utf-8")
+    return {
+        "version": "1",
+        "data": {
+            "csv_path": str(csv_path),
+            "date_column": "Date",
+            "frequency": "M",
+        },
+        "preprocessing": {},
+        "vol_adjust": {"target_vol": 0.1},
+        "sample_split": {},
+        "portfolio": {
+            "selection_mode": "all",
+            "rebalance_calendar": "NYSE",
+            "max_turnover": 1.0,
+            "transaction_cost_bps": 0.0,
+        },
+        "metrics": {},
+        "export": {},
+        "run": {},
+    }
+
+
+def _has_path(result, path: str) -> bool:
+    return any(issue.path == path for issue in result.errors)
+
+
+def test_resolve_period_bound_is_bound_aware() -> None:
+    # A bare month label resolves to the month start as a `start` bound and to
+    # the month end as an `end` bound; finer labels parse directly.
+    assert resolve_period_bound("2020-06", bound="start") == pd.Timestamp("2020-06-01")
+    assert resolve_period_bound("2020-06", bound="end") == pd.Timestamp("2020-06-30")
+    assert resolve_period_bound("2020-06-15", bound="end") == pd.Timestamp("2020-06-15")
+
+
+def test_validator_matches_slicer_in_end_boundary(tmp_path: Path) -> None:
+    # The slicer resolves a month `in_end` to month END and a mid-month
+    # `out_start` day directly, so these windows genuinely overlap.
+    in_end, out_start = "2020-06", "2020-06-20"
+    slicer_in_end = resolve_period_bound(in_end, bound="end")
+    slicer_out_start = resolve_period_bound(out_start, bound="start")
+    assert slicer_in_end >= slicer_out_start  # genuine overlap under slicing
+
+    cfg = _base_config(tmp_path)
+    cfg["sample_split"] = {
+        "in_start": "2020-01",
+        "in_end": in_end,
+        "out_start": out_start,
+        "out_end": "2020-12",
+    }
+    result = validate_config(cfg, base_path=tmp_path)
+
+    # The validator must see the same overlap the slicer would. Under the old
+    # month-start parse it resolved `in_end` to 2020-06-01 and wrongly accepted
+    # this config -- the deliberate-break gate for #5402.
+    assert not result.valid
+    assert _has_path(result, "sample_split.out_start")
+
+
+def test_validator_accepts_clean_month_split(tmp_path: Path) -> None:
+    # A valid, non-overlapping month-granularity split must remain valid:
+    # the boundary alignment must not change in/out semantics for good configs.
+    cfg = _base_config(tmp_path)
+    cfg["sample_split"] = {
+        "in_start": "2020-01",
+        "in_end": "2020-06",
+        "out_start": "2020-07",
+        "out_end": "2020-12",
+    }
+    result = validate_config(cfg, base_path=tmp_path)
+
+    assert not any(issue.path.startswith("sample_split.") for issue in result.errors)


### PR DESCRIPTION
Closes #5402.

## Problem
The ordering validator (`config/validation.py:_check_date_ranges`) parsed every `sample_split` label with `pd.to_datetime` → month **start**, while the window slicer (`stages/preprocessing.py:_build_sample_windows`) resolves `*_end` labels via `pd.Period.end_time` → month **end** with an inclusive `<=` mask. A month-granularity `in_end`/`out_end` therefore denoted a *different instant* in validation than in slicing — safe for distinct adjacent months but latent fragility when day/month granularities mix.

## Change
- Extract the slicer's bound-aware resolution into a shared **`time_utils.resolve_period_bound(label, *, bound)`**: `start` labels → month start, `end` labels → month end, finer-grained labels parsed directly, normalised to midnight (matching the slicing mask).
- Both `stages/preprocessing.py` (slicer) and `config/validation.py` (validator) now route boundary resolution through this single helper, so a label means one instant everywhere.
- Validator resolves each field with its bound role (`in_start`/`out_start`→start, `in_end`/`out_end`→end) instead of uniform month-start.

## Non-Goals honored
- In/out split semantics for **valid** configs are unchanged (distinct-month splits resolve identically for ordering; existing date-range tests unchanged).
- Not scaffold-only: the two conventions are genuinely unified through one resolver.

## Tests (`tests/test_sample_split_boundary.py`)
- `resolve_period_bound` is bound-aware (month start vs month end; finer labels direct).
- Validator matches the slicer's month-end `in_end` instant: a month `in_end` + mid-month `out_start` overlap is now correctly rejected.
- Clean month splits stay valid.
- **Deliberate-break gate** confirmed: restoring the month-start parse in the validator makes `test_validator_matches_slicer_in_end_boundary` FAIL (validator wrongly accepts the overlap); reverted.

## Validation
`pytest tests/test_sample_split_boundary.py tests/test_config_semantic_validation.py tests/test_config_human_errors.py tests/test_config_load.py tests/test_pipeline.py tests/test_pipeline_helpers.py tests/test_pipeline_stage_isolation.py` → all pass; ruff + mypy clean on touched files.