### PR TITLE
Issue #5426: deduplicate MC reporting helpers

### DIFF
--- a/src/trend/mc/viz.py
+++ b/src/trend/mc/viz.py
@@ -11,9 +11,9 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
-_OPTIONAL_STEM_EXTENSIONS: tuple[str, ...] = ("parquet", "csv", "json")
+from trend.mc.charts import NAV_PATH_REQUIRED_CHARTS
 
-NAV_PATH_REQUIRED_CHARTS: frozenset[str] = frozenset({"path_dist"})
+_OPTIONAL_STEM_EXTENSIONS: tuple[str, ...] = ("parquet", "csv", "json")
 
 CHART_REQUIREMENTS: dict[str, tuple[str, ...]] = {
     "fan": ("summary", "results"),

--- a/src/trend/reporting/_matplotlib.py
+++ b/src/trend/reporting/_matplotlib.py
@@ -1,0 +1,24 @@
+"""Shared matplotlib setup for trend reporting surfaces."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def init_matplotlib() -> Any:  # pragma: no cover - thin import/config wrapper
+    import matplotlib
+
+    matplotlib.use("Agg")
+    from matplotlib import pyplot as plt
+
+    matplotlib.rcParams["savefig.facecolor"] = "white"
+    matplotlib.rcParams["savefig.edgecolor"] = "white"
+    matplotlib.rcParams["savefig.bbox"] = "tight"
+    matplotlib.rcParams["savefig.pad_inches"] = 0.1
+    matplotlib.rcParams["savefig.dpi"] = 160
+    matplotlib.rcParams["savefig.transparent"] = False
+    matplotlib.rcParams["savefig.format"] = "png"
+    return plt
+
+
+__all__ = ["init_matplotlib"]

--- a/src/trend/reporting/quick_summary.py
+++ b/src/trend/reporting/quick_summary.py
@@ -25,24 +25,11 @@ if TYPE_CHECKING:
 import pandas as pd
 
 from trend.diagnostics import DiagnosticPayload, DiagnosticResult
+from trend.reporting._matplotlib import init_matplotlib
 from trend_analysis.reporting.portfolio_series import select_primary_portfolio_series
 
 
-def _init_matplotlib() -> Any:  # pragma: no cover - thin wrapper
-    import matplotlib
-
-    matplotlib.use("Agg")
-    from matplotlib import pyplot as plt
-
-    matplotlib.rcParams["savefig.facecolor"] = "white"
-    matplotlib.rcParams["savefig.edgecolor"] = "white"
-    matplotlib.rcParams["savefig.bbox"] = "tight"
-    matplotlib.rcParams["savefig.pad_inches"] = 0.1
-    matplotlib.rcParams["savefig.dpi"] = 160
-    return plt
-
-
-plt = _init_matplotlib()
+plt = init_matplotlib()
 
 
 def _coerce_series(obj: Any) -> pd.Series:

--- a/src/trend/reporting/unified.py
+++ b/src/trend/reporting/unified.py
@@ -12,10 +12,10 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal, Mapping, Sequence, cast
 
-import matplotlib
 import pandas as pd
 
 from trend.diagnostics import DiagnosticPayload, DiagnosticResult
+from trend.reporting._matplotlib import init_matplotlib
 from trend_analysis.backtesting import BacktestResult, CostModel
 from trend_analysis.reporting.narrative import (
     STANDARD_NARRATIVE_DISCLAIMER,
@@ -24,21 +24,7 @@ from trend_analysis.reporting.narrative import (
 from trend_analysis.reporting.portfolio_series import select_primary_portfolio_series
 
 
-def _init_matplotlib() -> Any:
-    matplotlib.use("Agg")
-    from matplotlib import pyplot as _pyplot  # noqa: E402
-
-    matplotlib.rcParams["savefig.facecolor"] = "white"
-    matplotlib.rcParams["savefig.edgecolor"] = "white"
-    matplotlib.rcParams["savefig.bbox"] = "tight"
-    matplotlib.rcParams["savefig.pad_inches"] = 0.1
-    matplotlib.rcParams["savefig.dpi"] = 160
-    matplotlib.rcParams["savefig.transparent"] = False
-    matplotlib.rcParams["savefig.format"] = "png"
-    return _pyplot
-
-
-plt = _init_matplotlib()
+plt = init_matplotlib()
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from trend_model.spec import TrendRunSpec

--- a/tests/test_mc_reporting_dedup.py
+++ b/tests/test_mc_reporting_dedup.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import trend.mc.charts as mc_charts
+import trend.mc.viz as mc_viz
+from trend.reporting import quick_summary, unified
+from trend.reporting._matplotlib import init_matplotlib
+
+
+def test_mc_viz_reuses_chart_nav_requirement_constant() -> None:
+    assert mc_viz.NAV_PATH_REQUIRED_CHARTS is mc_charts.NAV_PATH_REQUIRED_CHARTS
+
+
+def test_reporting_modules_reuse_shared_matplotlib_initializer() -> None:
+    assert quick_summary.init_matplotlib is init_matplotlib
+    assert unified.init_matplotlib is init_matplotlib
+
+
+def test_no_local_matplotlib_initializer_definitions_remain() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    for relative in ("src/trend/reporting/quick_summary.py", "src/trend/reporting/unified.py"):
+        module = ast.parse((repo_root / relative).read_text(encoding="utf-8"))
+        function_names = {node.name for node in module.body if isinstance(node, ast.FunctionDef)}
+        assert "_init_matplotlib" not in function_names


### PR DESCRIPTION
Closes #5426

## Summary
- reuse `trend.mc.charts.NAV_PATH_REQUIRED_CHARTS` from `trend.mc.viz` instead of redefining it
- add shared `trend.reporting._matplotlib.init_matplotlib()` with the reconciled rcParam superset
- wire quick-summary and unified reporting to the shared matplotlib initializer
- add regression coverage for the MC constant identity and shared reporting initializer

## Validation
- `PYTHONPATH=src python -m pytest tests/test_mc_reporting_dedup.py tests/unit/test_mc_io_nav_paths.py tests/test_quick_summary_report.py tests/test_unified_report.py -q` -> 18 passed, 11 existing FPDF deprecation warnings
- `python -m ruff check src/trend/mc/viz.py src/trend/reporting/_matplotlib.py src/trend/reporting/quick_summary.py src/trend/reporting/unified.py tests/test_mc_reporting_dedup.py` -> passed
- `git diff --check` -> passed

## Deliberate break
- Temporarily reintroduced a local `NAV_PATH_REQUIRED_CHARTS = frozenset({"path_dist"})` in `trend/mc/viz.py`; `tests/test_mc_reporting_dedup.py::test_mc_viz_reuses_chart_nav_requirement_constant` failed on object identity. Removed the temporary local constant and reran validation green.