### PR TITLE
Issue #5409: reject non-monthly data frequency

### DIFF
--- a/src/trend_analysis/config/validation.py
+++ b/src/trend_analysis/config/validation.py
@@ -439,8 +439,9 @@ def _check_data_required_fields(data: Mapping[str, Any], errors: list[Validation
         "data",
         "frequency",
         expected="non-empty string",
-        suggestion="Set data.frequency to one of the supported values (e.g., 'M').",
+        suggestion="Set data.frequency to 'M' or 'ME'.",
     )
+    _check_data_frequency_supported(data, errors)
     if not _is_present(csv_path) and not _is_present(managers_glob):
         issue = ValidationError(
             path="data.csv_path",
@@ -448,6 +449,41 @@ def _check_data_required_fields(data: Mapping[str, Any], errors: list[Validation
             expected="csv_path or managers_glob",
             actual="missing",
             suggestion="Set data.csv_path to a CSV file or data.managers_glob to a CSV glob.",
+        )
+        _append_issue(errors, issue)
+
+
+def _check_data_frequency_supported(
+    data: Mapping[str, Any], errors: list[ValidationError]
+) -> None:
+    value = data.get("frequency")
+    if not _is_present(value):
+        return
+    if not isinstance(value, str):
+        issue = ValidationError(
+            path="data.frequency",
+            message="Frequency must be a string.",
+            expected="'M' or 'ME'",
+            actual=type(value).__name__,
+            suggestion="Set data.frequency to 'M' or 'ME'.",
+        )
+        _append_issue(errors, issue)
+        return
+
+    frequency = value.strip().upper()
+    if frequency not in {"M", "ME"}:
+        issue = ValidationError(
+            path="data.frequency",
+            message=(
+                "Only monthly data.frequency values are currently supported; "
+                f"'{value}' would be silently resampled to monthly."
+            ),
+            expected="'M' or 'ME'",
+            actual=value,
+            suggestion=(
+                "Use data.frequency: M for the current monthly pipeline, or add "
+                "full non-monthly periods-per-year support before using D/W."
+            ),
         )
         _append_issue(errors, issue)
 

--- a/src/trend_analysis/config/validation.py
+++ b/src/trend_analysis/config/validation.py
@@ -101,6 +101,7 @@ def validate_config(
 
     _run_schema_validation(config, errors, warnings)
     _run_required_validation(config, errors, skip_required_fields)
+    _run_data_semantic_validation(config, errors)
     if include_model_validation:
         _collect_trend_model_errors(config, errors, base)
     _run_sample_split_validation(config, errors)
@@ -131,6 +132,15 @@ def _run_required_validation(
     if not skip_required_fields:
         _check_required_fields(config, errors)
     _check_version_field(config, errors)
+
+
+def _run_data_semantic_validation(
+    config: Mapping[str, Any],
+    errors: list[ValidationError],
+) -> None:
+    data = config.get("data")
+    if isinstance(data, Mapping):
+        _check_data_frequency_supported(data, errors)
 
 
 def _run_sample_split_validation(
@@ -441,7 +451,6 @@ def _check_data_required_fields(data: Mapping[str, Any], errors: list[Validation
         expected="non-empty string",
         suggestion="Set data.frequency to 'M' or 'ME'.",
     )
-    _check_data_frequency_supported(data, errors)
     if not _is_present(csv_path) and not _is_present(managers_glob):
         issue = ValidationError(
             path="data.csv_path",

--- a/tests/test_frequency_honored.py
+++ b/tests/test_frequency_honored.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from trend_analysis.config.validation import validate_config
+
+
+def _base_config(tmp_path: Path, frequency: str) -> dict[str, Any]:
+    csv_path = tmp_path / "returns.csv"
+    csv_path.write_text(
+        "Date,A,B\n2020-01-31,0.0,0.0\n2020-02-29,0.01,0.02\n",
+        encoding="utf-8",
+    )
+    return {
+        "version": "1",
+        "data": {
+            "csv_path": str(csv_path),
+            "date_column": "Date",
+            "frequency": frequency,
+        },
+        "preprocessing": {},
+        "vol_adjust": {"target_vol": 0.1},
+        "sample_split": {},
+        "portfolio": {
+            "selection_mode": "all",
+            "rebalance_calendar": "NYSE",
+            "max_turnover": 1.0,
+            "transaction_cost_bps": 0.0,
+        },
+        "metrics": {},
+        "export": {},
+        "run": {},
+    }
+
+
+def _frequency_errors(config: dict[str, Any]) -> list[str]:
+    result = validate_config(config)
+    return [issue.message for issue in result.errors if issue.path == "data.frequency"]
+
+
+def test_daily_frequency_is_rejected_instead_of_silently_monthly(tmp_path: Path) -> None:
+    messages = _frequency_errors(_base_config(tmp_path, "D"))
+
+    assert messages
+    assert any("silently resampled to monthly" in message for message in messages)
+
+
+def test_weekly_frequency_is_rejected_instead_of_silently_monthly(tmp_path: Path) -> None:
+    messages = _frequency_errors(_base_config(tmp_path, "W"))
+
+    assert messages
+    assert any("Only monthly data.frequency values" in message for message in messages)
+
+
+def test_monthly_frequency_values_remain_valid(tmp_path: Path) -> None:
+    assert not _frequency_errors(_base_config(tmp_path, "M"))
+    assert not _frequency_errors(_base_config(tmp_path, "ME"))

--- a/tests/test_frequency_honored.py
+++ b/tests/test_frequency_honored.py
@@ -35,7 +35,7 @@ def _base_config(tmp_path: Path, frequency: str) -> dict[str, Any]:
 
 
 def _frequency_errors(config: dict[str, Any]) -> list[str]:
-    result = validate_config(config)
+    result = validate_config(config, skip_required_fields=True)
     return [issue.message for issue in result.errors if issue.path == "data.frequency"]
 
 


### PR DESCRIPTION
Closes #5409

## Summary
- Add structured semantic validation that rejects data.frequency values outside M/ME before preprocessing can silently normalize to monthly.
- Add focused tests proving D/W configs fail while M/ME remain valid.

## Validation
- python -m pytest tests/test_frequency_honored.py -q
- python -m pytest tests/test_frequency_honored.py tests/test_config_semantic_validation.py tests/test_config_model_branch_coverage.py -q
- python -m ruff check src/trend_analysis/config/validation.py tests/test_frequency_honored.py
- python -m mypy src/trend_analysis/config/validation.py tests/test_frequency_honored.py
- git diff --check
- PYTHONPATH=src python -m trend.cli run -c config/demo.yml --returns demo/demo_returns.csv (passed; local environment still prints known NumPy/optional extension warnings)

Deliberate-break gate: temporarily allowed D/W in the new validator; tests/test_frequency_honored.py failed on the daily and weekly rejection assertions, then the validator was restored and rerun green.