### PR TITLE
Issue #5406: derive selector cache counters from active cache instance (A27)

### DIFF
--- a/src/trend_analysis/core/rank_selection.py
+++ b/src/trend_analysis/core/rank_selection.py
@@ -283,7 +283,7 @@ selector_cache_hits: int
 selector_cache_misses: int
 
 
-def __getattr__(name: str) -> int:
+def __getattr__(name: str) -> Any:
     if name in ("selector_cache_hits", "selector_cache_misses"):
         return _WINDOW_METRIC_CACHE.stats()[name]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/trend_analysis/core/rank_selection.py
+++ b/src/trend_analysis/core/rank_selection.py
@@ -169,7 +169,6 @@ class WindowMetricBundle:
         canonical = _METRIC_ALIASES.get(metric_name, metric_name)
         if canonical in self._metrics.columns:
             _WINDOW_METRIC_CACHE.record_hit()
-            _sync_cache_counters()
             return self._metrics[canonical]
         if canonical in {"AvgCorr", "__COV_VAR__"}:
             payload = self.cov_payload
@@ -200,7 +199,6 @@ class WindowMetricBundle:
         series = series.astype(float)
         self._metrics[canonical] = series
         _WINDOW_METRIC_CACHE.record_miss()
-        _sync_cache_counters()
         return self._metrics[canonical]
 
 
@@ -273,9 +271,22 @@ class WindowMetricCache:
 _CACHE_SCOPE: ContextVar[str] = ContextVar("RANK_SELECTOR_CACHE_SCOPE", default="default")
 _WINDOW_METRIC_CACHE = WindowMetricCache()
 
-# Backwards compatibility counters exposed in tests.
-selector_cache_hits = 0
-selector_cache_misses = 0
+# Backwards-compatibility read-only views. ``selector_cache_hits`` and
+# ``selector_cache_misses`` are derived live from the active cache instance's
+# ``stats()`` via module ``__getattr__`` (PEP 562) instead of being mirrored into
+# mutable module globals. This keeps the counters from persisting across cache
+# instances or leaking state between tests sharing a process.
+#
+# Declared (not assigned) so static tooling and ``__all__`` see the names while
+# ``__getattr__`` still serves them live -- a real assignment would shadow it.
+selector_cache_hits: int
+selector_cache_misses: int
+
+
+def __getattr__(name: str) -> int:
+    if name in ("selector_cache_hits", "selector_cache_misses"):
+        return _WINDOW_METRIC_CACHE.stats()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 @contextmanager
@@ -293,7 +304,6 @@ def set_window_metric_cache_limit(max_entries: int | None) -> int | None:
     """Set the selector cache size limit, returning the previous value."""
 
     previous = _WINDOW_METRIC_CACHE.set_limit(max_entries)
-    _sync_cache_counters()
     return previous
 
 
@@ -336,22 +346,6 @@ def _compute_covariance_payload(
     )
 
 
-_SELECTOR_CACHE_HITS = 0
-_SELECTOR_CACHE_MISSES = 0
-
-
-def _sync_cache_counters() -> None:
-    """Mirror internal cache counters to public module attributes."""
-
-    global selector_cache_hits, selector_cache_misses
-    stats = _WINDOW_METRIC_CACHE.stats()
-    selector_cache_hits = stats["selector_cache_hits"]
-    selector_cache_misses = stats["selector_cache_misses"]
-    _globals = globals()
-    _globals["_SELECTOR_CACHE_HITS"] = selector_cache_hits
-    _globals["_SELECTOR_CACHE_MISSES"] = selector_cache_misses
-
-
 def make_window_key(
     start: str, end: str, universe: Iterable[str], stats_cfg: "RiskStatsConfig"
 ) -> WindowKey:
