### PR TITLE
Issue #5419: unify weighting config resolution

### DIFF
--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -155,6 +155,7 @@ _SUPPORTED_WEIGHTING_NAMES = (
 _SUPPORTED_NORMALISED_WEIGHTING_NAMES = {
     _WEIGHTING_NAME_ALIASES.get(name, name) for name in _SUPPORTED_WEIGHTING_NAMES
 }
+_WEIGHTING_SCHEME_PLACEHOLDERS = {"equal", "custom"}
 
 
 def _normalise_weighting_name(value: Any) -> str:
@@ -167,18 +168,33 @@ def _resolve_portfolio_weighting(
 ) -> tuple[BaseWeighting, bool, Any, dict[str, Any] | None, str]:
     """Resolve portfolio weighting from either public weighting config key."""
 
-    w_cfg = cast(dict[str, Any], portfolio_cfg.get("weighting", {}) or {})
-    w_params = cast(dict[str, Any], w_cfg.get("params", {}) or {})
-    if "weighting_scheme" in portfolio_cfg and portfolio_cfg.get("weighting_scheme") not in (
+    raw_weighting = portfolio_cfg.get("weighting")
+    if raw_weighting is None:
+        raw_weighting = {}
+    if not isinstance(raw_weighting, Mapping):
+        raise ValueError("portfolio.weighting must be a mapping")
+    w_cfg = cast(Mapping[str, Any], raw_weighting)
+    raw_params = w_cfg.get("params")
+    if raw_params is None:
+        raw_params = {}
+    if not isinstance(raw_params, Mapping):
+        raise ValueError("portfolio.weighting.params must be a mapping")
+    w_params = cast(Mapping[str, Any], raw_params)
+    weighting_scheme = portfolio_cfg.get("weighting_scheme")
+    if "weighting_scheme" in portfolio_cfg and weighting_scheme not in (
         None,
         "",
     ):
-        weighting_name = _normalise_weighting_name(portfolio_cfg.get("weighting_scheme"))
+        scheme_name = _normalise_weighting_name(weighting_scheme)
+        if scheme_name in _WEIGHTING_SCHEME_PLACEHOLDERS and w_cfg.get("name"):
+            weighting_name = _normalise_weighting_name(w_cfg.get("name"))
+        else:
+            weighting_name = scheme_name
     else:
         weighting_name = _normalise_weighting_name(w_cfg.get("name", "equal"))
 
     if weighting_name not in _SUPPORTED_NORMALISED_WEIGHTING_NAMES:
-        allowed = ", ".join(sorted(_SUPPORTED_NORMALISED_WEIGHTING_NAMES))
+        allowed = ", ".join(sorted(_SUPPORTED_WEIGHTING_NAMES))
         raise ValueError(
             f"Unknown portfolio weighting scheme {weighting_name!r}. "
             f"Supported values: {allowed}."

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -66,6 +66,7 @@ from ..weighting import (
     BaseWeighting,
     EqualWeight,
     ScorePropBayesian,
+    ScorePropSimple,
 )
 from ..weights.robust_config import weight_engine_params_from_robustness
 from .loaders import load_benchmarks, load_membership, load_prices
@@ -116,6 +117,132 @@ def _coerce_previous_weights(
     if not normalized:
         return None
     return normalized
+
+
+_SCORE_WEIGHTING_NAMES = {
+    "score_prop",
+    "score_prop_simple",
+    "score",
+}
+_BAYES_WEIGHTING_NAMES = {
+    "score_prop_bayes",
+    "bayes",
+    "score_bayes",
+}
+_ADAPTIVE_BAYES_WEIGHTING_NAMES = {
+    "adaptive_bayes",
+    "adaptive",
+}
+_RISK_WEIGHTING_NAMES = {
+    "risk_parity",
+    "hrp",
+    "erc",
+    "robust_mv",
+    "robust_mean_variance",
+    "robust_risk_parity",
+}
+_WEIGHTING_NAME_ALIASES = {
+    "ew": "equal",
+    "robust": "robust_mv",
+}
+_SUPPORTED_WEIGHTING_NAMES = (
+    {"equal", "ew", "robust"}
+    | _SCORE_WEIGHTING_NAMES
+    | _BAYES_WEIGHTING_NAMES
+    | _ADAPTIVE_BAYES_WEIGHTING_NAMES
+    | _RISK_WEIGHTING_NAMES
+)
+_SUPPORTED_NORMALISED_WEIGHTING_NAMES = {
+    _WEIGHTING_NAME_ALIASES.get(name, name) for name in _SUPPORTED_WEIGHTING_NAMES
+}
+
+
+def _normalise_weighting_name(value: Any) -> str:
+    name = str(value or "equal").strip().lower()
+    return _WEIGHTING_NAME_ALIASES.get(name, name)
+
+
+def _resolve_portfolio_weighting(
+    portfolio_cfg: Mapping[str, Any],
+) -> tuple[BaseWeighting, bool, Any, dict[str, Any] | None, str]:
+    """Resolve portfolio weighting from either public weighting config key."""
+
+    w_cfg = cast(dict[str, Any], portfolio_cfg.get("weighting", {}) or {})
+    w_params = cast(dict[str, Any], w_cfg.get("params", {}) or {})
+    if "weighting_scheme" in portfolio_cfg and portfolio_cfg.get("weighting_scheme") not in (
+        None,
+        "",
+    ):
+        weighting_name = _normalise_weighting_name(portfolio_cfg.get("weighting_scheme"))
+    else:
+        weighting_name = _normalise_weighting_name(w_cfg.get("name", "equal"))
+
+    if weighting_name not in _SUPPORTED_NORMALISED_WEIGHTING_NAMES:
+        allowed = ", ".join(sorted(_SUPPORTED_NORMALISED_WEIGHTING_NAMES))
+        raise ValueError(
+            f"Unknown portfolio weighting scheme {weighting_name!r}. "
+            f"Supported values: {allowed}."
+        )
+
+    w_column = cast(str, w_params.get("column", "Sharpe"))
+    if weighting_name == "equal":
+        return EqualWeight(), False, None, None, weighting_name
+    if weighting_name in _SCORE_WEIGHTING_NAMES:
+        return ScorePropSimple(column=w_column), False, None, None, weighting_name
+    if weighting_name in _BAYES_WEIGHTING_NAMES:
+        return (
+            ScorePropBayesian(
+                column=w_column,
+                shrink_tau=float(w_params.get("shrink_tau", 0.25)),
+            ),
+            False,
+            None,
+            None,
+            weighting_name,
+        )
+    if weighting_name in _ADAPTIVE_BAYES_WEIGHTING_NAMES:
+        return (
+            AdaptiveBayesWeighting(
+                half_life=int(w_params.get("half_life", 90)),
+                obs_sigma=float(w_params.get("obs_sigma", 0.25)),
+                max_w=w_params.get("max_w"),
+                prior_mean=w_params.get("prior_mean", "equal"),
+                prior_tau=float(w_params.get("prior_tau", 1.0)),
+            ),
+            False,
+            None,
+            None,
+            weighting_name,
+        )
+
+    try:
+        from ..plugins import create_weight_engine
+
+        robustness_cfg = portfolio_cfg.get("robustness")
+        weight_engine_params = weight_engine_params_from_robustness(
+            weighting_name,
+            robustness_cfg if isinstance(robustness_cfg, Mapping) else None,
+        )
+        return (
+            EqualWeight(),
+            True,
+            create_weight_engine(weighting_name, **weight_engine_params),
+            None,
+            weighting_name,
+        )
+    except Exception as exc:
+        fallback = {
+            "engine": weighting_name,
+            "error_type": exc.__class__.__name__,
+            "error": str(exc) or exc.__class__.__name__,
+        }
+        logger.warning(
+            "Risk-weighting engine %r failed to construct (%s); falling back "
+            "to equal weight for this multi-period run.",
+            weighting_name,
+            exc,
+        )
+        return EqualWeight(), False, None, fallback, weighting_name
 
 
 def _get_missing_policy_settings(
@@ -1686,72 +1813,19 @@ def run(
         except (TypeError, ValueError):
             low_min_strikes_req = 2
 
-    w_cfg = cast(dict[str, Any], cfg.portfolio.get("weighting", {}))
-    w_name = str(w_cfg.get("name", "equal")).lower()
-    w_params = cast(dict[str, Any], w_cfg.get("params", {}))
-    # Column for score‑proportional weightings defaults to Sharpe
-    w_column = cast(str, w_params.get("column", "Sharpe"))
-    if w_name in {"equal", "ew"}:
-        weighting: BaseWeighting = EqualWeight()
-    elif w_name in {"score_prop_bayes", "bayes", "score_bayes"}:
-        weighting = ScorePropBayesian(
-            column=w_column, shrink_tau=float(w_params.get("shrink_tau", 0.25))
-        )
-    elif w_name in {"adaptive_bayes", "adaptive"}:
-        weighting = AdaptiveBayesWeighting(
-            half_life=int(w_params.get("half_life", 90)),
-            obs_sigma=float(w_params.get("obs_sigma", 0.25)),
-            max_w=w_params.get("max_w"),
-            prior_mean=w_params.get("prior_mean", "equal"),
-            prior_tau=float(w_params.get("prior_tau", 1.0)),
-        )
-    else:
-        weighting = EqualWeight()
+    portfolio_for_weighting = dict(cast(Mapping[str, Any], cfg.portfolio))
+    if not isinstance(portfolio_for_weighting.get("robustness"), Mapping):
+        root_robustness = getattr(cfg, "robustness", None)
+        if isinstance(root_robustness, Mapping):
+            portfolio_for_weighting["robustness"] = root_robustness
 
-    # Risk-based weighting scheme (risk_parity, hrp) from weighting_scheme config.
-    # This overrides the legacy `portfolio.weighting` dict config for primary weights.
-    weighting_scheme = str(cfg.portfolio.get("weighting_scheme", "equal") or "equal").lower()
-    if weighting_scheme == "robust":
-        weighting_scheme = "robust_mv"
-    use_risk_weighting = weighting_scheme in {
-        "risk_parity",
-        "hrp",
-        "erc",
-        "robust_mv",
-        "robust_mean_variance",
-        "robust_risk_parity",
-    }
-    risk_weight_engine: Any = None
-    # Records why we silently fell back to equal weight when a risk-weighting
-    # engine fails to construct, so the Results page banner (and the run
-    # envelope) can surface it instead of silently delivering equal weights.
-    weight_engine_fallback: dict[str, Any] | None = None
-    if use_risk_weighting:
-        try:
-            from ..plugins import create_weight_engine
-
-            robustness_cfg = cfg.portfolio.get("robustness")
-            if not isinstance(robustness_cfg, Mapping):
-                robustness_cfg = getattr(cfg, "robustness", None)
-            weight_engine_params = weight_engine_params_from_robustness(
-                weighting_scheme,
-                robustness_cfg if isinstance(robustness_cfg, Mapping) else None,
-            )
-            risk_weight_engine = create_weight_engine(weighting_scheme, **weight_engine_params)
-        except Exception as exc:
-            use_risk_weighting = False
-            risk_weight_engine = None
-            weight_engine_fallback = {
-                "engine": weighting_scheme,
-                "error_type": exc.__class__.__name__,
-                "error": str(exc) or exc.__class__.__name__,
-            }
-            logger.warning(
-                "Risk-weighting engine %r failed to construct (%s); falling back "
-                "to equal weight for this multi-period run.",
-                weighting_scheme,
-                exc,
-            )
+    (
+        weighting,
+        use_risk_weighting,
+        risk_weight_engine,
+        weight_engine_fallback,
+        weighting_scheme,
+    ) = _resolve_portfolio_weighting(portfolio_for_weighting)
 
     policy_cfg = cast(dict[str, Any], cfg.portfolio.get("weight_policy", {}))
     policy_mode = str(policy_cfg.get("mode", policy_cfg.get("policy", "drop"))).lower()

--- a/tests/test_multi_period_engine_branch_coverage.py
+++ b/tests/test_multi_period_engine_branch_coverage.py
@@ -44,7 +44,7 @@ class MinimalConfig:
                 "max_weight": 0.6,
                 "min_weight_strikes": 1,
             },
-            "weighting": {"name": "mystery", "params": {}},
+            "weighting": {"name": "equal", "params": {}},
             "indices_list": None,
         }
     )

--- a/tests/test_weighting_resolution.py
+++ b/tests/test_weighting_resolution.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from trend_analysis.multi_period.engine import _resolve_portfolio_weighting
+from trend_analysis.weighting import ScorePropSimple
+from trend_analysis.weights.risk_parity import RiskParity
+
+
+def test_weighting_name_risk_parity_uses_risk_engine() -> None:
+    weighting, use_risk, risk_engine, fallback, scheme = _resolve_portfolio_weighting(
+        {"weighting": {"name": "risk_parity"}}
+    )
+
+    assert scheme == "risk_parity"
+    assert use_risk is True
+    assert isinstance(risk_engine, RiskParity)
+    assert fallback is None
+    assert weighting.__class__.__name__ == "EqualWeight"
+
+
+def test_weighting_name_score_prop_is_reachable() -> None:
+    weighting, use_risk, risk_engine, fallback, scheme = _resolve_portfolio_weighting(
+        {"weighting": {"name": "score_prop", "params": {"column": "Sortino"}}}
+    )
+
+    assert scheme == "score_prop"
+    assert isinstance(weighting, ScorePropSimple)
+    assert weighting.column == "Sortino"
+    assert use_risk is False
+    assert risk_engine is None
+    assert fallback is None
+
+
+def test_weighting_scheme_risk_parity_uses_risk_engine() -> None:
+    weighting, use_risk, risk_engine, fallback, scheme = _resolve_portfolio_weighting(
+        {"weighting_scheme": "risk_parity"}
+    )
+
+    assert scheme == "risk_parity"
+    assert use_risk is True
+    assert isinstance(risk_engine, RiskParity)
+    assert fallback is None
+    assert weighting.__class__.__name__ == "EqualWeight"
+
+
+def test_unknown_weighting_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown portfolio weighting scheme"):
+        _resolve_portfolio_weighting({"weighting": {"name": "not_a_scheme"}})

--- a/tests/test_weighting_resolution.py
+++ b/tests/test_weighting_resolution.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from trend_analysis.multi_period.engine import _resolve_portfolio_weighting
+from trend_analysis.weighting import EqualWeight
 from trend_analysis.weighting import ScorePropSimple
 from trend_analysis.weights.risk_parity import RiskParity
 
@@ -16,7 +17,7 @@ def test_weighting_name_risk_parity_uses_risk_engine() -> None:
     assert use_risk is True
     assert isinstance(risk_engine, RiskParity)
     assert fallback is None
-    assert weighting.__class__.__name__ == "EqualWeight"
+    assert isinstance(weighting, EqualWeight)
 
 
 def test_weighting_name_score_prop_is_reachable() -> None:
@@ -41,9 +42,44 @@ def test_weighting_scheme_risk_parity_uses_risk_engine() -> None:
     assert use_risk is True
     assert isinstance(risk_engine, RiskParity)
     assert fallback is None
-    assert weighting.__class__.__name__ == "EqualWeight"
+    assert isinstance(weighting, EqualWeight)
+
+
+def test_placeholder_weighting_scheme_preserves_nested_weighting_name() -> None:
+    weighting, use_risk, risk_engine, fallback, scheme = _resolve_portfolio_weighting(
+        {
+            "weighting_scheme": "equal",
+            "weighting": {"name": "score_prop_bayes", "params": {"column": "Sharpe"}},
+        }
+    )
+
+    assert scheme == "score_prop_bayes"
+    assert weighting.__class__.__name__ == "ScorePropBayesian"
+    assert use_risk is False
+    assert risk_engine is None
+    assert fallback is None
+
+
+def test_custom_placeholder_preserves_nested_weighting_name() -> None:
+    weighting, use_risk, risk_engine, fallback, scheme = _resolve_portfolio_weighting(
+        {
+            "weighting_scheme": "custom",
+            "weighting": {"name": "score_prop", "params": {"column": "Sortino"}},
+        }
+    )
+
+    assert scheme == "score_prop"
+    assert isinstance(weighting, ScorePropSimple)
+    assert use_risk is False
+    assert risk_engine is None
+    assert fallback is None
 
 
 def test_unknown_weighting_raises() -> None:
-    with pytest.raises(ValueError, match="Unknown portfolio weighting scheme"):
+    with pytest.raises(ValueError, match="ew.*robust"):
         _resolve_portfolio_weighting({"weighting": {"name": "not_a_scheme"}})
+
+
+def test_weighting_config_must_be_mapping() -> None:
+    with pytest.raises(ValueError, match="portfolio.weighting must be a mapping"):
+        _resolve_portfolio_weighting({"weighting": []})

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,14 @@
+## 2026-06-04T03:06Z - opener (codex): issue #5419 weighting config resolver
+
+- Repo: `stranske/Trend_Model_Project`
+- Issue: `#5419` (`A6 - Unify the two weighting config keys; reject unsupported values; make ScorePropSimple reachable`)
+- Branch: `codex/issue-5419-weighting-config`
+- Worktree: `~/.codex/automations/pd-workloop-resume/worktrees/trend-5419-weighting-config`
+- Selection: raw opener cap below 5 after cap sweep. #5440 remains scoped/product-blocked on strict config key design; #5483 was repaired with `agent:retry` plus Gate Followups dispatch and now has fresh active Gate evidence. #5417 is merged awaiting verifier disposition and #5418 is linked to active PR #5483, so #5419 was the highest eligible unlinked implementation candidate outside scoped blockers.
+- Implementation: added a shared multi-period portfolio weighting resolver so `portfolio.weighting.name` and `portfolio.weighting_scheme` share the same value space. `risk_parity` now reaches the risk-engine path through either key, `score_prop` reaches `ScorePropSimple`, and unknown weighting names raise `ValueError` instead of silently falling back to `EqualWeight`. Existing risk-engine construction failure fallback remains surfaced through `weight_engine_fallback`.
+- Validation: `PYTHONPATH=src python -m pytest tests/test_weighting_resolution.py -q` -> 4 passed. Deliberate-break gate restored the old unknown-name equal-weight fallback and `tests/test_weighting_resolution.py::test_unknown_weighting_raises` failed with `DID NOT RAISE`, then the fix was restored. `PYTHONPATH=src python -m pytest tests/test_weighting_resolution.py tests/test_weighting.py tests/test_weight_engine_logging.py -q` -> 15 passed. Focused ruff passed, focused mypy passed, `git diff --check` passed. `PYTHONPATH=src python -m trend.cli run -c config/demo.yml --returns demo/demo_returns.csv` exited 0 while printing known local NumPy/optional-extension warnings.
+- Current state: ready to commit, push, and open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`.
+
 ## 2026-06-03T23:04Z - opener (codex): issue #5416 regime registry slice
 
 - Repo: `stranske/Trend_Model_Project`


### PR DESCRIPTION
Closes #5419

## Summary
- Add a shared multi-period weighting resolver for `portfolio.weighting.name` and `portfolio.weighting_scheme`.
- Route `risk_parity` through the risk-engine path from either key and expose `score_prop` as `ScorePropSimple`.
- Reject unknown weighting names with `ValueError` instead of silently falling back to equal weight.

## Validation
- `PYTHONPATH=src python -m pytest tests/test_weighting_resolution.py -q` -> 4 passed
- Deliberate-break: restored the old unknown-name equal-weight fallback; `tests/test_weighting_resolution.py::test_unknown_weighting_raises` failed with `DID NOT RAISE`; restored the fix
- `PYTHONPATH=src python -m pytest tests/test_weighting_resolution.py tests/test_weighting.py tests/test_weight_engine_logging.py -q` -> 15 passed
- `PYTHONPATH=src python -m ruff check src/trend_analysis/multi_period/engine.py tests/test_weighting_resolution.py` -> passed
- `PYTHONPATH=src python -m mypy src/trend_analysis/multi_period/engine.py tests/test_weighting_resolution.py` -> passed
- `git diff --check` -> passed
- `PYTHONPATH=src python -m trend.cli run -c config/demo.yml --returns demo/demo_returns.csv` -> exited 0; local environment printed known NumPy/optional-extension warnings before completing