### PR TITLE
Issue #5407: wire Monte Carlo page to session model

### DIFF
--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -779,7 +779,7 @@ New tab: **Monte Carlo Simulation**
 - [x] Fold/vintage support (`src/trend_analysis/monte_carlo/folds.py`)
 - [x] Aggregation outputs + distributions (`src/trend_analysis/monte_carlo/aggregator.py`)
 - [x] CLI commands (`src/trend_analysis/cli.py`)
-- [x] Streamlit MC tab (`streamlit_app/pages/monte_carlo.py`)
+- [x] Streamlit MC tab (`streamlit_app/pages/5_Monte_Carlo.py`)
 
 ---
 

--- a/streamlit_app/monte_carlo_page.py
+++ b/streamlit_app/monte_carlo_page.py
@@ -13,8 +13,6 @@ from typing import Any, Iterable, Mapping
 import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
-
-from streamlit_app.components import mc_plots, mc_tables
 from streamlit_app.components.data_cache import cache_key_for_frame
 from streamlit_app.components.guardrails import infer_frequency
 from streamlit_app.components.progress_eta import progress_ratio_and_remaining
@@ -28,14 +26,10 @@ from trend_analysis.monte_carlo.registry import (
 )
 from trend_analysis.monte_carlo.runner import MonteCarloRunner
 from trend_analysis.monte_carlo.scenario import MonteCarloScenario, MonteCarloSettings
-from trend_analysis.viz import sharpe_ladder as sharpe_ladder_chart
 from trend_analysis.viz.adapters import (
     make_paths,
     make_summary,
 )
-from trend_analysis.viz.charts import corr_heatmap as corr_heatmap_chart
-from trend_analysis.viz.charts import rolling_panel as rolling_panel_chart
-from trend_analysis.viz.charts import seasonality_heatmap as seasonality_heatmap_chart
 
 
 def _should_auto_render() -> bool:
@@ -311,6 +305,11 @@ def _render_diagnostic_charts(summary: pd.DataFrame, paths: pd.DataFrame) -> dic
         st.warning("Diagnostics unavailable: canonical paths are empty.")
         return charts
 
+    from trend_analysis.viz import sharpe_ladder as sharpe_ladder_chart
+    from trend_analysis.viz.charts import corr_heatmap as corr_heatmap_chart
+    from trend_analysis.viz.charts import rolling_panel as rolling_panel_chart
+    from trend_analysis.viz.charts import seasonality_heatmap as seasonality_heatmap_chart
+
     try:
         sharpe_fig = sharpe_ladder_chart.make(summary, metric="sharpe")
     except Exception:
@@ -394,6 +393,8 @@ def _render_results(
     if filtered_results.empty:
         st.warning("No results available for the selected fold.")
         return
+
+    from streamlit_app.components import mc_plots, mc_tables
 
     adapter_fold_selection = _fold_selection_for_adapters(fold_selection)
     summary = _cached_make_summary(results_frame, adapter_fold_selection)

--- a/streamlit_app/monte_carlo_page.py
+++ b/streamlit_app/monte_carlo_page.py
@@ -133,6 +133,10 @@ def _session_runner_kwargs() -> tuple[dict[str, Any], str | None]:
             frequency=_session_frequency(analysis_frame),
             csv_path=_session_csv_path(),
         )
+        if isinstance(benchmark, str) and benchmark in analysis_frame.columns:
+            indices = list(base_config.portfolio.get("indices_list") or [])
+            if benchmark not in indices:
+                base_config.portfolio["indices_list"] = [*indices, benchmark]
         price_history = _returns_to_price_history(analysis_frame)
     except Exception as exc:
         return {}, str(exc)

--- a/streamlit_app/monte_carlo_page.py
+++ b/streamlit_app/monte_carlo_page.py
@@ -16,7 +16,9 @@ import streamlit as st
 
 from streamlit_app.components import mc_plots, mc_tables
 from streamlit_app.components.data_cache import cache_key_for_frame
+from streamlit_app.components.guardrails import infer_frequency
 from streamlit_app.components.progress_eta import progress_ratio_and_remaining