@@ -368,14 +362,8 @@ def make_window_key(
 
 def get_window_metric_bundle(window_key: WindowKey) -> WindowMetricBundle | None:
     """Return the cached bundle for *window_key* if present."""
-    # Declare globals because we mutate (_SELECTOR_CACHE_HITS += 1) below.
 
-    bundle = _WINDOW_METRIC_CACHE.get(window_key)
-    if bundle is None:
-        _sync_cache_counters()
-        return None
-    _sync_cache_counters()
-    return bundle
+    return _WINDOW_METRIC_CACHE.get(window_key)
 
 
 def store_window_metric_bundle(window_key: WindowKey | None, bundle: WindowMetricBundle) -> None:
@@ -392,7 +380,6 @@ def clear_window_metric_cache(scope: str | None = None) -> None:
     """
 
     _WINDOW_METRIC_CACHE.clear(scope)
-    _sync_cache_counters()
 
 
 def reset_selector_cache(scope: str | None = None) -> None:
@@ -404,10 +391,7 @@ def reset_selector_cache(scope: str | None = None) -> None:
 def selector_cache_stats() -> dict[str, int]:
     """Return selector cache instrumentation counters."""
 
-    stats = _WINDOW_METRIC_CACHE.stats()
-    stats["selector_cache_hits"] = _SELECTOR_CACHE_HITS
-    stats["selector_cache_misses"] = _SELECTOR_CACHE_MISSES
-    return stats
+    return _WINDOW_METRIC_CACHE.stats()
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/tests/test_cache_counter_isolation.py
+++ b/tests/test_cache_counter_isolation.py
@@ -1,0 +1,67 @@
+"""Isolation tests for selector cache instrumentation counters (Issue #5406, A27).
+
+The public ``selector_cache_hits`` / ``selector_cache_misses`` views must be
+derived live from the *active* :class:`WindowMetricCache` instance via the module
+``__getattr__`` rather than mirrored into mutable module globals. That keeps the
+counts from persisting across independent cache instances or leaking state
+between tests that share a process.
+"""
+
+import trend_analysis.core.rank_selection as rs
+from trend_analysis.core.rank_selection import WindowMetricCache
+
+
+def test_counters_track_active_cache_instance(monkeypatch):
+    """The module-level views reflect whichever cache instance is active.
+
+    This is the deliberate-break gate: if ``selector_cache_hits`` /
+    ``selector_cache_misses`` are restored to mutable module globals mirrored via
+    ``global`` assignment, swapping the active cache below no longer updates the
+    views and these assertions fail.
+    """
+
+    cache_a = WindowMetricCache()
+    cache_a.record_hit()
+    cache_a.record_hit()
+    cache_a.record_miss()
+
+    cache_b = WindowMetricCache()  # independent, untouched
+
+    monkeypatch.setattr(rs, "_WINDOW_METRIC_CACHE", cache_a)
+    assert rs.selector_cache_hits == 2
+    assert rs.selector_cache_misses == 1
+    assert rs.selector_cache_stats()["selector_cache_hits"] == 2
+    assert rs.selector_cache_stats()["selector_cache_misses"] == 1
+
+    # Switching to an independent instance must NOT leak cache_a's counts.
+    monkeypatch.setattr(rs, "_WINDOW_METRIC_CACHE", cache_b)
+    assert rs.selector_cache_hits == 0
+    assert rs.selector_cache_misses == 0
+
+
+def test_two_instances_do_not_share_counts():
+    """Each :class:`WindowMetricCache` owns its own hit/miss counters."""
+
+    cache_a = WindowMetricCache()
+    cache_b = WindowMetricCache()
+
+    cache_a.record_hit()
+    cache_b.record_miss()
+    cache_b.record_miss()
+
+    assert cache_a.stats()["selector_cache_hits"] == 1
+    assert cache_a.stats()["selector_cache_misses"] == 0
+    assert cache_b.stats()["selector_cache_hits"] == 0
+    assert cache_b.stats()["selector_cache_misses"] == 2
+
+
+def test_clear_resets_counters_to_zero():
+    """Clearing the cache zeroes the derived views (no stale module state)."""
+
+    cache = WindowMetricCache()
+    cache.record_hit()
+    cache.record_miss()
+    cache.clear()
+
+    assert cache.stats()["selector_cache_hits"] == 0
+    assert cache.stats()["selector_cache_misses"] == 0


### PR DESCRIPTION
Closes #5406

## A27 — Encapsulate module-global mutable cache counters in `rank_selection`

### Why
`selector_cache_hits`/`selector_cache_misses` were mutable module globals, mirrored from the cache via `global`/`globals()[...]` assignment in `_sync_cache_counters` (plus the private `_SELECTOR_CACHE_HITS`/`_SELECTOR_CACHE_MISSES` shadow globals). Module-level mutable counters persist across runs/tests in the same process and are unsynchronized, so cache-stat assertions can leak state between tests and counts are unreliable.

### What
- Derive `selector_cache_hits`/`selector_cache_misses` **live** from the active `WindowMetricCache.stats()` via a module-level `__getattr__` (PEP 562), declared as read-only views (bare annotations, no assignment, so `__getattr__` serves them).
- Remove the `_SELECTOR_CACHE_HITS`/`_SELECTOR_CACHE_MISSES` globals, the `_sync_cache_counters()` function, and all of its call sites.
- `selector_cache_stats()` now returns `_WINDOW_METRIC_CACHE.stats()` directly.

Cache hit/miss **semantics are unchanged** — `record_hit`/`record_miss`/`get` still update the per-instance counters; only the redundant module-global mirroring is removed (Non-Goals respected).

### Tests
- `tests/test_cache_counter_isolation.py`: the views track whichever cache instance is active, switching instances does not leak counts, two independent instances keep separate counts, and `clear()` zeroes the views.

### Validation
- `python -m pytest tests/test_cache_counter_isolation.py tests/test_rank_selection.py -q` → passes (12 passed incl. related `test_selector_cache.py`/`test_selector_window_cache.py`).
- **Deliberate-break gate:** temporarily restoring the mutable module globals (which shadow `__getattr__`) makes `test_counters_track_active_cache_instance` FAIL (`assert 0 == 2`); reverted.
- `ruff check` clean, `mypy` clean, `git diff --check` clean.