### PR TITLE
Issue #5405: Refactor CLI dispatch and log score-frame config failures

### DIFF
--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -113,7 +113,9 @@ def _maybe_validate_config(
             payload = dict(cfg)
         elif hasattr(cfg, "model_dump"):
             try:
-                payload = cfg.model_dump(exclude_none=True, exclude_unset=True, mode="json")
+                payload = cfg.model_dump(
+                    exclude_none=True, exclude_unset=True, mode="json"
+                )
             except TypeError:
                 try:
                     payload = cfg.model_dump(exclude_none=True, exclude_unset=True)
@@ -156,7 +158,11 @@ def _maybe_track_config_coverage(config_path: Path, input_path: str) -> bool:
         return True
 
     data_section = dict(payload.get("data") or {})
-    if input_path and not data_section.get("csv_path") and not data_section.get("managers_glob"):
+    if (
+        input_path
+        and not data_section.get("csv_path")
+        and not data_section.get("managers_glob")
+    ):
         data_section["csv_path"] = input_path
         payload = dict(payload)
         payload["data"] = data_section
@@ -220,7 +226,9 @@ def _apply_trend_spec_preset(cfg: Any, preset: TrendSpecPreset) -> None:
         object.__setattr__(cfg, "trend_spec_preset", preset.name)
 
 
-def _log_step(run_id: str, event: str, message: str, level: str = "INFO", **fields: Any) -> None:
+def _log_step(
+    run_id: str, event: str, message: str, level: str = "INFO", **fields: Any
+) -> None:
     """Internal indirection for structured logging.
 
     Tests monkeypatch this symbol directly (`_log_step`) rather than the public
@@ -274,7 +282,9 @@ def _extract_cache_stats(payload: object) -> dict[str, int] | None:
     return found[-1] if found else None
 
 
-def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: str) -> pd.DataFrame:
+def _apply_universe_mask(
+    df: pd.DataFrame, mask: pd.DataFrame, *, date_column: str
+) -> pd.DataFrame:
     """Apply a time-varying membership mask to returns data."""
 
     if mask.empty:
@@ -284,7 +294,9 @@ def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: s
     try:
         date_col = lookup[date_column.lower()]
     except KeyError as exc:  # pragma: no cover - defensive guard
-        raise KeyError(f"Date column '{date_column}' is missing from the returns data") from exc
+        raise KeyError(
+            f"Date column '{date_column}' is missing from the returns data"
+        ) from exc
 
     working[date_col] = pd.to_datetime(working[date_col])
     working = working.set_index(date_col)
@@ -299,12 +311,16 @@ def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: s
         )
 
     masked = working.copy()
-    masked.loc[:, aligned_mask.columns] = masked.loc[:, aligned_mask.columns].where(aligned_mask)
+    masked.loc[:, aligned_mask.columns] = masked.loc[:, aligned_mask.columns].where(
+        aligned_mask
+    )
     masked.reset_index(inplace=True)
     return masked
 
 
-def _attach_universe_paths(cfg: Any, spec: NamedUniverse, *, csv_path: str | None) -> None:
+def _attach_universe_paths(
+    cfg: Any, spec: NamedUniverse, *, csv_path: str | None
+) -> None:
     """Persist the selected universe paths onto ``cfg.data`` when possible."""
 
     membership_value = str(spec.membership_path)
@@ -317,7 +333,7 @@ def _attach_universe_paths(cfg: Any, spec: NamedUniverse, *, csv_path: str | Non
             merged.setdefault("csv_path", csv_value)
         try:
             setattr(cfg, "data", merged)
-        except Exception:
+        except (AttributeError, TypeError):
             object.__setattr__(cfg, "data", merged)
         return
 
@@ -327,26 +343,33 @@ def _attach_universe_paths(cfg: Any, spec: NamedUniverse, *, csv_path: str | Non
             payload["csv_path"] = csv_value
         try:
             setattr(cfg, "data", payload)
-        except Exception:
+        except (AttributeError, TypeError):
             object.__setattr__(cfg, "data", payload)
         return
 
     try:
         setattr(data_section, "universe_membership_path", membership_value)
-    except Exception:
+    except (AttributeError, TypeError):
         try:
-            object.__setattr__(data_section, "universe_membership_path", membership_value)
-        except Exception:
+            object.__setattr__(
+                data_section, "universe_membership_path", membership_value
+            )
+        except (AttributeError, TypeError) as exc:
+            logging.getLogger(__name__).debug(
+                "Could not attach universe membership path to config data: %s", exc
+            )
             data_section = None
 
     if csv_value and data_section is not None:
         try:
             setattr(data_section, "csv_path", csv_value)
-        except Exception:
+        except (AttributeError, TypeError):
             try:
                 object.__setattr__(data_section, "csv_path", csv_value)
-            except Exception:
-                pass
+            except (AttributeError, TypeError) as exc:
+                logging.getLogger(__name__).debug(
+                    "Could not attach universe csv path to config data: %s", exc
+                )
 
 
 def _resolve_artifact_paths(
@@ -414,7 +437,9 @@ def check_environment(lock_path: Path | None = None) -> int:
     return 0
 
 
-def maybe_log_step(enabled: bool, run_id: str, event: str, message: str, **fields: Any) -> None:
+def maybe_log_step(
+    enabled: bool, run_id: str, event: str, message: str, **fields: Any
+) -> None:
     """Log a structured step when ``enabled`` is True."""
     if enabled:
         _log_step(run_id, event, message, **fields)
@@ -699,7 +724,9 @@ def _execute_analysis_run(
             if isinstance(bench_map, dict) and bench_map:
                 first_bench = next(iter(bench_map.values()))
                 setattr(run_result, "benchmark", first_bench)
-            weights_user = res.get("weights_user_weight") if isinstance(res, dict) else None
+            weights_user = (
+                res.get("weights_user_weight") if isinstance(res, dict) else None
+            )
             if weights_user is not None:
                 setattr(run_result, "weights", weights_user)
     else:  # pragma: no cover - legacy fallback
@@ -793,7 +820,9 @@ def _execute_analysis_run(
             formats=target_formats,
         )
         data_keys = list(data.keys())
-        artifact_paths = _resolve_artifact_paths(out_dir_path, filename, data_keys, fmt_list)
+        artifact_paths = _resolve_artifact_paths(
+            out_dir_path, filename, data_keys, fmt_list
+        )
         maybe_log_step(
             structured_log,
             run_id,
@@ -830,7 +859,9 @@ def _execute_analysis_run(
                     ),
                 )
             except Exception as exc:  # pragma: no cover - defensive guard
-                logging.getLogger(__name__).warning("Failed to write run artifacts: %s", exc)
+                logging.getLogger(__name__).warning(
+                    "Failed to write run artifacts: %s", exc
+                )
             else:
                 maybe_log_step(
                     structured_log,
@@ -864,7 +895,9 @@ def _execute_analysis_run(
                         run_dir=manifest_dir,
                     )
                 except Exception as exc:  # pragma: no cover - defensive guard
-                    logging.getLogger(__name__).warning("Failed to write run envelope: %s", exc)
+                    logging.getLogger(__name__).warning(
+                        "Failed to write run envelope: %s", exc
+                    )
                 else:
                     maybe_log_step(
                         structured_log,
@@ -915,7 +948,9 @@ def main(argv: list[str] | None = None) -> int:
     """Entry point for the ``trend-model`` command."""
 
     parser = argparse.ArgumentParser(prog="trend-model")
-    parser.add_argument("--check", action="store_true", help="Print environment info and exit")
+    parser.add_argument(
+        "--check", action="store_true", help="Print environment info and exit"
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     sub.add_parser("gui", help="Launch Streamlit interface")
@@ -923,7 +958,9 @@ def main(argv: list[str] | None = None) -> int:
     run_p = sub.add_parser("run", help="Run analysis pipeline")
     run_p.add_argument("-c", "--config", required=True, help="Path to YAML config")
     run_p.add_argument("-i", "--input", required=True, help="Path to returns CSV")
-    run_p.add_argument("--seed", type=int, help="Override random seed (takes precedence)")
+    run_p.add_argument(
+        "--seed", type=int, help="Override random seed (takes precedence)"
+    )
     run_p.add_argument(
         "--bundle",
         nargs="?",
@@ -980,7 +1017,9 @@ def main(argv: list[str] | None = None) -> int:
         "run-ui",
         help="Deprecated: use 'run' with Streamlit JSON params",
     )
-    run_ui_p.add_argument("--params", required=True, help="Path to Streamlit JSON params")
+    run_ui_p.add_argument(
+        "--params", required=True, help="Path to Streamlit JSON params"
+    )
     run_ui_p.add_argument("--data", required=True, help="Path to returns CSV or Excel")
     run_ui_p.add_argument(
         "--auto-fix-dates",
@@ -1050,7 +1089,9 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     mc_run_p = mc_sub.add_parser("run", help="Run Monte Carlo scenarios")
-    mc_run_p.add_argument("--scenario", required=True, help="Scenario name or config path")
+    mc_run_p.add_argument(
+        "--scenario", required=True, help="Scenario name or config path"
+    )
     mc_run_p.add_argument(
         "--data",
         help="CSV/Parquet path for price or returns history (overrides base config)",
@@ -1062,7 +1103,9 @@ def main(argv: list[str] | None = None) -> int:
         default=[],
         help="Output formats (csv, json, parquet). Repeatable or comma-separated.",
     )
-    mc_run_p.add_argument("--n-paths", type=int, help="Override number of Monte Carlo paths")
+    mc_run_p.add_argument(
+        "--n-paths", type=int, help="Override number of Monte Carlo paths"
+    )
     mc_run_p.add_argument("--jobs", type=int, help="Override parallel job count")
     mc_run_p.add_argument("--seed", type=int, help="Override Monte Carlo seed")
     mc_run_p.add_argument(
@@ -1079,7 +1122,9 @@ def main(argv: list[str] | None = None) -> int:
         "--registry",
         help="Override the scenario registry path",
     )
-    mc_viz_p = mc_sub.add_parser("viz", help="Render Monte Carlo chart artifacts from a bundle")
+    mc_viz_p = mc_sub.add_parser(
+        "viz", help="Render Monte Carlo chart artifacts from a bundle"
+    )
     mc_viz_p.add_argument(
         "--bundle",
         required=True,
@@ -1109,7 +1154,8 @@ def main(argv: list[str] | None = None) -> int:
         "--png",
         action="store_true",
         help=(
-            "Best-effort PNG export; requires a working kaleido install " "(pip install kaleido)"
+            "Best-effort PNG export; requires a working kaleido install "
+            "(pip install kaleido)"
         ),
     )
 
@@ -1136,165 +1182,177 @@ def main(argv: list[str] | None = None) -> int:
         return check_environment()
 
     if args.command == "gui":
-        proc = subprocess.run(["streamlit", "run", str(APP_PATH)])
-        return proc.returncode
+        return _handle_gui_command()
 
     if args.command == "run":
-        coverage_tracker: ConfigCoverageTracker | None = None
-        if getattr(args, "config_coverage", False):
-            coverage_tracker = ConfigCoverageTracker()
-            activate_config_coverage(coverage_tracker)
-        try:
-            config_path = Path(args.config).resolve()
-            if _should_handle_as_ui_config(config_path):
-                return _run_from_ui_payload(
-                    params_path=config_path,
-                    data_path=Path(args.input),
-                    auto_fix_dates=args.auto_fix_dates,
-                    yes=args.yes,
-                    no_cache=args.no_cache,
-                    log_file=Path(args.log_file) if args.log_file else None,
-                    structured_log=not args.no_structured_log,
-                    bundle=Path(args.bundle) if args.bundle else None,
-                )
-            cfg = load_config(args.config)
-            if coverage_tracker is not None:
-                if not _maybe_track_config_coverage(config_path, args.input):
-                    return 1
-                wrap_config_for_coverage(cfg, coverage_tracker)
-            if not _maybe_validate_config(
-                cfg, base_path=config_path.parent, config_path=config_path
-            ):
-                return 1
-            if args.preset:
-                try:
-                    spec_preset = get_trend_spec_preset(args.preset)
-                except KeyError:
-                    available = ", ".join(list_trend_spec_presets())
-                    print(
-                        f"Unknown preset '{args.preset}'. Available presets: {available}",
-                        file=sys.stderr,
-                    )
-                    return 2
-                _apply_trend_spec_preset(cfg, spec_preset)
-            set_cache_enabled(not args.no_cache)
-            if getattr(args, "preset", None):
-                try:
-                    portfolio_preset = get_trend_preset(args.preset)
-                except KeyError:
-                    available = ", ".join(list_preset_slugs())
-                    print(
-                        f"Unknown preset '{args.preset}'. Available: {available}",
-                        file=sys.stderr,
-                    )
-                    return 2
-                apply_trend_preset(cfg, portfolio_preset)
-            cli_seed = args.seed
-            env_seed = os.getenv("TREND_SEED")
-            # Precedence: CLI flag > TREND_SEED > config.seed > default 42
-            if cli_seed is not None:
-                setattr(cfg, "seed", int(cli_seed))
-            elif env_seed is not None and env_seed.isdigit():
-                setattr(cfg, "seed", int(env_seed))
-            data_section = getattr(cfg, "data", None)
-            missing_policy = None
-            missing_limit = None
-            if isinstance(data_section, Mapping):
-                missing_policy = data_section.get("missing_policy")
-                missing_limit = data_section.get("missing_limit")
-            else:
-                missing_policy = getattr(data_section, "missing_policy", None)
-                missing_limit = getattr(data_section, "missing_limit", None)
-
-            if args.auto_fix_dates:
-                try:
-                    issues = inspect_ui_date_issues(args.input)
-                except MarketDataValidationError as exc:
-                    print(exc.user_message, file=sys.stderr)
-                    for issue in exc.issues:
-                        print(f"- {issue}", file=sys.stderr)
-                    return 1
-                has_fixable = issues.has_corrections or issues.total_droppable_rows > 0
-                if has_fixable and not args.yes:
-                    if not sys.stdin.isatty():
-                        print(
-                            "Date corrections require confirmation. Re-run with --yes to approve.",
-                            file=sys.stderr,
-                        )
-                        return 1
-                    prompt = (
-                        f"Apply {len(issues.corrections)} date correction(s) and "
-                        f"drop {issues.total_droppable_rows} row(s)? [y/N]: "
-                    )
-                    response = input(prompt).strip().lower()
-                    if response not in {"y", "yes"}:
-                        print("Cancelled date corrections.")
-                        return 1
-
-            try:
-                loaded_frame, _, summary = load_ui_dataset(
-                    args.input,
-                    auto_fix_dates=args.auto_fix_dates,
-                    missing_policy=missing_policy or "drop",
-                    missing_limit=missing_limit,
-                )
-            except MarketDataValidationError as exc:
-                print(exc.user_message, file=sys.stderr)
-                for issue in exc.issues:
-                    print(f"- {issue}", file=sys.stderr)
-                return 1
-            if summary.corrected_dates or summary.dropped_rows:
-                parts: list[str] = []
-                if summary.corrected_dates:
-                    parts.append(f"{summary.corrected_dates} date correction(s)")
-                if summary.dropped_rows:
-                    parts.append(f"{summary.dropped_rows} row(s) dropped")
-                print(f"Applied UI-style date fixes: {', '.join(parts)}")
-
-            df = loaded_frame.reset_index()
-            universe_spec: NamedUniverse | None = None
-            if getattr(args, "universe", None):
-                mask, universe_spec = load_universe(args.universe, prices=df)
-                df = _apply_universe_mask(df, mask, date_column=universe_spec.date_column)
-            if universe_spec is not None:
-                _attach_universe_paths(cfg, universe_spec, csv_path=args.input)
-            return _execute_analysis_run(
-                cfg,
-                df,
-                config_path=config_path,
-                input_path=Path(args.input),
-                log_file=Path(args.log_file) if args.log_file else None,
-                structured_log=not args.no_structured_log,
-                bundle=Path(args.bundle) if args.bundle else None,
-                skip_if_exists=getattr(args, "skip_if_exists", False),
-            )
-        finally:
-            if coverage_tracker is not None:
-                print(coverage_tracker.format_report())
-                deactivate_config_coverage()
+        return _handle_run_command(args)
 
     if args.command == "run-ui":
-        print(
-            "WARNING: 'trend-model run-ui' is deprecated. "
-            "Use 'trend-model run' with the same --params JSON file instead.",
-            file=sys.stderr,
-        )
-        return _run_from_ui_payload(
-            params_path=Path(args.params),
-            data_path=Path(args.data),
-            auto_fix_dates=args.auto_fix_dates,
-            yes=args.yes,
-            no_cache=args.no_cache,
-            log_file=Path(args.log_file) if args.log_file else None,
-            structured_log=not args.no_structured_log,
-            bundle=Path(args.bundle) if args.bundle else None,
-        )
+        return _handle_run_ui_command(args)
 
     if args.command == "mc":
         return _handle_mc_command(args)
 
     # This shouldn't be reached with required=True.
     return 0
+
+
+def _handle_gui_command() -> int:
+    proc = subprocess.run(["streamlit", "run", str(APP_PATH)])
+    return proc.returncode
+
+
+def _handle_run_command(args: argparse.Namespace) -> int:
+    coverage_tracker: ConfigCoverageTracker | None = None
+    if getattr(args, "config_coverage", False):
+        coverage_tracker = ConfigCoverageTracker()
+        activate_config_coverage(coverage_tracker)
+    try:
+        config_path = Path(args.config).resolve()
+        if _should_handle_as_ui_config(config_path):
+            return _run_from_ui_payload(
+                params_path=config_path,
+                data_path=Path(args.input),
+                auto_fix_dates=args.auto_fix_dates,
+                yes=args.yes,
+                no_cache=args.no_cache,
+                log_file=Path(args.log_file) if args.log_file else None,
+                structured_log=not args.no_structured_log,
+                bundle=Path(args.bundle) if args.bundle else None,
+            )
+        cfg = load_config(args.config)
+        if coverage_tracker is not None:
+            if not _maybe_track_config_coverage(config_path, args.input):
+                return 1
+            wrap_config_for_coverage(cfg, coverage_tracker)
+        if not _maybe_validate_config(
+            cfg, base_path=config_path.parent, config_path=config_path
+        ):
+            return 1
+        if args.preset:
+            try:
+                spec_preset = get_trend_spec_preset(args.preset)
+            except KeyError:
+                available = ", ".join(list_trend_spec_presets())
+                print(
+                    f"Unknown preset '{args.preset}'. Available presets: {available}",
+                    file=sys.stderr,
+                )
+                return 2
+            _apply_trend_spec_preset(cfg, spec_preset)
+        set_cache_enabled(not args.no_cache)
+        if getattr(args, "preset", None):
+            try:
+                portfolio_preset = get_trend_preset(args.preset)
+            except KeyError:
+                available = ", ".join(list_preset_slugs())
+                print(
+                    f"Unknown preset '{args.preset}'. Available: {available}",
+                    file=sys.stderr,
+                )
+                return 2
+            apply_trend_preset(cfg, portfolio_preset)
+        cli_seed = args.seed
+        env_seed = os.getenv("TREND_SEED")
+        # Precedence: CLI flag > TREND_SEED > config.seed > default 42
+        if cli_seed is not None:
+            setattr(cfg, "seed", int(cli_seed))
+        elif env_seed is not None and env_seed.isdigit():
+            setattr(cfg, "seed", int(env_seed))
+        data_section = getattr(cfg, "data", None)
+        missing_policy = None
+        missing_limit = None
+        if isinstance(data_section, Mapping):
+            missing_policy = data_section.get("missing_policy")
+            missing_limit = data_section.get("missing_limit")
+        else:
+            missing_policy = getattr(data_section, "missing_policy", None)
+            missing_limit = getattr(data_section, "missing_limit", None)
+
+        if args.auto_fix_dates:
+            try:
+                issues = inspect_ui_date_issues(args.input)
+            except MarketDataValidationError as exc:
+                print(exc.user_message, file=sys.stderr)
+                for issue in exc.issues:
+                    print(f"- {issue}", file=sys.stderr)
+                return 1
+            has_fixable = issues.has_corrections or issues.total_droppable_rows > 0
+            if has_fixable and not args.yes:
+                if not sys.stdin.isatty():
+                    print(
+                        "Date corrections require confirmation. Re-run with --yes to approve.",
+                        file=sys.stderr,
+                    )
+                    return 1
+                prompt = (
+                    f"Apply {len(issues.corrections)} date correction(s) and "
+                    f"drop {issues.total_droppable_rows} row(s)? [y/N]: "
+                )
+                response = input(prompt).strip().lower()
+                if response not in {"y", "yes"}:
+                    print("Cancelled date corrections.")
+                    return 1
+
+        try:
+            loaded_frame, _, summary = load_ui_dataset(
+                args.input,
+                auto_fix_dates=args.auto_fix_dates,
+                missing_policy=missing_policy or "drop",
+                missing_limit=missing_limit,
+            )
+        except MarketDataValidationError as exc:
+            print(exc.user_message, file=sys.stderr)
+            for issue in exc.issues:
+                print(f"- {issue}", file=sys.stderr)
+            return 1
+        if summary.corrected_dates or summary.dropped_rows:
+            parts: list[str] = []
+            if summary.corrected_dates:
+                parts.append(f"{summary.corrected_dates} date correction(s)")
+            if summary.dropped_rows:
+                parts.append(f"{summary.dropped_rows} row(s) dropped")
+            print(f"Applied UI-style date fixes: {', '.join(parts)}")
+
+        df = loaded_frame.reset_index()
+        universe_spec: NamedUniverse | None = None
+        if getattr(args, "universe", None):
+            mask, universe_spec = load_universe(args.universe, prices=df)
+            df = _apply_universe_mask(df, mask, date_column=universe_spec.date_column)
+        if universe_spec is not None:
+            _attach_universe_paths(cfg, universe_spec, csv_path=args.input)
+        return _execute_analysis_run(
+            cfg,
+            df,
+            config_path=config_path,
+            input_path=Path(args.input),
+            log_file=Path(args.log_file) if args.log_file else None,
+            structured_log=not args.no_structured_log,
+            bundle=Path(args.bundle) if args.bundle else None,
+            skip_if_exists=getattr(args, "skip_if_exists", False),
+        )
+    finally:
+        if coverage_tracker is not None:
+            print(coverage_tracker.format_report())
+            deactivate_config_coverage()
+
+
+def _handle_run_ui_command(args: argparse.Namespace) -> int:
+    print(
+        "WARNING: 'trend-model run-ui' is deprecated. "
+        "Use 'trend-model run' with the same --params JSON file instead.",
+        file=sys.stderr,
+    )
+    return _run_from_ui_payload(
+        params_path=Path(args.params),
+        data_path=Path(args.data),
+        auto_fix_dates=args.auto_fix_dates,
+        yes=args.yes,
+        no_cache=args.no_cache,
+        log_file=Path(args.log_file) if args.log_file else None,
+        structured_log=not args.no_structured_log,
+        bundle=Path(args.bundle) if args.bundle else None,
+    )
 
 
 def _parse_mc_tags(raw_tags: Sequence[str] | None) -> list[str]:
@@ -1338,7 +1396,9 @@ def _render_mc_table(entries: Sequence[ScenarioRegistryEntry]) -> str:
     divider = "  ".join("-" * widths[col] for col in columns)
     lines = [header, divider]
     for row in rows:
-        lines.append("  ".join(str(row.get(col, "")).ljust(widths[col]) for col in columns))
+        lines.append(
+            "  ".join(str(row.get(col, "")).ljust(widths[col]) for col in columns)
+        )
     return "\n".join(lines)
 
 
@@ -1348,7 +1408,9 @@ def _resolve_mc_registry_path(raw: str | None) -> Path | None:
     return Path(raw).expanduser().resolve()
 
 
-def _load_mc_scenario_value(raw: str, *, registry_path: Path | None) -> MonteCarloScenario:
+def _load_mc_scenario_value(
+    raw: str, *, registry_path: Path | None
+) -> MonteCarloScenario:
     if not raw:
         raise ValueError("Scenario name is required")
     candidate = Path(raw).expanduser()
@@ -1483,7 +1545,9 @@ def _validate_mc_scenario(scenario: MonteCarloScenario) -> list[str]:
         skip_required_fields=True,
     )
     schema_key_errors = [
-        issue for issue in config_result.errors if issue.message.startswith("Unexpected field")
+        issue
+        for issue in config_result.errors
+        if issue.message.startswith("Unexpected field")
     ]
     if schema_key_errors:
         messages = format_validation_messages(
@@ -1503,11 +1567,15 @@ def _validate_mc_scenario(scenario: MonteCarloScenario) -> list[str]:
             "regime_conditioned",
         }
         if kind not in allowed:
-            errors.append(f"return_model.kind must be one of: {', '.join(sorted(allowed))}")
+            errors.append(
+                f"return_model.kind must be one of: {', '.join(sorted(allowed))}"
+            )
 
     outputs = scenario.outputs
     if isinstance(outputs, Mapping):
-        errors.extend(_validate_mc_formats(outputs.get("formats", outputs.get("format"))))
+        errors.extend(
+            _validate_mc_formats(outputs.get("formats", outputs.get("format")))
+        )
 
     try:
         strategies = runner.resolve_strategies()
@@ -1742,7 +1810,9 @@ def _validate_mc_viz_output_flags(args: argparse.Namespace) -> None:
 def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
     suffix = path.suffix.lower()
     if suffix not in {".parquet", ".csv", ".json"}:
-        raise ValueError(f"Unsupported {label} file format '{path.suffix}' for '{path.name}'.")
+        raise ValueError(
+            f"Unsupported {label} file format '{path.suffix}' for '{path.name}'."
+        )
     try:
         if suffix == ".parquet":
             frame = pd.read_parquet(path)
@@ -1760,7 +1830,9 @@ def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
 
 
 def _load_mc_frame(bundle_dir: Path, *, stem: str) -> pd.DataFrame:
-    candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
+    candidates = tuple(
+        bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json")
+    )
     existing = next((candidate for candidate in candidates if candidate.exists()), None)
     if existing is None:
         expected = ", ".join(path.name for path in candidates)
@@ -1790,7 +1862,9 @@ def _load_mc_bundle_frames(
     missing_inputs: list[str] = []
     expected_by_stem: dict[str, str] = {}
     for stem in required_stems:
-        candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
+        candidates = tuple(
+            bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json")
+        )
         if not any(candidate.exists() for candidate in candidates):
             missing_inputs.append(stem)
             expected_by_stem[stem] = ", ".join(path.name for path in candidates)
@@ -1802,7 +1876,9 @@ def _load_mc_bundle_frames(
                 f"Missing required MC {stem} file in '{bundle_dir}'. Expected one of: {expected}"
             )
         missing_text = ", ".join(missing_inputs)
-        expected_text = "; ".join(f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs)
+        expected_text = "; ".join(
+            f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs
+        )
         raise FileNotFoundError(
             f"Missing required MC input files in '{bundle_dir}': {missing_text}. "
             f"Expected one of each: {expected_text}"
@@ -1819,9 +1895,13 @@ def _load_mc_nav_paths_frame(bundle: str | os.PathLike[str]) -> pd.DataFrame | N
 
 
 def _parse_mc_chart_selection(charts_value: str) -> list[str]:
-    requested = [token.strip().lower() for token in charts_value.split(",") if token.strip()]
+    requested = [
+        token.strip().lower() for token in charts_value.split(",") if token.strip()
+    ]
     if not requested:
-        raise ValueError("The 'mc viz' command requires at least one chart in --charts.")
+        raise ValueError(
+            "The 'mc viz' command requires at least one chart in --charts."
+        )
 
     seen: set[str] = set()
     ordered: list[str] = []
@@ -1891,16 +1971,20 @@ def _build_mc_risk_return_chart(
     from trend_analysis.viz import risk_return
 
     nav_frame = _mc_nav_source_frame(summary_frame, results_frame, nav_paths_frame)
-    returns_frame = nav_frame.pct_change(fill_method=None).replace([np.inf, -np.inf], np.nan)
+    returns_frame = nav_frame.pct_change(fill_method=None).replace(
+        [np.inf, -np.inf], np.nan
+    )
     returns_frame = returns_frame.dropna(how="all")
     if returns_frame.empty:
-        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(how="all")
+        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(
+            how="all"
+        )
     return risk_return.make(returns_frame)
 
 
-def _mc_chart_builders() -> (
-    dict[str, Callable[[pd.DataFrame, pd.DataFrame, pd.DataFrame | None], Any]]
-):
+def _mc_chart_builders() -> dict[
+    str, Callable[[pd.DataFrame, pd.DataFrame, pd.DataFrame | None], Any]
+]:
     return {
         "fan": _build_mc_fan_chart,
         "path_dist": _build_mc_path_dist_chart,
@@ -1985,7 +2069,9 @@ def _handle_mc_command(args: argparse.Namespace) -> int:
         scenarios: list[MonteCarloScenario] = []
         if scenario_arg:
             try:
-                scenarios = [_load_mc_scenario_value(scenario_arg, registry_path=registry_path)]
+                scenarios = [
+                    _load_mc_scenario_value(scenario_arg, registry_path=registry_path)
+                ]
             except (ValueError, FileNotFoundError, IsADirectoryError) as exc:
                 print(f"Scenario validation failed: {exc}", file=sys.stderr)
                 return 1
@@ -2003,7 +2089,9 @@ def _handle_mc_command(args: argparse.Namespace) -> int:
                 return 2
             for entry in entries:
                 try:
-                    scenarios.append(load_scenario(entry.name, registry_path=registry_path))
+                    scenarios.append(
+                        load_scenario(entry.name, registry_path=registry_path)
+                    )
                 except (ValueError, FileNotFoundError, IsADirectoryError) as exc:
                     print(
                         f"Scenario '{entry.name}' failed to load: {exc}",
@@ -2032,7 +2120,9 @@ def _handle_mc_command(args: argparse.Namespace) -> int:
         registry_path = _resolve_mc_registry_path(getattr(args, "registry", None))
         scenario_arg = getattr(args, "scenario", None) or ""
         try:
-            scenario = _load_mc_scenario_value(scenario_arg, registry_path=registry_path)
+            scenario = _load_mc_scenario_value(
+                scenario_arg, registry_path=registry_path
+            )
         except (ValueError, FileNotFoundError, IsADirectoryError) as exc:
             print(f"Scenario run failed: {exc}", file=sys.stderr)
             return 1

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -110,7 +110,9 @@ def _coerce_optional_bool(value: Any, field: str) -> bool:
 
 def _coerce_turnover_guard(value: Any) -> float:
     if isinstance(value, bool):
-        raise ValueError(f"{_TURNOVER_GUARD_PATH} must be numeric or a distribution mapping")
+        raise ValueError(
+            f"{_TURNOVER_GUARD_PATH} must be numeric or a distribution mapping"
+        )
     try:
         return float(value)
     except (TypeError, ValueError) as exc:
@@ -160,9 +162,12 @@ def evaluate_strategies_for_path(
     results: dict[str, object] = {}
     columns_lookup = columns_by_strategy or {}
     try:
-        context_cache.compute_score_frames(path_id, rebalance_dates, compute_score_frame)
+        context_cache.compute_score_frames(
+            path_id, rebalance_dates, compute_score_frame
+        )
         base_frames = {
-            date: context_cache.select_score_frame(path_id, date, None) for date in rebalance_dates
+            date: context_cache.select_score_frame(path_id, date, None)
+            for date in rebalance_dates
         }
         for name, strategy in strategies.items():
             columns = columns_lookup.get(name)
@@ -305,9 +310,13 @@ class MonteCarloRunner:
                 outputs.get("pooled_distributions"),
                 "outputs.pooled_distributions",
             )
-        cross_fold_summary_frame = build_cross_fold_summary_frame(results_frame) if folds else None
+        cross_fold_summary_frame = (
+            build_cross_fold_summary_frame(results_frame) if folds else None
+        )
         pooled_summary_frame = (
-            build_pooled_summary_frame(results_frame) if folds and pooled_distributions else None
+            build_pooled_summary_frame(results_frame)
+            if folds and pooled_distributions
+            else None
         )
         pooled_distribution_frame = (
             build_pooled_distribution_frame(results_frame)
@@ -428,7 +437,9 @@ class MonteCarloRunner:
                 )
             except Exception as exc:
                 for path_id in range(total):
-                    self._log_path_error(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
+                    self._log_path_error(
+                        path_id, None, exc, fold_id=fold_id, fold_label=fold_label
+                    )
                     errors.append(
                         self._error_record(
                             path_id, None, exc, fold_id=fold_id, fold_label=fold_label
@@ -451,9 +462,13 @@ class MonteCarloRunner:
                     fold_label=fold_label,
                 )
             except Exception as exc:
-                self._log_path_error(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
+                self._log_path_error(
+                    path_id, None, exc, fold_id=fold_id, fold_label=fold_label
+                )
                 return [], [
-                    self._error_record(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
+                    self._error_record(
+                        path_id, None, exc, fold_id=fold_id, fold_label=fold_label
+                    )
                 ]
 
             path_evals: list[StrategyEvaluation] = []
@@ -482,11 +497,15 @@ class MonteCarloRunner:
             return path_evals, path_errors
 
         completed = 0
-        for path_id, path_eval, path_err in self._execute_paths(path_seeds, _evaluate_path, jobs):
+        for path_id, path_eval, path_err in self._execute_paths(
+            path_seeds, _evaluate_path, jobs
+        ):
             evaluations.extend(path_eval)
             errors.extend(path_err)
             completed += 1
-            self._emit_progress(progress_callback, completed, total, path_id, "two_layer")
+            self._emit_progress(
+                progress_callback, completed, total, path_id, "two_layer"
+            )
 
         return evaluations, errors
 
@@ -527,7 +546,11 @@ class MonteCarloRunner:
         mode_reason = (
             "matching-base-path-seeds"
             if seeds_match_base
-            else ("all-path-seeds-unset" if all_unset_path_seeds else "divergent-path-seeds")
+            else (
+                "all-path-seeds-unset"
+                if all_unset_path_seeds
+                else "divergent-path-seeds"
+            )
         )
         self._logger.debug(
             "Mixture mode path generation selected mode=%s reason=%s",
@@ -546,7 +569,9 @@ class MonteCarloRunner:
                 )
             except Exception as exc:
                 for path_id in range(total):
-                    self._log_path_error(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
+                    self._log_path_error(
+                        path_id, None, exc, fold_id=fold_id, fold_label=fold_label
+                    )
                     errors.append(
                         self._error_record(
                             path_id, None, exc, fold_id=fold_id, fold_label=fold_label
@@ -570,9 +595,13 @@ class MonteCarloRunner:
                     fold_label=fold_label,
                 )
             except Exception as exc:
-                self._log_path_error(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
+                self._log_path_error(
+                    path_id, None, exc, fold_id=fold_id, fold_label=fold_label
+                )
                 return [], [
-                    self._error_record(path_id, None, exc, fold_id=fold_id, fold_label=fold_label)
+                    self._error_record(
+                        path_id, None, exc, fold_id=fold_id, fold_label=fold_label
+                    )
                 ]
 
             try:
@@ -597,7 +626,9 @@ class MonteCarloRunner:
                 ]
 
         completed = 0
-        for path_id, path_eval, path_err in self._execute_paths(path_seeds, _evaluate_path, jobs):
+        for path_id, path_eval, path_err in self._execute_paths(
+            path_seeds, _evaluate_path, jobs
+        ):
             evaluations.extend(path_eval)
             errors.extend(path_err)
             completed += 1
@@ -681,11 +712,13 @@ class MonteCarloRunner:
         regime_settings = (
             normalise_settings(regime_cfg) if isinstance(regime_cfg, Mapping) else None
         )
-        turnover_series, binding, cap_series, cap_regimes = self._resolve_turnover_diagnostics(
-            run_result,
-            context,
-            max_turnover=max_turnover,
-            regime_settings=regime_settings,
+        turnover_series, binding, cap_series, cap_regimes = (
+            self._resolve_turnover_diagnostics(
+                run_result,
+                context,
+                max_turnover=max_turnover,
+                regime_settings=regime_settings,
+            )
         )
         if turnover_series is not None or binding is not None:
             if diagnostic is None:
@@ -727,7 +760,9 @@ class MonteCarloRunner:
             nav_series=nav_series,
         )
 
-    def _apply_regime_turnover_caps(self, config: ConfigType, context: _PathContext) -> None:
+    def _apply_regime_turnover_caps(
+        self, config: ConfigType, context: _PathContext
+    ) -> None:
         """Apply turnover-cap regime overrides to ``portfolio.max_turnover``.
 
         Supported shapes for ``portfolio.max_turnover`` are a numeric scalar or a
@@ -762,7 +797,9 @@ class MonteCarloRunner:
         if multi_period_enabled:
             resolved: float | Mapping[str, Any] | None = max_turnover
         else:
-            resolved = self._resolve_turnover_cap_for_context(config, context, max_turnover)
+            resolved = self._resolve_turnover_cap_for_context(
+                config, context, max_turnover
+            )
         if resolved is None or resolved is max_turnover:
             return
         if isinstance(portfolio, dict):
@@ -796,7 +833,11 @@ class MonteCarloRunner:
             freq = data_cfg.get("frequency")
         freq_label = str(freq or "M")
         periods_per_year = periods_per_year_from_code(freq_label)
-        proxy_window = (proxy_series.index[0], proxy_series.index[-1], len(proxy_series))
+        proxy_window = (
+            proxy_series.index[0],
+            proxy_series.index[-1],
+            len(proxy_series),
+        )
         cache_key = self._regime_cache_key(
             context,
             proxy_col,
@@ -818,7 +859,9 @@ class MonteCarloRunner:
             return max_turnover
         regime_label = str(regimes.iloc[-1])
         parsed = parse_regime_turnover_caps(max_turnover, settings)
-        resolved = self._resolve_turnover_cap_from_parsed(parsed, regime_label, settings)
+        resolved = self._resolve_turnover_cap_from_parsed(
+            parsed, regime_label, settings
+        )
         if resolved is None:
             return max_turnover
         return resolved
@@ -905,7 +948,9 @@ class MonteCarloRunner:
                 return str(col)
         return None
 
-    def _build_regime_proxy_series(self, returns: pd.DataFrame, proxy_col: str) -> pd.Series | None:
+    def _build_regime_proxy_series(
+        self, returns: pd.DataFrame, proxy_col: str
+    ) -> pd.Series | None:
         if proxy_col not in returns.columns:
             return None
         if "Date" in returns.columns:
@@ -975,7 +1020,9 @@ class MonteCarloRunner:
         try:
             n_strategies = int(n_value)
         except (TypeError, ValueError) as exc:
-            raise ValueError("strategy_set.sampled.n_strategies must be an integer") from exc
+            raise ValueError(
+                "strategy_set.sampled.n_strategies must be an integer"
+            ) from exc
         if n_strategies < 1:
             raise ValueError("strategy_set.sampled.n_strategies must be >= 1")
 
@@ -989,7 +1036,9 @@ class MonteCarloRunner:
             try:
                 seed = int(seed)
             except (TypeError, ValueError) as exc:
-                raise ValueError("strategy_set.sampled.seed must be an integer") from exc
+                raise ValueError(
+                    "strategy_set.sampled.seed must be an integer"
+                ) from exc
 
         max_rejection_attempts = sampled.get("max_rejection_attempts", 1000)
         try:
@@ -1048,9 +1097,13 @@ class MonteCarloRunner:
         else:
             raise ValueError(f"Unsupported return model '{kind}'")
 
-        resolved_history = history if history is not None else self._resolve_price_history()
+        resolved_history = (
+            history if history is not None else self._resolve_price_history()
+        )
         if calibration_start is not None or calibration_end is not None:
-            normalized, _summary = normalize_price_frequency(resolved_history, frequency)
+            normalized, _summary = normalize_price_frequency(
+                resolved_history, frequency
+            )
             windowed = normalized.loc[calibration_start:calibration_end]
             if windowed.empty:
                 raise ValueError(
@@ -1085,7 +1138,9 @@ class MonteCarloRunner:
         csv_path = data_cfg.get("csv_path")
         if csv_path:
             return self._load_history_from_path(Path(str(csv_path)))
-        raise ValueError("price_history must be provided or data.csv_path must be configured")
+        raise ValueError(
+            "price_history must be provided or data.csv_path must be configured"
+        )
 
     def _load_history_from_path(self, path: Path) -> pd.DataFrame:
         suffix = path.suffix.lower()
@@ -1124,7 +1179,9 @@ class MonteCarloRunner:
         ]
         return path_seeds, strategy_seeds
 
-    def _build_strategy_config(self, strategy: StrategyVariant, seed: int | None) -> ConfigType:
+    def _build_strategy_config(
+        self, strategy: StrategyVariant, seed: int | None
+    ) -> ConfigType:
         merged = strategy.apply_to(self._base_config)
         self._apply_strategy_guards(merged)
         self._apply_turnover_guard_distribution(merged, strategy, seed)
@@ -1196,7 +1253,10 @@ class MonteCarloRunner:
     def _compute_score_frame(self, returns: pd.DataFrame) -> pd.DataFrame:
         try:
             config = Config(**self._base_config)
-        except Exception:
+        except (TypeError, ValueError) as exc:
+            self._logger.warning(
+                "Invalid Monte Carlo base config; score frame omitted: %s", exc
+            )
             return pd.DataFrame()
         try:
             split = _resolve_sample_split(returns, config.sample_split)
@@ -1206,7 +1266,9 @@ class MonteCarloRunner:
             metrics = canonical_metric_list(metrics_raw)
             data_settings = config.data or {}
             metrics_settings = config.metrics or {}
-            use_resolver = self._should_resolve_risk_free(data_settings, metrics_settings)
+            use_resolver = self._should_resolve_risk_free(
+                data_settings, metrics_settings
+            )
             risk_free_value: float | pd.Series | None = None
             if use_resolver:
                 resolution = resolve_risk_free_source(returns, config)
@@ -1222,9 +1284,13 @@ class MonteCarloRunner:
             stats_cfg = RiskStatsConfig(
                 metrics_to_run=metrics,
                 risk_free=(
-                    float(risk_free_value) if isinstance(risk_free_value, (int, float)) else 0.0
+                    float(risk_free_value)
+                    if isinstance(risk_free_value, (int, float))
+                    else 0.0
                 ),
-                periods_per_year=int(periods_per_year_from_code(config.data.get("frequency"))),
+                periods_per_year=int(
+                    periods_per_year_from_code(config.data.get("frequency"))
+                ),
             )
             return single_period_run(
                 returns,
@@ -1324,7 +1390,9 @@ class MonteCarloRunner:
         """Backward-compatible alias for cash injection behavior."""
         return self._apply_cash_handling(returns)
 
-    def _extract_metrics(self, metrics_df: pd.DataFrame) -> tuple[dict[str, float], str | None]:
+    def _extract_metrics(
+        self, metrics_df: pd.DataFrame
+    ) -> tuple[dict[str, float], str | None]:
         if metrics_df is None or metrics_df.empty:
             return {}, None
         source = None
@@ -1364,7 +1432,9 @@ class MonteCarloRunner:
             rng=rng,
         )
 
-    def _resolve_cost_index(self, run_result: Any, context: _PathContext) -> pd.Index | None:
+    def _resolve_cost_index(
+        self, run_result: Any, context: _PathContext
+    ) -> pd.Index | None:
         details = getattr(run_result, "details", None)
         if isinstance(details, Mapping):
             out_scaled = details.get("out_sample_scaled")
@@ -1379,11 +1449,16 @@ class MonteCarloRunner:
         turnover_attr = getattr(run_result, "turnover", None)
         if isinstance(turnover_attr, pd.Series):
             return turnover_attr.index
-        if isinstance(context.returns, pd.DataFrame) and "Date" in context.returns.columns:
+        if (
+            isinstance(context.returns, pd.DataFrame)
+            and "Date" in context.returns.columns
+        ):
             return pd.DatetimeIndex(context.returns["Date"]).copy()
         return None
 
-    def _resolve_regime_labels(self, run_result: Any, out_index: pd.Index) -> pd.Series | None:
+    def _resolve_regime_labels(
+        self, run_result: Any, out_index: pd.Index
+    ) -> pd.Series | None:
         details = getattr(run_result, "details", None)
         if isinstance(details, Mapping):
             labels = details.get("regime_labels_out")
@@ -1392,7 +1467,9 @@ class MonteCarloRunner:
             labels = details.get("regime_labels")
             if isinstance(labels, pd.Series):
                 return labels.reindex(out_index)
-            period_labels = self._period_results_regimes(details.get("period_results"), out_index)
+            period_labels = self._period_results_regimes(
+                details.get("period_results"), out_index
+            )
             if period_labels is not None:
                 return period_labels
         return None
@@ -1406,9 +1483,13 @@ class MonteCarloRunner:
                 return turnover_attr
             if len(turnover_attr) == 1 and len(out_index) > 1:
                 value = float(turnover_attr.iloc[0])
-                return pd.Series(value, index=out_index, name=turnover_attr.name or "turnover")
+                return pd.Series(
+                    value, index=out_index, name=turnover_attr.name or "turnover"
+                )
             return turnover_attr.reindex(out_index).fillna(0.0)
-        turnover_value = turnover_attr if isinstance(turnover_attr, (float, int)) else None
+        turnover_value = (
+            turnover_attr if isinstance(turnover_attr, (float, int)) else None
+        )
         details = getattr(run_result, "details", None)
         if isinstance(details, Mapping):
             turnover = details.get("turnover")
@@ -1417,7 +1498,9 @@ class MonteCarloRunner:
                     return turnover
                 if len(turnover) == 1 and len(out_index) > 1:
                     value = float(turnover.iloc[0])
-                    return pd.Series(value, index=out_index, name=turnover.name or "turnover")
+                    return pd.Series(
+                        value, index=out_index, name=turnover.name or "turnover"
+                    )
                 return turnover.reindex(out_index).fillna(0.0)
             if isinstance(turnover, (float, int)):
                 return float(turnover)
@@ -1492,7 +1575,9 @@ class MonteCarloRunner:
         returns = returns.replace([np.inf, -np.inf], np.nan).dropna()
         if returns.empty:
             return None
-        nav_index = self._coerce_nav_index(returns.index, run_result, context, len(returns))
+        nav_index = self._coerce_nav_index(
+            returns.index, run_result, context, len(returns)
+        )
         if nav_index is None:
             self._logger.debug(
                 "nav_paths: non-datetime index for path %s; skipping NAV series",
@@ -1523,10 +1608,14 @@ class MonteCarloRunner:
         *,
         max_turnover: object | None,
         regime_settings: Any | None,
-    ) -> tuple[pd.Series | None, pd.Series | None, pd.Series | float | None, pd.Series | None]:
+    ) -> tuple[
+        pd.Series | None, pd.Series | None, pd.Series | float | None, pd.Series | None
+    ]:
         out_index = self._resolve_cost_index(run_result, context)
         regimes = (
-            self._resolve_regime_labels(run_result, out_index) if out_index is not None else None
+            self._resolve_regime_labels(run_result, out_index)
+            if out_index is not None
+            else None
         )
         turnover_raw = self._resolve_turnover_series(run_result, out_index)
         turnover_series = self._coerce_turnover_series(turnover_raw, out_index)
@@ -1536,7 +1625,9 @@ class MonteCarloRunner:
             regimes,
             out_index,
         )
