### PR TITLE
Issue #5425: deduplicate export and viz helpers

### DIFF
--- a/src/trend_analysis/export/__init__.py
+++ b/src/trend_analysis/export/__init__.py
@@ -25,6 +25,7 @@ from ..reporting.narrative import (
     narrative_generation_enabled,
     validate_narrative_quality,
 )
+from ..reporting.portfolio_series import weighted_sum
 from . import bundle as bundle  # noqa: F401  # re-exported module for tests/compat
 from .bundle import export_bundle
 
@@ -87,9 +88,14 @@ def _maybe_remove_openpyxl_default_sheet(book: Any) -> str | None:
         return None
     try:
         cell = ws.cell(row=1, column=1)
+    except TypeError:
+        try:
+            cell = ws.cell(1, 1)
+        except Exception:  # pragma: no cover - defensive guard
+            return None
     except Exception:  # pragma: no cover - defensive guard
         return None
-    if getattr(cell, "value", None) is None:
+    if getattr(cell, "value", None) in (None, ""):
         try:
             book.remove(ws)
             return title
@@ -108,6 +114,10 @@ class _OpenpyxlWorksheetProxy:
     @property
     def name(self) -> str:
         return getattr(self._ws, "title", "")
+
+    @property
+    def native(self) -> Any:
+        return self._ws
 
     def write(self, row: int, col: int, value: Any, fmt: Any | None = None) -> None:
         cell = self._ws.cell(row=row + 1, column=col + 1)
@@ -160,10 +170,10 @@ class _OpenpyxlWorkbookProxy:
     def _book(self) -> Any:
         return self._writer.book
 
-    def add_format(self, spec: Mapping[str, Any]) -> Mapping[str, Any]:
+    def add_format(self, spec: Mapping[str, Any] | None) -> Mapping[str, Any]:
         # Formatting support is best-effort under openpyxl; return the spec so
         # callers can still pass it back to ``write``.
-        return dict(spec)
+        return dict(spec or {})
 
     def add_worksheet(self, name: str) -> _OpenpyxlWorksheetProxy:
         book = self._book
@@ -171,94 +181,38 @@ class _OpenpyxlWorkbookProxy:
         if removed:
             self._writer.sheets.pop(removed, None)
         ws = book.create_sheet(title=name)
+        if getattr(ws, "title", name) != name:
+            ws.title = name
         return _OpenpyxlWorksheetProxy(ws)
 
     def __getattr__(self, name: str) -> Any:  # pragma: no cover - simple proxy
         return getattr(self._book, name)
 
