### PR TITLE
A22 — Share linear transaction-cost primitive (#5403)

### DIFF
--- a/src/trend_analysis/backtesting/harness.py
+++ b/src/trend_analysis/backtesting/harness.py
@@ -15,6 +15,7 @@ from pandas.tseries.frequencies import to_offset
 from backtest import shift_by_execution_lag
 
 from ..metrics import sortino_ratio
+from ..metrics.turnover import linear_turnover_cost
 from ..universe import MembershipTable, build_membership_mask
 
 logger = logging.getLogger(__name__)
@@ -65,10 +66,10 @@ class CostModel:
         return float(base)
 
     def apply(self, turnover: float) -> float:
-        if turnover <= 0:
-            return 0.0
-        multiplier = (self.effective_per_trade_bps + self.effective_half_spread_bps) / 10000.0
-        return float(turnover) * multiplier
+        return linear_turnover_cost(
+            turnover,
+            self.effective_per_trade_bps + self.effective_half_spread_bps,
+        )
 
     def as_dict(self) -> Dict[str, float]:
         return {

--- a/src/trend_analysis/metrics/turnover.py
+++ b/src/trend_analysis/metrics/turnover.py
@@ -50,7 +50,14 @@ def turnover_cost(
         Linear transaction cost in basis points applied to turnover.
     """
     turn_df = realized_turnover(weights)
-    return turn_df["turnover"] * (cost_bps / 10000.0)
+    return turn_df["turnover"].map(lambda turnover: linear_turnover_cost(turnover, cost_bps))
 
 
-__all__ = ["realized_turnover", "turnover_cost"]
+def linear_turnover_cost(turnover: float, cost_bps: float) -> float:
+    """Return the linear cost deduction for turnover and basis points."""
+    if turnover <= 0:
+        return 0.0
+    return float(turnover) * (float(cost_bps) / 10000.0)
+
+
+__all__ = ["linear_turnover_cost", "realized_turnover", "turnover_cost"]

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -33,6 +33,7 @@ from ..constants import NUMERICAL_TOLERANCE_HIGH
 from ..core.rank_selection import ASCENDING_METRICS
 from ..data import load_csv
 from ..diagnostics import PipelineResult, coerce_pipeline_result
+from ..metrics.turnover import linear_turnover_cost
 from ..pipeline import (
     _build_trend_spec,
     _compute_stats,
@@ -3706,7 +3707,7 @@ def run(
             abs_diff = float((effective_w - last_effective).abs().sum())
             period_turnover = 0.5 * abs_diff
 
-        period_cost = period_turnover * ((tc_bps + slippage_bps) / 10000.0)
+        period_cost = linear_turnover_cost(period_turnover, tc_bps + slippage_bps)
 
         # Reconcile manager change log to the realised holdings delta.
         actual_before = set(last_effective[last_effective.abs() > eps].index)

--- a/src/trend_analysis/rebalancing/strategies.py
+++ b/src/trend_analysis/rebalancing/strategies.py
@@ -15,6 +15,7 @@ import numpy as np
 import pandas as pd
 
 from ..cash_policy import CashPolicy
+from ..metrics.turnover import linear_turnover_cost
 from ..plugins import Rebalancer, create_rebalancer, rebalancer_registry
 
 # Backwards compatibility name
@@ -199,7 +200,7 @@ class TurnoverCapStrategy(Rebalancer):
     def _calculate_cost(self, turnover: float) -> float:
         """Calculate transaction cost based on turnover and cost basis
         points."""
-        return turnover * (self.cost_bps / 10000.0)
+        return linear_turnover_cost(turnover, self.cost_bps)
 
 
 @rebalancer_registry.register("periodic_rebalance")

--- a/tests/test_cost_primitive_shared.py
+++ b/tests/test_cost_primitive_shared.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pytest
+
+from trend_analysis.backtesting.harness import CostModel
+from trend_analysis.metrics.turnover import linear_turnover_cost
+from trend_analysis.multi_period import engine
+from trend_analysis.rebalancing.strategies import TurnoverCapStrategy
+
+
+def test_linear_transaction_cost_sites_share_canonical_primitive() -> None:
+    turnover = 0.42
+    trade_bps = 17.0
+    slippage_bps = 3.0
+    combined_bps = trade_bps + slippage_bps
+    expected = linear_turnover_cost(turnover, combined_bps)
+
+    harness_model = CostModel(bps_per_trade=trade_bps, slippage_bps=slippage_bps)
+    rebalancer = TurnoverCapStrategy({"cost_bps": combined_bps})
+
+    assert harness_model.apply(turnover) == pytest.approx(expected)
+    assert rebalancer._calculate_cost(turnover) == pytest.approx(expected)
+    assert engine.linear_turnover_cost(turnover, combined_bps) == pytest.approx(expected)
+
+
+def test_linear_transaction_cost_zero_or_negative_turnover_is_zero() -> None:
+    assert linear_turnover_cost(0.0, 25.0) == 0.0
+    assert linear_turnover_cost(-0.1, 25.0) == 0.0


### PR DESCRIPTION
Closes #5403

## Summary
- Added a canonical `linear_turnover_cost()` primitive beside the existing turnover helpers.
- Repointed the plain linear-cost sites in the backtesting harness, turnover-cap rebalancer, and multi-period engine to the shared primitive.
- Left the Monte Carlo regime/slippage cost process independent because it samples regime-specific costs and applies a slippage multiplier.

## Validation
- `python -m pytest tests/test_cost_primitive_shared.py -q`
- Deliberate-break gate: adding a divergent bps constant to one repointed site made `test_linear_transaction_cost_sites_share_canonical_primitive` fail, then reverted.
- `python -m pytest tests/test_cost_primitive_shared.py tests/test_turnover_vectorization.py tests/backtesting/test_harness.py::test_transaction_costs_applied_to_turnover tests/backtesting/test_harness.py::test_cost_model_slippage_costs_returns tests/test_multi_period_engine_additional.py::test_run_threshold_hold_low_weight_replacement -q`
- `python -m ruff check src/trend_analysis/metrics/turnover.py src/trend_analysis/backtesting/harness.py src/trend_analysis/rebalancing/strategies.py src/trend_analysis/multi_period/engine.py tests/test_cost_primitive_shared.py`
- `python -m mypy src/trend_analysis/metrics/turnover.py src/trend_analysis/backtesting/harness.py src/trend_analysis/rebalancing/strategies.py src/trend_analysis/multi_period/engine.py`
- `git diff --check`