-        cap_regimes = self._resolve_turnover_cap_regimes(parsed_caps, regimes, out_index)
+        cap_regimes = self._resolve_turnover_cap_regimes(
+            parsed_caps, regimes, out_index
+        )
         binding = self._turnover_cap_binding_indicator(turnover_series, cap_series)
         return turnover_series, binding, cap_series, cap_regimes
 
@@ -1577,7 +1668,8 @@ class MonteCarloRunner:
             # Enforce canonical NAV normalization: each path must start at 1.0.
             if not np.isclose(nav.iloc[0], 1.0, atol=NUMERICAL_TOLERANCE_LOW):
                 self._logger.debug(
-                    "nav_paths: path %s did not normalize to 1.0; skipping", evaluation.path_id
+                    "nav_paths: path %s did not normalize to 1.0; skipping",
+                    evaluation.path_id,
                 )
                 continue
             if index_ref is None:
@@ -1585,7 +1677,8 @@ class MonteCarloRunner:
             # All NAV series must share the same datetime-like index.
             elif not nav.index.equals(index_ref):
                 self._logger.debug(
-                    "nav_paths: index mismatch for path %s; skipping", evaluation.path_id
+                    "nav_paths: index mismatch for path %s; skipping",
+                    evaluation.path_id,
                 )
                 continue
             paths[int(evaluation.path_id)] = nav
