### PR TITLE
Issue #5409: reject unsupported data frequencies

### DIFF
--- a/src/trend_analysis/config/validation.py
+++ b/src/trend_analysis/config/validation.py
@@ -19,6 +19,7 @@ from trend_analysis.time_utils import resolve_period_bound
 from utils.paths import proj_path
 
 _PATH_PATTERN = re.compile(r"^([A-Za-z0-9_.\[\]-]+)(:|\s+)(.+)$")
+_MONTHLY_DATA_FREQUENCIES = {"M", "ME"}
 
 
 class ValidationError(BaseModel):
@@ -131,6 +132,7 @@ def _run_required_validation(
     if not skip_required_fields:
         _check_required_fields(config, errors)
     _check_version_field(config, errors)
+    _check_data_frequency_supported(config, errors)
 
 
 def _run_sample_split_validation(
@@ -363,6 +365,34 @@ def _check_version_field(config: Mapping[str, Any], errors: list[ValidationError
             suggestion="Provide a non-empty version string.",
         )
         _append_issue(errors, issue)
+
+
+def _check_data_frequency_supported(
+    config: Mapping[str, Any],
+    errors: list[ValidationError],
+) -> None:
+    data = config.get("data")
+    if not isinstance(data, Mapping):
+        return
+    frequency = data.get("frequency")
+    if frequency is None:
+        return
+    if isinstance(frequency, str) and not frequency.strip():
+        return
+    normalized = str(frequency).strip().upper()
+    if normalized in _MONTHLY_DATA_FREQUENCIES:
+        return
+    issue = ValidationError(
+        path="data.frequency",
+        message="Only monthly data.frequency is currently supported.",
+        expected="M or ME",
+        actual=frequency,
+        suggestion=(
+            "Set data.frequency to 'M' until daily/weekly preprocessing and "
+            "annualisation are wired end-to-end."
+        ),
+    )
+    _append_issue(errors, issue)
 
 
 def _require_field(

--- a/tests/test_frequency_honored.py
+++ b/tests/test_frequency_honored.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from trend_analysis.config.validation import validate_config
+
+
+def _write_returns(path: Path) -> Path:
+    path.write_text("Date,FundA\n2020-01-31,0.01\n2020-02-29,0.02\n", encoding="utf-8")
+    return path
+
+
+def _config(tmp_path: Path, frequency: str) -> dict[str, object]:
+    csv_path = _write_returns(tmp_path / "returns.csv")
+    return {
+        "version": "1",
+        "data": {
+            "csv_path": str(csv_path),
+            "date_column": "Date",
+            "frequency": frequency,
+            "missing_policy": "drop",
+        },
+        "preprocessing": {},
+        "vol_adjust": {"target_vol": 0.15},
+        "sample_split": {},
+        "portfolio": {
+            "selection_mode": "all",
+            "rebalance_calendar": "NYSE",
+            "max_turnover": 0.25,
+            "transaction_cost_bps": 10,
+            "cost_model": {
+                "bps_per_trade": 0,
+                "slippage_bps": 0,
+            },
+        },
+        "metrics": {},
+        "export": {},
+        "run": {},
+    }
+
+
+@pytest.mark.parametrize("frequency", ["D", "W"])
+def test_non_monthly_data_frequency_is_rejected(tmp_path: Path, frequency: str) -> None:
+    result = validate_config(_config(tmp_path, frequency), base_path=tmp_path)
+
+    frequency_errors = [error for error in result.errors if error.path == "data.frequency"]
+    assert frequency_errors
+    assert any("Only monthly data.frequency" in error.message for error in frequency_errors)
+    assert not result.valid
+
+
+def test_non_monthly_data_frequency_is_rejected_during_cli_preflight() -> None:
+    result = validate_config(
+        {"version": "1", "data": {"frequency": "D"}},
+        skip_required_fields=True,
+    )
+
+    assert any(
+        error.path == "data.frequency" and "Only monthly data.frequency" in error.message
+        for error in result.errors
+    )
+
+
+@pytest.mark.parametrize("frequency", ["M", "ME"])
+def test_monthly_data_frequency_remains_valid(tmp_path: Path, frequency: str) -> None:
+    result = validate_config(_config(tmp_path, frequency), base_path=tmp_path)
+
+    assert not [error for error in result.errors if error.path == "data.frequency"]


### PR DESCRIPTION
Closes #5409

## Summary
- Reject `data.frequency` values other than monthly/month-end during config validation, including CLI preflight validation with `skip_required_fields=True`.
- Add focused coverage proving daily/weekly configs fail fast while `M`/`ME` remain accepted by the new guard.

## Validation
- `python -m pytest tests/test_frequency_honored.py -q` passed.
- Deliberate-break gate: temporarily allowed `D`/`W` in the new monthly-frequency guard; `tests/test_frequency_honored.py` failed for both non-monthly cases, then the temporary change was reverted.
- `PYTHONPATH=src python -m trend_analysis.cli run -c config/demo.yml -i demo/demo_returns.csv` completed for the monthly demo config.
- `python -m pytest tests/test_frequency_honored.py tests/test_config_load.py -q` passed.
- `python -m ruff check src/trend_analysis/config/validation.py tests/test_frequency_honored.py` passed.
- `python -m mypy src/trend_analysis/config/validation.py` passed.
- `git diff --check` passed.

## Notes
- The local demo command emitted pre-existing NumPy 2 ABI warnings from optional compiled packages (`pyarrow`, `numexpr`, `bottleneck`) during import, but the command completed successfully.
