### PR TITLE
Issue #5418: wire missing_fill_limit alias

### DIFF
--- a/src/trend_analysis/config/model.py
+++ b/src/trend_analysis/config/model.py
@@ -198,6 +198,15 @@ class DataSettings(BaseModel):
 
     model_config = ConfigDict(extra="ignore")
 
+    @model_validator(mode="before")
+    @classmethod
+    def _alias_missing_fill_limit(cls, data: Any) -> Any:
+        if not isinstance(data, Mapping):
+            return data
+        if "missing_fill_limit" not in data or "missing_limit" in data:
+            return data
+        return {**data, "missing_limit": data["missing_fill_limit"]}
+
     @field_validator("csv_path", mode="before")
     @classmethod
     def _validate_csv_path(cls, value: Any, info: Any) -> Path | None:

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -749,6 +749,23 @@ REQUIRED_SECTIONS = (
 )
 
 
+def _config_from_validated(data: dict[str, Any], validated: Any | None) -> ConfigProtocol:
+    if isinstance(validated, Config):
+        return validated
+    if hasattr(validated, "model_dump"):
+        dumped = cast(Any, validated).model_dump()
+        if isinstance(dumped, Mapping):
+            merged: dict[str, Any] = dict(data)
+            for key, value in dumped.items():
+                merged[key] = value
+            if "version" not in merged and "version" in data:
+                merged["version"] = data["version"]
+            return Config(**merged)
+    if isinstance(validated, Mapping):
+        return Config(**dict(validated))
+    return Config(**data)
+
+
 def load_config(cfg: Mapping[str, Any] | str | Path) -> ConfigProtocol:
     """Load configuration from a mapping or file path."""
     if isinstance(cfg, (str, Path)):
@@ -771,17 +788,18 @@ def load_config(cfg: Mapping[str, Any] | str | Path) -> ConfigProtocol:
             # Preserve type-specific message
             raise ValueError(f"{section} must be a dictionary")
     pydantic_present = sys.modules.get("pydantic") is not None
+    validated: Any | None = None
     if _HAS_PYDANTIC:
         # Allow ValidationError to propagate (tests expect this)
-        validate_trend_config(cfg_dict, base_path=proj_path())
+        validated = validate_trend_config(cfg_dict, base_path=proj_path())
     else:
         validator_module = str(getattr(validate_trend_config, "__module__", ""))
         if (not pydantic_present) or validator_module.startswith("trend_analysis.config"):
             try:
-                validate_trend_config(cfg_dict, base_path=proj_path())
+                validated = validate_trend_config(cfg_dict, base_path=proj_path())
             except Exception:
                 pass
-    return Config(**cfg_dict)
+    return _config_from_validated(cfg_dict, validated)
 
 
 def load(path: str | Path | None = None) -> ConfigProtocol:
@@ -858,20 +876,7 @@ def load(path: str | Path | None = None) -> ConfigProtocol:
             except Exception:
                 validated = None
 
