### PR TITLE
Issue #5424: guard harness Sortino annualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on Keep a Changelog (https://keepachangelog.com/) and this p
 - Reusable `agents-64-verify-agent-assignment.yml` workflow that checks `agent:codex` issues for valid automation assignees and emits markdown summaries, available via manual dispatch or reusable calls (Issue #2386).
 
 ### Changed
+- Backtesting harness Sortino reporting now follows the canonical annualized
+  `metrics.sortino_ratio` calculation, preventing understated values in harness
+  summaries (Issue #5424).
 - `compute_signal` now returns a strictly causal rolling mean shifted by one period (previously included the current row). Prevents subtle look‑ahead bias in downstream position construction (Issue #1438).
 - Documented the continued manual use of `docker-compose.yml` and `scripts/test_docker.sh` for local smoke tests and GHCR release verification, avoiding archival after confirming no CI dependencies.
 

--- a/tests/backtesting/test_harness.py
+++ b/tests/backtesting/test_harness.py
@@ -704,6 +704,28 @@ def test_compute_drawdown_and_metrics_variants() -> None:
     assert math.isnan(empty_metrics["cagr"])
 
 
+def test_compute_metrics_sortino_matches_canonical_metric() -> None:
+    index = pd.date_range("2024-01-31", periods=6, freq="ME")
+    active_returns = pd.Series(
+        [0.012, -0.018, 0.006, -0.009, 0.015, 0.004],
+        index=index,
+    )
+    equity = (1.0 + active_returns).cumprod()
+    drawdown = _compute_drawdown(equity)
+
+    metrics = _compute_metrics(
+        active_returns,
+        equity,
+        drawdown,
+        periods_per_year=12,
+        active_mask=pd.Series(True, index=index),
+    )
+
+    assert metrics["sortino"] == pytest.approx(
+        sortino_ratio(active_returns, periods_per_year=12)
+    )
+
+
 def test_rolling_sharpe_and_series_weights_dict_helpers() -> None:
     idx = pd.date_range("2020-01-01", periods=5)
     returns = pd.Series([0.0, 0.01, -0.01, 0.02, -0.02], index=idx)


### PR DESCRIPTION
Closes #5424

## Summary
- add a direct `_compute_metrics` regression asserting harness Sortino matches canonical `metrics.sortino_ratio`
- document the harness Sortino value correction in the Unreleased changelog
- record opener lane state for the selected issue

## Validation
- `PYTHONPATH=src python -m pytest tests/backtesting/test_harness.py -q` -> 28 passed
- Deliberate-break gate: temporarily restored the old under-annualized Sortino formula; `test_compute_metrics_sortino_matches_canonical_metric` failed with `0.0756` vs `0.8781`, then restored and reran green
- `PYTHONPATH=src python -m ruff check src/trend_analysis/backtesting/harness.py tests/backtesting/test_harness.py` -> passed
- `PYTHONPATH=src python -m mypy src/trend_analysis/backtesting/harness.py` -> passed
- `git diff --check` -> passed