-
-class _OpenpyxlWorksheetAdapter:
-    """Lightweight adapter exposing a subset of the xlsxwriter worksheet
-    API."""
-
-    __slots__ = ("_ws",)
-
-    def __init__(self, worksheet: Any) -> None:
-        self._ws = worksheet
-
-    @property
-    def native(self) -> Any:
-        return self._ws
-
-    def write(
-        self, row: int, col: int, value: object, fmt: object | None = None
-    ) -> None:  # noqa: ARG002
-        # The `fmt` parameter is ignored because openpyxl's formatting model is
-        # different from xlsxwriter's, and this adapter does not support cell formatting.
-        self._ws.cell(row=row + 1, column=col + 1, value=value)
-
-    def write_row(
-        self,
-        row: int,
-        col: int,
-        data: Iterable[object],
-        fmt: object | None = None,  # noqa: ARG002
-    ) -> None:
-        for offset, value in enumerate(data):
-            self.write(row, col + offset, value)
-
-    def set_column(self, first_col: int, last_col: int, width: float) -> None:
-        from openpyxl.utils import get_column_letter
-
-        for idx in range(first_col, last_col + 1):
-            letter = get_column_letter(idx + 1)
-            self._ws.column_dimensions[letter].width = width
-
-    def freeze_panes(self, row: int, col: int) -> None:
-        self._ws.freeze_panes = self._ws.cell(row=row + 1, column=col + 1)
-
-    def autofilter(self, fr: int, fc: int, lr: int, lc: int) -> None:
-        from openpyxl.utils import get_column_letter
-
-        start = f"{get_column_letter(fc + 1)}{fr + 1}"
-        end = f"{get_column_letter(lc + 1)}{lr + 1}"
-        self._ws.auto_filter.ref = f"{start}:{end}"
-
-
-class _OpenpyxlWorkbookAdapter:
-    """Adapter that exposes minimal workbook hooks expected by formatters."""
-
-    __slots__ = ("_wb",)
-
-    def __init__(self, workbook: Any) -> None:
-        self._wb = workbook
-        self._prune_default_sheet()
-
-    def _prune_default_sheet(self) -> None:
-        sheets = getattr(self._wb, "worksheets", [])
-        if len(sheets) == 1:
-            sheet = sheets[0]
-            title = getattr(sheet, "title", "")
-            value = sheet.cell(1, 1).value if hasattr(sheet, "cell") else None
-            if title == "Sheet" and value in (None, "") and hasattr(self._wb, "remove"):
-                self._wb.remove(sheet)
-
-    def add_worksheet(self, name: str) -> _OpenpyxlWorksheetAdapter:
-        ws = self._wb.create_sheet(title=name)
-        if getattr(ws, "title", name) != name:
-            ws.title = name
-        return _OpenpyxlWorksheetAdapter(ws)
-
-    def add_format(self, spec: Mapping[str, Any] | None) -> Mapping[str, Any]:
-        return dict(spec or {})
-
     def rename_last_sheet(self, name: str) -> None:
-        sheets = getattr(self._wb, "worksheets", [])
+        sheets = getattr(self._book, "worksheets", [])
         if sheets:
             sheets[-1].title = name
 
