### PR TITLE
Issue #5429: share periods-per-year inference

### DIFF
--- a/src/trend_analysis/backtesting/harness.py
+++ b/src/trend_analysis/backtesting/harness.py
@@ -17,6 +17,7 @@ from backtest import shift_by_execution_lag
 from ..metrics.turnover import linear_turnover_cost
 from ..metrics import sortino_ratio
 from ..universe import MembershipTable, build_membership_mask
+from ..util.frequency import infer_periods_per_year as _infer_periods_per_year
 
 logger = logging.getLogger(__name__)
 
@@ -554,28 +555,6 @@ def _normalise_frequency(freq: str) -> str:
                 continue
             return prefix + replacement
     return freq_clean
-
-
-def _infer_periods_per_year(index: pd.DatetimeIndex) -> int:
-    if len(index) < 2:
-        return 1
-    diffs = np.diff(index.values.astype("datetime64[ns]").astype(np.int64))
-    if len(diffs) == 0:
-        return 1
-    median_ns = np.median(diffs)
-    if median_ns <= 0:
-        return 1
-    median_days = median_ns / (24 * 60 * 60 * 1e9)
-    approx = int(round(365 / median_days)) if median_days else 1
-    if approx >= 300:
-        return 252
-    if 45 <= approx <= 60:
-        return 52
-    if 10 <= approx <= 14:
-        return 12
-    if 3 <= approx <= 5:
-        return 4
-    return max(1, approx)
 
 
 def _initial_weights(columns: Sequence[str], initial: Mapping[str, float] | None) -> pd.Series:

--- a/src/trend_analysis/engine/walkforward.py
+++ b/src/trend_analysis/engine/walkforward.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 from trend_analysis.metrics import information_ratio
+from trend_analysis.util.frequency import infer_periods_per_year as _infer_periods_per_year
 
 
 @dataclass