@@ -1609,7 +1702,11 @@ class MonteCarloRunner:
             if len(names) <= path_level:
                 names.extend([None] * (path_level + 1 - len(names)))
             names[path_level] = "path"
-            asset_level = names.index("asset") if "asset" in names else (1 if nlevels > 1 else None)
+            asset_level = (
+                names.index("asset")
+                if "asset" in names
+                else (1 if nlevels > 1 else None)
+            )
             if asset_level is None:
                 # Append an "asset" level containing NAV when absent.
                 arrays = [frame.columns.get_level_values(i) for i in range(nlevels)]
@@ -1626,7 +1723,9 @@ class MonteCarloRunner:
                 # Force asset labels to NAV for fan chart compatibility.
                 arrays = [frame.columns.get_level_values(i) for i in range(nlevels)]
                 arrays[asset_level] = pd.Index(["NAV"] * len(frame.columns))
-                frame.columns = pd.MultiIndex.from_arrays(arrays, names=frame.columns.names)
+                frame.columns = pd.MultiIndex.from_arrays(
+                    arrays, names=frame.columns.names
+                )
             try:
                 # Keep paths ordered for deterministic fan chart exports.
                 frame = frame.sort_index(axis=1, level=path_level)
@@ -1670,8 +1769,10 @@ class MonteCarloRunner:
         series = pd.Series(labels, index=pd.Index(values, name="period"), name="regime")
         try:
             series = series.astype("string")
