### PR TITLE
Issue #5416: add pluggable regime registry

### DIFF
--- a/config.schema.compact.json
+++ b/config.schema.compact.json
@@ -178,6 +178,7 @@
       "lookback": 126,
       "method": "rolling_return",
       "min_observations": 4,
+      "model": "binary_threshold",
       "neutral_band": 0.001,
       "proxy": "SPX",
       "risk_off_fund_count_multiplier": 0.5,
@@ -1743,6 +1744,7 @@
         "lookback": 126,
         "method": "rolling_return",
         "min_observations": 4,
+        "model": "binary_threshold",
         "neutral_band": 0.001,
         "proxy": "SPX",
         "risk_off_fund_count_multiplier": 0.5,
@@ -1790,6 +1792,12 @@
           "description": "Minimum observations for regime signals.",
           "nl_editable": true,
           "type": "integer"
+        },
+        "model": {
+          "default": "binary_threshold",
+          "description": "Registered regime classifier model name.",
+          "nl_editable": true,
+          "type": "string"
         },
         "neutral_band": {
           "default": 0.001,

--- a/config.schema.json
+++ b/config.schema.json
@@ -180,6 +180,7 @@
       "lookback": 126,
       "method": "rolling_return",
       "min_observations": 4,
+      "model": "binary_threshold",
       "neutral_band": 0.001,
       "proxy": "SPX",
       "risk_off_fund_count_multiplier": 0.5,
@@ -2180,6 +2181,7 @@
         "lookback": 126,
         "method": "rolling_return",
         "min_observations": 4,
+        "model": "binary_threshold",
         "neutral_band": 0.001,
         "proxy": "SPX",
         "risk_off_fund_count_multiplier": 0.5,
@@ -2233,6 +2235,13 @@
           "description": "Minimum observations for regime signals.",
           "nl_editable": true,
           "type": "integer"
+        },
+        "model": {
+          "constraints": {},
+          "default": "binary_threshold",
+          "description": "Registered regime classifier model name.",
+          "nl_editable": true,
+          "type": "string"
         },
         "neutral_band": {
           "constraints": {},

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -131,6 +131,7 @@ benchmarks:
 regime:
   enabled: true
   proxy: "SPX"
+  model: "binary_threshold"
   method: "rolling_return"
   lookback: 126
   smoothing: 3

--- a/config/demo.yml
+++ b/config/demo.yml
@@ -55,6 +55,7 @@ benchmarks:
 regime:
   enabled: true
   proxy: "SPX"
+  model: "binary_threshold"
   method: rolling_return
   lookback: 24            # two-year lookback keeps demo responsive
   smoothing: 3

--- a/docs/methodology/GENERALIZATION_EPIC.md
+++ b/docs/methodology/GENERALIZATION_EPIC.md
@@ -7,7 +7,7 @@ Issue #5416 decomposes the manager-of-managers generalization work into bounded 
 - Cadence aliases for monthly, quarterly, and annual runs already map to pandas end-of-period codes in `src/trend_analysis/multi_period/scheduler.py:17`.
 - Dated universe membership and survivorship handling already live in `src/trend_analysis/universe.py`.
 - Benchmark labels already map to data columns through `config/defaults.yml:123`.
-- The default regime path is the binary threshold classifier in `src/trend_analysis/regimes.py:173` and remains registered as `binary_threshold`.
+- The default regime path is implemented by `_compute_regime_series` in `src/trend_analysis/regimes.py`, and remains registered as `binary_threshold` on `BinaryThresholdRegimeModel`.
 
 ## Children
 
@@ -27,7 +27,7 @@ Issue #5416 decomposes the manager-of-managers generalization work into bounded 
 
 ### Pluggable Regime Interface
 
-- Current evidence: `src/trend_analysis/regimes.py:173` implements the binary return/volatility threshold classifier directly.
+- Current evidence: `src/trend_analysis/regimes.py` implements the binary return/volatility threshold classifier in `_compute_regime_series`.
 - Proposed seam: `RegimeModel` plus `regime_registry`, with the existing classifier registered as `binary_threshold`.
 - Acceptance shape: `tests/test_regime_registry.py::test_default_binary_regime_unchanged` proves default output is unchanged, and `tests/test_regime_registry.py::test_registry_dispatches_named_model` proves named dispatch works.
 - Dependencies: none.

--- a/docs/methodology/GENERALIZATION_EPIC.md
+++ b/docs/methodology/GENERALIZATION_EPIC.md
@@ -1,0 +1,47 @@
+# Generalization Epic
+
+Issue #5416 decomposes the manager-of-managers generalization work into bounded children. The current engine is reusable in places, but several surrounding seams still assume the original trend/SPX framing.
+
+## Already Exists
+
+- Cadence aliases for monthly, quarterly, and annual runs already map to pandas end-of-period codes in `src/trend_analysis/multi_period/scheduler.py:17`.
+- Dated universe membership and survivorship handling already live in `src/trend_analysis/universe.py`.
+- Benchmark labels already map to data columns through `config/defaults.yml:123`.
+- The default regime path is the binary threshold classifier in `src/trend_analysis/regimes.py:173` and remains registered as `binary_threshold`.
+
+## Children
+
+### Cadence Generalization
+
+- Current evidence: `src/trend_analysis/multi_period/scheduler.py:17` covers M/Q/A aliases, so the remaining gap is weekly/daily cadence end-to-end rather than re-adding monthly support.
+- Proposed seam: extend scheduler frequency validation and downstream period consumers for shorter cadence names.
+- Acceptance shape: a weekly or daily fixture runs through period generation and the main analysis path with a named regression test.
+- Dependencies: none.
+
+### Convex Constraints
+
+- Current evidence: the weighting interface now has a constrained convex backend from issue #5414.
+- Proposed seam: keep additional group/turnover/position-limit constraints behind the weighting registry rather than embedding them in strategy code.
+- Acceptance shape: child issues should cite the existing #5414 backend and add one constraint type plus a named test.
+- Dependencies: existing issue #5414.
+
+### Pluggable Regime Interface
+
+- Current evidence: `src/trend_analysis/regimes.py:173` implements the binary return/volatility threshold classifier directly.
+- Proposed seam: `RegimeModel` plus `regime_registry`, with the existing classifier registered as `binary_threshold`.
+- Acceptance shape: `tests/test_regime_registry.py::test_default_binary_regime_unchanged` proves default output is unchanged, and `tests/test_regime_registry.py::test_registry_dispatches_named_model` proves named dispatch works.
+- Dependencies: none.
+
+### Pluggable Cost Interface
+
+- Current evidence: transaction-cost behavior is not exposed as a registry-backed model seam in the weighting/turnover path.
+- Proposed seam: a cost-model protocol and registry consumed where turnover costs are computed.
+- Acceptance shape: the default cost model preserves current output, while a named toy model changes costs in a focused fixture.
+- Dependencies: cadence and weighting callers must pass enough context to the cost model.
+
+### Benchmark And Peer-Index Integration
+
+- Current evidence: `config/defaults.yml:123` maps benchmark labels to columns, but benchmark and peer-index series are not first-class attribution/significance inputs.
+- Proposed seam: benchmark/peer series should flow into attribution and reporting through an explicit input contract.
+- Acceptance shape: a benchmark fixture affects attribution/significance output with a named test and leaves no-benchmark behavior unchanged.
+- Dependencies: issue #5415 factor attribution should be merged before this child expands benchmark attribution.

--- a/src/trend/config_schema.py
+++ b/src/trend/config_schema.py
@@ -269,6 +269,15 @@ def validate_core_config(
     if tracker is not None:
         tracker.track_validated("data.frequency")
 
+    regime_section = _as_mapping(payload.get("regime", {}), field="regime")
+    _normalise_string(
+        regime_section.get("model", "binary_threshold"),
+        field="regime.model",
+        default="binary_threshold",
+    )
+    if tracker is not None:
+        tracker.track_validated("regime.model")
+
     portfolio_section = _as_mapping(payload.get("portfolio"), field="portfolio")
     transaction_cost = _coerce_float(
         portfolio_section.get("transaction_cost_bps", _DEFAULT_TRANSACTION_COST),

--- a/src/trend_analysis/config/schema_generator.py
+++ b/src/trend_analysis/config/schema_generator.py
@@ -170,6 +170,7 @@ _MANUAL_DESCRIPTIONS: dict[str, str] = {
     "regime": "Market regime detection settings.",
     "regime.enabled": "Enable regime detection.",
     "regime.proxy": "Benchmark proxy used for regime detection.",
+    "regime.model": "Registered regime classifier model name.",
     "regime.method": "Regime detection method.",
     "regime.lookback": "Lookback window for regime detection.",
     "regime.smoothing": "Smoothing window for regime signal.",

--- a/src/trend_analysis/regimes.py
+++ b/src/trend_analysis/regimes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from abc import abstractmethod
 from dataclasses import asdict, dataclass
 from typing import Any, Mapping
 
@@ -11,6 +12,7 @@ import pandas as pd
 
 from .metrics import annual_return, max_drawdown, sharpe_ratio
 from .perf.rolling_cache import compute_dataset_hash, get_cache
+from .plugins import Plugin, PluginRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +23,7 @@ class RegimeSettings:
 
     enabled: bool = False
     proxy: str | None = None
+    model: str = "binary_threshold"
     method: str = "rolling_return"
     lookback: int = 126
     smoothing: int = 3
@@ -64,6 +67,9 @@ def normalise_settings(cfg: Mapping[str, Any] | None) -> RegimeSettings:
     proxy = cfg.get("proxy")
     if proxy is not None:
         proxy = str(proxy).strip() or None
+    model = str(cfg.get("model", "binary_threshold") or "binary_threshold").strip()
+    if not model:
+        model = "binary_threshold"
 
     method_raw = str(cfg.get("method", "rolling_return") or "rolling_return").strip().lower()
     method_lookup = {
@@ -103,6 +109,7 @@ def normalise_settings(cfg: Mapping[str, Any] | None) -> RegimeSettings:
     return RegimeSettings(
         enabled=enabled,
         proxy=proxy,
+        model=model,
         method=method,
         lookback=lookback,
         smoothing=smoothing,
@@ -263,6 +270,44 @@ def _compute_regime_series(
     return cache.get_or_compute(dataset_hash, window, freq, method_tag, _compute)
 
 
+class RegimeModel(Plugin):
+    """Base class for pluggable regime classifiers."""
+
+    @abstractmethod
+    def classify(
+        self,
+        proxy: pd.Series,
+        settings: RegimeSettings,
+        *,
+        freq: str,
+        periods_per_year: float | None,
+    ) -> pd.Series:
+        """Return per-period regime labels for ``proxy``."""
+
+
+regime_registry: PluginRegistry[RegimeModel] = PluginRegistry()
+
+
+@regime_registry.register("binary_threshold")
+class BinaryThresholdRegimeModel(RegimeModel):
+    """Existing binary return/volatility threshold classifier."""
+
+    def classify(
+        self,
+        proxy: pd.Series,
+        settings: RegimeSettings,
+        *,
+        freq: str,
+        periods_per_year: float | None,
+    ) -> pd.Series:
+        return _compute_regime_series(
+            proxy,
+            settings,
+            freq=freq,
+            periods_per_year=periods_per_year,
+        )
+
+
 def compute_regimes(
     proxy: pd.Series,
     settings: RegimeSettings,
@@ -275,7 +320,8 @@ def compute_regimes(
 
     if not settings.enabled:
         return pd.Series(dtype="string")
-    return _compute_regime_series(proxy, settings, freq=freq, periods_per_year=periods_per_year)
+    model = regime_registry.create(settings.model)
+    return model.classify(proxy, settings, freq=freq, periods_per_year=periods_per_year)
 
 
 def _format_hit_rate(series: pd.Series) -> float:

--- a/tests/test_config_schema_generation.py
+++ b/tests/test_config_schema_generation.py
@@ -58,6 +58,16 @@ def test_schema_validation_accepts_rf_override_enabled() -> None:
     assert errors == []
 
 
+def test_schema_validation_accepts_regime_model() -> None:
+    schema = generate_schema()
+    regime_schema = schema["properties"]["regime"]["properties"]["model"]
+    assert regime_schema["type"] == "string"
+    assert regime_schema["default"] == "binary_threshold"
+
+    errors = validate_config_data({"regime": {"model": "binary_threshold"}}, schema)
+    assert errors == []
+
+
 def test_schema_validation_accepts_cost_model_float_bps() -> None:
     schema = generate_schema()
     cost_schema = schema["properties"]["portfolio"]["properties"]["cost_model"]["properties"]

--- a/tests/test_regime_registry.py
+++ b/tests/test_regime_registry.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from trend_analysis.regimes import (
+    RegimeModel,
+    RegimeSettings,
+    _compute_regime_series,
+    compute_regimes,
+    normalise_settings,
+    regime_registry,
+)
+
+
+def _proxy() -> pd.Series:
+    return pd.Series(
+        [0.01, 0.02, -0.03, 0.01, 0.04, -0.02],
+        index=pd.date_range("2024-01-31", periods=6, freq="ME"),
+        name="SPX",
+    )
+
+
+def test_default_binary_regime_unchanged() -> None:
+    settings = RegimeSettings(
+        enabled=True,
+        lookback=2,
+        smoothing=1,
+        threshold=0.0,
+        neutral_band=0.0,
+        cache=False,
+    )
+
+    expected = _compute_regime_series(
+        _proxy(),
+        settings,
+        freq="ME",
+        periods_per_year=12,
+    )
+
+    routed = compute_regimes(_proxy(), settings, freq="ME", periods_per_year=12)
+
+    assert routed.equals(expected)
+
+
+def test_registry_dispatches_named_model() -> None:
+    @regime_registry.register("toy_all_weather")
+    class ToyAllWeatherRegimeModel(RegimeModel):
+        def classify(
+            self,
+            proxy: pd.Series,
+            settings: RegimeSettings,
+            *,
+            freq: str,
+            periods_per_year: float | None,
+        ) -> pd.Series:
+            del settings, freq, periods_per_year
+            return pd.Series("All-Weather", index=proxy.index, dtype="string")
+
+    settings = RegimeSettings(enabled=True, model="toy_all_weather", cache=False)
+
+    routed = compute_regimes(_proxy(), settings, freq="ME", periods_per_year=12)
+
+    assert set(routed.dropna()) == {"All-Weather"}
+
+
+def test_normalise_settings_accepts_regime_model_name() -> None:
+    settings = normalise_settings({"enabled": True, "model": "binary_threshold"})
+
+    assert settings.model == "binary_threshold"
+    assert "binary_threshold" in regime_registry.available()

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -3,10 +3,12 @@
 - Repo: `stranske/Trend_Model_Project`
 - Issue: `#5416` (`A37 - Umbrella: generalize beyond trend`)
 - Branch: `codex/issue-5416-regime-registry`
+- PR: `#5479` (`https://github.com/stranske/Trend_Model_Project/pull/5479`)
 - Worktree: `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/trend-5416-regime-registry`
 - Selection: high-priority remaining liveness candidates were scoped on owner evidence; priority-normal #5476 already has PR #5477/source disposition pending; #5416 is the oldest unlinked implementation candidate with a bounded first-child deliverable.
 - Implementation: added `docs/methodology/GENERALIZATION_EPIC.md`, introduced `RegimeModel`/`regime_registry`, registered default `binary_threshold`, and added `tests/test_regime_registry.py`.
 - Validation so far: `python -m pytest tests/test_regime_registry.py -q` passed; deliberate-break dispatch check failed as expected when forced to `binary_threshold`; `HOME=/tmp/trend-test-home python -m pytest tests/test_regimes.py tests/test_pipeline_helpers.py -q` passed; focused ruff and `git diff --check` passed. Plain `tests/ -k regime` hit local NumPy 2.x vs xarray/pyarrow ABI/cache issues before code assertions.
+- Routing: PR opened ready-for-review/non-draft with `agent:codex`, `agents:keepalive`, and `autofix`; after initial cancelled runs, added `agent:retry` and dispatched `agents-81-gate-followups.yml` with `force_retry=true` (run `26918773577`). Cap-health at `2026-06-03T23:09:07Z` classified #5479 as `draining` with active Gate and Agents Gate Followups evidence.
 
 # stranske/Trend_Model_Project
 # Workloop State

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -4,7 +4,7 @@
 - Issue: `#5416` (`A37 - Umbrella: generalize beyond trend`)
 - Branch: `codex/issue-5416-regime-registry`
 - PR: `#5479` (`https://github.com/stranske/Trend_Model_Project/pull/5479`)
-- Worktree: `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/trend-5416-regime-registry`
+- Worktree: `~/.codex/automations/pd-workloop-resume/worktrees/trend-5416-regime-registry`
 - Selection: high-priority remaining liveness candidates were scoped on owner evidence; priority-normal #5476 already has PR #5477/source disposition pending; #5416 is the oldest unlinked implementation candidate with a bounded first-child deliverable.
 - Implementation: added `docs/methodology/GENERALIZATION_EPIC.md`, introduced `RegimeModel`/`regime_registry`, registered default `binary_threshold`, and added `tests/test_regime_registry.py`.
 - Validation so far: `python -m pytest tests/test_regime_registry.py -q` passed; deliberate-break dispatch check failed as expected when forced to `binary_threshold`; `HOME=/tmp/trend-test-home python -m pytest tests/test_regimes.py tests/test_pipeline_helpers.py -q` passed; focused ruff and `git diff --check` passed. Plain `tests/ -k regime` hit local NumPy 2.x vs xarray/pyarrow ABI/cache issues before code assertions.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,13 @@
+## 2026-06-03T23:04Z - opener (codex): issue #5416 regime registry slice
+
+- Repo: `stranske/Trend_Model_Project`
+- Issue: `#5416` (`A37 - Umbrella: generalize beyond trend`)
+- Branch: `codex/issue-5416-regime-registry`
+- Worktree: `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/trend-5416-regime-registry`
+- Selection: high-priority remaining liveness candidates were scoped on owner evidence; priority-normal #5476 already has PR #5477/source disposition pending; #5416 is the oldest unlinked implementation candidate with a bounded first-child deliverable.
+- Implementation: added `docs/methodology/GENERALIZATION_EPIC.md`, introduced `RegimeModel`/`regime_registry`, registered default `binary_threshold`, and added `tests/test_regime_registry.py`.
+- Validation so far: `python -m pytest tests/test_regime_registry.py -q` passed; deliberate-break dispatch check failed as expected when forced to `binary_threshold`; `HOME=/tmp/trend-test-home python -m pytest tests/test_regimes.py tests/test_pipeline_helpers.py -q` passed; focused ruff and `git diff --check` passed. Plain `tests/ -k regime` hit local NumPy 2.x vs xarray/pyarrow ABI/cache issues before code assertions.
+
 # stranske/Trend_Model_Project
 # Workloop State
 


### PR DESCRIPTION
Closes #5416

## Summary
- add docs/methodology/GENERALIZATION_EPIC.md to decompose the generalization children and dependencies
- introduce RegimeModel plus regime_registry with the existing binary classifier registered as binary_threshold
- route compute_regimes through the named registry while preserving the default output

## Validation
- python -m pytest tests/test_regime_registry.py -q
- HOME=/tmp/trend-test-home python -m pytest tests/test_regimes.py tests/test_pipeline_helpers.py -q
- python -m ruff check src/trend_analysis/regimes.py tests/test_regime_registry.py
- python -m mypy src/trend_analysis/regimes.py tests/test_regime_registry.py
- deliberate-break: forced registry dispatch to binary_threshold and confirmed tests/test_regime_registry.py::test_registry_dispatches_named_model fails with Risk-On vs All-Weather

Note: plain python -m pytest tests/ -k regime -q is blocked in this local environment by existing NumPy 2.x / xarray / pyarrow ABI collection failures and the default rolling cache under ~/.cache; redirecting HOME to /tmp isolates the repo tests and passes.