-    if isinstance(validated, Config):
-        return validated
-    if hasattr(validated, "model_dump"):
-        dumped = cast(Any, validated).model_dump()
-        if isinstance(dumped, Mapping):
-            merged: dict[str, Any] = dict(data)
-            for key, value in dumped.items():
-                merged[key] = value
-            if "version" not in merged and "version" in data:
-                merged["version"] = data["version"]
-            return Config(**merged)
-    if isinstance(validated, Mapping):
-        return Config(**dict(validated))
-    return Config(**data)
+    return _config_from_validated(data, validated)
 
 
 __all__ = [

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -753,7 +753,10 @@ def _config_from_validated(data: dict[str, Any], validated: Any | None) -> Confi
     if isinstance(validated, Config):
         return validated
     if hasattr(validated, "model_dump"):
-        dumped = cast(Any, validated).model_dump()
+        try:
+            dumped = cast(Any, validated).model_dump(mode="json")
+        except TypeError:
+            dumped = cast(Any, validated).model_dump()
         if isinstance(dumped, Mapping):
             merged: dict[str, Any] = dict(data)
             for key, value in dumped.items():

--- a/tests/config/test_missing_fill_limit.py
+++ b/tests/config/test_missing_fill_limit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from trend_analysis.config import model as config_model
+from trend_analysis.config.models import load_config
 
 
 def _returns_csv(tmp_path: Path) -> Path:
@@ -44,3 +45,45 @@ def test_missing_limit_wins_when_both_alias_and_canonical_are_set(tmp_path: Path
     )
 
     assert settings.missing_limit == 4
+
+
+def _config_payload(tmp_path: Path, data_overrides: dict[str, object]) -> dict[str, object]:
+    csv_path = _returns_csv(tmp_path)
+    data = {
+        "csv_path": str(csv_path),
+        "date_column": "Date",
+        "frequency": "D",
+        "missing_policy": "ffill",
+    }
+    data.update(data_overrides)
+    return {
+        "version": "1",
+        "data": data,
+        "preprocessing": {},
+        "vol_adjust": {"target_vol": 0.1},
+        "sample_split": {},
+        "portfolio": {
+            "rebalance_calendar": "NYSE",
+            "max_turnover": 0.5,
+            "transaction_cost_bps": 0.0,
+        },
+        "metrics": {},
+        "export": {},
+        "run": {},
+    }
+
+
+def test_load_config_mapping_canonicalizes_missing_fill_limit(tmp_path: Path) -> None:
+    cfg = load_config(_config_payload(tmp_path, {"missing_fill_limit": 2}))
+
+    assert cfg.data["missing_limit"] == 2
+    assert "missing_fill_limit" not in cfg.data
+
+
+def test_load_config_mapping_preserves_canonical_missing_limit(tmp_path: Path) -> None:
+    cfg = load_config(
+        _config_payload(tmp_path, {"missing_fill_limit": 2, "missing_limit": 4})
+    )
+
+    assert cfg.data["missing_limit"] == 4
+    assert "missing_fill_limit" not in cfg.data

--- a/tests/config/test_missing_fill_limit.py
+++ b/tests/config/test_missing_fill_limit.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from trend_analysis.config import model as config_model
+
+
+def _returns_csv(tmp_path: Path) -> Path:
+    path = tmp_path / "returns.csv"
+    path.write_text("Date,Asset\n2024-01-01,1\n", encoding="utf-8")
+    return path
+
+
+def test_missing_fill_limit_alias_populates_missing_limit(tmp_path: Path) -> None:
+    csv_path = _returns_csv(tmp_path)
+
+    settings = config_model.DataSettings.model_validate(
+        {
+            "csv_path": str(csv_path),
+            "date_column": "Date",
+            "frequency": "D",
+            "missing_policy": "ffill",
+            "missing_fill_limit": "2",
+        },
+        context={"base_path": tmp_path},
+    )
+
+    assert settings.missing_limit == 2
+
+
+def test_missing_limit_wins_when_both_alias_and_canonical_are_set(tmp_path: Path) -> None:
+    csv_path = _returns_csv(tmp_path)
+
+    settings = config_model.DataSettings.model_validate(
+        {
+            "csv_path": str(csv_path),
+            "date_column": "Date",
+            "frequency": "D",
+            "missing_policy": "ffill",
+            "missing_fill_limit": 2,
+            "missing_limit": 4,
+        },
+        context={"base_path": tmp_path},
+    )
+
+    assert settings.missing_limit == 4

--- a/tests/config/test_no_inert_keys.py
+++ b/tests/config/test_no_inert_keys.py
@@ -65,7 +65,6 @@ ALLOWLIST_PATHS: dict[str, str] = {
     "data.currency": "Declared ingestion key; A1/#5389 strict-config owner decision pending.",
     "data.lookback_required": "Declared ingestion key; A1/#5389 strict-config owner decision pending.",
     # Declared feature flags retained as config surface (not in A2's enumerated set).
-    "data.missing_fill_limit": "A5/#5418 owns migration to missing_limit; retained until that issue lands.",
     "preprocessing.winsorise.limits": "Declared winsorisation settings; not in A2's enumerated inert set.",
     "preprocessing.de_duplicate": "Declared preprocessing flag; not in A2's enumerated inert set.",
     "preprocessing.log_prices": "Declared preprocessing flag; not in A2's enumerated inert set.",

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,17 +1,3 @@
-## 2026-06-04T02:09Z - opener (codex): issue #5418 missing_fill_limit alias
-
-- Repo: `stranske/Trend_Model_Project`
-- Issue: `#5418` (`A5 - data.missing_fill_limit is a dead alias shadowing data.missing_limit`)
-- Branch: `codex/issue-5418-missing-fill-limit`
-- PR: `#5483` (`https://github.com/stranske/Trend_Model_Project/pull/5483`)
-- Worktree: `~/.codex/automations/pd-workloop-resume/worktrees/trend-5418-missing-fill-limit`
-- Selection: raw opener cap was below 5. High-priority #5343 and LMS #180 remain scoped on owner evidence; #5389/#5440 remains scoped on strict-config product decision. Approved normal queue entries were stale/completed: Inv-Man #518/#519 and duplicate #521 are closed/merged, and Trend #5476/#5477 is closed/merged. #5415 is merged/follow-up disposition work and #5417 is linked to PR #5481, so #5418 was the highest eligible unlinked implementation issue.
-- Drain sweep evidence: #5481 has green Gate evidence and is closer-drain/ready-for-closer; #5440 remains terminal/scoped for opener with failing Gate and documented strict-config owner decision. Neither blocked opening #5418 while cap was below five.
-- Implementation: added a `DataSettings` pre-validation alias that maps `data.missing_fill_limit` to canonical `data.missing_limit` before `extra="ignore"` drops unknown keys, while preserving canonical `missing_limit` precedence when both are set. Removed `data.missing_fill_limit` from the inert-key allowlist and added `tests/config/test_missing_fill_limit.py`.
-- Validation: `python -m pytest tests/config/test_missing_fill_limit.py tests/config/test_no_inert_keys.py -q` -> 3 passed; `python -m ruff check src/trend_analysis/config/model.py tests/config/test_missing_fill_limit.py tests/config/test_no_inert_keys.py` -> passed; `python -m mypy src/trend_analysis/config/model.py tests/config/test_missing_fill_limit.py` -> passed; `git diff --check` -> passed.
-- Deliberate-break gate: temporarily removed the alias validator; `python -m pytest tests/config/test_missing_fill_limit.py::test_missing_fill_limit_alias_populates_missing_limit -q` failed with `assert None == 2`; restored and reran green.
-- Routing: PR #5483 is open/non-draft, closes #5418, labels `[agent:codex, agents:keepalive, autofix]`. Handoff event `pr_opened` recorded with `active.source_repo=stranske/Trend_Model_Project`, `active.source_issue=5418`, `active.source_pr=5483`, `active.next_action=wait_for_keepalive`. Cap-health at `2026-06-04T02:08:52Z` classified #5483 as `draining` with an active queued Gate run.
-
 ## 2026-06-03T23:04Z - opener (codex): issue #5416 regime registry slice
 
 - Repo: `stranske/Trend_Model_Project`

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,17 @@
+## 2026-06-04T02:09Z - opener (codex): issue #5418 missing_fill_limit alias
+
+- Repo: `stranske/Trend_Model_Project`
+- Issue: `#5418` (`A5 - data.missing_fill_limit is a dead alias shadowing data.missing_limit`)
+- Branch: `codex/issue-5418-missing-fill-limit`
+- PR: `#5483` (`https://github.com/stranske/Trend_Model_Project/pull/5483`)
+- Worktree: `~/.codex/automations/pd-workloop-resume/worktrees/trend-5418-missing-fill-limit`
+- Selection: raw opener cap was below 5. High-priority #5343 and LMS #180 remain scoped on owner evidence; #5389/#5440 remains scoped on strict-config product decision. Approved normal queue entries were stale/completed: Inv-Man #518/#519 and duplicate #521 are closed/merged, and Trend #5476/#5477 is closed/merged. #5415 is merged/follow-up disposition work and #5417 is linked to PR #5481, so #5418 was the highest eligible unlinked implementation issue.
+- Drain sweep evidence: #5481 has green Gate evidence and is closer-drain/ready-for-closer; #5440 remains terminal/scoped for opener with failing Gate and documented strict-config owner decision. Neither blocked opening #5418 while cap was below five.
+- Implementation: added a `DataSettings` pre-validation alias that maps `data.missing_fill_limit` to canonical `data.missing_limit` before `extra="ignore"` drops unknown keys, while preserving canonical `missing_limit` precedence when both are set. Removed `data.missing_fill_limit` from the inert-key allowlist and added `tests/config/test_missing_fill_limit.py`.
+- Validation: `python -m pytest tests/config/test_missing_fill_limit.py tests/config/test_no_inert_keys.py -q` -> 3 passed; `python -m ruff check src/trend_analysis/config/model.py tests/config/test_missing_fill_limit.py tests/config/test_no_inert_keys.py` -> passed; `python -m mypy src/trend_analysis/config/model.py tests/config/test_missing_fill_limit.py` -> passed; `git diff --check` -> passed.
+- Deliberate-break gate: temporarily removed the alias validator; `python -m pytest tests/config/test_missing_fill_limit.py::test_missing_fill_limit_alias_populates_missing_limit -q` failed with `assert None == 2`; restored and reran green.
+- Routing: PR #5483 is open/non-draft, closes #5418, labels `[agent:codex, agents:keepalive, autofix]`. Handoff event `pr_opened` recorded with `active.source_repo=stranske/Trend_Model_Project`, `active.source_issue=5418`, `active.source_pr=5483`, `active.next_action=wait_for_keepalive`. Cap-health at `2026-06-04T02:08:52Z` classified #5483 as `draining` with an active queued Gate run.
+
 ## 2026-06-03T23:04Z - opener (codex): issue #5416 regime registry slice
 
 - Repo: `stranske/Trend_Model_Project`


### PR DESCRIPTION
Closes #5418

## Summary
- Map `data.missing_fill_limit` into canonical `data.missing_limit` before startup config validation drops extras.
- Keep canonical `missing_limit` precedence when both keys are present.
- Add focused regression tests and remove the stale inert-key allowlist entry.

## Validation
- `python -m pytest tests/config/test_missing_fill_limit.py tests/config/test_no_inert_keys.py -q` -> 3 passed
- `python -m ruff check src/trend_analysis/config/model.py tests/config/test_missing_fill_limit.py tests/config/test_no_inert_keys.py` -> passed
- `python -m mypy src/trend_analysis/config/model.py tests/config/test_missing_fill_limit.py` -> passed
- `git diff --check` -> passed

## Deliberate break
- Temporarily removed the alias validator; `python -m pytest tests/config/test_missing_fill_limit.py::test_missing_fill_limit_alias_populates_missing_limit -q` failed with `assert None == 2`. Restored the alias and reran green.