-        except Exception:
-            pass
+        except (TypeError, ValueError) as exc:
+            self._logger.debug(
+                "Could not coerce regime labels to string dtype: %s", exc
+            )
         if out_index is None:
             return series
         return series.reindex(out_index)
@@ -1767,8 +1868,10 @@ class MonteCarloRunner:
         resolved = labels.map(_canonical_label)
         try:
             resolved = resolved.astype("string")
-        except Exception:
-            pass
+        except (TypeError, ValueError) as exc:
+            self._logger.debug(
+                "Could not coerce turnover-cap regimes to string dtype: %s", exc
+            )
         return resolved.rename("turnover_cap_regime")
 
     def _turnover_cap_binding_indicator(
@@ -1805,7 +1908,9 @@ class MonteCarloRunner:
             "total_cost_drag": payload.total_cost_drag,
         }
 
-    def _extract_path_frame(self, frame: pd.DataFrame, path_index: int = 0) -> pd.DataFrame:
+    def _extract_path_frame(
+        self, frame: pd.DataFrame, path_index: int = 0
+    ) -> pd.DataFrame:
         if isinstance(frame.columns, pd.MultiIndex) and "path" in frame.columns.names:
             return frame.xs(path_index, level="path", axis=1)
         return frame.copy()
@@ -1947,7 +2052,9 @@ class MonteCarloRunner:
             expected_shortfall_spec = aggregation_config.get("expected_shortfall")
         quantiles = outputs.get("quantiles", quantiles)
         breach_spec = outputs.get("breach", breach_spec)
