### PR TITLE
Issue #5414: add constrained convex weighting engine

### DIFF
--- a/src/trend_analysis/plugins/__init__.py
+++ b/src/trend_analysis/plugins/__init__.py
@@ -102,6 +102,9 @@ def _load_weight_engines() -> None:  # pragma: no cover - tiny import shim
     """
     # Local import scope prevents premature evaluation during type checking
     from ..weights import (
+        constrained_optimization as _constrained_optimization,
+    )  # noqa: F401
+    from ..weights import (
         equal_risk_contribution as _equal_risk_contribution,
     )  # noqa: F401
     from ..weights import (
@@ -114,6 +117,7 @@ def _load_weight_engines() -> None:  # pragma: no cover - tiny import shim
     globals().update(
         {
             "_equal_risk_contribution": _equal_risk_contribution,
+            "_constrained_optimization": _constrained_optimization,
             "_hierarchical_risk_parity": _hierarchical_risk_parity,
             "_risk_parity": _risk_parity,
             "_robust_weighting": _robust_weighting,
@@ -151,6 +155,7 @@ __all__ = [
     "create_selector",
     "create_rebalancer",
     "create_weight_engine",
+    "_constrained_optimization",
     "_equal_risk_contribution",
     "_hierarchical_risk_parity",  # ensures HRP is exported
     "_risk_parity",

--- a/src/trend_analysis/weights/constrained_optimization.py
+++ b/src/trend_analysis/weights/constrained_optimization.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+from scipy.optimize import minimize
+
+from ..plugins import WeightEngine, weight_engine_registry
+
+
+@weight_engine_registry.register("convex_constrained")
+class ConstrainedConvexWeighting(WeightEngine):
+    """Minimum-variance weighting with simple convex constraints."""
+
+    def __init__(
+        self,
+        *,
+        min_weight: float = 0.0,
+        max_weight: float = 1.0,
+        groups: Mapping[str, Sequence[str]] | None = None,
+        group_bounds: Mapping[str, tuple[float, float]] | None = None,
+    ) -> None:
+        self.min_weight = float(min_weight)
+        self.max_weight = float(max_weight)
+        self.groups = dict(groups or {})
+        self.group_bounds = dict(group_bounds or {})
+
+        if self.min_weight > self.max_weight:
+            raise ValueError("min_weight must be <= max_weight")
+
+    def weight(self, cov: pd.DataFrame) -> pd.Series:
+        if cov.empty:
+            return pd.Series(dtype=float)
+        if not cov.index.equals(cov.columns):
+            raise ValueError("Covariance matrix must be square with matching labels")
+
+        labels = list(cov.index)
+        label_positions = {label: idx for idx, label in enumerate(labels)}
+        matrix = cov.to_numpy(dtype=float)
+        matrix = (matrix + matrix.T) / 2.0
+        n_assets = len(labels)
+
+        constraints = [{"type": "eq", "fun": lambda weights: float(np.sum(weights) - 1.0)}]
+        for group_name, (lower, upper) in self.group_bounds.items():
+            try:
+                group_members = self.groups[group_name]
+            except KeyError as exc:
+                raise ValueError(f"group_bounds references unknown group {group_name!r}") from exc
+
+            missing = [asset for asset in group_members if asset not in label_positions]
+            if missing:
+                raise ValueError(
+                    f"group {group_name!r} references assets missing from covariance: {missing}"
+                )
+
+            group_idx = np.array([label_positions[asset] for asset in group_members], dtype=int)
+            lower_bound = float(lower)
+            upper_bound = float(upper)
+            constraints.extend(
+                [
+                    {
+                        "type": "ineq",
+                        "fun": lambda weights, idx=group_idx, lb=lower_bound: float(
+                            np.sum(weights[idx]) - lb
+                        ),
+                    },
+                    {
+                        "type": "ineq",
+                        "fun": lambda weights, idx=group_idx, ub=upper_bound: float(
+                            ub - np.sum(weights[idx])
+                        ),
+                    },
+                ]
+            )
+
+        bounds = [(self.min_weight, self.max_weight)] * n_assets
+        initial = np.repeat(1.0 / n_assets, n_assets)
+
+        result = minimize(
+            lambda weights: float(weights @ matrix @ weights),
+            initial,
+            method="SLSQP",
+            bounds=bounds,
+            constraints=constraints,
+            options={"ftol": 1e-12, "maxiter": 1000},
+        )
+        if not result.success:
+            raise ValueError(f"Constrained optimization failed: {result.message}")
+
+        weights = pd.Series(result.x, index=cov.index, dtype=float)
+        weights[weights.abs() < 1e-12] = 0.0
+        return weights / weights.sum()

--- a/tests/test_constrained_optimization.py
+++ b/tests/test_constrained_optimization.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pandas as pd
+
+from trend_analysis.plugins import create_weight_engine, weight_engine_registry
+
+
+def test_group_upper_bound_is_honored():
+    cov = pd.DataFrame(
+        np.diag([0.01, 0.01, 0.09, 0.09]),
+        index=["low_a", "low_b", "high_a", "high_b"],
+        columns=["low_a", "low_b", "high_a", "high_b"],
+    )
+    engine = create_weight_engine(
+        "convex_constrained",
+        groups={"low_vol": ["low_a", "low_b"]},
+        group_bounds={"low_vol": (0.0, 0.30)},
+    )
+
+    weights = engine.weight(cov)
+
+    assert "convex_constrained" in weight_engine_registry.available()
+    assert weights.loc[["low_a", "low_b"]].sum() <= 0.30 + 1e-6
+    assert abs(weights.sum() - 1.0) <= 1e-6
+    assert (weights >= -1e-9).all()
+
+
+def test_unconstrained_matches_min_variance():
+    cov = pd.DataFrame(
+        [[0.04, 0.006, 0.0], [0.006, 0.09, 0.0], [0.0, 0.0, 0.16]],
+        index=["a", "b", "c"],
+        columns=["a", "b", "c"],
+    )
+    engine = create_weight_engine("convex_constrained")
+
+    weights = engine.weight(cov)
+
+    inverse_cov = np.linalg.inv(cov.to_numpy(dtype=float))
+    expected = inverse_cov @ np.ones(len(cov))
+    expected = expected / expected.sum()
+    assert np.allclose(weights.to_numpy(), expected, atol=1e-6)

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,16 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-06-03T18:12Z - opener lane issue #5414 PR materializing
+
+- Repo/issue: stranske/Trend_Model_Project #5414 (`A35 - General convex-constraint optimization backend behind the weighting interface`).
+- Branch: `codex/issue-5414-convex-constraints`; base `origin/phase-3`.
+- Agent: codex opener from neutral Code workspace; used persistent automation worktree `~/.codex/automations/pd-workloop-resume/worktrees/trend-5414-convex-constraints`.
+- Selection: raw opener cap was below 5. Cap sweep classified #5440 as scoped/product-blocked on strict config keys, #5470/#5473 as green-Gate but needing keepalive/closer drain, and #5472 as runner-failed with no branch-local deterministic opener patch target. Liveness fallback selected #5414 as the oldest unlinked implementation issue outside scoped blockers after #5411/#5412/#5413 were already linked to open PRs.
+- Implementation: added `ConstrainedConvexWeighting`, registered as `convex_constrained`, solving minimum-variance weights with SLSQP under full-investment, per-asset min/max, and named group lower/upper sum bounds. Added tests proving the group upper bound is binding and the unconstrained solution matches analytic minimum variance.
+- Validation: `python -m pytest tests/test_constrained_optimization.py tests/test_weight_engines.py -q` -> 5 passed; focused `ruff` -> passed; focused `mypy` -> passed; `git diff --check` -> clean. Deliberate-break gate: temporarily removed the group upper-bound inequality and confirmed `test_group_upper_bound_is_honored` failed with low-vol group sum about 0.90 > 0.30, then restored and reran green.
+- Current state: implementation validated locally; next action is commit, push, open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`, then relay `pr_opened`.
+
 ## 2026-06-03T09:08:49Z - opener lane issue #5403 PR materializing
 
 - Repo/issue: stranske/Trend_Model_Project #5403 (`A22 - Consolidate transaction-cost logic fanned across >=5 implementations`).

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -9,7 +9,7 @@
 - Selection: raw opener cap was below 5. Cap sweep classified #5440 as scoped/product-blocked on strict config keys, #5470/#5473 as green-Gate but needing keepalive/closer drain, and #5472 as runner-failed with no branch-local deterministic opener patch target. Liveness fallback selected #5414 as the oldest unlinked implementation issue outside scoped blockers after #5411/#5412/#5413 were already linked to open PRs.
 - Implementation: added `ConstrainedConvexWeighting`, registered as `convex_constrained`, solving minimum-variance weights with SLSQP under full-investment, per-asset min/max, and named group lower/upper sum bounds. Added tests proving the group upper bound is binding and the unconstrained solution matches analytic minimum variance.
 - Validation: `python -m pytest tests/test_constrained_optimization.py tests/test_weight_engines.py -q` -> 5 passed; focused `ruff` -> passed; focused `mypy` -> passed; `git diff --check` -> clean. Deliberate-break gate: temporarily removed the group upper-bound inequality and confirmed `test_group_upper_bound_is_honored` failed with low-vol group sum about 0.90 > 0.30, then restored and reran green.
-- Current state: implementation validated locally; next action is commit, push, open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`, then relay `pr_opened`.
+- Current state: ready-for-review PR #5474 opened at https://github.com/stranske/Trend_Model_Project/pull/5474 from `codex/issue-5414-convex-constraints`, non-draft, with `agent:codex`, `agents:keepalive`, and `autofix`. Cap-health shows fresh Gate and Agents Gate Followups runs active after the branch update. Next action belongs to keepalive/Gate.
 
 ## 2026-06-03T09:08:49Z - opener lane issue #5403 PR materializing
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,15 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-06-03T20:06Z - opener cap-drain repair for PR #5474
+
+- Repo/issue/PR: stranske/Trend_Model_Project #5414 / #5474 (`codex/issue-5414-convex-constraints`).
+- Agent: codex opener from neutral Code workspace; used persistent automation worktree `~/.codex/automations/pd-workloop-resume/worktrees/trend-5414-convex-constraints`.
+- Repair evidence: cap-health showed raw opener cap below 5 but PR #5474 was infra-stalled with stale `agent:needs-attention`, skipped keepalive runner evidence, and `DIRTY` merge state despite green Gate/Python checks on the prior head. Direct PR audit showed the review fixes were already pushed and Gate was green; the remaining opener-safe repair was merge recovery plus stale-label cleanup.
+- Fix: merged current `origin/phase-3` into the PR branch. The only conflict was `workloop-state.md`; preserved both the #5414 and #5412 durable entries. Removed stale `agent:needs-attention` after pushing and forced `agents-81-gate-followups.yml` with `force_retry=true`.
+- Validation before push: `python -m pytest tests/test_constrained_optimization.py tests/test_weighting_fallback_surfaced.py tests/monte_carlo/strategy/test_variant.py::test_to_trend_config_rejects_invalid_weighting_scheme_value tests/test_config_schema_generation.py tests/monte_carlo/strategy/test_validation.py::test_validate_strategy_pack_rejects_invalid_weighting_scheme -q` -> 13 passed; focused `ruff` -> passed; focused `mypy` -> passed; `git diff --check` -> passed.
+- Current state: merge-recovery commit pushed; fresh Gate/Gate Followups should evaluate asynchronously. Next action belongs to keepalive/closer after checks settle.
+
 ## 2026-06-03T18:12Z - opener lane issue #5414 PR materializing
 
 - Repo/issue: stranske/Trend_Model_Project #5414 (`A35 - General convex-constraint optimization backend behind the weighting interface`).


### PR DESCRIPTION
Closes #5414.

## Summary
- Add `ConstrainedConvexWeighting`, registered as `convex_constrained`, for minimum-variance weights under full-investment, per-asset min/max, and named group sum bounds.
- Load the new engine through the built-in weight-engine registry shim.
- Add focused tests for registration, binding group upper bounds, and analytic unconstrained minimum-variance behavior.

## Validation
- `python -m pytest tests/test_constrained_optimization.py tests/test_weight_engines.py -q` -> 5 passed
- Deliberate-break gate: temporarily removed the group upper-bound inequality; `test_group_upper_bound_is_honored` failed with low-vol group sum about 0.90 > 0.30; restored and reran green.
- `python -m ruff check src/trend_analysis/weights/constrained_optimization.py src/trend_analysis/plugins/__init__.py tests/test_constrained_optimization.py` -> passed
- `python -m mypy src/trend_analysis/weights/constrained_optimization.py tests/test_constrained_optimization.py` -> passed
- `git diff --check` -> clean

## Routing
- Opener-created PR on `codex/issue-5414-convex-constraints` with concrete `agent:codex`, `agents:keepalive`, and `autofix` routing.