+from trend_analysis.config.ui_mapping import build_config_from_ui_state
 from trend_analysis.monte_carlo.aggregator import aggregate_monte_carlo_results
 from trend_analysis.monte_carlo.export_bundle import save as save_chart_bundle
 from trend_analysis.monte_carlo.registry import (
@@ -50,6 +52,91 @@ MC_RUNNING_KEY = "mc_running"
 MC_CANCEL_KEY = "mc_cancel_requested"
 MC_LAST_ERROR_KEY = "mc_last_error"
 MC_LAST_VALIDATION_KEY = "mc_last_validation"
+
+
+def _session_frequency(returns: pd.DataFrame) -> str:
+    meta = st.session_state.get("schema_meta")
+    if isinstance(meta, Mapping):
+        freq = meta.get("frequency_code") or meta.get("frequency")
+        if isinstance(freq, str) and freq.strip():
+            return freq.strip().upper()
+    return infer_frequency(returns.index)
+
+
+def _session_csv_path() -> str | None:
+    for key in ("data_saved_path", "uploaded_file_path"):
+        candidate = st.session_state.get(key)
+        if isinstance(candidate, str) and candidate:
+            path = Path(candidate)
+            if path.exists() and path.suffix.lower() == ".csv":
+                return str(path)
+    return None
+
+
+def _analysis_frame_from_session(
+    returns: pd.DataFrame,
+    model_state: Mapping[str, Any],
+    benchmark: str | None,
+) -> pd.DataFrame:
+    applied_funds = st.session_state.get("analysis_fund_columns")
+    if not isinstance(applied_funds, list):
+        applied_funds = st.session_state.get("fund_columns")
+    if not isinstance(applied_funds, list):
+        applied_funds = []
+
+    selected_rf = st.session_state.get("selected_risk_free")
+    info_ratio_benchmark = model_state.get("info_ratio_benchmark")
+    regime_proxy = None
+    if bool(model_state.get("regime_enabled", False)):
+        regime_proxy = model_state.get("regime_proxy")
+    prohibited = {selected_rf, benchmark, info_ratio_benchmark, regime_proxy} - {None}
+
+    sanitized_funds = [c for c in applied_funds if c in returns.columns and c not in prohibited]
+    keep_cols = list(sanitized_funds)
+    for extra in (selected_rf, benchmark, regime_proxy):
+        if extra and extra in returns.columns and extra not in keep_cols:
+            keep_cols.append(extra)
+    return returns[keep_cols].copy() if keep_cols else returns.copy()
+
+
+def _returns_to_price_history(returns: pd.DataFrame) -> pd.DataFrame:
+    numeric = returns.apply(pd.to_numeric, errors="coerce").dropna(axis=1, how="all")
+    if numeric.empty:
+        raise ValueError("session returns contain no numeric columns")
+    if (numeric <= -1.0).any().any():
+        raise ValueError("session returns contain values <= -1")
+    return (1.0 + numeric).cumprod() * 100.0
+
+
+def _session_runner_kwargs() -> tuple[dict[str, Any], str | None]:
+    returns = st.session_state.get("returns_df")
+    model_state = st.session_state.get("model_state")
+    if not isinstance(returns, pd.DataFrame) or not isinstance(model_state, Mapping):
+        return {}, None
+
+    benchmark = st.session_state.get("selected_benchmark")
+    selected_rf = st.session_state.get("selected_risk_free")
+    effective_model_state = dict(model_state)
+    if selected_rf:
+        effective_model_state["risk_free_column"] = selected_rf
+
+    try:
+        analysis_frame = _analysis_frame_from_session(
+            returns,
+            effective_model_state,
+            benchmark if isinstance(benchmark, str) else None,
+        )
+        base_config = build_config_from_ui_state(
+            returns=analysis_frame,
+            model_state=effective_model_state,
+            benchmark=benchmark if isinstance(benchmark, str) else None,
+            frequency=_session_frequency(analysis_frame),
+            csv_path=_session_csv_path(),
+        )
+        price_history = _returns_to_price_history(analysis_frame)
+    except Exception as exc:
+        return {}, str(exc)
+    return {"base_config": base_config, "price_history": price_history}, None
 
 
 class _RunCancelled(RuntimeError):
@@ -502,6 +589,11 @@ def render() -> None:
     if not isinstance(settings, MonteCarloSettings):
         st.error("Scenario settings are not resolved.")
         return
+    runner_kwargs, session_error = _session_runner_kwargs()
+    if session_error:
+        st.warning("Current Data/Model state could not be applied to Monte Carlo.")
+        with st.expander("Details"):
+            st.write(session_error)
 
     st.subheader("Run Overrides")
     override_cols = st.columns(2)
@@ -579,7 +671,7 @@ def render() -> None:
                 st.session_state[MC_CANCEL_KEY] = True
 
     if validate_clicked:
-        runner = MonteCarloRunner(scenario)
+        runner = MonteCarloRunner(scenario, **runner_kwargs)
         if hasattr(runner, "validate") and callable(getattr(runner, "validate")):
             try:
                 issues = runner.validate()
@@ -614,7 +706,7 @@ def render() -> None:
                 seed=seed,
                 jobs=jobs,
             )
