### PR TITLE
Issue #5417: honor configured date column

### DIFF
--- a/src/trend_analysis/data.py
+++ b/src/trend_analysis/data.py
@@ -363,6 +363,18 @@ def _validate_payload(
     return priced
 
 
+def _canonicalise_date_column(payload: pd.DataFrame, date_column: str) -> pd.DataFrame:
+    configured = str(date_column or "Date")
+    if configured == "Date":
+        return payload
+    if configured not in payload.columns:
+        return payload
+    normalised = payload.copy()
+    if "Date" in normalised.columns:
+        normalised = normalised.drop(columns=["Date"])
+    return normalised.rename(columns={configured: "Date"})
+
+
 def _is_readable(mode: int) -> bool:
     """Check if a file mode indicates the file is readable.
 
@@ -385,11 +397,12 @@ def load_csv(
     *,
     errors: ValidationErrorMode = "log",
     include_date_column: bool = True,
+    date_column: str = "Date",
     missing_policy: str | Mapping[str, str] | None = None,
     missing_limit: MissingLimitArg = None,
     **_legacy_kwargs: object,
 ) -> Optional[pd.DataFrame]:
-    """Load and validate a CSV expecting a ``Date`` column."""
+    """Load and validate a CSV using ``date_column`` as the date field."""
 
     if missing_policy is None and "nan_policy" in _legacy_kwargs:
         missing_policy = _coerce_policy_kwarg(_legacy_kwargs.pop("nan_policy"))
@@ -419,7 +432,7 @@ def load_csv(
             logger.error(f"Permission denied accessing file: {path}")
             return None
 
-        raw = pd.read_csv(str(p))
+        raw = _canonicalise_date_column(pd.read_csv(str(p)), date_column)
         result = _validate_payload(
             raw,
             origin=str(p),

--- a/src/trend_analysis/data.py
+++ b/src/trend_analysis/data.py
@@ -368,8 +368,10 @@ def _canonicalise_date_column(payload: pd.DataFrame, date_column: str) -> pd.Dat
     if configured == "Date":
         return payload
     if configured not in payload.columns:
-        return payload
-    normalised = payload.copy()
+        raise MarketDataValidationError(
+            f"Configured date column '{configured}' is missing from the input data"
+        )
+    normalised = payload
     if "Date" in normalised.columns:
         normalised = normalised.drop(columns=["Date"])
     return normalised.rename(columns={configured: "Date"})

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -17,6 +17,7 @@ multi-period run path. When ``cfg.portfolio.policy == 'threshold_hold'`` we:
 
 from __future__ import annotations  # mypy: ignore-errors
 
+import inspect
 import logging
 import os
 from dataclasses import dataclass, field
@@ -877,6 +878,7 @@ def run(
             raise ValueError("price_frames is empty - no data to process")
 
     data_settings = getattr(cfg, "data", {}) or {}
+    date_column_cfg = data_settings.get("date_column", "Date")
     missing_policy_cfg, missing_limit_cfg = _get_missing_policy_settings(data_settings)
     (
         risk_free_column_cfg,
@@ -889,13 +891,15 @@ def run(
         csv_path = data_settings.get("csv_path")
         if not csv_path:
             raise KeyError("cfg.data['csv_path'] must be provided")
+        load_kwargs: dict[str, Any] = {
+            "errors": "raise",
+            "missing_policy": missing_policy_cfg,
+            "missing_limit": missing_limit_cfg,
+        }
+        if _accepts_keyword(load_csv, "date_column"):
+            load_kwargs["date_column"] = date_column_cfg
         try:
-            df = load_csv(
-                csv_path,
-                errors="raise",
-                missing_policy=missing_policy_cfg,
-                missing_limit=missing_limit_cfg,
-            )
+            df = load_csv(csv_path, **load_kwargs)
         except FileNotFoundError as exc:
             raise MissingPriceDataError(
                 "multi_period.run requires either a pre-loaded DataFrame or "
@@ -3996,3 +4000,13 @@ def run_from_config(cfg: Any) -> List[MultiPeriodPeriodResult]:
         inputs_meta["benchmarks"] = benchmarks
     membership_arg = membership_df if not membership_df.empty else None
     return run(cfg, df=prices, membership=membership_arg)
+
+
+def _accepts_keyword(func: Any, keyword: str) -> bool:
+    try:
+        params = inspect.signature(func).parameters
+    except (TypeError, ValueError):
+        return True
+    return keyword in params or any(
+        param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values()
+    )

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -4006,7 +4006,7 @@ def _accepts_keyword(func: Any, keyword: str) -> bool:
     try:
         params = inspect.signature(func).parameters
     except (TypeError, ValueError):
-        return True
+        return False
     return keyword in params or any(
         param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values()
     )

--- a/src/trend_analysis/multi_period/loaders.py
+++ b/src/trend_analysis/multi_period/loaders.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import inspect
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -20,6 +21,16 @@ __all__ = [
     "load_benchmarks",
     "detect_index_columns",
 ]
+
+
+def _accepts_keyword(func: Any, keyword: str) -> bool:
+    try:
+        params = inspect.signature(func).parameters
+    except (TypeError, ValueError):
+        return True
+    return keyword in params or any(
+        param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values()
+    )
 
 
 def _coerce_path(value: Any, *, field: str) -> Path:
@@ -63,12 +74,15 @@ def load_prices(cfg: Any) -> pd.DataFrame:
     missing_limit = data.get("missing_limit")
     if missing_limit is None:
         missing_limit = data.get("nan_limit")
-    frame = load_csv(
-        str(resolved),
-        errors="raise",
-        missing_policy=missing_policy,
-        missing_limit=missing_limit,
-    )
+    date_column = str(data.get("date_column") or "Date")
+    load_kwargs: dict[str, Any] = {
+        "errors": "raise",
+        "missing_policy": missing_policy,
+        "missing_limit": missing_limit,
+    }
+    if _accepts_keyword(load_csv, "date_column"):
+        load_kwargs["date_column"] = date_column
+    frame = load_csv(str(resolved), **load_kwargs)
     if frame is None:
         raise FileNotFoundError(str(resolved))
     frame = coerce_to_utc(frame)

--- a/src/trend_analysis/multi_period/loaders.py
+++ b/src/trend_analysis/multi_period/loaders.py
@@ -27,7 +27,7 @@ def _accepts_keyword(func: Any, keyword: str) -> bool:
     try:
         params = inspect.signature(func).parameters
     except (TypeError, ValueError):
-        return True
+        return False
     return keyword in params or any(
         param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values()
     )

--- a/src/trend_analysis/pipeline_entrypoints.py
+++ b/src/trend_analysis/pipeline_entrypoints.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import inspect
 from dataclasses import dataclass
 from typing import Any, Mapping, cast
 
@@ -31,6 +32,16 @@ class ConfigBindings:
     RiskStatsConfig: Any
 
 
+def _accepts_keyword(func: Any, keyword: str) -> bool:
+    try:
+        params = inspect.signature(func).parameters
+    except (TypeError, ValueError):
+        return True
+    return keyword in params or any(
+        param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values()
+    )
+
+
 def run_from_config(cfg: Any, *, bindings: ConfigBindings) -> pd.DataFrame:
     """Run the analysis pipeline using a config-like object.
 
@@ -56,13 +67,18 @@ def run_from_config(cfg: Any, *, bindings: ConfigBindings) -> pd.DataFrame:
     missing_limit_cfg = bindings.section_get(data_settings, "missing_limit")
     if missing_limit_cfg is None:
         missing_limit_cfg = bindings.section_get(data_settings, "nan_limit")
+    date_column_cfg = bindings.section_get(data_settings, "date_column")
+    if date_column_cfg is None:
+        date_column_cfg = "Date"
 
-    df = bindings.load_csv(
-        csv_path,
-        errors="raise",
-        missing_policy=missing_policy_cfg,
-        missing_limit=missing_limit_cfg,
-    )
+    load_kwargs: dict[str, Any] = {
+        "errors": "raise",
+        "missing_policy": missing_policy_cfg,
+        "missing_limit": missing_limit_cfg,
+    }
+    if _accepts_keyword(bindings.load_csv, "date_column"):
+        load_kwargs["date_column"] = date_column_cfg
+    df = bindings.load_csv(csv_path, **load_kwargs)
     df = cast(pd.DataFrame, df)
 
     bindings.attach_calendar_settings(df, cfg)
@@ -188,13 +204,18 @@ def run_full_from_config(cfg: Any, *, bindings: ConfigBindings) -> PipelineResul
     missing_limit_cfg = bindings.section_get(data_settings, "missing_limit")
     if missing_limit_cfg is None:
         missing_limit_cfg = bindings.section_get(data_settings, "nan_limit")
+    date_column_cfg = bindings.section_get(data_settings, "date_column")
+    if date_column_cfg is None:
+        date_column_cfg = "Date"
 
-    df = bindings.load_csv(
-        csv_path,
-        errors="raise",
-        missing_policy=missing_policy_cfg,
-        missing_limit=missing_limit_cfg,
-    )
+    load_kwargs: dict[str, Any] = {
+        "errors": "raise",
+        "missing_policy": missing_policy_cfg,
+        "missing_limit": missing_limit_cfg,
+    }
+    if _accepts_keyword(bindings.load_csv, "date_column"):
+        load_kwargs["date_column"] = date_column_cfg
+    df = bindings.load_csv(csv_path, **load_kwargs)
     df = cast(pd.DataFrame, df)
 
     bindings.attach_calendar_settings(df, cfg)

--- a/src/trend_analysis/pipeline_entrypoints.py
+++ b/src/trend_analysis/pipeline_entrypoints.py
@@ -36,7 +36,7 @@ def _accepts_keyword(func: Any, keyword: str) -> bool:
     try:
         params = inspect.signature(func).parameters
     except (TypeError, ValueError):
-        return True
+        return False
     return keyword in params or any(
         param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values()
     )

--- a/src/trend_analysis/run_analysis.py
+++ b/src/trend_analysis/run_analysis.py
@@ -39,6 +39,7 @@ def main(argv: list[str] | None = None) -> int:
     csv_path = str(csv_path)
 
     data_settings = getattr(cfg, "data", {}) or {}
+    date_column_cfg = data_settings.get("date_column", "Date")
     missing_policy_cfg = data_settings.get("missing_policy")
     if missing_policy_cfg is None:
         missing_policy_cfg = data_settings.get("nan_policy")
@@ -52,6 +53,8 @@ def main(argv: list[str] | None = None) -> int:
     load_kwargs: dict[str, Any] = {}
     if "errors" in load_csv_params:
         load_kwargs["errors"] = "raise"
+    if "date_column" in load_csv_params:
+        load_kwargs["date_column"] = date_column_cfg
     if missing_policy_cfg is not None:
         if "missing_policy" in load_csv_params:
             load_kwargs["missing_policy"] = missing_policy_cfg

--- a/tests/test_date_column_main_path.py
+++ b/tests/test_date_column_main_path.py
@@ -1,9 +1,13 @@
 from types import SimpleNamespace
 
 import pandas as pd
+import pytest
 
+from trend_analysis import pipeline_entrypoints, run_analysis
 from trend_analysis.data import load_csv
-from trend_analysis import run_analysis
+from trend_analysis.io.market_data import MarketDataValidationError
+from trend_analysis.multi_period import engine as multi_period_engine
+from trend_analysis.multi_period import loaders as multi_period_loaders
 
 
 class DummyResult(SimpleNamespace):
@@ -34,6 +38,26 @@ def test_load_csv_still_accepts_standard_date_column(tmp_path):
 
     assert frame is not None
     assert list(frame.columns) == ["Date", "ManagerA"]
+
+
+def test_load_csv_rejects_missing_configured_date_column(tmp_path):
+    csv_path = tmp_path / "returns.csv"
+    csv_path.write_text(
+        "Date,ManagerA\n"
+        "2024-01-31,0.01\n"
+        "2024-02-29,0.03\n"
+    )
+
+    with pytest.raises(MarketDataValidationError, match="Timestamp"):
+        load_csv(str(csv_path), errors="raise", date_column="Timestamp")
+
+
+def test_accepts_keyword_is_conservative_when_signature_fails():
+    marker = object()
+
+    assert pipeline_entrypoints._accepts_keyword(marker, "date_column") is False
+    assert multi_period_loaders._accepts_keyword(marker, "date_column") is False
+    assert multi_period_engine._accepts_keyword(marker, "date_column") is False
 
 
 def test_run_analysis_passes_configured_date_column(monkeypatch, tmp_path):

--- a/tests/test_date_column_main_path.py
+++ b/tests/test_date_column_main_path.py
@@ -1,0 +1,109 @@
+from types import SimpleNamespace
+
+import pandas as pd
+
+from trend_analysis.data import load_csv
+from trend_analysis import run_analysis
+
+
+class DummyResult(SimpleNamespace):
+    metrics: pd.DataFrame
+    details: dict
+
+
+def test_load_csv_honors_configured_date_column(tmp_path):
+    csv_path = tmp_path / "returns.csv"
+    csv_path.write_text(
+        "Timestamp,ManagerA,ManagerB\n"
+        "2024-01-31,0.01,0.02\n"
+        "2024-02-29,0.03,0.04\n"
+    )
+
+    frame = load_csv(str(csv_path), errors="raise", date_column="Timestamp")
+
+    assert frame is not None
+    assert list(frame.columns) == ["Date", "ManagerA", "ManagerB"]
+    assert pd.api.types.is_datetime64_any_dtype(frame["Date"])
+
+
+def test_load_csv_still_accepts_standard_date_column(tmp_path):
+    csv_path = tmp_path / "returns.csv"
+    csv_path.write_text("Date,ManagerA\n2024-01-31,0.01\n2024-02-29,0.03\n")
+
+    frame = load_csv(str(csv_path), errors="raise")
+
+    assert frame is not None
+    assert list(frame.columns) == ["Date", "ManagerA"]
+
+
+def test_run_analysis_passes_configured_date_column(monkeypatch, tmp_path):
+    csv_path = tmp_path / "returns.csv"
+    csv_path.write_text("Timestamp,ManagerA\n2024-01-31,0.01\n")
+    cfg = SimpleNamespace(
+        data={"csv_path": str(csv_path), "date_column": "Timestamp"},
+        sample_split={
+            "in_start": "2024-01-01",
+            "in_end": "2024-01-31",
+            "out_start": "2024-02-01",
+            "out_end": "2024-02-29",
+        },
+        export={"directory": str(tmp_path), "formats": ["json"], "filename": "report"},
+    )
+
+    monkeypatch.setattr(run_analysis, "load", lambda path: cfg)
+    captured: dict[str, object] = {}
+
+    def fake_load_csv(path, *, errors="raise", date_column="Date", **kwargs):
+        captured.update(
+            {
+                "path": path,
+                "errors": errors,
+                "date_column": date_column,
+                "kwargs": kwargs,
+            }
+        )
+        return pd.DataFrame({"Date": pd.to_datetime(["2024-01-31"]), "ManagerA": [0.01]})
+
+    monkeypatch.setattr(run_analysis, "load_csv", fake_load_csv)
+    monkeypatch.setattr(
+        run_analysis.api,
+        "run_simulation",
+        lambda config, df: DummyResult(metrics=pd.DataFrame(), details={}),
+    )
+
+    assert run_analysis.main(["--config", "config.yml"]) == 0
+    assert captured["path"] == str(csv_path)
+    assert captured["errors"] == "raise"
+    assert captured["date_column"] == "Timestamp"
+
+
+def test_run_analysis_without_date_column_keeps_default(monkeypatch, tmp_path):
+    csv_path = tmp_path / "returns.csv"
+    csv_path.write_text("Date,ManagerA\n2024-01-31,0.01\n")
+    cfg = SimpleNamespace(
+        data={"csv_path": str(csv_path)},
+        sample_split={
+            "in_start": "2024-01-01",
+            "in_end": "2024-01-31",
+            "out_start": "2024-02-01",
+            "out_end": "2024-02-29",
+        },
+        export={"directory": str(tmp_path), "formats": ["json"], "filename": "report"},
+    )
+
+    monkeypatch.setattr(run_analysis, "load", lambda path: cfg)
+    captured: dict[str, object] = {}
+
+    def fake_load_csv(path, *, errors="raise", date_column="Date", **kwargs):
+        captured["date_column"] = date_column
+        return pd.DataFrame({"Date": pd.to_datetime(["2024-01-31"]), "ManagerA": [0.01]})
+
+    monkeypatch.setattr(run_analysis, "load_csv", fake_load_csv)
+    monkeypatch.setattr(
+        run_analysis.api,
+        "run_simulation",
+        lambda config, df: DummyResult(metrics=pd.DataFrame(), details={}),
+    )
+
+    assert run_analysis.main(["--config", "config.yml"]) == 0
+    assert captured["date_column"] == "Date"


### PR DESCRIPTION
Closes #5417

## Summary
- add a `date_column` argument to `load_csv` and canonicalize configured date columns before existing validation
- pass `data.date_column` through the single-run, multi-period, and pipeline entrypoint load paths
- add focused regression coverage for `Timestamp`-named date columns plus the default `Date` path

## Validation
- `python -m pytest tests/test_date_column_main_path.py -q`
- `python -m pytest tests/test_run_analysis_cli.py tests/test_multi_period_loaders.py -q`
- `python -m pytest tests/test_date_column_main_path.py tests/test_run_analysis_cli.py tests/test_multi_period_loaders.py -q`
- `python -m ruff check src/trend_analysis/data.py src/trend_analysis/run_analysis.py src/trend_analysis/multi_period/engine.py src/trend_analysis/multi_period/loaders.py src/trend_analysis/pipeline_entrypoints.py tests/test_date_column_main_path.py`
- `python -m mypy src/trend_analysis/data.py src/trend_analysis/run_analysis.py src/trend_analysis/multi_period/loaders.py src/trend_analysis/pipeline_entrypoints.py tests/test_date_column_main_path.py`
- `git diff --check`

## Deliberate-break gate
- Temporarily made `load_csv` ignore `date_column`; `python -m pytest tests/test_date_column_main_path.py::test_load_csv_honors_configured_date_column -q` failed with `MarketDataValidationError: Missing required column 'Date'`. Restored implementation and reran green.
