### PR TITLE
Issue #5428: remove metrics import side effects

### DIFF
--- a/src/trend_analysis/metrics/__init__.py
+++ b/src/trend_analysis/metrics/__init__.py
@@ -7,9 +7,6 @@ Legacy *annualize_* wrappers are kept for back-compat with the test-suite.
 
 from __future__ import annotations
 
-import builtins as _bi
-import sys
-import types
 from importlib import import_module
 from typing import Any, Callable, cast
 
@@ -400,9 +397,6 @@ def information_ratio(
         return ann_act / tr_error
 
 
-# ------------------------------------------------------------------ #
-# 2A.  Ensure tests.legacy_metrics exists and exposes the old names. #
-# ------------------------------------------------------------------ #
 annualize_return = annual_return
 annualize_volatility = volatility
 annualize_sharpe_ratio = sharpe_ratio
@@ -415,28 +409,6 @@ from .deflated_sharpe import (  # noqa: E402
     probabilistic_sharpe_ratio,
 )
 from .factor_attribution import factor_exposures  # noqa: E402
-
-_legacy = types.ModuleType("tests.legacy_metrics")
-for _name in (
-    "annualize_return",
-    "annualize_volatility",
-    "sharpe_ratio",
-    "sortino_ratio",
-    "max_drawdown",
-    "information_ratio",
-    "info_ratio",
-    "volatility",
-):
-    _legacy.__dict__[_name] = globals()[
-        _name if _name in globals() else _name.replace("info_", "information_")
-    ]
-sys.modules.setdefault("tests.legacy_metrics", _legacy)
-
-# trend_analysis/metrics.py  (append near the bottom ­– after all definitions)
-# ---------------------------------------------------------------------------
-
-setattr(_bi, "annualize_return", annualize_return)
-setattr(_bi, "annualize_volatility", annualize_volatility)
 
 # Public submodules exposed via attribute assignment for compatibility while
 # keeping Ruff satisfied about unused imports.

--- a/tests/test_metrics_no_import_side_effects.py
+++ b/tests/test_metrics_no_import_side_effects.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _drop_metrics_modules() -> None:
+    for name in list(sys.modules):
+        if name == "trend_analysis.metrics" or name.startswith("trend_analysis.metrics."):
+            sys.modules.pop(name, None)
+
+
+def test_metrics_import_does_not_patch_builtins(monkeypatch) -> None:
+    monkeypatch.delattr(builtins, "annualize_return", raising=False)
+    monkeypatch.delattr(builtins, "annualize_volatility", raising=False)
+    _drop_metrics_modules()
+
+    metrics = importlib.import_module("trend_analysis.metrics")
+
+    assert metrics.annualize_return is metrics.annual_return
+    assert metrics.annualize_volatility is metrics.volatility
+    assert not hasattr(builtins, "annualize_return")
+    assert not hasattr(builtins, "annualize_volatility")
+
+
+def test_metrics_import_does_not_replace_real_legacy_metrics_module() -> None:
+    sys.modules.pop("tests.legacy_metrics", None)
+    legacy = importlib.import_module("tests.legacy_metrics")
+    _drop_metrics_modules()
+
+    importlib.import_module("trend_analysis.metrics")
+
+    assert sys.modules["tests.legacy_metrics"] is legacy
+    assert isinstance(legacy, ModuleType)
+    assert legacy.__file__
+    assert Path(legacy.__file__).parts[-2:] == ("tests", "legacy_metrics.py")
+
+
+def test_metrics_first_import_does_not_shadow_legacy_metrics_module() -> None:
+    sys.modules.pop("tests.legacy_metrics", None)
+    _drop_metrics_modules()
+
+    importlib.import_module("trend_analysis.metrics")
+    legacy = importlib.import_module("tests.legacy_metrics")
+
+    assert sys.modules["tests.legacy_metrics"] is legacy
+    assert isinstance(legacy, ModuleType)
+    assert legacy.__file__
+    assert Path(legacy.__file__).parts[-2:] == ("tests", "legacy_metrics.py")


### PR DESCRIPTION
Closes #5428

## Summary
- remove the synthetic `tests.legacy_metrics` registration from `trend_analysis.metrics`
- remove the `builtins.annualize_return` / `builtins.annualize_volatility` monkey-patches while preserving explicit package aliases
- add import-side-effect regression coverage for builtins and the real `tests/legacy_metrics.py` module

## Validation
- `PYTHONPATH=src python -m pytest tests/test_metrics_no_import_side_effects.py tests/test_metric_vectorise.py tests/test_metric_vectorise_param.py -q` -> 8 passed
- `python -m ruff check src/trend_analysis/metrics/__init__.py tests/test_metrics_no_import_side_effects.py` -> passed
- `python -m mypy src/trend_analysis/metrics/__init__.py tests/test_metrics_no_import_side_effects.py` -> passed
- `git diff --check` -> passed

## Deliberate break
- Temporarily restored the `builtins` patch; `tests/test_metrics_no_import_side_effects.py::test_metrics_import_does_not_patch_builtins` failed on `hasattr(builtins, "annualize_return")`. Removed the temporary patch and reran focused validation green.

## Broad selector note
- `PYTHONPATH=src python -m pytest tests/test_metrics_no_import_side_effects.py tests/ -k "metric_vectorise" -q` is currently blocked during collection by existing local NumPy 2.x/xarray/pyarrow/Streamlit import errors before selected metric tests run.