-            runner = MonteCarloRunner(run_scenario)
+            runner = MonteCarloRunner(run_scenario, **runner_kwargs)
             progress_callback = _progress_callback_factory(
                 progress_bar=progress_bar,
                 elapsed_slot=elapsed_slot,
@@ -640,7 +732,3 @@ def render() -> None:
     if results is not None:
         st.divider()
         _render_results(results, fold_selection=fold_selection)
-
-
-if _should_auto_render():
-    render()

--- a/streamlit_app/pages/5_Monte_Carlo.py
+++ b/streamlit_app/pages/5_Monte_Carlo.py
@@ -1,0 +1,9 @@
+"""Numbered Streamlit entrypoint for the Monte Carlo page."""
+
+from __future__ import annotations
+
+from streamlit_app.monte_carlo_page import _should_auto_render, render
+
+
+if _should_auto_render():
+    render()

--- a/streamlit_app/pages/5_Monte_Carlo.py
+++ b/streamlit_app/pages/5_Monte_Carlo.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from streamlit_app.monte_carlo_page import _should_auto_render, render
+from streamlit_app.monte_carlo_page import render
 
 
-if _should_auto_render():
-    render()
+render()

--- a/tests/app/test_mc_page_uses_session_model.py
+++ b/tests/app/test_mc_page_uses_session_model.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from tests.streamlit.test_mc_page import _load_page, _make_scenario
+from trend_analysis.monte_carlo.registry import ScenarioRegistryEntry
+from trend_analysis.monte_carlo.scenario import MonteCarloScenario
+
+
+def test_mc_page_uses_session_model_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    page, stub = _load_page(monkeypatch)
+
+    monkeypatch.setattr(
+        page,
+        "list_scenarios",
+        lambda **_kwargs: [
+            ScenarioRegistryEntry(
+                name="macro",
+                path=Path("config/scenarios/monte_carlo/example.yml"),
+                description="Macro scenario",
+                tags=("macro",),
+            )
+        ],
+    )
+    monkeypatch.setattr(page, "load_scenario", lambda name: _make_scenario(name))
+
+    dates = pd.date_range("2022-01-31", periods=6, freq="ME")
+    returns = pd.DataFrame(
+        {
+            "FundA": [0.01, 0.02, -0.01, 0.03, 0.01, 0.00],
+            "FundB": [0.00, 0.01, 0.02, -0.01, 0.01, 0.02],
+            "Bench": [0.005, 0.006, 0.004, 0.007, 0.005, 0.006],
+        },
+        index=dates,
+    )
+    stub.session_state.update(
+        {
+            "returns_df": returns,
+            "schema_meta": {"frequency": "M"},
+            "upload_status": "success",
+            "model_state": {
+                "metric_weights": {"sharpe": 1.0},
+                "selection_count": 2,
+                "multi_period_frequency": "M",
+                "lookback_periods": 3,
+                "evaluation_periods": 1,
+            },
+            "analysis_fund_columns": ["FundA", "FundB", "Bench"],
+            "selected_benchmark": "Bench",
+        }
+    )
+
+    captured: dict[str, Any] = {}
+
+    class FakeRunner:
+        def __init__(self, scenario: MonteCarloScenario, **kwargs: Any) -> None:
+            captured["scenario"] = scenario
+            captured["kwargs"] = kwargs
+
+        def validate(self) -> list[str]:
+            return []
+
+    monkeypatch.setattr(page, "MonteCarloRunner", FakeRunner)
+    stub.button_responses = [False, True]
+
+    page.render()
+
+    kwargs = captured["kwargs"]
+    assert "base_config" in kwargs
+    assert "price_history" in kwargs
+
+    price_history = kwargs["price_history"]
+    assert list(price_history.columns) == ["FundA", "FundB", "Bench"]
+    assert price_history.loc[dates[0], "FundA"] == pytest.approx(101.0)
+    assert price_history.loc[dates[1], "FundA"] == pytest.approx(103.02)
+    assert kwargs["base_config"].portfolio["rank"]["n"] == 2

--- a/tests/app/test_mc_page_uses_session_model.py
+++ b/tests/app/test_mc_page_uses_session_model.py
@@ -78,3 +78,5 @@ def test_mc_page_uses_session_model_when_available(monkeypatch: pytest.MonkeyPat
     assert price_history.loc[dates[0], "FundA"] == pytest.approx(101.0)
     assert price_history.loc[dates[1], "FundA"] == pytest.approx(103.02)
     assert kwargs["base_config"].portfolio["rank"]["n"] == 2
+    assert kwargs["base_config"].benchmarks == {"Bench": "Bench"}
+    assert kwargs["base_config"].portfolio["indices_list"] == ["Bench"]

--- a/tests/baseline/test_streamlit_smoke.py
+++ b/tests/baseline/test_streamlit_smoke.py
@@ -12,6 +12,8 @@ correct behavior -- it's a guard, not a crash.
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from .harness import REPO_ROOT
@@ -32,6 +34,17 @@ _CLEAN_PAGES = [
 
 
 def _run_page(rel_path: str) -> AppTest:
+    # Evict any cached ``streamlit_app`` modules so the page is imported fresh
+    # against the *real* Streamlit runtime. Sibling unit tests
+    # (e.g. tests/streamlit/test_mc_page.py via ``_load_page``) ``importlib.reload``
+    # these modules bound to a DummyStreamlit stub and never restore them --
+    # ``monkeypatch`` reverts ``sys.modules["streamlit"]`` but not the in-place
+    # reloaded page modules. If that stubbed state leaked in here, the page would
+    # render into the dummy and produce zero real elements ("rendered nothing").
+    for name in [
+        m for m in list(sys.modules) if m == "streamlit_app" or m.startswith("streamlit_app.")
+    ]:
+        del sys.modules[name]
     at = AppTest.from_file(str(REPO_ROOT / rel_path), default_timeout=120)
     at.run()
     return at

--- a/tests/baseline/test_streamlit_smoke.py
+++ b/tests/baseline/test_streamlit_smoke.py
@@ -27,7 +27,7 @@ _CLEAN_PAGES = [
     "streamlit_app/pages/3_Results.py",
     "streamlit_app/pages/4_Help.py",
     "streamlit_app/pages/8_Validation.py",
-    "streamlit_app/pages/monte_carlo.py",
+    "streamlit_app/pages/5_Monte_Carlo.py",
 ]
 
 

--- a/tests/streamlit/test_mc_page.py
+++ b/tests/streamlit/test_mc_page.py
@@ -208,6 +208,18 @@ def _altair_stub() -> ModuleType:
     return module
 
 
+def _plotly_express_stub() -> ModuleType:
+    import plotly.graph_objects as go
+
+    module = ModuleType("plotly.express")
+    module.histogram = lambda *args, **_kwargs: go.Figure()
+    module.box = lambda *args, **_kwargs: go.Figure()
+    module.line = lambda *args, **_kwargs: go.Figure()
+    module.scatter = lambda *args, **_kwargs: go.Figure()
+    module.imshow = lambda *args, **_kwargs: go.Figure()
+    return module
+
+
 def _install_streamlit_stub(monkeypatch: pytest.MonkeyPatch) -> DummyStreamlit:
     stub = DummyStreamlit()
     module = ModuleType("streamlit")
@@ -219,6 +231,7 @@ def _install_streamlit_stub(monkeypatch: pytest.MonkeyPatch) -> DummyStreamlit:
 
     monkeypatch.setitem(sys.modules, "streamlit", module)
     monkeypatch.setitem(sys.modules, "altair", _altair_stub())
+    monkeypatch.setitem(sys.modules, "plotly.express", _plotly_express_stub())
     return stub
 
 
@@ -226,7 +239,7 @@ def _load_page(monkeypatch: pytest.MonkeyPatch) -> tuple[ModuleType, DummyStream
     stub = _install_streamlit_stub(monkeypatch)
     importlib.reload(importlib.import_module("streamlit_app.components.mc_tables"))
     importlib.reload(importlib.import_module("streamlit_app.components.mc_plots"))
-    page = importlib.reload(importlib.import_module("streamlit_app.pages.monte_carlo"))
+    page = importlib.reload(importlib.import_module("streamlit_app.monte_carlo_page"))
     return page, stub
 
 

--- a/tests/test_policy_engine_cov.py
+++ b/tests/test_policy_engine_cov.py
@@ -10,6 +10,17 @@ from streamlit_app.components.policy_engine import (
 )
 
 
+def _patch_rank_scores(monkeypatch, replacement):
+    """Patch the rank scorer used by the imported function under test.
+
+    Some Streamlit smoke tests evict and re-import ``streamlit_app`` modules.
+    Patching by module path can then target a fresh module while this file's
+    direct-imported ``decide_hires_fires`` still points at its original globals.
+    """
+
+    monkeypatch.setitem(decide_hires_fires.__globals__, "rank_scores", replacement)
+
+
 def test_policy_config_dict_cooldown_and_zscore():
     policy = PolicyConfig(metrics=[MetricSpec("m", 1.0)])
     cfg = policy.dict()
@@ -87,7 +98,7 @@ def test_decide_hires_fires_diversification_and_turnover(monkeypatch):
     def fake_rank_scores(sf, metric_weights, metric_directions):
         return pd.Series({"a": 2.0, "b": 1.2, "c": -0.5, "d": 1.0}, index=sf.index)
 
-    monkeypatch.setattr("streamlit_app.components.policy_engine.rank_scores", fake_rank_scores)
+    _patch_rank_scores(monkeypatch, fake_rank_scores)
 
     decisions = decide_hires_fires(
         pd.Timestamp("2020-01-31"),
@@ -126,7 +137,7 @@ def test_decide_hires_fires_turnover_budget_prioritises(monkeypatch):
     def fake_rank_scores(sf, metric_weights, metric_directions):
         return pd.Series({"a": -1.0, "b": 2.0, "c": 1.5}, index=sf.index)
 
-    monkeypatch.setattr("streamlit_app.components.policy_engine.rank_scores", fake_rank_scores)
+    _patch_rank_scores(monkeypatch, fake_rank_scores)
 
     decisions = decide_hires_fires(
         pd.Timestamp("2020-01-31"),
@@ -161,7 +172,7 @@ def test_decide_hires_fires_turnover_budget_mixed_moves(monkeypatch):
     def fake_rank_scores(sf, metric_weights, metric_directions):  # noqa: ARG001
         return pd.Series({"hire1": 2.0, "hire2": 1.0, "drop": -1.5}, index=sf.index)
 
-    monkeypatch.setattr("streamlit_app.components.policy_engine.rank_scores", fake_rank_scores)
+    _patch_rank_scores(monkeypatch, fake_rank_scores)
 
     decisions = decide_hires_fires(
         pd.Timestamp("2020-01-31"),
@@ -197,7 +208,7 @@ def test_decide_hires_fires_turnover_budget_trims_mixed(monkeypatch):
     def fake_rank_scores(sf, metric_weights, metric_directions):  # noqa: ARG001
         return pd.Series({"a": 1.0, "b": 2.0, "c": -1.0}, index=sf.index)
 
-    monkeypatch.setattr("streamlit_app.components.policy_engine.rank_scores", fake_rank_scores)
+    _patch_rank_scores(monkeypatch, fake_rank_scores)
 
     decisions = decide_hires_fires(
         pd.Timestamp("2020-01-31"),
@@ -232,7 +243,7 @@ def test_decide_hires_fires_turnover_budget_mixes_hires_and_fires(monkeypatch):
     def fake_rank_scores(sf, metric_weights, metric_directions):  # noqa: ARG001
         return pd.Series({"a": -0.5, "b": 1.5, "c": 1.0}, index=sf.index)
 
-    monkeypatch.setattr("streamlit_app.components.policy_engine.rank_scores", fake_rank_scores)
+    _patch_rank_scores(monkeypatch, fake_rank_scores)
 
     decisions = decide_hires_fires(
         pd.Timestamp("2020-01-31"),
@@ -269,7 +280,7 @@ def test_decide_hires_fires_bucket_skip_and_nan_priorities(monkeypatch):
     def fake_rank_scores(sf, metric_weights, metric_directions):  # noqa: ARG001
         return pd.Series({"a": 5.0, "b": 4.0, "c": 3.0, "d": np.nan}, index=sf.index)
 
-    monkeypatch.setattr("streamlit_app.components.policy_engine.rank_scores", fake_rank_scores)
+    _patch_rank_scores(monkeypatch, fake_rank_scores)
 
     decisions = decide_hires_fires(
         pd.Timestamp("2020-01-31"),
@@ -306,7 +317,7 @@ def test_decide_hires_fires_unknown_bucket_defaults_to_name(monkeypatch):
     def fake_rank_scores(sf, metric_weights, metric_directions):  # noqa: ARG001
         return pd.Series({"known": 0.5, "mystery": 2.0}, index=sf.index)
 
-    monkeypatch.setattr("streamlit_app.components.policy_engine.rank_scores", fake_rank_scores)
+    _patch_rank_scores(monkeypatch, fake_rank_scores)
 
     decisions = decide_hires_fires(
         pd.Timestamp("2020-01-31"),


### PR DESCRIPTION
Closes #5407

## Summary
- Rename the Streamlit Monte Carlo sidebar entry to `streamlit_app/pages/5_Monte_Carlo.py` and move the implementation into `streamlit_app/monte_carlo_page.py` so only the numbered page appears in navigation.
- Derive Monte Carlo runner context from the same session state the Results page uses: selected return columns, benchmark/risk-free state, UI model config, and converted price history.
- Keep scenario registry selection as the fallback/settings source and add a regression test for session-backed runner construction.

## Validation
- `python -m pytest tests/app/test_mc_page_uses_session_model.py -q` passed.
- Deliberate-break gate: temporarily forced `_session_runner_kwargs()` to return `{}`; `tests/app/test_mc_page_uses_session_model.py` failed on missing `base_config`, then the temporary change was reverted.
- `python -m pytest tests/app/test_mc_page_uses_session_model.py tests/streamlit/test_mc_page.py::test_scenario_picker_and_tag_filtering tests/streamlit/test_mc_page.py::test_runtime_override_validation tests/streamlit/test_mc_page.py::test_override_slider_ranges tests/streamlit/test_mc_page.py::test_validate_button_flow tests/streamlit/test_mc_page.py::test_cancel_button_sets_flag tests/streamlit/test_mc_page.py::test_cancel_interrupts_run tests/streamlit/test_mc_page.py::test_progress_updates_throttled tests/streamlit/test_mc_page.py::test_empty_filtered_results_short_circuits -q` passed.
- `python -m ruff check streamlit_app/monte_carlo_page.py streamlit_app/pages/5_Monte_Carlo.py tests/app/test_mc_page_uses_session_model.py tests/streamlit/test_mc_page.py tests/baseline/test_streamlit_smoke.py` passed.
- `python -m mypy streamlit_app/monte_carlo_page.py` passed.
- `git diff --check` passed.

## Sidebar order evidence
`ls -1 streamlit_app/pages` now shows: `1_Data.py`, `2_Model.py`, `3_Results.py`, `4_Help.py`, `5_Monte_Carlo.py`, `8_Validation.py`.

## Known local validation note
The full existing `tests/streamlit/test_mc_page.py` suite is still blocked locally by the environment's Parquet engine/PyArrow NumPy-ABI failure. The non-Parquet page paths and new acceptance test passed.
