### PR TITLE
Issue #5415: add returns factor attribution

### DIFF
--- a/src/trend_analysis/metrics/__init__.py
+++ b/src/trend_analysis/metrics/__init__.py
@@ -414,6 +414,7 @@ from .deflated_sharpe import (  # noqa: E402
     estimate_sharpe_moments,
     probabilistic_sharpe_ratio,
 )
+from .factor_attribution import factor_exposures  # noqa: E402
 
 _legacy = types.ModuleType("tests.legacy_metrics")
 for _name in (
@@ -440,6 +441,7 @@ setattr(_bi, "annualize_volatility", annualize_volatility)
 # Public submodules exposed via attribute assignment for compatibility while
 # keeping Ruff satisfied about unused imports.
 attribution = import_module(".attribution", __name__)
+factor_attribution = import_module(".factor_attribution", __name__)
 rolling = import_module(".rolling", __name__)
 summary = import_module(".summary", __name__)
 turnover = import_module(".turnover", __name__)
@@ -454,6 +456,7 @@ __all__ = [
     "available_metrics",
     "deflated_sharpe_ratio",
     "estimate_sharpe_moments",
+    "factor_exposures",
     "info_ratio",
     "information_ratio",
     "max_drawdown",

--- a/src/trend_analysis/metrics/factor_attribution.py
+++ b/src/trend_analysis/metrics/factor_attribution.py
@@ -14,40 +14,45 @@ def factor_exposures(
 ) -> pd.DataFrame:
     """Estimate per-manager factor exposures with ordinary least squares.
 
-    Rows are aligned by index, then any row containing a missing manager return
-    or factor value is dropped before fitting each manager column independently.
+    Rows are aligned by index, then missing manager returns are dropped per
+    manager together with factor rows before fitting each manager independently.
     """
 
     if not isinstance(returns, pd.DataFrame):
         raise TypeError("returns must be a pandas DataFrame")
     if not isinstance(factors, pd.DataFrame):
         raise TypeError("factors must be a pandas DataFrame")
-    if returns.empty:
+    if len(returns.columns) == 0:
         raise ValueError("returns must contain at least one manager column")
-    if factors.empty:
+    if len(factors.columns) == 0:
         raise ValueError("factors must contain at least one factor column")
 
-    joined = returns.join(factors, how="inner", lsuffix="__return")
-    aligned = joined.dropna(axis=0, how="any")
-    clean_returns = aligned.loc[:, returns.columns]
-    clean_factors = aligned.loc[:, factors.columns]
-
     min_observations = len(factors.columns) + 2
-    if len(aligned) < min_observations:
-        raise ValueError(
-            "insufficient observations after alignment: "
-            f"need at least {min_observations}, got {len(aligned)}"
-        )
-
-    factor_matrix = clean_factors.to_numpy(dtype=float)
-    if add_intercept:
-        design = np.column_stack([np.ones(len(clean_factors), dtype=float), factor_matrix])
-    else:
-        design = factor_matrix
+    aligned_index = returns.index.intersection(factors.index)
+    aligned_returns = returns.loc[aligned_index]
+    aligned_factors = factors.loc[aligned_index]
 
     rows: list[dict[str, float]] = []
-    for manager in clean_returns.columns:
-        y = clean_returns[manager].to_numpy(dtype=float)
+    for manager in aligned_returns.columns:
+        manager_returns = aligned_returns.loc[:, manager]
+        valid_rows = manager_returns.notna() & aligned_factors.notna().all(axis=1)
+        clean_factors = aligned_factors.loc[valid_rows]
+        clean_returns = manager_returns.loc[valid_rows]
+        if len(clean_factors) < min_observations:
+            raise ValueError(
+                f"insufficient observations after alignment for {manager}: "
+                f"need at least {min_observations}, got {len(clean_factors)}"
+            )
+
+        factor_matrix = clean_factors.to_numpy(dtype=float)
+        if add_intercept:
+            design = np.column_stack(
+                [np.ones(len(clean_factors), dtype=float), factor_matrix]
+            )
+        else:
+            design = factor_matrix
+
+        y = clean_returns.to_numpy(dtype=float)
         coefficients, *_ = np.linalg.lstsq(design, y, rcond=None)
         if add_intercept:
             alpha = float(coefficients[0])
@@ -71,8 +76,8 @@ def factor_exposures(
         row["r_squared"] = float(r_squared)
         rows.append(row)
 
-    columns = list(clean_factors.columns) + ["alpha", "r_squared"]
-    return pd.DataFrame(rows, index=clean_returns.columns, columns=columns)
+    columns = list(aligned_factors.columns) + ["alpha", "r_squared"]
+    return pd.DataFrame(rows, index=aligned_returns.columns, columns=columns)
 
 
 __all__ = ["factor_exposures"]

--- a/src/trend_analysis/metrics/factor_attribution.py
+++ b/src/trend_analysis/metrics/factor_attribution.py
@@ -1,0 +1,78 @@
+"""Returns-based factor attribution helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def factor_exposures(
+    returns: pd.DataFrame,
+    factors: pd.DataFrame,
+    *,
+    add_intercept: bool = True,
+) -> pd.DataFrame:
+    """Estimate per-manager factor exposures with ordinary least squares.
+
+    Rows are aligned by index, then any row containing a missing manager return
+    or factor value is dropped before fitting each manager column independently.
+    """
+
+    if not isinstance(returns, pd.DataFrame):
+        raise TypeError("returns must be a pandas DataFrame")
+    if not isinstance(factors, pd.DataFrame):
+        raise TypeError("factors must be a pandas DataFrame")
+    if returns.empty:
+        raise ValueError("returns must contain at least one manager column")
+    if factors.empty:
+        raise ValueError("factors must contain at least one factor column")
+
+    joined = returns.join(factors, how="inner", lsuffix="__return")
+    aligned = joined.dropna(axis=0, how="any")
+    clean_returns = aligned.loc[:, returns.columns]
+    clean_factors = aligned.loc[:, factors.columns]
+
+    min_observations = len(factors.columns) + 2
+    if len(aligned) < min_observations:
+        raise ValueError(
+            "insufficient observations after alignment: "
+            f"need at least {min_observations}, got {len(aligned)}"
+        )
+
+    factor_matrix = clean_factors.to_numpy(dtype=float)
+    if add_intercept:
+        design = np.column_stack([np.ones(len(clean_factors), dtype=float), factor_matrix])
+    else:
+        design = factor_matrix
+
+    rows: list[dict[str, float]] = []
+    for manager in clean_returns.columns:
+        y = clean_returns[manager].to_numpy(dtype=float)
+        coefficients, *_ = np.linalg.lstsq(design, y, rcond=None)
+        if add_intercept:
+            alpha = float(coefficients[0])
+            betas = coefficients[1:]
+        else:
+            alpha = 0.0
+            betas = coefficients
+
+        fitted = design @ coefficients
+        residual = y - fitted
+        ss_residual = float(np.dot(residual, residual))
+        centered = y - float(np.mean(y))
+        ss_total = float(np.dot(centered, centered))
+        if np.isclose(ss_total, 0.0):
+            r_squared = 1.0 if np.isclose(ss_residual, 0.0) else 0.0
+        else:
+            r_squared = 1.0 - (ss_residual / ss_total)
+
+        row = {factor: float(beta) for factor, beta in zip(clean_factors.columns, betas)}
+        row["alpha"] = alpha
+        row["r_squared"] = float(r_squared)
+        rows.append(row)
+
+    columns = list(clean_factors.columns) + ["alpha", "r_squared"]
+    return pd.DataFrame(rows, index=clean_returns.columns, columns=columns)
+
+
+__all__ = ["factor_exposures"]

--- a/tests/test_factor_attribution.py
+++ b/tests/test_factor_attribution.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from trend_analysis.metrics.factor_attribution import factor_exposures
+
+
+def test_recovers_planted_betas() -> None:
+    index = pd.date_range("2025-01-31", periods=8, freq="ME")
+    factors = pd.DataFrame(
+        {
+            "equity": [0.01, -0.02, 0.03, 0.00, 0.04, -0.01, 0.02, -0.03],
+            "trend": [0.03, 0.01, -0.02, 0.04, -0.01, 0.02, -0.03, 0.00],
+        },
+        index=index,
+    )
+    alpha = 0.001
+    manager = 0.6 * factors["equity"] - 0.2 * factors["trend"] + alpha
+    returns = pd.DataFrame({"manager_a": manager}, index=index)
+
+    exposures = factor_exposures(returns, factors)
+
+    assert exposures.loc["manager_a", "equity"] == pytest.approx(0.6, abs=1e-6)
+    assert exposures.loc["manager_a", "trend"] == pytest.approx(-0.2, abs=1e-6)
+    assert exposures.loc["manager_a", "alpha"] == pytest.approx(alpha, abs=1e-6)
+    assert exposures.loc["manager_a", "r_squared"] >= 1 - 1e-6
+
+
+def test_raises_on_insufficient_observations() -> None:
+    index = pd.RangeIndex(3)
+    returns = pd.DataFrame({"manager_a": [0.01, 0.02, 0.03]}, index=index)
+    factors = pd.DataFrame(
+        {
+            "equity": [0.01, 0.02, 0.03],
+            "trend": [0.00, 0.01, 0.02],
+        },
+        index=index,
+    )
+
+    with pytest.raises(ValueError, match="insufficient observations after alignment"):
+        factor_exposures(returns, factors)
+
+
+def test_aligns_and_drops_nan_rows() -> None:
+    returns = pd.DataFrame(
+        {"manager_a": [0.001, 0.006, np.nan, 0.004, 0.007, 0.002]},
+        index=pd.RangeIndex(6),
+    )
+    factors = pd.DataFrame(
+        {
+            "equity": [0.0, 0.01, 0.02, 0.03, 0.04, 0.05],
+            "trend": [0.01, 0.00, 0.03, 0.02, 0.05, 0.04],
+        },
+        index=pd.RangeIndex(1, 7),
+    )
+
+    exposures = factor_exposures(returns, factors)
+
+    assert list(exposures.columns) == ["equity", "trend", "alpha", "r_squared"]
+    assert list(exposures.index) == ["manager_a"]

--- a/tests/test_factor_attribution.py
+++ b/tests/test_factor_attribution.py
@@ -60,3 +60,47 @@ def test_aligns_and_drops_nan_rows() -> None:
 
     assert list(exposures.columns) == ["equity", "trend", "alpha", "r_squared"]
     assert list(exposures.index) == ["manager_a"]
+
+
+def test_drops_missing_returns_per_manager() -> None:
+    index = pd.RangeIndex(8)
+    factors = pd.DataFrame(
+        {
+            "equity": [0.01, -0.02, 0.03, 0.00, 0.04, -0.01, 0.02, -0.03],
+            "trend": [0.03, 0.01, -0.02, 0.04, -0.01, 0.02, -0.03, 0.00],
+        },
+        index=index,
+    )
+    returns = pd.DataFrame(
+        {
+            "manager_a": 0.6 * factors["equity"] - 0.2 * factors["trend"] + 0.001,
+            "manager_b": [0.01, np.nan, 0.02, np.nan, 0.03, np.nan, 0.04, np.nan],
+        },
+        index=index,
+    )
+
+    exposures = factor_exposures(returns, factors)
+
+    assert exposures.loc["manager_a", "equity"] == pytest.approx(0.6, abs=1e-6)
+    assert exposures.loc["manager_a", "trend"] == pytest.approx(-0.2, abs=1e-6)
+
+
+def test_preserves_manager_returns_when_column_names_overlap_factors() -> None:
+    index = pd.date_range("2025-01-31", periods=8, freq="ME")
+    factors = pd.DataFrame(
+        {
+            "equity": [0.01, -0.02, 0.03, 0.00, 0.04, -0.01, 0.02, -0.03],
+            "trend": [0.03, 0.01, -0.02, 0.04, -0.01, 0.02, -0.03, 0.00],
+        },
+        index=index,
+    )
+    returns = pd.DataFrame(
+        {"equity": 0.35 * factors["equity"] + 0.15 * factors["trend"] + 0.002},
+        index=index,
+    )
+
+    exposures = factor_exposures(returns, factors)
+
+    assert exposures.loc["equity", "equity"] == pytest.approx(0.35, abs=1e-6)
+    assert exposures.loc["equity", "trend"] == pytest.approx(0.15, abs=1e-6)
+    assert exposures.loc["equity", "alpha"] == pytest.approx(0.002, abs=1e-6)

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,16 @@
 # stranske/Trend_Model_Project
 # Workloop State
 
+## 2026-06-03T22:06Z - opener lane issue #5415 PR materializing
+
+- Repo/issue: stranske/Trend_Model_Project #5415 (`A36 - Factor attribution / returns decomposition`).
+- Branch: `codex/issue-5415-factor-attribution`; base `origin/phase-3`.
+- Agent: codex opener from neutral Code workspace; used persistent automation worktree `~/.codex/automations/pd-workloop-resume/worktrees/trend-5415-factor-attribution`.
+- Selection: raw opener cap was below 5. Cap/drain sweep found only opener-owned PR #5440, already scoped/product-blocked on strict config key design. Priority high issues #5343 and LMS #180 remain scoped outside automation reach; #5476 and #5414 are already merged and awaiting closer/verifier source-issue disposition; #5415 was the oldest unlinked implementation candidate outside scoped blockers.
+- Implementation: added `metrics.factor_attribution.factor_exposures`, a pure numpy/pandas OLS regression helper that aligns returns and factor frames by index, drops NaN rows, enforces at least `n_factors + 2` observations, and returns per-manager factor betas, `alpha`, and `r_squared`. Exported it from `trend_analysis.metrics` while leaving existing PnL contribution attribution untouched.
+- Validation: `python -m pytest tests/test_factor_attribution.py tests/test_metrics_attribution.py -q` -> 11 passed; `python -m pytest tests/test_factor_attribution.py::test_recovers_planted_betas -q` -> passed after restoration; `git diff --check` -> passed. Deliberate-break gate: temporarily ignored `add_intercept` inside `factor_exposures`; `test_recovers_planted_betas` failed because recovered `equity` beta was `-0.18518518518518517` instead of `0.6`, then restored and reran green.
+- Current state: implementation ready to commit, push, and open as a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`.
+
 ## 2026-06-03T20:06Z - opener cap-drain repair for PR #5474
 
 - Repo/issue/PR: stranske/Trend_Model_Project #5414 / #5474 (`codex/issue-5414-convex-constraints`).


### PR DESCRIPTION
Closes #5415

## Summary
- add a pure numpy/pandas factor_exposures helper for returns-based OLS attribution
- align returns/factor data, drop NaN rows, enforce observation count, and return betas, alpha, and r_squared per manager
- export the helper from trend_analysis.metrics while preserving existing PnL attribution behavior

## Validation
- python -m pytest tests/test_factor_attribution.py tests/test_metrics_attribution.py -q
- python -m pytest tests/test_factor_attribution.py::test_recovers_planted_betas -q
- git diff --check

## Deliberate-break gate
- Temporarily ignored add_intercept inside factor_exposures; tests/test_factor_attribution.py::test_recovers_planted_betas failed because the equity beta was -0.18518518518518517 instead of 0.6. Restored the intercept path and reran green.