### PR TITLE
Issue #5422: extract multi-period run stages

### DIFF
--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -21,7 +21,7 @@ import inspect
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Mapping, Protocol, cast
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Protocol, cast
 
 import numpy as np
 import pandas as pd
@@ -91,7 +91,9 @@ def _run_analysis(*args: Any, **kwargs: Any) -> PipelineResult:
     return _invoke_analysis_with_diag(*args, **kwargs)
 
 
-def _call_pipeline_with_diag(*args: Any, **kwargs: Any) -> DiagnosticResult[dict[str, Any] | None]:
+def _call_pipeline_with_diag(
+    *args: Any, **kwargs: Any
+) -> DiagnosticResult[dict[str, Any] | None]:
     """Execute ``_run_analysis`` and normalise into a ``DiagnosticResult``.
 
     Tests and legacy callers monkeypatch ``_run_analysis`` to return raw dict
@@ -295,7 +297,9 @@ def _optional_cost_bps(value: Any, *, field: str) -> float | None:
     return parsed
 
 
-def _resolve_portfolio_cost_bps(portfolio_cfg: Mapping[str, Any]) -> tuple[float, float]:
+def _resolve_portfolio_cost_bps(
+    portfolio_cfg: Mapping[str, Any],
+) -> tuple[float, float]:
     """Resolve canonical turnover-cost inputs for the multi-period engine."""
 
     cost_model = portfolio_cfg.get("cost_model")
@@ -333,7 +337,10 @@ def _resolve_pipeline_monthly_cost(
 ) -> float:
     """Return decimal per-period cost for delegated non-threshold analysis."""
 
-    if any(key in portfolio_cfg for key in ("cost_model", "transaction_cost_bps", "slippage_bps")):
+    if any(
+        key in portfolio_cfg
+        for key in ("cost_model", "transaction_cost_bps", "slippage_bps")
+    ):
         return (tc_bps + slippage_bps) / 10000.0
     try:
         return float(run_cfg.get("monthly_cost", 0.0) or 0.0)
@@ -426,9 +433,13 @@ def _resolve_max_turnover_cap(
     regime_frequency: str,
     regime_ppy: float,
 ) -> float:
-    allowed_types = "numeric scalars: int/float/numpy numeric types, or a valid regime mapping"
+    allowed_types = (
+        "numeric scalars: int/float/numpy numeric types, or a valid regime mapping"
+    )
 
-    def _raise_invalid_max_turnover(value: Any, *, cause: Exception | None = None) -> None:
+    def _raise_invalid_max_turnover(
+        value: Any, *, cause: Exception | None = None
+    ) -> None:
         value_repr = repr(value)
         value_type = type(value).__name__
         message = f"max_turnover must be {allowed_types}; got {value_repr} (type {value_type})"
@@ -457,7 +468,9 @@ def _resolve_max_turnover_cap(
     )
     try:
         parsed = parse_regime_turnover_caps(max_turnover_cfg, regime_settings)
-        resolved = _resolve_turnover_cap_from_parsed(parsed, regime_label, regime_settings)
+        resolved = _resolve_turnover_cap_from_parsed(
+            parsed, regime_label, regime_settings
+        )
     except (CoreConfigError, KeyError) as exc:
         _raise_invalid_max_turnover(max_turnover_cfg, cause=exc)
     if resolved is None:
@@ -476,7 +489,9 @@ def _membership_table_from_frame(frame: pd.DataFrame) -> MembershipTable:
     eff_col = lookup.get("effective_date")
     end_col = lookup.get("end_date")
     if not fund_col or not eff_col or not end_col:
-        raise ValueError("membership data must include fund, effective_date, and end_date columns")
+        raise ValueError(
+            "membership data must include fund, effective_date, and end_date columns"
+        )
 
     normalised = frame.rename(
         columns={fund_col: "fund", eff_col: "effective_date", end_col: "end_date"}
@@ -535,9 +550,9 @@ def _compute_turnover_state(
     new_aligned: FloatArray = new_series.reindex(union_index, fill_value=0.0).to_numpy(
         dtype=float, copy=False
     )
-    prev_aligned: FloatArray = prev_series.reindex(union_index, fill_value=0.0).to_numpy(
-        dtype=float, copy=False
-    )
+    prev_aligned: FloatArray = prev_series.reindex(
+        union_index, fill_value=0.0
+    ).to_numpy(dtype=float, copy=False)
 
     turnover = float(np.abs(new_aligned - prev_aligned).sum())
     return turnover, nidx, nvals
@@ -621,9 +636,9 @@ def _apply_weight_bounds(
                 room = (max_w_bound - receivers).clip(lower=0.0)
                 rm = room.sum()
                 if rm > 0:
-                    floored.loc[receivers.index] = (receivers + (room / rm) * deficit).clip(
-                        upper=max_w_bound
-                    )
+                    floored.loc[receivers.index] = (
+                        receivers + (room / rm) * deficit
+                    ).clip(upper=max_w_bound)
 
     return floored
 
@@ -663,7 +678,12 @@ def _enforce_max_active_positions(
                 .index
             )
     else:
-        keep = active.abs().sort_values(ascending=False, kind="mergesort").head(max_active).index
+        keep = (
+            active.abs()
+            .sort_values(ascending=False, kind="mergesort")
+            .head(max_active)
+            .index
+        )
     trimmed = weights.copy()
     trimmed.loc[~trimmed.index.isin(keep)] = 0.0
 
@@ -694,6 +714,24 @@ def _apply_turnover_penalty(
 
     shrunk = last_aligned + (target_w - last_aligned) * (1.0 - lambda_tc)
     return _apply_weight_bounds(shrunk, min_w_bound, max_w_bound)
+
+
+def _zscore_or_zero(series: pd.Series) -> pd.Series:
+    series = series.astype(float)
+    sigma = float(series.std(ddof=0))
+    if sigma > 0:
+        return (series - float(series.mean())) / sigma
+    return pd.Series(0.0, index=series.index)
+
+
+def _cooldown_reseed_skip_event(manager: str, firm: str) -> dict[str, object]:
+    return {
+        "action": "skipped",
+        "manager": manager,
+        "firm": firm,
+        "reason": "cooldown",
+        "detail": "reseed blocked by cooldown",
+    }
 
 
 @dataclass
@@ -848,7 +886,11 @@ def run_schedule(
         turnover = float(np.abs(new_aligned - prev_aligned).sum())
         return turnover, nidx, nvals
 
-    col = rank_column or getattr(selector, "rank_column", None) or getattr(selector, "column", None)
+    col = (
+        rank_column
+        or getattr(selector, "rank_column", None)
+        or getattr(selector, "column", None)
+    )
 
     for date in sorted(score_frames):
         sf = score_frames[date]
@@ -882,7 +924,9 @@ def run_schedule(
 
         # Apply rebalancing strategies if configured
         if rebalance_strategies and rebalance_params:
-            current_weights = prev_weights if prev_weights is not None else pd.Series(dtype=float)
+            current_weights = (
+                prev_weights if prev_weights is not None else pd.Series(dtype=float)
+            )
             target_weight_series = target_weights["weight"].astype(float)
 
             # Get scores for priority-based strategies
@@ -907,7 +951,9 @@ def run_schedule(
             cost = 0.0
             weights = target_weights
             tw = target_weights["weight"].astype(float)
-            turnover, prev_tidx, prev_tvals = _compute_turnover_state(prev_tidx, prev_tvals, tw)
+            turnover, prev_tidx, prev_tvals = _compute_turnover_state(
+                prev_tidx, prev_tvals, tw
+            )
             prev_weights = tw
 
         pf.rebalance(date, weights, turnover, cost)
@@ -942,7 +988,9 @@ def run_schedule(
                     pv = prev.reindex(u, fill_value=0.0).to_numpy()
                     expected = float(np.abs(dv - pv).sum())
                 got = pf.turnover[d]
-                if not np.isclose(expected, got, rtol=0, atol=1e-12):  # pragma: no cover
+                if not np.isclose(
+                    expected, got, rtol=0, atol=1e-12
+                ):  # pragma: no cover
                     raise AssertionError(
                         f"Turnover mismatch for {d}: expected {expected} got {got}"
                     )
@@ -950,6 +998,330 @@ def run_schedule(
         except Exception:  # pragma: no cover - defensive
             pass
     return pf
+
+
+def _run_phase1_multi_periods(
+    cfg: Any,
+    df: pd.DataFrame,
+    *,
+    missing_policy_metadata: Mapping[str, Any],
+    missing_policy_diagnostic: Mapping[str, Any],
+    policy_spec: str | Mapping[str, str] | None,
+    missing_limit_cfg: int | None,
+    risk_free_column_cfg: str | None,
+    allow_risk_free_fallback_cfg: bool,
+    regime_cfg: Mapping[str, Any],
+    trend_spec: Any,
+    resolved_monthly_cost: float,
+) -> List[MultiPeriodPeriodResult]:
+    cfg_dump: dict[str, Any] = {}
+    try:
+        cfg_dump = cfg.model_dump()
+    except Exception:  # pragma: no cover - defensive
+        cfg_dump = {}
+
+    periods = generate_periods(cfg_dump)
+    if not periods:
+        logger.warning(
+            "generate_periods produced no periods; skipping multi-period run"
+        )
+        return []
+    out_results: List[MultiPeriodPeriodResult] = []
+    perf_flags = getattr(cfg, "performance", {}) or {}
+    enable_cache = bool(perf_flags.get("enable_cache", True))
+    incremental_cov = bool(perf_flags.get("incremental_cov", False))
+    prev_cov_payload = None
+    cov_cache_obj = None
+    if enable_cache:
+        try:  # lazy import to avoid hard dependency if module layout changes
+            from ..perf.cache import CovCache
+
+            cov_cache_obj = CovCache()
+        except Exception:  # pragma: no cover - defensive
+            cov_cache_obj = None
+    prev_in_df = None
+    prev_weights_for_pipeline = _coerce_previous_weights(
+        cfg.portfolio.get("previous_weights")
+    )
+
+    for pt in periods:
+        analysis_res = _call_pipeline_with_diag(
+            df,
+            pt.in_start[:7],
+            pt.in_end[:7],
+            pt.out_start[:7],
+            pt.out_end[:7],
+            _resolve_target_vol(getattr(cfg, "vol_adjust", {})),
+            resolved_monthly_cost,
+            floor_vol=cfg.vol_adjust.get("floor_vol"),
+            warmup_periods=int(cfg.vol_adjust.get("warmup_periods", 0) or 0),
+            selection_mode=cfg.portfolio.get("selection_mode", "all"),
+            random_n=cfg.portfolio.get("random_n", 8),
+            custom_weights=cfg.portfolio.get("custom_weights"),
+            rank_kwargs=cfg.portfolio.get("rank"),
+            manual_funds=cfg.portfolio.get("manual_list"),
+            indices_list=cfg.portfolio.get("indices_list"),
+            benchmarks=cfg.benchmarks,
+            seed=getattr(cfg, "seed", 42),
+            missing_policy=policy_spec,
+            missing_limit=missing_limit_cfg,
+            risk_window=cfg.vol_adjust.get("window"),
+            previous_weights=prev_weights_for_pipeline,
+            max_turnover=cfg.portfolio.get("max_turnover"),
+            constraints=cfg.portfolio.get("constraints"),
+            regime_cfg=regime_cfg,
+            risk_free_column=risk_free_column_cfg,
+            allow_risk_free_fallback=allow_risk_free_fallback_cfg,
+            signal_spec=trend_spec,
+        )
+        payload = analysis_res.value
+        diag = analysis_res.diagnostic
+        if payload is None:
+            if diag is not None:
+                logger.warning(
+                    "Multi-period analysis skipped period %s/%s (%s): %s",
+                    pt.in_start,
+                    pt.out_start,
+                    diag.reason_code,
+                    diag.message,
+                )
+            continue
+        res_dict = dict(payload)
+        res_dict.update(missing_policy_metadata)
+        res_dict["period"] = (
+            pt.in_start,
+            pt.in_end,
+            pt.out_start,
+            pt.out_end,
+        )
+        res_dict["missing_policy_diagnostic"] = dict(missing_policy_diagnostic)
+        risk_diag_payload = res_dict.get("risk_diagnostics")
+        if isinstance(risk_diag_payload, dict):
+            prev_weights_for_pipeline = _coerce_previous_weights(
+                risk_diag_payload.get("final_weights")
+            )
+        if prev_weights_for_pipeline is None:
+            fund_weights = res_dict.get("fund_weights")
+            if isinstance(fund_weights, Mapping):
+                prev_weights_for_pipeline = _coerce_previous_weights(fund_weights)
+
+        if enable_cache:
+            from ..perf.cache import compute_cov_payload, incremental_cov_update
+
+            in_start = pt.in_start[:7]
+            in_end = pt.in_end[:7]
+            sub = df.copy()
+            sub["Date"] = pd.to_datetime(sub["Date"], utc=True).dt.tz_localize(None)
+            sub.sort_values("Date", inplace=True)
+            sdate = pd.to_datetime(f"{in_start}-01", utc=True).tz_localize(
+                None
+            ) + pd.offsets.MonthEnd(0)
+            edate = pd.to_datetime(f"{in_end}-01", utc=True).tz_localize(
+                None
+            ) + pd.offsets.MonthEnd(0)
+            in_df_full = sub[(sub["Date"] >= sdate) & (sub["Date"] <= edate)].set_index(
+                "Date"
+            )
+            fund_cols = [
+                c
+                for c in in_df_full.columns
+                if c not in (cfg.benchmarks or {}).values()
+            ]
+            in_df_full = in_df_full[fund_cols]
+            in_df_prepared = _prepare_returns_frame(in_df_full)
+
+            if (
+                incremental_cov
+                and prev_cov_payload is not None
+                and prev_in_df is not None
+            ):
+                same_len = prev_in_df.shape[0] == in_df_prepared.shape[0]
+                same_cols = (
+                    prev_in_df.columns.tolist() == in_df_prepared.columns.tolist()
+                )
+                n_rows = in_df_prepared.shape[0]
+                if same_cols and n_rows >= 3:
+                    k = None
+                    if same_len:
+                        raw_max_steps = perf_flags.get(
+                            "shift_detection_max_steps",
+                            SHIFT_DETECTION_MAX_STEPS_DEFAULT,
+                        )
+                        try:
+                            max_shift_steps = int(raw_max_steps)
+                        except (TypeError, ValueError):
+                            max_shift_steps = SHIFT_DETECTION_MAX_STEPS_DEFAULT
+                        max_shift_steps = max(1, max_shift_steps)
+                        for step in range(1, min(max_shift_steps, n_rows - 1)):
+                            prev_block = prev_in_df.iloc[step:].to_numpy()
+                            new_block = in_df_prepared.iloc[:-step].to_numpy()
+                            if np.allclose(
+                                prev_block,
+                                new_block,
+                                rtol=0,
+                                atol=1e-12,
+                            ) or np.array_equal(prev_block, new_block):
+                                k = step
+                                break
+                    if k is None:
+                        prev_cov_payload = compute_cov_payload(
+                            in_df_prepared, materialise_aggregates=incremental_cov
+                        )
+                    else:
+                        try:
+                            for step in range(k):
+                                old_row = prev_in_df.iloc[step].to_numpy(dtype=float)
+                                new_row = in_df_prepared.iloc[
+                                    n_rows - k + step
+                                ].to_numpy(dtype=float)
+                                prev_cov_payload = incremental_cov_update(
+                                    prev_cov_payload, old_row, new_row
+                                )
+                                if cov_cache_obj is not None:
+                                    cov_cache_obj.incremental_updates += 1
+                        except Exception:  # pragma: no cover - fallback safety
+                            prev_cov_payload = compute_cov_payload(
+                                in_df_prepared,
+                                materialise_aggregates=incremental_cov,
+                            )
+                else:
+                    prev_cov_payload = compute_cov_payload(
+                        in_df_prepared, materialise_aggregates=incremental_cov
+                    )
+            else:
+                from ..perf.cache import compute_cov_payload as _ccp
+
+                prev_cov_payload = _ccp(
+                    in_df_prepared, materialise_aggregates=incremental_cov
+                )
+            prev_in_df = in_df_prepared
+            res_dict["cov_diag"] = prev_cov_payload.cov.diagonal().tolist()
+            if cov_cache_obj is not None:
+                res_dict.setdefault("cache_stats", cov_cache_obj.stats())
+        out_results.append(res_dict)
+    return out_results
+
+
+def _build_rebalance_frame(
+    cfg: Any,
+    *,
+    out_df: pd.DataFrame,
+    df_indexed: pd.DataFrame,
+    realised_holdings: list[str],
+    effective_w: pd.Series,
+    rf_override: float | pd.Series | None,
+    periods_per_year: int,
+    metric: str,
+    weighting: BaseWeighting,
+    min_w_bound: float,
+    max_w_bound: float,
+    max_active_positions: int | None,
+    min_tenure_guard: set[str],
+    score_frame_fn: Callable[..., pd.DataFrame],
+    ensure_zscore_fn: Callable[[pd.DataFrame, str], pd.DataFrame],
+    apply_policy_to_weights_fn: Callable[[pd.DataFrame, pd.Series | None], pd.Series],
+) -> pd.DataFrame | None:
+    try:
+        rebalance_freq = str(cfg.portfolio.get("rebalance_freq", "") or "").strip()
+    except Exception:  # pragma: no cover - defensive
+        rebalance_freq = ""
+    if not rebalance_freq or out_df.empty:
+        return None
+
+    try:
+        schedule = get_rebalance_dates(out_df.index, rebalance_freq)
+        if len(out_df.index) and (out_df.index[0] not in schedule):
+            schedule = schedule.insert(0, out_df.index[0])
+        if schedule.empty:
+            return None
+
+        in_len_years = int(
+            (getattr(cfg, "multi_period", {}) or {}).get("in_sample_len", 3) or 3
+        )
+        in_months = max(1, in_len_years * 12)
+
+        try:
+            from ..plugins import create_weight_engine
+
+            weighting_scheme = str(
+                cfg.portfolio.get("weighting_scheme", "equal") or "equal"
+            ).lower()
+            risk_engine = create_weight_engine(weighting_scheme)
+            use_risk_engine = weighting_scheme not in {"equal", "ew"}
+        except Exception:  # pragma: no cover - best-effort only
+            risk_engine = None
+            use_risk_engine = False
+
+        rebalance_rows: list[dict[str, float]] = []
+        prev_reb_w = effective_w.copy()
+        for reb_date in pd.DatetimeIndex(schedule):
+            end_dt = pd.Timestamp(reb_date)
+            start_dt = (
+                end_dt - pd.DateOffset(months=in_months - 1)
+            ) + pd.offsets.MonthEnd(0)
+
+            window = df_indexed.reindex(columns=realised_holdings).loc[
+                (df_indexed.index >= start_dt) & (df_indexed.index <= end_dt)
+            ]
+            if window.empty:
+                w_row = prev_reb_w
+            else:
+                try:
+                    if use_risk_engine and risk_engine is not None:
+                        prepared = _prepare_returns_frame(window)
+                        cov = prepared.cov()
+                        w_series = risk_engine.weight(cov)
+                    else:
+                        rf_aligned = rf_override
+                        if isinstance(rf_override, pd.Series) and not window.empty:
+                            rf_aligned = rf_override.reindex(window.index)
+                        sf_roll = score_frame_fn(
+                            window,
+                            realised_holdings,
+                            risk_free_override=rf_aligned,
+                            periods_per_year=int(periods_per_year),
+                        )
+                        sf_roll = ensure_zscore_fn(sf_roll, metric)
+                        weights_df_roll = weighting.weight(
+                            sf_roll.loc[realised_holdings], end_dt
+                        )
+                        signal_slice = (
+                            sf_roll.loc[realised_holdings, metric]
+                            if metric in sf_roll.columns
+                            else None
+                        )
+                        w_series = apply_policy_to_weights_fn(
+                            weights_df_roll, signal_slice
+                        )
+                    bounded = _apply_weight_bounds(
+                        w_series.reindex(realised_holdings).fillna(0.0),
+                        min_w_bound,
+                        max_w_bound,
+                    )
+                    bounded = _enforce_max_active_positions(
+                        bounded,
+                        max_active_positions,
+                        protected=min_tenure_guard,
+                    )
+                    bounded = bounded[bounded.abs() > 1e-12]
+                    total = float(bounded.sum())
+                    if total > 1e-12 and abs(total - 1.0) <= 1e-8:
+                        bounded = bounded / total
+                    w_row = bounded
+                    prev_reb_w = w_row
+                except Exception:  # pragma: no cover - best-effort only
+                    w_row = prev_reb_w
+
+            rebalance_rows.append({str(k): float(v) for k, v in w_row.items()})
+
+        rebalance_frame = pd.DataFrame(
+            rebalance_rows,
+            index=pd.DatetimeIndex(schedule),
+        )
+        rebalance_frame.index.name = "rebalance_date"
+        return rebalance_frame
+    except Exception:  # pragma: no cover - best-effort only
+        return None
 
 
 def run(
@@ -992,9 +1364,13 @@ def run(
             raise TypeError("price_frames must be a dict[str, pd.DataFrame] or None")
         for date_key, frame in price_frames.items():
             if not isinstance(frame, pd.DataFrame):
-                raise TypeError(f"price_frames['{date_key}'] must be a pandas DataFrame")
+                raise TypeError(
+                    f"price_frames['{date_key}'] must be a pandas DataFrame"
+                )
             required_columns = ["Date"]
-            missing_columns = [col for col in required_columns if col not in frame.columns]
+            missing_columns = [
+                col for col in required_columns if col not in frame.columns
+            ]
             if missing_columns:
                 raise ValueError(
                     (
@@ -1011,7 +1387,9 @@ def run(
         # columns are included, handling missing data gracefully.
         combined_frames = [frame.copy() for frame in price_frames.values()]
         if combined_frames:
-            df = pd.concat(combined_frames, axis=0, join="outer", ignore_index=True, sort=True)
+            df = pd.concat(
+                combined_frames, axis=0, join="outer", ignore_index=True, sort=True
+            )
             # Sort by Date to ensure proper ordering
             df = df.sort_values("Date").reset_index(drop=True)
             # Remove any duplicates created during concatenation
@@ -1201,7 +1579,8 @@ def run(
         # Persist for debugging/export consumers.
         cleaned.attrs = dict(cleaned.attrs)
         cleaned.attrs["inception_dates"] = {
-            k: (v.strftime("%Y-%m-%d") if v is not None else None) for k, v in inception_raw.items()
+            k: (v.strftime("%Y-%m-%d") if v is not None else None)
+            for k, v in inception_raw.items()
         }
     except Exception:  # pragma: no cover - defensive
         pass
@@ -1265,191 +1644,19 @@ def run(
     )
 
     if str(cfg.portfolio.get("policy", "").lower()) != "threshold_hold":
-        cfg_dump: dict[str, Any] = {}
-        try:
-            cfg_dump = cfg.model_dump()
-        except Exception:  # pragma: no cover - defensive
-            cfg_dump = {}
-
-        periods = generate_periods(cfg_dump)
-        if not periods:
-            logger.warning("generate_periods produced no periods; skipping multi-period run")
-            return []
-        out_results: List[MultiPeriodPeriodResult] = []
-        # Performance flags
-        perf_flags = getattr(cfg, "performance", {}) or {}
-        enable_cache = bool(perf_flags.get("enable_cache", True))
-        incremental_cov = bool(perf_flags.get("incremental_cov", False))
-        prev_cov_payload = None  # rolling covariance state
-        cov_cache_obj = None
-        if enable_cache:
-            try:  # lazy import to avoid hard dependency if module layout changes
-                from ..perf.cache import CovCache
-
-                cov_cache_obj = CovCache()
-            except Exception:  # pragma: no cover - defensive
-                cov_cache_obj = None
-        prev_in_df = None
-        prev_weights_for_pipeline = _coerce_previous_weights(cfg.portfolio.get("previous_weights"))
-
-        for pt in periods:
-            analysis_res = _call_pipeline_with_diag(
-                df,
-                pt.in_start[:7],
-                pt.in_end[:7],
-                pt.out_start[:7],
-                pt.out_end[:7],
-                _resolve_target_vol(getattr(cfg, "vol_adjust", {})),
-                resolved_monthly_cost,
-                floor_vol=cfg.vol_adjust.get("floor_vol"),
-                warmup_periods=int(cfg.vol_adjust.get("warmup_periods", 0) or 0),
-                selection_mode=cfg.portfolio.get("selection_mode", "all"),
-                random_n=cfg.portfolio.get("random_n", 8),
-                custom_weights=cfg.portfolio.get("custom_weights"),
-                rank_kwargs=cfg.portfolio.get("rank"),
-                manual_funds=cfg.portfolio.get("manual_list"),
-                indices_list=cfg.portfolio.get("indices_list"),
-                benchmarks=cfg.benchmarks,
-                seed=getattr(cfg, "seed", 42),
-                missing_policy=policy_spec,
-                missing_limit=missing_limit_cfg,
-                risk_window=cfg.vol_adjust.get("window"),
-                previous_weights=prev_weights_for_pipeline,
-                max_turnover=cfg.portfolio.get("max_turnover"),
-                constraints=cfg.portfolio.get("constraints"),
-                regime_cfg=regime_cfg,
-                risk_free_column=risk_free_column_cfg,
-                allow_risk_free_fallback=allow_risk_free_fallback_cfg,
-                signal_spec=trend_spec,
-            )
-            payload = analysis_res.value
-            diag = analysis_res.diagnostic
-            if payload is None:
-                if diag is not None:
-                    logger.warning(
-                        "Multi-period analysis skipped period %s/%s (%s): %s",
-                        pt.in_start,
-                        pt.out_start,
-                        diag.reason_code,
-                        diag.message,
-                    )
-                continue
-            res_dict = dict(payload)
-            res_dict.update(missing_policy_metadata)
-            res_dict["period"] = (
-                pt.in_start,
-                pt.in_end,
-                pt.out_start,
-                pt.out_end,
-            )
-            res_dict["missing_policy_diagnostic"] = dict(missing_policy_diagnostic)
-            risk_diag_payload = res_dict.get("risk_diagnostics")
-            if isinstance(risk_diag_payload, dict):
-                prev_weights_for_pipeline = _coerce_previous_weights(
-                    risk_diag_payload.get("final_weights")
-                )
-            if prev_weights_for_pipeline is None:
-                fund_weights = res_dict.get("fund_weights")
-                if isinstance(fund_weights, Mapping):
-                    prev_weights_for_pipeline = _coerce_previous_weights(fund_weights)
-
-            # (Experimental) attach covariance diag using cache/incremental path for diagnostics.
-            # Keeps existing outputs stable; adds optional "cov_diag" key.
-            if enable_cache:
-                from ..perf.cache import compute_cov_payload, incremental_cov_update
-
-                in_start = pt.in_start[:7]
-                in_end = pt.in_end[:7]
-                # Recreate in-sample frame identical to _run_analysis slice
-                date_col = "Date"
-                sub = df.copy()
-                sub[date_col] = pd.to_datetime(sub[date_col], utc=True).dt.tz_localize(None)
-                sub.sort_values(date_col, inplace=True)
-                sdate = pd.to_datetime(f"{in_start}-01", utc=True).tz_localize(
-                    None
-                ) + pd.offsets.MonthEnd(0)
-                edate = pd.to_datetime(f"{in_end}-01", utc=True).tz_localize(
-                    None
-                ) + pd.offsets.MonthEnd(0)
-                in_df_full = sub[(sub[date_col] >= sdate) & (sub[date_col] <= edate)].set_index(
-                    date_col
-                )
-                # Remove benchmark columns if present in result universe
-                fund_cols = [
-                    c for c in in_df_full.columns if c not in (cfg.benchmarks or {}).values()
-                ]
-                in_df_full = in_df_full[fund_cols]
-                in_df_prepared = _prepare_returns_frame(in_df_full)
-
-                if incremental_cov and prev_cov_payload is not None and prev_in_df is not None:
-                    same_len = prev_in_df.shape[0] == in_df_prepared.shape[0]
-                    same_cols = prev_in_df.columns.tolist() == in_df_prepared.columns.tolist()
-                    n_rows = in_df_prepared.shape[0]
-                    if same_cols and n_rows >= 3:
-                        # Determine shift distance k (number of rows replaced at head and appended at tail)
-                        k = None
-                        if same_len:
-                            # Compare trailing blocks to find minimal k
-                            raw_max_steps = perf_flags.get(
-                                "shift_detection_max_steps",
-                                SHIFT_DETECTION_MAX_STEPS_DEFAULT,
-                            )
-                            try:
-                                max_shift_steps = int(raw_max_steps)
-                            except (TypeError, ValueError):
-                                max_shift_steps = SHIFT_DETECTION_MAX_STEPS_DEFAULT
-                            max_shift_steps = max(1, max_shift_steps)
-                            for step in range(
-                                1, min(max_shift_steps, n_rows - 1)
-                            ):  # cap search for safety
-                                prev_block = prev_in_df.iloc[step:].to_numpy()
-                                new_block = in_df_prepared.iloc[:-step].to_numpy()
-                                if np.allclose(
-                                    prev_block,
-                                    new_block,
-                                    rtol=0,
-                                    atol=1e-12,
-                                ) or np.array_equal(prev_block, new_block):
-                                    k = step
-                                    break
-                        if k is None:
-                            # Fallback full recompute
-                            prev_cov_payload = compute_cov_payload(
-                                in_df_prepared, materialise_aggregates=incremental_cov
-                            )
-                        else:
-                            # Apply k incremental updates sequentially
-                            try:
-                                for step in range(k):
-                                    old_row = prev_in_df.iloc[step].to_numpy(dtype=float)
-                                    new_row = in_df_prepared.iloc[n_rows - k + step].to_numpy(
-                                        dtype=float
-                                    )
-                                    prev_cov_payload = incremental_cov_update(
-                                        prev_cov_payload, old_row, new_row
-                                    )
-                                    if cov_cache_obj is not None:
-                                        cov_cache_obj.incremental_updates += 1
-                            except Exception:  # pragma: no cover - fallback safety
-                                prev_cov_payload = compute_cov_payload(
-                                    in_df_prepared,
-                                    materialise_aggregates=incremental_cov,
-                                )
-                    else:
-                        prev_cov_payload = compute_cov_payload(
-                            in_df_prepared, materialise_aggregates=incremental_cov
-                        )
-                else:
-                    from ..perf.cache import compute_cov_payload as _ccp
-
-                    prev_cov_payload = _ccp(in_df_prepared, materialise_aggregates=incremental_cov)
-                prev_in_df = in_df_prepared
-                res_dict["cov_diag"] = prev_cov_payload.cov.diagonal().tolist()
-                if cov_cache_obj is not None:
-                    # attach cache stats for observability (does not alter existing keys)
-                    res_dict.setdefault("cache_stats", cov_cache_obj.stats())
-            out_results.append(res_dict)
-        return out_results
+        return _run_phase1_multi_periods(
+            cfg,
+            df,
+            missing_policy_metadata=missing_policy_metadata,
+            missing_policy_diagnostic=missing_policy_diagnostic,
+            policy_spec=policy_spec,
+            missing_limit_cfg=missing_limit_cfg,
+            risk_free_column_cfg=risk_free_column_cfg,
+            allow_risk_free_fallback_cfg=allow_risk_free_fallback_cfg,
+            regime_cfg=regime_cfg,
+            trend_spec=trend_spec,
+            resolved_monthly_cost=resolved_monthly_cost,
+        )
 
     # Threshold-hold path with Bayesian weighting
     periods = generate_periods(cfg.model_dump())
@@ -1515,12 +1722,14 @@ def run(
                 continue
             seen.add(resolved)
             benchmark_cols.append(resolved)
-    resolved_rf_col, _resolver_fund_cols, resolved_rf_source = _resolve_risk_free_column(
-        df,
-        date_col="Date",
-        indices_list=indices_list,
-        risk_free_column=risk_free_column_cfg,
-        allow_risk_free_fallback=allow_risk_free_fallback_cfg,
+    resolved_rf_col, _resolver_fund_cols, resolved_rf_source = (
+        _resolve_risk_free_column(
+            df,
+            date_col="Date",
+            indices_list=indices_list,
+            risk_free_column=risk_free_column_cfg,
+            allow_risk_free_fallback=allow_risk_free_fallback_cfg,
+        )
     )
 
     # Build a stable investable universe list.
@@ -1533,7 +1742,9 @@ def run(
     idx_set |= {str(c) for c in benchmark_cols}
     resolved_fund_candidates = [c for c in numeric_cols_all if c not in idx_set]
     if resolved_rf_source == "configured" and resolved_rf_col:
-        resolved_fund_candidates = [c for c in resolved_fund_candidates if c != resolved_rf_col]
+        resolved_fund_candidates = [
+            c for c in resolved_fund_candidates if c != resolved_rf_col
+        ]
     elif resolved_rf_source == "fallback" and resolved_rf_col:
         # Fallback RF selection can legitimately pick a true cash proxy (flat
         # zero-return series). Treat such near-constant columns as non-investable
@@ -1550,7 +1761,9 @@ def run(
 
     # --- helpers --------------------------------------------------------
     def _parse_month(s: str) -> pd.Timestamp:
-        return pd.to_datetime(f"{s}-01", utc=True).tz_localize(None) + pd.offsets.MonthEnd(0)
+        return pd.to_datetime(f"{s}-01", utc=True).tz_localize(
+            None
+        ) + pd.offsets.MonthEnd(0)
 
     regime_settings = normalise_settings(regime_cfg)
     regime_frequency = str(data_settings.get("frequency") or "M")
@@ -1572,16 +1785,22 @@ def run(
         sub.sort_values(date_col, inplace=True)
         in_sdate, in_edate = _parse_month(in_start), _parse_month(in_end)
         out_sdate, out_edate = _parse_month(out_start), _parse_month(out_end)
-        in_df = sub[(sub[date_col] >= in_sdate) & (sub[date_col] <= in_edate)].set_index(date_col)
-        out_df = sub[(sub[date_col] >= out_sdate) & (sub[date_col] <= out_edate)].set_index(
-            date_col
-        )
+        in_df = sub[
+            (sub[date_col] >= in_sdate) & (sub[date_col] <= in_edate)
+        ].set_index(date_col)
+        out_df = sub[
+            (sub[date_col] >= out_sdate) & (sub[date_col] <= out_edate)
+        ].set_index(date_col)
         if in_df.empty or out_df.empty:
             return in_df, out_df, [], ""
         numeric_cols = [c for c in sub.select_dtypes("number").columns if c != date_col]
         idx_set = {str(c) for c in indices_list}
         idx_set |= {str(c) for c in benchmark_cols}
-        fund_cols = [c for c in resolved_fund_candidates if c in numeric_cols and c not in idx_set]
+        fund_cols = [
+            c
+            for c in resolved_fund_candidates
+            if c in numeric_cols and c not in idx_set
+        ]
 
         if not fund_cols:
             return in_df, out_df, [], resolved_rf_col
@@ -1600,7 +1819,9 @@ def run(
         if require_out_sample:
             out_ok = ~out_df[fund_cols].isna().any()
             fund_cols = [
-                c for c in fund_cols if bool(in_ok.get(c, False)) and bool(out_ok.get(c, False))
+                c
+                for c in fund_cols
+                if bool(in_ok.get(c, False)) and bool(out_ok.get(c, False))
             ]
         else:
             # For scoring purposes (e.g., hiring candidates), only require
@@ -1731,11 +1952,15 @@ def run(
     z_exit_hard = _parse_optional_float(th_cfg.get("z_exit_hard"))
 
     target_n = int(
-        th_cfg.get("target_n", portfolio_cfg.get("target_n", cfg.portfolio.get("random_n", 8)))
+        th_cfg.get(
+            "target_n", portfolio_cfg.get("target_n", cfg.portfolio.get("random_n", 8))
+        )
     )
     seed_metric = cast(
         str,
-        (cfg.portfolio.get("selector", {}) or {}).get("params", {}).get("rank_column", "Sharpe"),
+        (cfg.portfolio.get("selector", {}) or {})
+        .get("params", {})
+        .get("rank_column", "Sharpe"),
     )
     selector = create_selector_by_name("rank", top_n=target_n, rank_column=seed_metric)
 
@@ -1780,7 +2005,9 @@ def run(
     if cooldown_periods_raw is None:
         cooldown_periods_raw = mp_cfg.get("cooldown_months")
     try:
-        cooldown_periods = int(cooldown_periods_raw) if cooldown_periods_raw is not None else 0
+        cooldown_periods = (
+            int(cooldown_periods_raw) if cooldown_periods_raw is not None else 0
+        )
     except (TypeError, ValueError):
         cooldown_periods = 0
     cooldown_periods = max(0, cooldown_periods)
@@ -1808,7 +2035,9 @@ def run(
     if raw_max_active is None:
         raw_max_active = constraints.get("max_active")
     try:
-        max_active_positions = int(raw_max_active) if raw_max_active is not None else None
+        max_active_positions = (
+            int(raw_max_active) if raw_max_active is not None else None
+        )
     except (TypeError, ValueError):
         max_active_positions = None
     if max_active_positions is not None and max_active_positions <= 0:
@@ -1864,7 +2093,9 @@ def run(
     # --- main loop ------------------------------------------------------
     # Pre-index returns once for intra-period rebalance snapshots.
     df_indexed = df.copy()
-    df_indexed["Date"] = pd.to_datetime(df_indexed["Date"], utc=True).dt.tz_localize(None)
+    df_indexed["Date"] = pd.to_datetime(df_indexed["Date"], utc=True).dt.tz_localize(
+        None
+    )
     df_indexed.sort_values("Date", inplace=True)
     df_indexed = df_indexed.set_index("Date")
 
@@ -1900,7 +2131,9 @@ def run(
             return True
         return int(add_streaks.get(manager, 0)) >= sticky_add_periods
 
-    def _min_tenure_protected(holdings: Iterable[str], score_frame: pd.DataFrame) -> set[str]:
+    def _min_tenure_protected(
+        holdings: Iterable[str], score_frame: pd.DataFrame
+    ) -> set[str]:
         if min_tenure_n <= 0:
             return set()
         protected: set[str] = set()
@@ -1969,7 +2202,9 @@ def run(
                 int(cooldown_periods) + 1,
             )
 
-    def _dedupe_one_per_firm(sf: pd.DataFrame, holdings: list[str], metric: str) -> list[str]:
+    def _dedupe_one_per_firm(
+        sf: pd.DataFrame, holdings: list[str], metric: str
+    ) -> list[str]:
         if not holdings:
             return holdings
         col = metric if metric in sf.columns else "Sharpe"
@@ -2105,7 +2340,9 @@ def run(
         keep = ordered[:-bottom_k]
         return filtered.loc[keep]
 
-    def _filter_entry_candidates(candidates: list[str], score_frame: pd.DataFrame) -> list[str]:
+    def _filter_entry_candidates(
+        candidates: list[str], score_frame: pd.DataFrame
+    ) -> list[str]:
         if not candidates:
             return candidates
         eligible_frame = _filter_entry_frame(score_frame)
@@ -2114,7 +2351,9 @@ def run(
         eligible = {str(ix) for ix in eligible_frame.index}
         return [str(ix) for ix in candidates if str(ix) in eligible]
 
-    def _hard_exit_forced(holdings: Iterable[str], score_frame: pd.DataFrame) -> set[str]:
+    def _hard_exit_forced(
+        holdings: Iterable[str], score_frame: pd.DataFrame
+    ) -> set[str]:
         if z_exit_hard is None or "zscore" not in score_frame.columns:
             return set()
         z = pd.to_numeric(score_frame["zscore"], errors="coerce")
@@ -2251,7 +2490,9 @@ def run(
             # Risk-based weighting requires returns data
             try:
                 if returns_window is not None and not returns_window.empty:
-                    subset = returns_window.reindex(columns=holdings).dropna(axis=1, how="all")
+                    subset = returns_window.reindex(columns=holdings).dropna(
+                        axis=1, how="all"
+                    )
                 else:
                     # Fall back to score frame data if no returns window provided
                     subset = sf.loc[holdings]
@@ -2354,7 +2595,9 @@ def run(
         rf_rate_annual = float(metrics_cfg.get("rf_rate_annual", 0.0) or 0.0)
         # Convert annualised RF to a per-period return.
         # Use geometric conversion so 2% annual becomes ~0.165% monthly.
-        rf_rate_periodic = (1.0 + rf_rate_annual) ** (1.0 / float(periods_per_year)) - 1.0
+        rf_rate_periodic = (1.0 + rf_rate_annual) ** (
+            1.0 / float(periods_per_year)
+        ) - 1.0
 
         # UI semantics:
         # - override disabled: use the selected risk-free column series (if available)
@@ -2423,12 +2666,16 @@ def run(
                     holdings = []
                 else:
                     # Seed varies per period to get different selections
-                    period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(hash(str(pt)) % 10000)
+                    period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(
+                        hash(str(pt)) % 10000
+                    )
                     rng = np.random.default_rng(period_seed)
                     n_select = max(1, min(target_n, len(available)))
                     holdings = list(rng.choice(available, size=n_select, replace=False))
                     # Enforce one-per-firm constraint
-                    holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
+                    holdings = _dedupe_one_per_firm_with_events(
+                        sf, holdings, metric, events
+                    )
                     # If dedupe reduced us, refill with random selection
                     if len(holdings) < n_select:
                         candidates = [c for c in available if c not in holdings]
@@ -2453,11 +2700,15 @@ def run(
                     holdings = []
                 elif buy_hold_initial == "random":
                     # Random initial selection
-                    period_seed = abs((getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000)
+                    period_seed = abs(
+                        (getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000
+                    )
                     rng = np.random.default_rng(period_seed)
                     n_select = max(1, min(buy_hold_n, len(available)))
                     holdings = list(rng.choice(available, size=n_select, replace=False))
-                    holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
+                    holdings = _dedupe_one_per_firm_with_events(
+                        sf, holdings, metric, events
+                    )
                     # Refill if dedupe reduced holdings
                     if len(holdings) < n_select:
                         candidates = [c for c in available if c not in holdings]
@@ -2480,7 +2731,9 @@ def run(
                     if rank_score_by == "blended" and rank_blended_weights:
                         total_w = sum(rank_blended_weights.values())
                         if total_w > 0:
-                            norm_w = {k: v / total_w for k, v in rank_blended_weights.items()}
+                            norm_w = {
+                                k: v / total_w for k, v in rank_blended_weights.items()
+                            }
                         else:
                             norm_w = {"Sharpe": 1.0}
                         combo = pd.Series(0.0, index=eligible_sf.index, dtype=float)
@@ -2500,7 +2753,9 @@ def run(
                         scores = combo
                     else:
                         score_col = (
-                            rank_score_by if rank_score_by in eligible_sf.columns else "Sharpe"
+                            rank_score_by
+                            if rank_score_by in eligible_sf.columns
+                            else "Sharpe"
                         )
                         scores = eligible_sf[score_col].astype(float)
 
@@ -2513,7 +2768,10 @@ def run(
                             scores = pd.Series(0.0, index=scores.index)
 
                     ascending = False
-                    if rank_score_by in ASCENDING_METRICS and buy_hold_initial != "threshold":
+                    if (
+                        rank_score_by in ASCENDING_METRICS
+                        and buy_hold_initial != "threshold"
+                    ):
                         ascending = True
 
                     sorted_scores = scores.sort_values(ascending=ascending)
@@ -2538,7 +2796,9 @@ def run(
                         holdings = all_candidates[:buy_hold_n]
 
                     # Enforce one-per-firm constraint
-                    holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
+                    holdings = _dedupe_one_per_firm_with_events(
+                        sf, holdings, metric, events
+                    )
                     # Historical weighting call
                     if holdings:
                         try:
@@ -2569,7 +2829,9 @@ def run(
                         and rank_col in selected.columns
                     ):
                         ascending = rank_col in ASCENDING_METRICS
-                        ordered = selected.sort_values(rank_col, ascending=ascending).index
+                        ordered = selected.sort_values(
+                            rank_col, ascending=ascending
+                        ).index
                         holdings = [str(x) for x in ordered.tolist()]
                     else:
                         holdings = [str(x) for x in selected.index.tolist()]
@@ -2590,31 +2852,26 @@ def run(
                             # Normalize weights
                             total_w = sum(rank_blended_weights.values())
                             if total_w > 0:
-                                norm_w = {k: v / total_w for k, v in rank_blended_weights.items()}
+                                norm_w = {
+                                    k: v / total_w
+                                    for k, v in rank_blended_weights.items()
+                                }
                             else:
                                 norm_w = {"Sharpe": 1.0}
                             # Compute blended score from the score frame
                             combo = pd.Series(0.0, index=score_frame.index, dtype=float)
                             for m, w in norm_w.items():
                                 if m in score_frame.columns:
-                                    col_series = score_frame[m].astype(float)
-                                    # Z-score normalize
-                                    mu = float(col_series.mean())
-                                    sigma = float(col_series.std(ddof=0))
-                                    z = (
-                                        (col_series - mu) / sigma
-                                        if sigma > 0
-                                        else pd.Series(0.0, index=col_series.index)
-                                    )
+                                    z = _zscore_or_zero(score_frame[m])
                                     # Invert for ascending metrics (smaller is better)
-                                    if m in ASCENDING_METRICS:
-                                        z = -z
-                                    combo += w * z
+                                    combo += w * (-z if m in ASCENDING_METRICS else z)
                             scores = combo
                         else:
                             # Single metric
                             score_col = (
-                                rank_score_by if rank_score_by in score_frame.columns else "Sharpe"
+                                rank_score_by
+                                if rank_score_by in score_frame.columns
+                                else "Sharpe"
                             )
                             scores = score_frame[score_col].astype(float)
 
@@ -2628,7 +2885,10 @@ def run(
 
                         # Determine sort order
                         ascending = False  # Higher score is better for blended/zscore
-                        if rank_score_by in ASCENDING_METRICS and rank_transform != "zscore":
+                        if (
+                            rank_score_by in ASCENDING_METRICS
+                            and rank_transform != "zscore"
+                        ):
                             ascending = True
 
                         # Sort scores
@@ -2684,11 +2944,15 @@ def run(
                 if len(holdings) > target_n:
                     holdings = holdings[:target_n]
                 # Enforce one-per-firm on seed
-                holdings = _dedupe_one_per_firm_with_events(sf, holdings, metric, events)
+                holdings = _dedupe_one_per_firm_with_events(
+                    sf, holdings, metric, events
+                )
                 desired_seed = min(max_funds, target_n)
                 # If we're still above the desired size, trim by zscore (best-first).
                 if len(holdings) > desired_seed:
-                    zsorted = sf.loc[holdings].sort_values("zscore", ascending=False).index
+                    zsorted = (
+                        sf.loc[holdings].sort_values("zscore", ascending=False).index
+                    )
                     holdings = list(zsorted[:desired_seed])
 
                 # If dedupe reduced us below the target size, fill from the remaining
@@ -2698,8 +2962,12 @@ def run(
                 # that percentage of the universe.
                 if len(holdings) < desired_seed and inclusion_approach != "top_pct":
                     candidates = [c for c in sf.index if c not in holdings]
-                    candidates = _filter_entry_candidates([str(c) for c in candidates], sf)
-                    add_from = sf.loc[candidates].sort_values("zscore", ascending=False).index
+                    candidates = _filter_entry_candidates(
+                        [str(c) for c in candidates], sf
+                    )
+                    add_from = (
+                        sf.loc[candidates].sort_values("zscore", ascending=False).index
+                    )
                     seen_firms = {_firm(h) for h in holdings}
                     for f in add_from:
                         if len(holdings) >= desired_seed:
@@ -2719,7 +2987,9 @@ def run(
                     and resolved_rf_col in holdings
                 ):
                     candidates = [c for c in sf.index if c not in holdings]
-                    candidates = _filter_entry_candidates([str(c) for c in candidates], sf)
+                    candidates = _filter_entry_candidates(
+                        [str(c) for c in candidates], sf
+                    )
                     add_from = (
                         sf.loc[candidates].sort_values("zscore", ascending=False).index
                         if candidates
@@ -2738,7 +3008,9 @@ def run(
                         holdings.append(replacement)
 
             # Compute weights using risk engine or fallback to legacy weighting
-            weights_df = _compute_weights(sf, holdings, period_ts, in_df.reindex(columns=fund_cols))
+            weights_df = _compute_weights(
+                sf, holdings, period_ts, in_df.reindex(columns=fund_cols)
+            )
             raw_weight_series = _as_weight_series(weights_df)
             signal_slice = sf.loc[holdings, metric] if metric in sf.columns else None
             weight_series = _apply_policy_to_weights(weights_df, signal_slice)
@@ -2802,12 +3074,16 @@ def run(
                 # Replace exited funds using the same initial selection method
                 n_needed = buy_hold_n - len(current_holdings)
                 if n_needed > 0:
-                    available = [str(c) for c in sf.index if str(c) not in current_holdings]
+                    available = [
+                        str(c) for c in sf.index if str(c) not in current_holdings
+                    ]
                     # Only consider funds that still have out-of-sample data;
                     # prevents re-adding funds whose data has disappeared.
                     if isinstance(out_df, pd.DataFrame) and not out_df.empty:
                         available = [
-                            c for c in available if c in out_df.columns and out_df[c].notna().any()
+                            c
+                            for c in available
+                            if c in out_df.columns and out_df[c].notna().any()
                         ]
                     if cooldown_periods > 0 and cooldown_book:
                         available = [c for c in available if c not in cooldown_book]
@@ -2835,26 +3111,24 @@ def run(
                         if rank_score_by == "blended" and rank_blended_weights:
                             total_w = sum(rank_blended_weights.values())
                             if total_w > 0:
-                                norm_w = {k: v / total_w for k, v in rank_blended_weights.items()}
+                                norm_w = {
+                                    k: v / total_w
+                                    for k, v in rank_blended_weights.items()
+                                }
                             else:
                                 norm_w = {"Sharpe": 1.0}
                             combo = pd.Series(0.0, index=sf.index, dtype=float)
                             for m, w in norm_w.items():
                                 if m in sf.columns:
-                                    col_series = sf[m].astype(float)
-                                    mu = float(col_series.mean())
-                                    sigma = float(col_series.std(ddof=0))
-                                    z = (
-                                        (col_series - mu) / sigma
-                                        if sigma > 0
-                                        else pd.Series(0.0, index=col_series.index)
-                                    )
-                                    if m in ASCENDING_METRICS:
-                                        z = -z
-                                    combo += w * z
+                                    z = _zscore_or_zero(sf[m])
+                                    combo += w * (-z if m in ASCENDING_METRICS else z)
                             scores = combo
                         else:
-                            score_col = rank_score_by if rank_score_by in sf.columns else "Sharpe"
+                            score_col = (
+                                rank_score_by
+                                if rank_score_by in sf.columns
+                                else "Sharpe"
+                            )
                             scores = sf[score_col].astype(float)
 
                         # Apply zscore transform if threshold mode
@@ -2866,11 +3140,16 @@ def run(
                                 scores = pd.Series(0.0, index=scores.index)
 
                         ascending = False
-                        if rank_score_by in ASCENDING_METRICS and buy_hold_initial != "threshold":
+                        if (
+                            rank_score_by in ASCENDING_METRICS
+                            and buy_hold_initial != "threshold"
+                        ):
                             ascending = True
 
                         # Sort scores and filter to available candidates
-                        sorted_scores = scores.loc[available].sort_values(ascending=ascending)
+                        sorted_scores = scores.loc[available].sort_values(
+                            ascending=ascending
+                        )
 
                         # Select replacements respecting threshold if applicable
                         if buy_hold_initial == "threshold":
@@ -2913,7 +3192,9 @@ def run(
                 # each period. This is essential to avoid survivorship bias - we select
                 # from the available universe at each point in time, not funds we know
                 # will survive.
-                period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(hash(str(pt)) % 10000)
+                period_seed = abs(getattr(cfg, "seed", 42) or 42) + abs(
+                    hash(str(pt)) % 10000
+                )
                 rebased = rebalancer.apply_triggers(
                     prev_weights.astype(float),
                     sf,
@@ -2930,7 +3211,9 @@ def run(
                 ]
 
             if hard_exit_forced:
-                proposed_holdings = [m for m in proposed_holdings if m not in hard_exit_forced]
+                proposed_holdings = [
+                    m for m in proposed_holdings if m not in hard_exit_forced
+                ]
 
             raw_proposed_holdings = [str(h) for h in proposed_holdings]
 
@@ -3003,7 +3286,8 @@ def run(
                                 "firm": _firm(mgr),
                                 "reason": "sticky_add",
                                 "detail": (
-                                    f"streak={add_streaks.get(mgr, 0)}/" f"{sticky_add_periods}"
+                                    f"streak={add_streaks.get(mgr, 0)}/"
+                                    f"{sticky_add_periods}"
                                 ),
                             }
                         )
@@ -3024,7 +3308,8 @@ def run(
                                 "firm": _firm(mgr),
                                 "reason": "sticky_drop",
                                 "detail": (
-                                    f"streak={drop_streaks.get(mgr, 0)}/" f"{sticky_drop_periods}"
+                                    f"streak={drop_streaks.get(mgr, 0)}/"
+                                    f"{sticky_drop_periods}"
                                 ),
                             }
                         )
@@ -3058,7 +3343,8 @@ def run(
                             "firm": _firm(mgr),
                             "reason": "min_tenure",
                             "detail": (
-                                f"tenure={int(holdings_tenure.get(mgr, 0))}/" f"{min_tenure_n}"
+                                f"tenure={int(holdings_tenure.get(mgr, 0))}/"
+                                f"{min_tenure_n}"
                             ),
                         }
                     )
@@ -3122,12 +3408,18 @@ def run(
                 candidates = _filter_entry_candidates(candidates, sf)
                 if candidates:
                     if is_random_mode:
-                        period_seed = abs((getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000)
+                        period_seed = abs(
+                            (getattr(cfg, "seed", 42) or 42) + hash(str(pt)) % 10000
+                        )
                         rng = np.random.default_rng(period_seed)
                         rng.shuffle(candidates)
                         ranked = candidates
                     else:
-                        ranked = sf.loc[candidates].sort_values("zscore", ascending=False).index
+                        ranked = (
+                            sf.loc[candidates]
+                            .sort_values("zscore", ascending=False)
+                            .index
+                        )
                     for c in ranked:
                         if len(proposed_holdings) >= desired_size:
                             break
@@ -3146,8 +3438,12 @@ def run(
             pruned_existing: set[str] = set()
             if desired_size > 0:
                 current_set = {str(x) for x in before_reb}
-                kept_existing = [str(h) for h in proposed_holdings if str(h) in current_set]
-                new_candidates = [str(h) for h in proposed_holdings if str(h) not in current_set]
+                kept_existing = [
+                    str(h) for h in proposed_holdings if str(h) in current_set
+                ]
+                new_candidates = [
+                    str(h) for h in proposed_holdings if str(h) not in current_set
+                ]
 
                 def _zscore(mgr: str) -> float:
                     try:
@@ -3170,14 +3466,20 @@ def run(
                 # not happen), prune incumbents by weakest zscore.
                 # In random mode, prune randomly instead.
                 if len(kept_existing) > desired_size:
-                    protected_existing = [mgr for mgr in kept_existing if mgr in protected_holdings]
+                    protected_existing = [
+                        mgr for mgr in kept_existing if mgr in protected_holdings
+                    ]
                     unprotected_existing = [
                         mgr for mgr in kept_existing if mgr not in protected_holdings
                     ]
                     if is_random_mode:
-                        unprotected_sorted = sorted(unprotected_existing, key=_random_key)
+                        unprotected_sorted = sorted(
+                            unprotected_existing, key=_random_key
+                        )
                     else:
-                        unprotected_sorted = sorted(unprotected_existing, key=_zscore, reverse=True)
+                        unprotected_sorted = sorted(
+                            unprotected_existing, key=_zscore, reverse=True
+                        )
                     if protected_existing:
                         slots = max(0, desired_size - len(protected_existing))
                         if slots > 0:
@@ -3233,18 +3535,14 @@ def run(
                 selected, _ = selector.select(_filter_entry_frame(sf))
                 proposed_holdings = [str(x) for x in selected.index.tolist()]
                 if cooldown_periods > 0 and cooldown_book:
-                    filtered = [mgr for mgr in proposed_holdings if mgr not in cooldown_book]
+                    filtered = [
+                        mgr for mgr in proposed_holdings if mgr not in cooldown_book
+                    ]
                     if filtered:
                         for mgr in proposed_holdings:
                             if mgr in cooldown_book:
                                 events.append(
-                                    {
-                                        "action": "skipped",
-                                        "manager": mgr,
-                                        "firm": _firm(mgr),
-                                        "reason": "cooldown",
-                                        "detail": "reseed blocked by cooldown",
-                                    }
+                                    _cooldown_reseed_skip_event(mgr, _firm(mgr))
                                 )
                         proposed_holdings = filtered
                 proposed_holdings = _dedupe_one_per_firm_with_events(
@@ -3430,7 +3728,9 @@ def run(
                 )
 
             # Compute weights using risk engine or fallback to legacy weighting
-            weights_df = _compute_weights(sf, holdings, period_ts, in_df.reindex(columns=fund_cols))
+            weights_df = _compute_weights(
+                sf, holdings, period_ts, in_df.reindex(columns=fund_cols)
+            )
             raw_weight_series = _as_weight_series(weights_df)
             signal_slice = sf.loc[holdings, metric] if metric in sf.columns else None
             weight_series = _apply_policy_to_weights(weights_df, signal_slice)
@@ -3480,7 +3780,8 @@ def run(
                         "firm": _firm(f),
                         "reason": "low_weight_strikes",
                         "detail": (
-                            f"below min {min_w_bound:.2%} for " f"{low_min_strikes_req} periods"
+                            f"below min {min_w_bound:.2%} for "
+                            f"{low_min_strikes_req} periods"
                         ),
                     }
                 )
@@ -3493,11 +3794,17 @@ def run(
             need = max(0, desired_after_low_weight - len(holdings))
             if need > 0:
                 candidates = [
-                    c for c in sf.index if c not in holdings and _eligible_sticky_add(str(c))
+                    c
+                    for c in sf.index
+                    if c not in holdings and _eligible_sticky_add(str(c))
                 ]
                 if cooldown_periods > 0 and cooldown_book:
                     candidates = [c for c in candidates if str(c) not in cooldown_book]
-                add_from = sf.loc[candidates].sort_values("zscore", ascending=False).index.tolist()
+                add_from = (
+                    sf.loc[candidates]
+                    .sort_values("zscore", ascending=False)
+                    .index.tolist()
+                )
                 for f in add_from:
                     if len(holdings) >= desired_after_low_weight:
                         break
@@ -3519,7 +3826,9 @@ def run(
                     sf, holdings, period_ts, in_df.reindex(columns=fund_cols)
                 )
                 raw_weight_series = _as_weight_series(weights_df)
-                signal_slice = sf.loc[holdings, metric] if metric in sf.columns else None
+                signal_slice = (
+                    sf.loc[holdings, metric] if metric in sf.columns else None
+                )
                 weight_series = _apply_policy_to_weights(weights_df, signal_slice)
                 weight_series = _ensure_holdings_weights(
                     weight_series,
@@ -3535,7 +3844,9 @@ def run(
             holdings = _enforce_min_funds(
                 sf,
                 holdings,
-                before_reb=(set(prev_weights.index) if prev_weights is not None else None),
+                before_reb=(
+                    set(prev_weights.index) if prev_weights is not None else None
+                ),
                 cooldowns=cooldown_book,
                 desired_min=min_funds,
                 events=events,
@@ -3546,7 +3857,9 @@ def run(
                     sf, holdings, period_ts, in_df.reindex(columns=fund_cols)
                 )
                 raw_weight_series = _as_weight_series(weights_df)
-                signal_slice = sf.loc[holdings, metric] if metric in sf.columns else None
+                signal_slice = (
+                    sf.loc[holdings, metric] if metric in sf.columns else None
+                )
                 weight_series = _apply_policy_to_weights(weights_df, signal_slice)
                 weight_series = _ensure_holdings_weights(
                     weight_series,
@@ -3565,7 +3878,9 @@ def run(
         # Use the holdings list so newly hired funds are included even if
         # their weights were altered by turnover/bounds logic.
         manual_holdings = (
-            [str(x) for x in holdings] if holdings else [str(x) for x in bounded_w.index.tolist()]
+            [str(x) for x in holdings]
+            if holdings
+            else [str(x) for x in bounded_w.index.tolist()]
         )
 
         # Enforce optional turnover cap by scaling trades towards target
@@ -3630,7 +3945,9 @@ def run(
             mandatory = desired_trades.copy()
             if forced_ix:
                 # Keep only forced exit trades in mandatory bucket
-                mandatory.loc[[ix for ix in mandatory.index if ix not in forced_ix]] = 0.0
+                mandatory.loc[[ix for ix in mandatory.index if ix not in forced_ix]] = (
+                    0.0
+                )
             else:
                 mandatory[:] = 0.0
 
@@ -3644,7 +3961,11 @@ def run(
                 final_w = last_aligned + mandatory
             else:
                 remaining_turnover = max_turnover_cap - mandatory_turnover
-                scale = remaining_turnover / optional_turnover if optional_turnover > 0 else 0.0
+                scale = (
+                    remaining_turnover / optional_turnover
+                    if optional_turnover > 0
+                    else 0.0
+                )
                 scale = max(0.0, min(1.0, scale))
                 final_w = last_aligned + mandatory + optional * scale
         # Ensure bounds and normalisation remain satisfied
@@ -3667,11 +3988,12 @@ def run(
             if total > eps and abs(total - 1.0) <= 1e-8:
                 final_w = final_w / total
         # Only pass the selected holdings (if still present after filtering).
-        manual_funds: list[str] = [str(h) for h in manual_holdings if h in final_w.index]
-        custom: dict[str, float] = {str(k): float(v) * 100.0 for k, v in final_w.items()}
-
-        # Construct previous weights dict for pipeline (turnover tracking)
-        prev_weights_for_pipeline = _coerce_previous_weights(prev_final_weights)
+        manual_funds: list[str] = [
+            str(h) for h in manual_holdings if h in final_w.index
+        ]
+        custom: dict[str, float] = {
+            str(k): float(v) * 100.0 for k, v in final_w.items()
+        }
 
         res = _call_pipeline_with_diag(
             df,
@@ -3722,7 +4044,10 @@ def run(
         # consumers can audit soft-entry/soft-exit decisions without
         # recomputation.
         score_frame_payload = res_dict.get("score_frame")
-        if isinstance(score_frame_payload, pd.DataFrame) and not score_frame_payload.empty:
+        if (
+            isinstance(score_frame_payload, pd.DataFrame)
+            and not score_frame_payload.empty
+        ):
             score_frame_out = score_frame_payload.copy()
             if "zscore" in sf.columns and "zscore" not in score_frame_out.columns:
                 score_frame_out = score_frame_out.join(sf[["zscore"]], how="left")
@@ -3880,7 +4205,9 @@ def run(
         realised_holdings = [str(x) for x in effective_nonzero.index]
         # Do not emit zero-weight positions: they are not real holdings and
         # confuse downstream audits (e.g., a dropped fund showing up with 0.0).
-        res_dict["fund_weights"] = {str(k): float(v) for k, v in effective_nonzero.items()}
+        res_dict["fund_weights"] = {
+            str(k): float(v) for k, v in effective_nonzero.items()
+        }
 
         # Record cooldowns for any managers that exited based on realised holdings.
         if cooldown_periods > 0 and prev_final_weights is not None:
@@ -3901,114 +4228,33 @@ def run(
         # rebalance schedule (e.g. quarterly) via ``portfolio.rebalance_freq``.
         # Emit a per-period weights frame keyed by those rebalance dates so the
         # Streamlit UI can render weights by rebalance date.
-        try:
-            rebalance_freq = str(cfg.portfolio.get("rebalance_freq", "") or "").strip()
-        except Exception:  # pragma: no cover - defensive
-            rebalance_freq = ""
-        rebalance_frame: pd.DataFrame | None = None
-        if rebalance_freq and isinstance(out_df, pd.DataFrame) and not out_df.empty:
-            try:
-                schedule = get_rebalance_dates(out_df.index, rebalance_freq)
-                if len(out_df.index) and (out_df.index[0] not in schedule):
-                    schedule = schedule.insert(0, out_df.index[0])
-                if not schedule.empty:
-                    # Recompute weights per rebalance date using a rolling
-                    # in-sample window ending at that date. Holdings remain
-                    # fixed intra-period; only weights are refreshed.
-                    in_len_years = int(mp_cfg.get("in_sample_len", 3) or 3)
-                    in_months = max(1, in_len_years * 12)
-
-                    # Prefer configured risk-based weighting for intra-period
-                    # rebalances when available.
-                    try:
-                        from ..plugins import create_weight_engine
-
-                        weighting_scheme = str(
-                            cfg.portfolio.get("weighting_scheme", "equal") or "equal"
-                        ).lower()
-                        risk_engine = create_weight_engine(weighting_scheme)
-                        use_risk_engine = weighting_scheme not in {"equal", "ew"}
-                    except Exception:  # pragma: no cover - best-effort only
-                        risk_engine = None
-                        use_risk_engine = False
-
-                    rebalance_rows: list[dict[str, float]] = []
-                    prev_reb_w = effective_w.copy()
-                    for reb_date in pd.DatetimeIndex(schedule):
-                        end_dt = pd.Timestamp(reb_date)
-                        start_dt = (
-                            end_dt - pd.DateOffset(months=in_months - 1)
-                        ) + pd.offsets.MonthEnd(0)
-
-                        window = df_indexed.reindex(columns=realised_holdings).loc[
-                            (df_indexed.index >= start_dt) & (df_indexed.index <= end_dt)
-                        ]
-                        if window.empty:
-                            w_row = prev_reb_w
-                        else:
-                            try:
-                                if use_risk_engine and risk_engine is not None:
-                                    prepared = _prepare_returns_frame(window)
-                                    cov = prepared.cov()
-                                    w_series = risk_engine.weight(cov)
-                                else:
-                                    # Align rf_override to the rolling window's date index
-                                    # to avoid shape mismatch in metric calculations.
-                                    rf_aligned = rf_override
-                                    if isinstance(rf_override, pd.Series) and not window.empty:
-                                        rf_aligned = rf_override.reindex(window.index)
-                                    sf_roll = _score_frame(
-                                        window,
-                                        realised_holdings,
-                                        risk_free_override=rf_aligned,
-                                        periods_per_year=int(periods_per_year),
-                                    )
-                                    sf_roll = _ensure_zscore(sf_roll, metric)
-                                    weights_df_roll = weighting.weight(
-                                        sf_roll.loc[realised_holdings], end_dt
-                                    )
-                                    signal_slice = (
-                                        sf_roll.loc[realised_holdings, metric]
-                                        if metric in sf_roll.columns
-                                        else None
-                                    )
-                                    w_series = _apply_policy_to_weights(
-                                        weights_df_roll, signal_slice
-                                    )
-                                bounded = _apply_weight_bounds(
-                                    w_series.reindex(realised_holdings).fillna(0.0),
-                                    min_w_bound,
-                                    max_w_bound,
-                                )
-                                bounded = _enforce_max_active_positions(
-                                    bounded,
-                                    max_active_positions,
-                                    protected=min_tenure_guard,
-                                )
-                                bounded = bounded[bounded.abs() > eps]
-                                total = float(bounded.sum())
-                                if total > eps and abs(total - 1.0) <= 1e-8:
-                                    bounded = bounded / total
-                                w_row = bounded
-                                prev_reb_w = w_row
-                            except Exception:  # pragma: no cover - best-effort only
-                                w_row = prev_reb_w
-
-                        rebalance_rows.append({str(k): float(v) for k, v in w_row.items()})
-
-                    rebalance_frame = pd.DataFrame(
-                        rebalance_rows,
-                        index=pd.DatetimeIndex(schedule),
-                    )
-                    rebalance_frame.index.name = "rebalance_date"
-                    res_dict["rebalance_weights"] = rebalance_frame
-            except Exception:  # pragma: no cover - best-effort only
-                pass
+        rebalance_frame = _build_rebalance_frame(
+            cfg,
+            out_df=out_df,
+            df_indexed=df_indexed,
+            realised_holdings=realised_holdings,
+            effective_w=effective_w,
+            rf_override=rf_override,
+            periods_per_year=int(periods_per_year),
+            metric=metric,
+            weighting=weighting,
+            min_w_bound=min_w_bound,
+            max_w_bound=max_w_bound,
+            max_active_positions=max_active_positions,
+            min_tenure_guard=min_tenure_guard,
+            score_frame_fn=_score_frame,
+            ensure_zscore_fn=_ensure_zscore,
+            apply_policy_to_weights_fn=_apply_policy_to_weights,
+        )
+        if rebalance_frame is not None:
+            res_dict["rebalance_weights"] = rebalance_frame
 
         if rebalance_frame is not None and not rebalance_frame.empty:
             out_scaled = res_dict.get("out_sample_scaled")
             if isinstance(out_scaled, pd.DataFrame) and not out_scaled.empty:
-                weights_by_date = rebalance_frame.reindex(out_scaled.index).ffill().fillna(0.0)
+                weights_by_date = (
+                    rebalance_frame.reindex(out_scaled.index).ffill().fillna(0.0)
+                )
                 weights_by_date = weights_by_date.reindex(
                     columns=out_scaled.columns, fill_value=0.0
                 )
@@ -4020,7 +4266,9 @@ def run(
                     rf_out = pd.Series(0.0, index=out_scaled.index)
 
                 cash_weight_series = 1.0 - weights_by_date.sum(axis=1)
-                cash_weight_series = cash_weight_series.where(cash_weight_series > 1e-10, 0.0)
+                cash_weight_series = cash_weight_series.where(
+                    cash_weight_series > 1e-10, 0.0
+                )
                 res_dict["cash_weight_series"] = cash_weight_series
 
                 rebalance_returns = (out_scaled * weights_by_date).sum(axis=1)
@@ -4036,8 +4284,12 @@ def run(
 
                 out_raw = out_df.reindex(columns=out_scaled.columns)
                 if isinstance(out_raw, pd.DataFrame) and not out_raw.empty:
-                    weights_raw = rebalance_frame.reindex(out_raw.index).ffill().fillna(0.0)
-                    weights_raw = weights_raw.reindex(columns=out_raw.columns, fill_value=0.0)
+                    weights_raw = (
+                        rebalance_frame.reindex(out_raw.index).ffill().fillna(0.0)
+                    )
+                    weights_raw = weights_raw.reindex(
+                        columns=out_raw.columns, fill_value=0.0
+                    )
                     rebalance_raw = (out_raw * weights_raw).sum(axis=1)
                     rebalance_raw = rebalance_raw + (
                         rf_out.reindex(out_raw.index).fillna(0.0) * cash_weight_series

--- a/tests/test_engine_run_refactor_parity.py
+++ b/tests/test_engine_run_refactor_parity.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pandas as pd
+
+from trend_analysis.multi_period import engine
+
+
+class RefactorParityConfig:
+    def __init__(self) -> None:
+        self.data = {"allow_risk_free_fallback": True, "missing_policy": "ffill"}
+        self.multi_period = {
+            "frequency": "M",
+            "in_sample_len": 2,
+            "out_sample_len": 1,
+            "start": "2020-01",
+            "end": "2020-05",
+        }
+        self.portfolio = {
+            "policy": "threshold_hold",
+            "threshold_hold": {
+                "metric": "Sharpe",
+                "target_n": 2,
+                "z_exit_soft": -10.0,
+                "z_entry_soft": -10.0,
+            },
+            "constraints": {"max_funds": 2, "min_weight": 0.0, "max_weight": 1.0},
+            "weighting": {"name": "equal"},
+            "transaction_cost_bps": 0.0,
+            "max_turnover": 1.0,
+            "indices_list": None,
+        }
+        self.metrics = {"rf_override_enabled": True, "rf_rate_annual": 0.0}
+        self.vol_adjust = {"target_vol": 1.0}
+        self.run = {"monthly_cost": 0.0}
+        self.benchmarks = {}
+        self.seed = 7
+
+    def model_dump(self) -> dict[str, Any]:
+        return {
+            "data": self.data,
+            "multi_period": self.multi_period,
+            "portfolio": self.portfolio,
+            "metrics": self.metrics,
+            "vol_adjust": self.vol_adjust,
+            "run": self.run,
+            "benchmarks": self.benchmarks,
+            "seed": self.seed,
+        }
+
+
+class SelectorStub:
+    rank_column = "Sharpe"
+
+    def select(self, frame: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+        selected = frame.sort_values("Sharpe", ascending=False).head(2)
+        return selected, frame
+
+
+class RebalancerStub:
+    def apply_triggers(
+        self,
+        prev_weights: pd.Series,
+        score_frame: pd.DataFrame,
+        **_kwargs: Any,
+    ) -> pd.Series:
+        return prev_weights.reindex(score_frame.index).dropna()
+
+
+def test_run_refactor_preserves_period_parity(monkeypatch) -> None:
+    periods = [
+        SimpleNamespace(
+            in_start="2020-01", in_end="2020-02", out_start="2020-03", out_end="2020-03"
+        ),
+        SimpleNamespace(
+            in_start="2020-02", in_end="2020-03", out_start="2020-04", out_end="2020-04"
+        ),
+        SimpleNamespace(
+            in_start="2020-03", in_end="2020-04", out_start="2020-05", out_end="2020-05"
+        ),
+    ]
+    monkeypatch.setattr(engine, "generate_periods", lambda _cfg: periods)
+    monkeypatch.setattr(
+        engine, "apply_missing_policy", lambda frame, **_kwargs: (frame, {})
+    )
+    monkeypatch.setattr(
+        engine, "Rebalancer", lambda *_args, **_kwargs: RebalancerStub()
+    )
+
+    from trend_analysis import selector as selector_mod
+
+    monkeypatch.setattr(
+        selector_mod,
+        "create_selector_by_name",
+        lambda *_args, **_kwargs: SelectorStub(),
+    )
+
+    pipeline_calls: list[
+        tuple[str, tuple[str, ...], tuple[tuple[str, float], ...]]
+    ] = []
+
+    def fake_run_analysis(
+        _df_arg: pd.DataFrame,
+        _in_start: str,
+        _in_end: str,
+        out_start: str,
+        _out_end: str,
+        *_args: Any,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        manual_funds = tuple(kwargs["manual_funds"])
+        custom_weights = tuple(sorted(kwargs["custom_weights"].items()))
+        pipeline_calls.append((out_start, manual_funds, custom_weights))
+        return {
+            "fund_weights": dict(kwargs["custom_weights"]),
+            "out_sample_scaled": pd.DataFrame(
+                index=pd.date_range(f"{out_start}-28", periods=1)
+            ),
+            "score_frame": pd.DataFrame(index=manual_funds),
+        }
+
+    monkeypatch.setattr(engine, "_run_analysis", fake_run_analysis)
+
+    df = pd.DataFrame(
+        {
+            "Date": pd.date_range("2020-01-31", periods=5, freq="ME"),
+            "FundA": [0.01, 0.02, 0.03, 0.04, 0.05],
+            "FundB": [0.02, 0.01, 0.02, 0.01, 0.02],
+            "FundC": [0.03, 0.03, 0.01, 0.01, 0.03],
+        }
+    )
+
+    results = engine.run(RefactorParityConfig(), df=df)
+
+    assert [result["period"] for result in results] == [
+        ("2020-01", "2020-02", "2020-03", "2020-03"),
+        ("2020-02", "2020-03", "2020-04", "2020-04"),
+        ("2020-03", "2020-04", "2020-05", "2020-05"),
+    ]
+    assert len(pipeline_calls) == 3
+    assert [call[0] for call in pipeline_calls] == ["2020-03", "2020-04", "2020-05"]
+    assert all(len(call[1]) == 2 for call in pipeline_calls)
+    assert [tuple(result["selected_funds"]) for result in results] == [
+        call[1] for call in pipeline_calls
+    ]


### PR DESCRIPTION
Closes #5422

## Summary
- Extract the non-threshold Phase-1 style period runner from `multi_period.engine.run()` into `_run_phase1_multi_periods`.
- Extract intra-period rebalance snapshot construction into `_build_rebalance_frame` and hoist small repeated z-score/cooldown helpers.
- Keep the public `run()` signature and result schema unchanged while reducing `run()` from 3,127 lines / max indent 40 to 3,007 lines / max indent 36.

## Validation
- PYTHONPATH=src python -m pytest tests/test_engine_run_refactor_parity.py tests/test_multi_period_engine.py tests/test_multi_period_engine_additional.py -q
- HOME=/private/tmp TREND_ROLLING_CACHE=/private/tmp/trend_model/rolling PYTHONPATH=src python -m pytest tests/test_multi_period*.py tests/test_engine_run_refactor_parity.py -q
- python -m ruff check src/trend_analysis/multi_period/engine.py tests/test_engine_run_refactor_parity.py
- python -m mypy src/trend_analysis/multi_period/engine.py tests/test_engine_run_refactor_parity.py
- git diff --check

Deliberate-break: temporarily changed the period append to retain only `periods[-1]`; `tests/test_engine_run_refactor_parity.py::test_run_refactor_preserves_period_parity` failed because only the final period remained. Restored and reran green.