### PR TITLE
Issue #5411: gate Data-page perf diagnostics behind debug flag (A31)

### DIFF
--- a/streamlit_app/pages/1_Data.py
+++ b/streamlit_app/pages/1_Data.py
@@ -742,22 +742,25 @@ def render_data_page() -> None:
 
             _t_render_done = time.perf_counter()
 
-            # Always-visible measurements (so you don't need to open Debug).
-            st.caption(
-                " | ".join(
-                    [
-                        f"Perf: total {(_t_render_done - _t_fund_start) * 1000:.0f}ms",
-                        f"render {(_t_render_done - _t_render_start) * 1000:.0f}ms",
-                        f"seed {(_t_seed_done - _t_seed_start) * 1000:.0f}ms",
-                        f"funds {len(available_funds)}",
-                        f"selected {n_selected}",
-                        f"default_selected {len(default_selected_funds)}",
-                        f"init_applied {bool(st.session_state.get(init_key))}",
-                        f"defaults_seeded {len(defaults)}",
-                        f"range {len(range_funds)}",
-                    ]
+            # Perf diagnostics are developer-only; gate behind a debug flag so the
+            # production UI does not leak raw timings/internal counters (issue #5411).
+            # The same measurements remain available in the Debug expander below.
+            if st.session_state.get("show_perf_diagnostics"):
+                st.caption(
+                    " | ".join(
+                        [
+                            f"Perf: total {(_t_render_done - _t_fund_start) * 1000:.0f}ms",
+                            f"render {(_t_render_done - _t_render_start) * 1000:.0f}ms",
+                            f"seed {(_t_seed_done - _t_seed_start) * 1000:.0f}ms",
+                            f"funds {len(available_funds)}",
+                            f"selected {n_selected}",
+                            f"default_selected {len(default_selected_funds)}",
+                            f"init_applied {bool(st.session_state.get(init_key))}",
+                            f"defaults_seeded {len(defaults)}",
+                            f"range {len(range_funds)}",
+                        ]
+                    )
                 )
-            )
 
             new_selection_list = [
                 fund

--- a/tests/app/test_data_page_no_perf_caption.py
+++ b/tests/app/test_data_page_no_perf_caption.py
@@ -1,0 +1,88 @@
+"""Guard that developer perf diagnostics stay out of the production Data UI.
+
+Issue #5411 (A31): ``streamlit_app/pages/1_Data.py`` rendered an always-visible
+``st.caption`` exposing internal perf telemetry (raw ms timings, ``init_applied``,
+``defaults_seeded`` counters, ...) to end users. The same data already lives in
+the collapsed "Debug: Fund selection state" expander. The fix gates the caption
+behind a ``show_perf_diagnostics`` session-state debug flag.
+
+These tests pin that behaviour: the perf caption must be absent when the debug
+flag is off, and present when it is on. Restoring the unconditional caption (the
+deliberate-break gate in the issue) makes ``test_perf_caption_hidden_by_default``
+fail.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+import pandas as pd
+import pytest
+
+# Reuse the established DummyStreamlit harness + page fixture from the sibling
+# Data-page test module. ``data_page`` is a pytest fixture; importing it here
+# registers it for this module's tests.
+from tests.app.test_data_page import DummyStreamlit, data_page  # noqa: F401
+
+_PERF_MARKER = "Perf: total"
+
+
+def _load_sample(
+    monkeypatch: pytest.MonkeyPatch, page: ModuleType, stub: DummyStreamlit
+) -> None:
+    """Drive the Data page into the loaded-dataset state that renders the
+    fund-selection section (where the perf caption lives)."""
+    stub.session_state.clear()
+    stub.clear_calls = 0
+
+    df = pd.DataFrame(
+        {"FundA": [0.01, 0.02, -0.01], "SPX Index": [0.03, -0.02, 0.01]},
+        index=pd.date_range("2024-01-31", periods=3, freq="ME"),
+    )
+    meta = {"validation": {"issues": [], "warnings": []}, "frequency_label": "monthly"}
+    sample = page.data_cache.SampleDataset("demo.csv", Path("demo/demo_returns.csv"))
+
+    monkeypatch.setattr(page.data_cache, "default_sample_dataset", lambda: sample)
+    monkeypatch.setattr(
+        page.data_cache, "dataset_choices", lambda: {sample.label: sample}
+    )
+    monkeypatch.setattr(
+        page.data_cache, "load_dataset_from_path", lambda path: (df, meta)
+    )
+    stub.selectbox_map["Choose a sample"] = sample.label
+    stub.selectbox_map["Benchmark column (optional)"] = "SPX Index"
+    monkeypatch.setattr(page, "infer_benchmarks", lambda columns: ["SPX Index"])
+
+
+def _perf_captions(stub: DummyStreamlit) -> list[str]:
+    return [c for c in stub.captions if _PERF_MARKER in c]
+
+
+def test_perf_caption_hidden_by_default(
+    monkeypatch: pytest.MonkeyPatch, data_page  # noqa: F811 - reused pytest fixture
+) -> None:
+    page, stub = data_page
+    _load_sample(monkeypatch, page, stub)
+
+    page.render_data_page()
+
+    # The fund-selection UI rendered (sanity: otherwise the assertion is vacuous).
+    assert stub.dataframes
+    # No developer perf caption leaks into the production UI when the flag is off.
+    assert _perf_captions(stub) == []
+
+
+def test_perf_caption_visible_with_debug_flag(
+    monkeypatch: pytest.MonkeyPatch, data_page  # noqa: F811 - reused pytest fixture
+) -> None:
+    page, stub = data_page
+    _load_sample(monkeypatch, page, stub)
+    # Opt in to developer diagnostics; flag must be set after _load_sample clears
+    # session_state.
+    stub.session_state["show_perf_diagnostics"] = True
+
+    page.render_data_page()
+
+    perf = _perf_captions(stub)
+    assert perf, "perf caption should render when show_perf_diagnostics is on"


### PR DESCRIPTION
Closes #5411.

Supersedes #5469 by rehoming the same head commit e61b005fc6d3ac343d5ed8056778aba975edae32 from the Claude registry branch onto a Codex registry branch after the Claude keepalive runner hit its weekly limit.

## Summary
- Gates the Data-page perf caption behind show_perf_diagnostics so production UI stays clean by default.
- Preserves the existing Debug expander as the developer diagnostics surface.
- Carries forward the tested implementation from #5469 unchanged.

## Validation
- tests/app/test_data_page_no_perf_caption.py
- tests/app/test_data_page.py
- focused ruff, mypy, and git diff --check were recorded on #5469.

## Routing
- Replacement PR uses codex/issue-5411-data-perf-caption with concrete agent:codex keepalive routing.