### PR TITLE
Follow-up #5415: use global NaN alignment for factor attribution

### DIFF
--- a/src/trend_analysis/metrics/factor_attribution.py
+++ b/src/trend_analysis/metrics/factor_attribution.py
@@ -14,8 +14,8 @@ def factor_exposures(
 ) -> pd.DataFrame:
     """Estimate per-manager factor exposures with ordinary least squares.
 
-    Rows are aligned by index, then missing manager returns are dropped per
-    manager together with factor rows before fitting each manager independently.
+    Rows are aligned by index, then any row with a missing manager return or
+    factor value is dropped before fitting every manager on the same sample.
     """
 
     if not isinstance(returns, pd.DataFrame):
@@ -31,13 +31,15 @@ def factor_exposures(
     aligned_index = returns.index.intersection(factors.index)
     aligned_returns = returns.loc[aligned_index]
     aligned_factors = factors.loc[aligned_index]
+    valid_rows = aligned_returns.notna().all(axis=1) & aligned_factors.notna().all(
+        axis=1
+    )
+    clean_returns_all = aligned_returns.loc[valid_rows]
+    clean_factors = aligned_factors.loc[valid_rows]
 
     rows: list[dict[str, float]] = []
-    for manager in aligned_returns.columns:
-        manager_returns = aligned_returns.loc[:, manager]
-        valid_rows = manager_returns.notna() & aligned_factors.notna().all(axis=1)
-        clean_factors = aligned_factors.loc[valid_rows]
-        clean_returns = manager_returns.loc[valid_rows]
+    for manager in clean_returns_all.columns:
+        clean_returns = clean_returns_all.loc[:, manager]
         if len(clean_factors) < min_observations:
             raise ValueError(
                 f"insufficient observations after alignment for {manager}: "
@@ -77,7 +79,7 @@ def factor_exposures(
         rows.append(row)
 
     columns = list(aligned_factors.columns) + ["alpha", "r_squared"]
-    return pd.DataFrame(rows, index=aligned_returns.columns, columns=columns)
+    return pd.DataFrame(rows, index=clean_returns_all.columns, columns=columns)
 
 
 __all__ = ["factor_exposures"]

--- a/tests/test_factor_attribution.py
+++ b/tests/test_factor_attribution.py
@@ -62,27 +62,31 @@ def test_aligns_and_drops_nan_rows() -> None:
     assert list(exposures.index) == ["manager_a"]
 
 
-def test_drops_missing_returns_per_manager() -> None:
-    index = pd.RangeIndex(8)
+def test_drops_missing_returns_globally() -> None:
+    index = pd.RangeIndex(10)
     factors = pd.DataFrame(
         {
-            "equity": [0.01, -0.02, 0.03, 0.00, 0.04, -0.01, 0.02, -0.03],
-            "trend": [0.03, 0.01, -0.02, 0.04, -0.01, 0.02, -0.03, 0.00],
+            "equity": [0.01, -0.02, 0.03, 0.00, 0.04, -0.01, 0.02, -0.03, 0.05, -0.04],
+            "trend": [0.03, 0.01, -0.02, 0.04, -0.01, 0.02, -0.03, 0.00, 0.06, -0.05],
         },
         index=index,
     )
+    manager_a = 0.6 * factors["equity"] - 0.2 * factors["trend"] + 0.001
+    manager_a.iloc[[1, 5]] += 0.05
     returns = pd.DataFrame(
         {
-            "manager_a": 0.6 * factors["equity"] - 0.2 * factors["trend"] + 0.001,
-            "manager_b": [0.01, np.nan, 0.02, np.nan, 0.03, np.nan, 0.04, np.nan],
+            "manager_a": manager_a,
+            "manager_b": [0.01, np.nan, 0.02, 0.03, 0.04, np.nan, 0.05, 0.06, 0.07, 0.08],
         },
         index=index,
     )
 
     exposures = factor_exposures(returns, factors)
+    expected_clean = returns.join(factors, rsuffix="_factor").dropna(how="any")
 
     assert exposures.loc["manager_a", "equity"] == pytest.approx(0.6, abs=1e-6)
     assert exposures.loc["manager_a", "trend"] == pytest.approx(-0.2, abs=1e-6)
+    assert len(expected_clean) == 8
 
 
 def test_preserves_manager_returns_when_column_names_overlap_factors() -> None:


### PR DESCRIPTION
Follow-up for #5415 / merged PR #5478 verifier CONCERNS.

## Summary
- Align `factor_exposures` with the source issue acceptance criteria by dropping rows with any missing manager return or factor value before fitting every manager on the same sample.
- Update the NaN regression test so noisy rows that are globally invalid are excluded before beta recovery.

## Validation
- `PYTHONPATH=src python -m pytest tests/test_factor_attribution.py tests/test_metrics_attribution.py -q` -> 13 passed
- `PYTHONPATH=src python -m ruff check src/trend_analysis/metrics/factor_attribution.py tests/test_factor_attribution.py` -> passed
- `git diff --check` -> passed

Closes no issue directly; this is bounded verification follow-up debt for #5415 and should merge before #5415 is closed.