@@ -105,36 +106,6 @@ def _information_ratio_frame(
         ser = pd.Series(data)
     ser.name = "information_ratio"
     return ser.to_frame().T
-
-
-def _infer_periods_per_year(index: pd.DatetimeIndex) -> int:
-    if len(index) < 2:
-        return 1
-
-    diffs = np.diff(index.values.astype("datetime64[ns]").astype(np.int64))
-    if len(diffs) == 0:
-        return 1
-
-    median_ns = np.median(diffs)
-    if median_ns <= 0:
-        return 1
-
-    median_days = median_ns / (24 * 60 * 60 * 1e9)
-    if median_days <= 0:
-        return 1
-
-    approx = int(round(365 / median_days))
-    if approx >= 300:
-        return 252
-    if 45 <= approx <= 60:
-        return 52
-    if 10 <= approx <= 14:
-        return 12
-    if 3 <= approx <= 5:
-        return 4
-    if approx <= 0:
-        return 1
-    return approx
 
 
 def _agg_label(agg: Any) -> str:

--- a/src/trend_analysis/util/frequency.py
+++ b/src/trend_analysis/util/frequency.py
@@ -14,6 +14,7 @@ __all__ = [
     "FrequencySummary",
     "FREQUENCY_LABELS",
     "detect_frequency",
+    "infer_periods_per_year",
 ]
 
 FrequencyCode = Literal["D", "W", "M", "Q", "Y"]
@@ -153,3 +154,33 @@ def detect_frequency(index: Iterable[object]) -> FrequencySummary:
     diffs_days = _intervals_in_days(idx)
     code = _classify_from_diffs(diffs_days)
     return _summary_from_code(code)
+
+
+def infer_periods_per_year(index: pd.DatetimeIndex) -> int:
+    """Infer annualization periods from a datetime cadence."""
+
+    if len(index) < 2:
+        return 1
+
+    diffs = np.diff(index.values.astype("datetime64[ns]").astype(np.int64))
+    if len(diffs) == 0:
+        return 1
+
+    median_ns = np.median(diffs)
+    if median_ns <= 0:
+        return 1
+
+    median_days = median_ns / (24 * 60 * 60 * 1e9)
+    if median_days <= 0:
+        return 1
+
+    approx = int(round(365 / median_days))
+    if approx >= 300:
+        return 252
+    if 45 <= approx <= 60:
+        return 52
+    if 10 <= approx <= 14:
+        return 12
+    if 3 <= approx <= 5:
+        return 4
+    return max(1, approx)

--- a/tests/test_infer_periods_per_year.py
+++ b/tests/test_infer_periods_per_year.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from trend_analysis.backtesting.harness import _infer_periods_per_year as harness_periods
+from trend_analysis.engine.walkforward import _infer_periods_per_year as engine_periods
+from trend_analysis.util.frequency import infer_periods_per_year
+
+
+def test_infer_periods_per_year_reuses_shared_helper() -> None:
+    monthly = pd.date_range("2020-01-31", periods=8, freq="ME")
+
+    assert harness_periods is infer_periods_per_year
+    assert engine_periods is infer_periods_per_year
+    assert harness_periods(monthly) == 12
+    assert engine_periods(monthly) == 12
+
+
+def test_infer_periods_per_year_combines_branch_guards() -> None:
+    zero_spacing = pd.DatetimeIndex(["2020-01-01", "2020-01-01"])
+    sparse = pd.date_range("2020-01-01", periods=2, freq="36ME")
+    start = pd.Timestamp("2020-01-01")
+    tiny_spacing = pd.DatetimeIndex(
+        [
+            start,
+            start + pd.Timedelta(microseconds=1),
+            start + pd.Timedelta(microseconds=2),
+        ]
+    )
+
+    assert infer_periods_per_year(zero_spacing) == 1
+    assert infer_periods_per_year(sparse) == 1
+    assert infer_periods_per_year(tiny_spacing) >= 1

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,14 @@
+## 2026-06-04T05:08Z - opener (codex): issue #5429 frequency inference helper
+
+- Repo: `stranske/Trend_Model_Project`
+- Issue: `#5429` (`T16 - Hoist duplicated _infer_periods_per_year and reconcile drift`)
+- Branch: `codex/issue-5429-frequency-inference`
+- Worktree: `~/.codex/automations/pd-workloop-resume/worktrees/trend-5429-frequency-inference`
+- Selection: raw opener cap was below 5 after required cap discovery and an infra repair dispatch for PR #5485. The oldest unlinked issue #5420 explicitly depends on T16, so #5429 was selected as the nearest bounded upstream implementation issue outside scoped blockers.
+- Implementation: added shared `trend_analysis.util.frequency.infer_periods_per_year`, imported it into `backtesting.harness` and `engine.walkforward` under their existing private `_infer_periods_per_year` names, and removed the two duplicated local implementations.
+- Validation: `PYTHONPATH=src python -m pytest tests/test_infer_periods_per_year.py tests/test_walkforward_engine.py tests/backtesting/test_harness.py -q` -> 45 passed. Deliberate-break gate changed the shared helper to return raw `approx`; `tests/test_infer_periods_per_year.py::test_infer_periods_per_year_combines_branch_guards` failed with sparse cadence returning `0` instead of `1`, then the floor was restored. Focused ruff passed; focused mypy passed; `git diff --check` passed.
+- Current state: ready to commit, push, and open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`.
+
 ## 2026-06-04T03:06Z - opener (codex): issue #5419 weighting config resolver
 
 - Repo: `stranske/Trend_Model_Project`

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -7,7 +7,8 @@
 - Selection: raw opener cap was below 5 after required cap discovery and an infra repair dispatch for PR #5485. The oldest unlinked issue #5420 explicitly depends on T16, so #5429 was selected as the nearest bounded upstream implementation issue outside scoped blockers.
 - Implementation: added shared `trend_analysis.util.frequency.infer_periods_per_year`, imported it into `backtesting.harness` and `engine.walkforward` under their existing private `_infer_periods_per_year` names, and removed the two duplicated local implementations.
 - Validation: `PYTHONPATH=src python -m pytest tests/test_infer_periods_per_year.py tests/test_walkforward_engine.py tests/backtesting/test_harness.py -q` -> 45 passed. Deliberate-break gate changed the shared helper to return raw `approx`; `tests/test_infer_periods_per_year.py::test_infer_periods_per_year_combines_branch_guards` failed with sparse cadence returning `0` instead of `1`, then the floor was restored. Focused ruff passed; focused mypy passed; `git diff --check` passed.
-- Current state: ready to commit, push, and open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`.
+- PR/routing: ready-for-review PR #5486 opened at https://github.com/stranske/Trend_Model_Project/pull/5486, non-draft, closing #5429, with `agent:codex`, `agents:keepalive`, and `autofix`. Post-open cap repair added `agent:retry` and dispatched Gate Followups after the initial workflow runs cancelled; cap-health then classified #5486 as `draining` with fresh active Gate evidence. The same repair pass removed stale `agent:needs-attention` from #5485 after keepalive completion evidence.
+- Current state: PR #5486 is open and waiting on asynchronous Gate/keepalive checks. Next action belongs to keepalive/closer after checks settle.
 
 ## 2026-06-04T03:06Z - opener (codex): issue #5419 weighting config resolver
 


### PR DESCRIPTION
Closes #5429

## Summary
- add shared `trend_analysis.util.frequency.infer_periods_per_year`
- route backtesting harness and engine walkforward through the shared helper
- add regression coverage proving both call sites share the helper and floor sparse/tiny cadence estimates

## Validation
- `PYTHONPATH=src python -m pytest tests/test_infer_periods_per_year.py tests/test_walkforward_engine.py tests/backtesting/test_harness.py -q`
- deliberate-break gate: returning raw `approx` failed `test_infer_periods_per_year_combines_branch_guards` (`0` instead of `1`), then restored
- `python -m ruff check src/trend_analysis/util/frequency.py src/trend_analysis/backtesting/harness.py src/trend_analysis/engine/walkforward.py tests/test_infer_periods_per_year.py`
- `python -m mypy src/trend_analysis/util/frequency.py src/trend_analysis/backtesting/harness.py src/trend_analysis/engine/walkforward.py tests/test_infer_periods_per_year.py`
- `git diff --check`