-        expected_shortfall_spec = outputs.get("expected_shortfall", expected_shortfall_spec)
+        expected_shortfall_spec = outputs.get(
+            "expected_shortfall", expected_shortfall_spec
+        )
         aggregation = aggregate_monte_carlo_results(
             results.results_frame,
             quantiles=quantiles,
@@ -1961,7 +2068,9 @@ class MonteCarloRunner:
         rendered = template.format(scenario_name=self.scenario.name, timestamp=now)
         return Path(rendered)
 
-    def _coerce_base_config(self, base_config: Mapping[str, Any] | None) -> dict[str, Any]:
+    def _coerce_base_config(
+        self, base_config: Mapping[str, Any] | None
+    ) -> dict[str, Any]:
         if base_config is None:
             path = self._base_config_path()
             if not path.exists():

--- a/tests/test_compute_score_frame_logs.py
+++ b/tests/test_compute_score_frame_logs.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pandas as pd
+
+from trend_analysis.monte_carlo.runner import MonteCarloRunner
+from trend_analysis.monte_carlo.scenario import MonteCarloScenario
+from trend_analysis.monte_carlo.strategy import StrategyVariant
+
+
+def _scenario() -> MonteCarloScenario:
+    return MonteCarloScenario(
+        name="invalid_config_log_test",
+        base_config="config/defaults.yml",
+        monte_carlo={
+            "mode": "two_layer",
+            "n_paths": 2,
+            "horizon_years": 1.0,
+            "frequency": "M",
+            "seed": 123,
+            "jobs": 1,
+        },
+        strategy_set={"curated": [StrategyVariant(name="StrategyA")]},
+        return_model={"kind": "stationary_bootstrap", "params": {"block_size": 3}},
+    )
+
+
+def _base_config() -> dict[str, Any]:
+    return {
+        "version": "0.1.0",
+        "data": {
+            "date_column": "Date",
+            "frequency": "M",
+            "allow_risk_free_fallback": True,
+        },
+        "preprocessing": {},
+        "vol_adjust": {"enabled": False, "target_vol": 0.1, "window": {"length": 3}},
+        "sample_split": {"method": "ratio", "ratio": 0.6},
+        "portfolio": {"selection_mode": "all", "weighting_scheme": "equal"},
+        "benchmarks": {},
+        "metrics": {"registry": ["annual_return", "volatility", "sharpe_ratio"]},
+        "regime": {},
+        "export": {},
+        "run": {"monthly_cost": 0.0},
+    }
+
+
+def _returns() -> pd.DataFrame:
+    dates = pd.date_range("2020-01-31", periods=6, freq="ME")
+    return pd.DataFrame(
+        {
+            "Date": dates,
+            "AssetA": [0.02, 0.01, 0.03, -0.01, 0.01, 0.02],
+            "AssetB": [0.005, 0.004, 0.006, 0.004, 0.005, 0.004],
+        }
+    )
+
+
+def test_compute_score_frame_logs_invalid_base_config(caplog) -> None:
+    config = _base_config()
+    config["sample_split"] = None
+    runner = MonteCarloRunner(_scenario(), base_config=config)
+
+    with caplog.at_level(logging.WARNING, logger="trend_analysis.monte_carlo"):
+        frame = runner._compute_score_frame(_returns())
+
+    assert frame.empty
+    assert "Invalid Monte Carlo base config; score frame omitted" in caplog.text

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,16 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-06-03T10:12Z - opener lane issue #5405 PR materializing
+
+- Repo/issue: stranske/Trend_Model_Project #5405 (`A25 - Refactor cli.main()/_handle_mc_command; narrow broad excepts; log swallowed config errors`).
+- Branch: `codex/issue-5405-cli-excepts`; base `origin/phase-3`.
+- Agent: codex opener from neutral Code workspace; used persistent automation worktree `~/.codex/automations/pd-workloop-resume/worktrees/trend-5405-cli-excepts`.
+- Selection: raw opener cap was below 5. Existing opener PR #5459 was repaired with `agent:retry` + Gate Followups dispatch and then showed fresh Gate activity; #5440 remains scoped/terminal on #5389 design decision. Priority-high candidates were scoped or already closed/merged, so liveness fallback selected #5405 as the oldest unlinked implementation issue outside scoped blockers.
+- Implementation: extracted `gui`, `run`, and deprecated `run-ui` command execution from `main()` into handlers so `main()` parses and dispatches; narrowed the named `_attach_universe_paths` broad catches to attribute/type failures with debug logging; added warning logging for invalid Monte Carlo base config before `_compute_score_frame()` returns an empty frame; replaced two silent pandas string-coercion fallbacks with debug logs.
+- Validation: `PYTHONPATH=src python -m pytest tests/test_compute_score_frame_logs.py` passed; deliberate-break gate removed the warning and the new test failed, then the warning was restored; focused runner slice `tests/test_compute_score_frame_logs.py tests/monte_carlo/test_runner.py -k 'score_frame or should_resolve_risk_free'` passed (7 passed); focused CLI suite `tests/test_cli.py tests/test_trend_model_cli.py tests/test_trend_cli_entrypoints.py` passed (62 passed); focused `ruff check`/`ruff format --check` and `git diff --check` passed. Full requested `tests/ -k cli` collection is blocked in this local environment by pre-existing NumPy 2.x incompatibilities in xarray/pyarrow plus Streamlit upload-page import behavior.
+- Current state: branch ready to commit and open as a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`. Next action after PR open belongs to keepalive/Gate.
+
 ## 2026-06-03T09:08:49Z - opener lane issue #5403 PR materializing
 
 - Repo/issue: stranske/Trend_Model_Project #5403 (`A22 - Consolidate transaction-cost logic fanned across >=5 implementations`).


### PR DESCRIPTION
Closes #5405

## Summary
- Extract `gui`, `run`, and deprecated `run-ui` command bodies into dedicated handlers so `main()` parses and dispatches.
- Narrow the named universe-path broad catches and replace silent config/series coercion fallbacks with warning/debug logging.
- Add `tests/test_compute_score_frame_logs.py` proving invalid Monte Carlo base config logs before returning an empty score frame.

## Validation
- `PYTHONPATH=src python -m pytest tests/test_compute_score_frame_logs.py`
- Deliberate-break gate: removed the score-frame warning and confirmed the new test failed, then restored and reran green.
- `PYTHONPATH=src python -m pytest tests/test_compute_score_frame_logs.py tests/monte_carlo/test_runner.py -k 'score_frame or should_resolve_risk_free' -q`\n- `PYTHONPATH=src python -m pytest tests/test_cli.py tests/test_trend_model_cli.py tests/test_trend_cli_entrypoints.py -q`\n- `PYTHONPATH=src python -m ruff check src/trend_analysis/monte_carlo/runner.py src/trend_analysis/cli.py tests/test_compute_score_frame_logs.py`\n- `PYTHONPATH=src python -m ruff format --check src/trend_analysis/monte_carlo/runner.py src/trend_analysis/cli.py tests/test_compute_score_frame_logs.py`\n- `git diff --check`\n\nNote: the broader requested `tests/ -k cli` collection is blocked in this local environment by pre-existing NumPy 2.x import incompatibilities in xarray/pyarrow plus Streamlit upload-page import behavior.