-    def __getattr__(self, attr: str) -> Any:
-        return getattr(self._wb, attr)
+
+class _BookWriterShim:
+    """Minimal writer-like wrapper for compatibility adapter construction."""
+
+    def __init__(self, book: Any) -> None:
+        self.book = book
+        self.sheets = {
+            getattr(sheet, "title", ""): sheet for sheet in getattr(book, "worksheets", [])
+        }
+
+
+class _OpenpyxlWorkbookAdapter(_OpenpyxlWorkbookProxy):
+    """Compatibility alias around the shared openpyxl workbook proxy."""
+
+    def __init__(self, workbook: Any) -> None:
+        _maybe_remove_openpyxl_default_sheet(workbook)
+        super().__init__(_BookWriterShim(workbook))
+
+
+_OpenpyxlWorksheetAdapter = _OpenpyxlWorksheetProxy
 
 
 def register_formatter_excel(
@@ -590,22 +544,6 @@ def _build_summary_formatter(
             total = float((1.0 + s.astype(float)).prod() - 1.0)
             return (total, int(s.shape[0]))
 
-        def portfolio_series(
-            df: pd.DataFrame | None, weights: Mapping[str, float] | None
-        ) -> pd.Series | None:
-            if df is None or df.empty:
-                return None
-            if weights:
-                w = pd.Series({c: float(weights.get(c, 0.0)) for c in df.columns})
-                s = float(w.sum())
-                if s > 0:
-                    w = w / s
-                else:
-                    w = pd.Series(1.0 / float(len(df.columns)), index=df.columns)
-            else:
-                w = pd.Series(1.0 / float(len(df.columns)), index=df.columns)
-            return df.mul(w, axis=1).sum(axis=1)
-
         row = header_row + 1
         for label, ins, outs in [
             ("Equal Weight", res["in_ew_stats"], res["out_ew_stats"]),
@@ -616,8 +554,8 @@ def _build_summary_formatter(
             weights = None
             if label == "User Weight":
                 weights = cast(Mapping[str, float], res.get("fund_weights", {}))
-            os_tr, os_m = total_return_months(portfolio_series(out_df, weights))
-            is_tr, is_m = total_return_months(portfolio_series(in_df, weights))
+            os_tr, os_m = total_return_months(weighted_sum(out_df, weights))
+            is_tr, is_m = total_return_months(weighted_sum(in_df, weights))
             ins_vals = metrics_list(ins)
             outs_vals = metrics_list(outs)
             vals = [os_tr, os_m, *outs_vals[:5]]
@@ -870,22 +808,6 @@ def format_summary_text(
         total = float((1.0 + s.astype(float)).prod() - 1.0)
         return (total * 100.0, int(s.shape[0]))
 
-    def portfolio_series(
-        df: pd.DataFrame | None, weights: Mapping[str, float] | None
-    ) -> pd.Series | None:
-        if df is None or df.empty:
-            return None
-        if weights:
-            w = pd.Series({c: float(weights.get(c, 0.0)) for c in df.columns})
-            s = float(w.sum())
-            if s > 0:
-                w = w / s
-            else:
-                w = pd.Series(1.0 / float(len(df.columns)), index=df.columns)
-        else:
-            w = pd.Series(1.0 / float(len(df.columns)), index=df.columns)
-        return df.mul(w, axis=1).sum(axis=1)
-
     rows: list[list[str | float | None]] = []
 
     base_rows: list[tuple[str, Any, Any]] = []
@@ -902,8 +824,8 @@ def format_summary_text(
         weights = None
         if label == "User Weight":
             weights = cast(Mapping[str, float], res.get("fund_weights", {}))
-        os_tr, os_m = total_return_months(portfolio_series(out_df, weights))
-        is_tr, is_m = total_return_months(portfolio_series(in_df, weights))
+        os_tr, os_m = total_return_months(weighted_sum(out_df, weights))
+        is_tr, is_m = total_return_months(weighted_sum(in_df, weights))
         os_vals = pct(outs)
         is_vals = pct(ins)
         extra = [
@@ -1111,8 +1033,6 @@ def export_to_excel(
                 proxy = None
         else:
             proxy = None
-        if proxy is not None:
-            pass
         # Iterate over frames and either let a registered sheet formatter
         # render the entire sheet (preferred), or fall back to writing the
         # DataFrame directly when no formatter is available.
@@ -1368,22 +1288,6 @@ def summary_frame_from_result(res: Mapping[str, object]) -> pd.DataFrame:
         total = float((1.0 + s.astype(float)).prod() - 1.0)
         return (total * 100.0, int(s.shape[0]))
 
-    def portfolio_series(
-        df: pd.DataFrame | None, weights: Mapping[str, float] | None
-    ) -> pd.Series | None:
-        if df is None or df.empty:
-            return None
-        if weights:
-            w = pd.Series({c: float(weights.get(c, 0.0)) for c in df.columns})
-            s = float(w.sum())
-            if s > 0:
-                w = w / s
-            else:
-                w = pd.Series(1.0 / float(len(df.columns)), index=df.columns)
-        else:
-            w = pd.Series(1.0 / float(len(df.columns)), index=df.columns)
-        return df.mul(w, axis=1).sum(axis=1)
-
     base_rows: list[tuple[str, Any, Any]] = []
     in_ew = res.get("in_ew_stats")
     out_ew = res.get("out_ew_stats")
@@ -1398,8 +1302,8 @@ def summary_frame_from_result(res: Mapping[str, object]) -> pd.DataFrame:
         weights = None
         if label == "User Weight":
             weights = cast(Mapping[str, float], res.get("fund_weights", {}))
-        os_tr, os_m = total_return_months(portfolio_series(out_df, weights))
-        is_tr, is_m = total_return_months(portfolio_series(in_df, weights))
+        os_tr, os_m = total_return_months(weighted_sum(out_df, weights))
+        is_tr, is_m = total_return_months(weighted_sum(in_df, weights))
         os_vals = pct(outs)
         is_vals = pct(ins)
         extra = [

--- a/src/trend_analysis/export/bundle.py
+++ b/src/trend_analysis/export/bundle.py
@@ -1,6 +1,7 @@
 import datetime as _dt
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import zipfile
@@ -20,7 +21,8 @@ from trend_analysis.util.hash import (
 from trend_analysis.util.git import git_hash
 
 
-_git_hash = git_hash
+def _git_hash() -> str:
+    return git_hash(subprocess_module=subprocess)
 
 
 def export_bundle(run: Any, path: Path) -> Path:

--- a/src/trend_analysis/export/bundle.py
+++ b/src/trend_analysis/export/bundle.py
@@ -1,7 +1,6 @@
 import datetime as _dt
 import json
 import os
-import subprocess
 import sys
 import tempfile
 import zipfile
@@ -18,19 +17,10 @@ from trend_analysis.util.hash import (
     sha256_config,
     sha256_file,
 )
+from trend_analysis.util.git import git_hash
 
 
-def _git_hash() -> str:
-    try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "HEAD"], encoding="utf-8", shell=False
-        ).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        # Ensure a non-empty fallback so callers always receive at least a
-        # short hash.  This prevents downstream checks from failing when the
-        # repository metadata isn't available (e.g. in a zipped release
-        # environment where the ``.git`` directory is absent).
-        return "unknown"
+_git_hash = git_hash
 
 
 def export_bundle(run: Any, path: Path) -> Path:

--- a/src/trend_analysis/reporting/portfolio_series.py
+++ b/src/trend_analysis/reporting/portfolio_series.py
@@ -113,6 +113,14 @@ def _weighted_portfolio(
     return portfolio
 
 
+def weighted_sum(
+    df: pd.DataFrame | None, weights: Mapping[str, float] | None
+) -> pd.Series | None:
+    """Return a weighted row-wise portfolio series with equal-weight fallback."""
+
+    return _weighted_portfolio(df, weights)
+
+
 @overload
 def select_primary_portfolio_series(
     res: Mapping[str, Any], *, prefer_raw: Literal[False] = False

--- a/src/trend_analysis/reporting/portfolio_series.py
+++ b/src/trend_analysis/reporting/portfolio_series.py
@@ -95,9 +95,14 @@ def _weighted_portfolio(
                 target_total = 1.0 - cash_value
             elif math.isfinite(cash_value) and cash_value >= 1:
                 target_total = 0.0
-        series = _normalise_weights(weights, target_total=target_total)
-        if not series.empty:
-            aligned = series.reindex(out_df.columns, fill_value=0.0)
+        raw_series = _normalise_weights(weights)
+        if not raw_series.empty:
+            aligned_weights = raw_series.reindex(out_df.columns, fill_value=0.0)
+            aligned = _normalise_weights(
+                aligned_weights.to_dict(),
+                target_total=target_total,
+            )
+            aligned = aligned.reindex(out_df.columns, fill_value=0.0)
             portfolio = out_df.mul(aligned, axis=1).sum(axis=1)
             if isinstance(cash_weight, numbers.Real) and isinstance(risk_free, pd.Series):
                 cash_series = risk_free.reindex(out_df.index).fillna(0.0)
@@ -113,9 +118,7 @@ def _weighted_portfolio(
     return portfolio
 
 
-def weighted_sum(
-    df: pd.DataFrame | None, weights: Mapping[str, float] | None
-) -> pd.Series | None:
+def weighted_sum(df: pd.DataFrame | None, weights: Mapping[str, float] | None) -> pd.Series | None:
     """Return a weighted row-wise portfolio series with equal-weight fallback."""
 
     return _weighted_portfolio(df, weights)

--- a/src/trend_analysis/reporting/run_artifacts.py
+++ b/src/trend_analysis/reporting/run_artifacts.py
@@ -6,13 +6,13 @@ import datetime as _dt
 import html
 import json
 import shutil
-import subprocess
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 import pandas as pd
 
 from trend_analysis.identity import IdentityMap
+from trend_analysis.util.git import git_hash
 from trend_analysis.util.hash import normalise_for_json, sha256_config, sha256_file
 
 _METRIC_FIELDS = (
@@ -25,15 +25,7 @@ _METRIC_FIELDS = (
 )
 
 
-def _git_hash() -> str:
-    """Return the current git commit hash when available."""
-
-    try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "HEAD"], encoding="utf-8", shell=False
-        ).strip()
-    except Exception:
-        return "unknown"
+_git_hash = git_hash
 
 
 def _serialise_stats(stats: Any) -> dict[str, float]:

--- a/src/trend_analysis/util/git.py
+++ b/src/trend_analysis/util/git.py
@@ -1,0 +1,16 @@
+"""Small git metadata helpers shared by export/reporting code."""
+
+from __future__ import annotations
+
+import subprocess
+
+
+def git_hash() -> str:
+    """Return the current git commit hash, or ``unknown`` outside a checkout."""
+
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], encoding="utf-8", shell=False
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"

--- a/src/trend_analysis/util/git.py
+++ b/src/trend_analysis/util/git.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import subprocess
+from typing import Any, cast
 
 
-def git_hash() -> str:
+def git_hash(subprocess_module: Any = subprocess) -> str:
     """Return the current git commit hash, or ``unknown`` outside a checkout."""
 
     try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "HEAD"], encoding="utf-8", shell=False
-        ).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError):
+        return cast(
+            str,
+            subprocess_module.check_output(
+                ["git", "rev-parse", "HEAD"], encoding="utf-8", shell=False
+            ).strip(),
+        )
+    except (subprocess_module.CalledProcessError, FileNotFoundError):
         return "unknown"

--- a/src/trend_analysis/viz/charts/rolling_panel.py
+++ b/src/trend_analysis/viz/charts/rolling_panel.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, TypeVar, cast
 import pandas as pd
 import plotly.graph_objects as go
 
-from trend_analysis.viz.adapters import rolling_stats
+from trend_analysis.viz.adapters import _paths_to_wide_nav, rolling_stats
 
 st: Any | None
 try:
@@ -31,16 +31,6 @@ def _cache_data(*args: object, **kwargs: object) -> Callable[[F], F]:
     return _identity
 
 
-def _to_nav_wide(paths: pd.DataFrame) -> pd.DataFrame:
-    if paths.empty:
-        return pd.DataFrame()
-    nav = pd.to_numeric(paths["nav"], errors="coerce")
-    wide = nav.unstack("path")
-    wide.index = pd.to_datetime(wide.index, errors="coerce")
-    wide = wide[wide.index.notna()]
-    return wide.sort_index()
-
-
 @_cache_data(show_spinner=False)
 def _prepare_panel_series(
     paths: pd.DataFrame,
@@ -53,7 +43,7 @@ def _prepare_panel_series(
     if rolling.empty:
         return pd.DataFrame()
 
-    wide_nav = _to_nav_wide(paths).ffill()
+    wide_nav = _paths_to_wide_nav(paths).ffill()
     if wide_nav.empty:
         return pd.DataFrame()
 

--- a/src/trend_analysis/viz/charts/seasonality_heatmap.py
+++ b/src/trend_analysis/viz/charts/seasonality_heatmap.py
@@ -34,6 +34,8 @@ def _cache_data(*args: object, **kwargs: object) -> Callable[[F], F]:
 
 @_cache_data(show_spinner=False)
 def _prepare_seasonality_matrix(paths: pd.DataFrame) -> pd.DataFrame:
+    if paths.empty:
+        return pd.DataFrame()
     wide_nav = _paths_to_wide_nav(paths).ffill()
     if wide_nav.empty:
         return pd.DataFrame()

--- a/src/trend_analysis/viz/charts/seasonality_heatmap.py
+++ b/src/trend_analysis/viz/charts/seasonality_heatmap.py
@@ -8,6 +8,8 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 
+from trend_analysis.viz.adapters import _paths_to_wide_nav
+
 st: Any | None
 try:
     import streamlit
@@ -30,19 +32,9 @@ def _cache_data(*args: object, **kwargs: object) -> Callable[[F], F]:
     return _identity
 
 
-def _to_nav_wide(paths: pd.DataFrame) -> pd.DataFrame:
-    if paths.empty:
-        return pd.DataFrame()
-    nav = pd.to_numeric(paths["nav"], errors="coerce")
-    wide = nav.unstack("path")
-    wide.index = pd.to_datetime(wide.index, errors="coerce")
-    wide = wide[wide.index.notna()]
-    return wide.sort_index()
-
-
 @_cache_data(show_spinner=False)
 def _prepare_seasonality_matrix(paths: pd.DataFrame) -> pd.DataFrame:
-    wide_nav = _to_nav_wide(paths).ffill()
+    wide_nav = _paths_to_wide_nav(paths).ffill()
     if wide_nav.empty:
         return pd.DataFrame()
 

--- a/tests/test_export_dedup.py
+++ b/tests/test_export_dedup.py
@@ -3,16 +3,27 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 from trend_analysis.reporting.portfolio_series import weighted_sum
-
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
 def _module_ast(relative_path: str) -> ast.Module:
     return ast.parse((ROOT / relative_path).read_text(encoding="utf-8"))
+
+
+def _has_call(tree: ast.AST, function_name: str) -> bool:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name) and node.func.id == function_name:
+            return True
+        if isinstance(node.func, ast.Attribute) and node.func.attr == function_name:
+            return True
+    return False
 
 
 def test_export_uses_shared_weighted_sum_helper() -> None:
@@ -24,18 +35,14 @@ def test_export_uses_shared_weighted_sum_helper() -> None:
     ]
 
     assert local_portfolio_defs == []
-    assert "weighted_sum(" in (ROOT / "src/trend_analysis/export/__init__.py").read_text(
-        encoding="utf-8"
-    )
+    assert _has_call(tree, "weighted_sum")
 
 
 def test_weighted_sum_preserves_export_weighting_behavior() -> None:
     frame = pd.DataFrame({"A": [0.10, 0.00], "B": [0.05, 0.02]})
 
     weighted = weighted_sum(frame, {"A": 2.0, "B": 1.0})
-    expected_weighted = frame.mul(pd.Series({"A": 2.0 / 3.0, "B": 1.0 / 3.0}), axis=1).sum(
-        axis=1
-    )
+    expected_weighted = frame.mul(pd.Series({"A": 2.0 / 3.0, "B": 1.0 / 3.0}), axis=1).sum(axis=1)
     pd.testing.assert_series_equal(weighted, expected_weighted)
 
     equal = weighted_sum(frame, None)
@@ -43,17 +50,33 @@ def test_weighted_sum_preserves_export_weighting_behavior() -> None:
     pd.testing.assert_series_equal(equal, expected_equal)
 
 
+def test_weighted_sum_ignores_missing_weight_keys_before_normalizing() -> None:
+    frame = pd.DataFrame({"A": [0.10, 0.00], "B": [0.05, 0.02]})
+
+    weighted = weighted_sum(frame, {"A": 2.0, "B": 1.0, "missing": 7.0})
+    expected = frame.mul(pd.Series({"A": 2.0 / 3.0, "B": 1.0 / 3.0}), axis=1).sum(axis=1)
+
+    pd.testing.assert_series_equal(weighted, expected)
+
+
 def test_viz_charts_reuse_canonical_nav_adapter() -> None:
     for relative_path in (
         "src/trend_analysis/viz/charts/rolling_panel.py",
         "src/trend_analysis/viz/charts/seasonality_heatmap.py",
     ):
-        source = (ROOT / relative_path).read_text(encoding="utf-8")
-        tree = ast.parse(source)
+        tree = _module_ast(relative_path)
         local_to_nav_wide = [
             node
             for node in ast.walk(tree)
             if isinstance(node, ast.FunctionDef) and node.name == "_to_nav_wide"
         ]
         assert local_to_nav_wide == []
-        assert "_paths_to_wide_nav(" in source
+        assert _has_call(tree, "_paths_to_wide_nav")
+
+
+def test_seasonality_heatmap_preserves_empty_input_behavior() -> None:
+    if not hasattr(np, "unicode_"):
+        np.unicode_ = np.str_
+    from trend_analysis.viz.charts.seasonality_heatmap import build_figure
+
+    assert not build_figure(pd.DataFrame()).data

--- a/tests/test_export_dedup.py
+++ b/tests/test_export_dedup.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pandas as pd
+
+from trend_analysis.reporting.portfolio_series import weighted_sum
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _module_ast(relative_path: str) -> ast.Module:
+    return ast.parse((ROOT / relative_path).read_text(encoding="utf-8"))
+
+
+def test_export_uses_shared_weighted_sum_helper() -> None:
+    tree = _module_ast("src/trend_analysis/export/__init__.py")
+    local_portfolio_defs = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "portfolio_series"
+    ]
+
+    assert local_portfolio_defs == []
+    assert "weighted_sum(" in (ROOT / "src/trend_analysis/export/__init__.py").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_weighted_sum_preserves_export_weighting_behavior() -> None:
+    frame = pd.DataFrame({"A": [0.10, 0.00], "B": [0.05, 0.02]})
+
+    weighted = weighted_sum(frame, {"A": 2.0, "B": 1.0})
+    expected_weighted = frame.mul(pd.Series({"A": 2.0 / 3.0, "B": 1.0 / 3.0}), axis=1).sum(
+        axis=1
+    )
+    pd.testing.assert_series_equal(weighted, expected_weighted)
+
+    equal = weighted_sum(frame, None)
+    expected_equal = frame.mul(pd.Series({"A": 0.5, "B": 0.5}), axis=1).sum(axis=1)
+    pd.testing.assert_series_equal(equal, expected_equal)
+
+
+def test_viz_charts_reuse_canonical_nav_adapter() -> None:
+    for relative_path in (
+        "src/trend_analysis/viz/charts/rolling_panel.py",
+        "src/trend_analysis/viz/charts/seasonality_heatmap.py",
+    ):
+        source = (ROOT / relative_path).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        local_to_nav_wide = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "_to_nav_wide"
+        ]
+        assert local_to_nav_wide == []
+        assert "_paths_to_wide_nav(" in source


### PR DESCRIPTION
Closes #5425

## Summary
- centralize export portfolio weighting through `reporting.portfolio_series.weighted_sum`
- reuse the canonical Monte Carlo NAV adapter in rolling/seasonality charts
- share git hash lookup and collapse duplicate openpyxl adapter implementation bodies
- add AST/parity coverage that fails if local duplicate helpers return

## Validation
- `PYTHONPATH=src python -m pytest tests/test_export_dedup.py tests/test_portfolio_series_selection.py tests/test_export_openpyxl_adapter.py tests/test_export_additional_coverage.py -q` -> 54 passed
- `python -m ruff check src/trend_analysis/export/__init__.py src/trend_analysis/reporting/portfolio_series.py src/trend_analysis/viz/charts/rolling_panel.py src/trend_analysis/viz/charts/seasonality_heatmap.py src/trend_analysis/export/bundle.py src/trend_analysis/reporting/run_artifacts.py src/trend_analysis/util/git.py tests/test_export_dedup.py` -> passed
- `git diff --check` -> passed

## Deliberate break
- Temporarily reintroduced a local `portfolio_series` function in `src/trend_analysis/export/__init__.py`; `tests/test_export_dedup.py::test_export_uses_shared_weighted_sum_helper` failed. Removed the temporary function and reran the focused suite green.

## Broad selector note
- `PYTHONPATH=src python -m pytest tests/ -k "export or viz" -q` still fails during collection on existing local NumPy 2.x/xarray/pyarrow/Streamlit issues before this diff's selected tests run.