### PR TITLE
Issue #5432: bind repo servers to localhost by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,12 @@ services:
       - ./data:/app/data
   api:
     image: *trend-image
-    command: python -m trend_analysis.api_server
+    command:
+      [
+        "python",
+        "-c",
+        "from trend_analysis.api_server import run; run(host='0.0.0.0', port=8000)",
+      ]
     ports:
       - "8000:8000"
     volumes:

--- a/src/trend_analysis/api_server/__main__.py
+++ b/src/trend_analysis/api_server/__main__.py
@@ -4,4 +4,4 @@ from . import run
 
 if __name__ == "__main__":
     # Run FastAPI server on port 8000 to match docker-compose.yml
-    run(host="0.0.0.0", port=8000)
+    run(host="127.0.0.1", port=8000)

--- a/src/trend_analysis/llm_proxy/cli.py
+++ b/src/trend_analysis/llm_proxy/cli.py
@@ -14,10 +14,10 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="OpenAI-compatible LLM proxy")
     parser.add_argument(
         "--host",
-        default="0.0.0.0",
+        default="127.0.0.1",
         help=(
-            "Host to bind the proxy server (default: 0.0.0.0). "
-            "Use 127.0.0.1 for local-only access."
+            "Host to bind the proxy server (default: 127.0.0.1). "
+            "Pass 0.0.0.0 explicitly to listen on all interfaces."
         ),
     )
     parser.add_argument(

--- a/src/trend_analysis/llm_proxy/server.py
+++ b/src/trend_analysis/llm_proxy/server.py
@@ -204,7 +204,7 @@ class LLMProxy:
             headers=filtered,
         )
 
-    async def start(self, host: str = "0.0.0.0", port: int = 8799) -> None:  # noqa: D401
+    async def start(self, host: str = "127.0.0.1", port: int = 8799) -> None:  # noqa: D401
         _assert_deps()
         if uvicorn is None:
             raise RuntimeError("uvicorn dependency is required to start the proxy server")
@@ -221,7 +221,7 @@ class LLMProxy:
 
 def run_proxy(
     upstream_base: str | None = None,
-    host: str = "0.0.0.0",
+    host: str = "127.0.0.1",
     port: int = 8799,
 ) -> None:
     """Run the LLM proxy synchronously (convenience wrapper)."""

--- a/src/trend_analysis/proxy/cli.py
+++ b/src/trend_analysis/proxy/cli.py
@@ -27,8 +27,11 @@ def main() -> int:
     )
     parser.add_argument(
         "--proxy-host",
-        default="0.0.0.0",
-        help="Host to bind the proxy server (default: 0.0.0.0)",
+        default="127.0.0.1",
+        help=(
+            "Host to bind the proxy server (default: 127.0.0.1; "
+            "pass 0.0.0.0 explicitly to listen on all interfaces)"
+        ),
     )
     parser.add_argument(
         "--proxy-port",

--- a/src/trend_analysis/proxy/server.py
+++ b/src/trend_analysis/proxy/server.py
@@ -234,7 +234,7 @@ class StreamlitProxy:
             logger.error("HTTP proxy error: %s", e)
             return {"error": str(e), "status_code": 502}
 
-    async def start(self, host: str = "0.0.0.0", port: int = 8500) -> None:  # noqa: D401
+    async def start(self, host: str = "127.0.0.1", port: int = 8500) -> None:  # noqa: D401
         _assert_deps()
         if uvicorn is None:
             raise RuntimeError("uvicorn dependency is required to start the proxy server")
@@ -252,7 +252,7 @@ class StreamlitProxy:
 def run_proxy(
     streamlit_host: str = "localhost",
     streamlit_port: int = 8501,
-    proxy_host: str = "0.0.0.0",
+    proxy_host: str = "127.0.0.1",
     proxy_port: int = 8500,
 ) -> None:
     """Run the proxy synchronously (convenience wrapper)."""

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -554,4 +554,4 @@ def test_api_server_module_entrypoint(monkeypatch):
 
     runpy.run_module("trend_analysis.api_server.__main__", run_name="__main__")
 
-    assert called["args"] == ("0.0.0.0", 8000)
+    assert called["args"] == ("127.0.0.1", 8000)

--- a/tests/test_api_server_entrypoint.py
+++ b/tests/test_api_server_entrypoint.py
@@ -28,7 +28,7 @@ def test_api_server_entrypoint_invokes_run(monkeypatch):
 
     runpy.run_module("trend_analysis.api_server.__main__", run_name="__main__")
 
-    assert called == {"host": "0.0.0.0", "port": 8000}
+    assert called == {"host": "127.0.0.1", "port": 8000}
 
 
 def test_api_server_package_main_invokes_run(monkeypatch):

--- a/tests/test_proxy_cli_entrypoint.py
+++ b/tests/test_proxy_cli_entrypoint.py
@@ -32,7 +32,7 @@ def test_proxy_cli_main_invocation(monkeypatch, capsys):
     assert call_args == {
         "streamlit_host": "localhost",
         "streamlit_port": 1234,
-        "proxy_host": "0.0.0.0",
+        "proxy_host": "127.0.0.1",
         "proxy_port": 5678,
     }
     captured = capsys.readouterr()

--- a/tests/test_server_bind_defaults.py
+++ b/tests/test_server_bind_defaults.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import inspect
+import runpy
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from trend_analysis.llm_proxy import cli as llm_proxy_cli
+from trend_analysis.llm_proxy import server as llm_proxy_server
+from trend_analysis.proxy import cli as streamlit_proxy_cli
+from trend_analysis.proxy import server as streamlit_proxy_server
+
+
+def test_streamlit_proxy_default_bind_is_localhost(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_proxy(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(streamlit_proxy_cli, "run_proxy", fake_run_proxy)
+    monkeypatch.setattr(
+        streamlit_proxy_cli, "setup_logging", lambda **_: Path("/tmp/proxy.log")
+    )
+    monkeypatch.setattr(sys, "argv", ["trend-proxy"])
+
+    assert streamlit_proxy_cli.main() == 0
+
+    assert captured["proxy_host"] == "127.0.0.1"
+    assert (
+        inspect.signature(streamlit_proxy_server.StreamlitProxy.start)
+        .parameters["host"]
+        .default
+        == "127.0.0.1"
+    )
+    assert (
+        inspect.signature(streamlit_proxy_server.run_proxy)
+        .parameters["proxy_host"]
+        .default
+        == "127.0.0.1"
+    )
+
+
+def test_streamlit_proxy_all_interfaces_requires_explicit_host(monkeypatch) -> None:
+    events: list[tuple[str, object]] = []
+
+    class DummyProxy:
+        def __init__(self, streamlit_host: str, streamlit_port: int) -> None:
+            events.append(("init", (streamlit_host, streamlit_port)))
+
+        async def start(self, host: str, port: int) -> None:
+            events.append(("start", (host, port)))
+
+        async def close(self) -> None:
+            events.append(("close", None))
+
+    monkeypatch.setattr(streamlit_proxy_server, "StreamlitProxy", DummyProxy)
+
+    streamlit_proxy_server.run_proxy(proxy_host="0.0.0.0", proxy_port=9000)
+
+    assert ("start", ("0.0.0.0", 9000)) in events
+
+
+def test_llm_proxy_default_bind_is_localhost(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_proxy(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(llm_proxy_cli, "run_proxy", fake_run_proxy)
+    monkeypatch.setattr(llm_proxy_cli, "setup_logging", lambda **_: Path("/tmp/llm.log"))
+    monkeypatch.setattr(sys, "argv", ["trend-llm-proxy"])
+
+    assert llm_proxy_cli.main() == 0
+
+    assert captured["host"] == "127.0.0.1"
+    assert (
+        inspect.signature(llm_proxy_server.LLMProxy.start).parameters["host"].default
+        == "127.0.0.1"
+    )
+    assert (
+        inspect.signature(llm_proxy_server.run_proxy).parameters["host"].default
+        == "127.0.0.1"
+    )
+
+
+def test_llm_proxy_all_interfaces_requires_explicit_host(monkeypatch) -> None:
+    events: list[tuple[str, object]] = []
+
+    class DummyProxy:
+        def __init__(self, upstream_base: str | None = None) -> None:
+            events.append(("init", upstream_base))
+
+        async def start(self, *, host: str, port: int) -> None:
+            events.append(("start", (host, port)))
+
+        async def close(self) -> None:
+            events.append(("close", None))
+
+    monkeypatch.setattr(llm_proxy_server, "LLMProxy", DummyProxy)
+
+    llm_proxy_server.run_proxy(host="0.0.0.0", port=8799)
+
+    assert ("start", ("0.0.0.0", 8799)) in events
+
+
+def test_api_server_module_entrypoint_default_bind_is_localhost(monkeypatch) -> None:
+    called: dict[str, object] = {}
+
+    def fake_run(*, host: str, port: int) -> None:
+        called["host"] = host
+        called["port"] = port
+
+    package = ModuleType("trend_analysis.api_server")
+    package.run = fake_run  # type: ignore[attr-defined]
+    package.__path__ = [str(Path("src/trend_analysis/api_server").resolve())]
+    monkeypatch.setitem(sys.modules, "trend_analysis.api_server", package)
+    sys.modules.pop("trend_analysis.api_server.__main__", None)
+
+    runpy.run_module("trend_analysis.api_server.__main__", run_name="__main__")
+
+    assert called == {"host": "127.0.0.1", "port": 8000}
+
+
+def test_api_server_explicit_all_interfaces_override_still_works(monkeypatch) -> None:
+    import trend_analysis.api_server as api_server
+
+    calls: list[dict[str, Any]] = []
+
+    class StubUvicorn:
+        @staticmethod
+        def run(app: Any, host: str, port: int, *, reload: bool, log_level: str) -> None:
+            calls.append(
+                {
+                    "app": app,
+                    "host": host,
+                    "port": port,
+                    "reload": reload,
+                    "log_level": log_level,
+                }
+            )
+
+    monkeypatch.setitem(sys.modules, "uvicorn", StubUvicorn())
+
+    assert api_server.run(host="0.0.0.0", port=1234) == ("0.0.0.0", 1234)
+    assert any(call["host"] == "0.0.0.0" and call["port"] == 1234 for call in calls)

--- a/tests/test_server_bind_defaults.py
+++ b/tests/test_server_bind_defaults.py
@@ -13,6 +13,13 @@ from trend_analysis.proxy import cli as streamlit_proxy_cli
 from trend_analysis.proxy import server as streamlit_proxy_server
 
 
+def test_docker_compose_api_service_uses_explicit_external_bind() -> None:
+    compose = Path("docker-compose.yml").read_text()
+
+    assert "from trend_analysis.api_server import run" in compose
+    assert "run(host='0.0.0.0', port=8000)" in compose
+
+
 def test_streamlit_proxy_default_bind_is_localhost(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -7,7 +7,9 @@
 - Tests: added `tests/test_server_bind_defaults.py` covering default localhost binds for Streamlit proxy CLI/helper, LLM proxy CLI/helper, and API server module entrypoint, plus explicit all-interface override coverage.
 - Validation: `PYTHONPATH=src python -m pytest tests/test_server_bind_defaults.py tests/test_proxy_cli_entrypoint.py tests/test_api_server_entrypoint.py tests/test_proxy_cli.py tests/test_proxy_server_additional.py::test_streamlit_proxy_start_invokes_uvicorn tests/test_proxy_server_additional.py::test_run_proxy_starts_and_closes tests/proxy/test_server.py::test_start_invokes_uvicorn tests/proxy/test_server.py::test_run_proxy_closes_on_start_failure tests/test_api_server.py::test_run_invokes_uvicorn -q` -> 18 passed, 1 existing runpy warning. Focused `ruff` passed. `git diff --check` passed.
 - Deliberate-break gate: temporarily restored `src/trend_analysis/proxy/cli.py` `--proxy-host` default to `0.0.0.0`; `tests/test_server_bind_defaults.py::test_streamlit_proxy_default_bind_is_localhost` failed on the expected default-host assertion. Restored localhost default and reran focused validation green.
-- Current state: ready to commit/push/open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`.
+- PR/routing: ready-for-review PR `#5499` opened at https://github.com/stranske/Trend_Model_Project/pull/5499, non-draft, closes `#5432`, with `agent:codex`, `agents:keepalive`, and `autofix`. Handoff `pr_opened` event recorded with `active.next_action=wait_for_keepalive`.
+- Post-open cap repair: initial cap-health classified `#5499` as `needs-dispatch-evidence`; `opener-repair-infra-stalls.py` added `agent:retry` and dispatched Gate Followups. Refreshed cap-health at 2026-06-04T17:09:36Z showed total_opener_owned=4/raw_cap_reached=false/non_drainable_cap_blocker=false and `#5499` as `draining` with active Gate evidence.
+- Current state: PR `#5499` is open and waiting on asynchronous Gate/keepalive checks. Next action belongs to keepalive/closer after checks settle.
 
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,14 @@
+## 2026-06-04T17:15Z - opener (codex): issue #5432 localhost bind defaults
+
+- Repo/issue: `stranske/Trend_Model_Project` issue `#5432` (`T19a - Tighten default network bind to 127.0.0.1`).
+- Branch/worktree: `codex/issue-5432-localhost-bind-defaults` in `~/.codex/automations/pd-workloop-resume/worktrees/trend-5432-localhost-bind-defaults`.
+- Selection: raw opener cap was below 5. Scoped blockers refreshed for `#5343`, `#5389/#5440`, and LMS `#180`. Existing opener-owned PRs were classified as #5440 terminal/scoped strict-config decision, #5492 draining with green Gate/Followups evidence, and #5498 green Gate after closer recovery but still with non-required Claude review failure. #5432 was the oldest unlinked implementation candidate outside the scoped blockers and already-linked issues.
+- Implementation: changed repo-owned Streamlit proxy, LLM proxy, and API server entrypoint defaults from `0.0.0.0` to `127.0.0.1`, while preserving explicit `0.0.0.0` override support. Included the LLM proxy CLI default/help so the public entry point matches the server helper.
+- Tests: added `tests/test_server_bind_defaults.py` covering default localhost binds for Streamlit proxy CLI/helper, LLM proxy CLI/helper, and API server module entrypoint, plus explicit all-interface override coverage.
+- Validation: `PYTHONPATH=src python -m pytest tests/test_server_bind_defaults.py tests/test_proxy_cli_entrypoint.py tests/test_api_server_entrypoint.py tests/test_proxy_cli.py tests/test_proxy_server_additional.py::test_streamlit_proxy_start_invokes_uvicorn tests/test_proxy_server_additional.py::test_run_proxy_starts_and_closes tests/proxy/test_server.py::test_start_invokes_uvicorn tests/proxy/test_server.py::test_run_proxy_closes_on_start_failure tests/test_api_server.py::test_run_invokes_uvicorn -q` -> 18 passed, 1 existing runpy warning. Focused `ruff` passed. `git diff --check` passed.
+- Deliberate-break gate: temporarily restored `src/trend_analysis/proxy/cli.py` `--proxy-host` default to `0.0.0.0`; `tests/test_server_bind_defaults.py::test_streamlit_proxy_default_bind_is_localhost` failed on the expected default-host assertion. Restored localhost default and reran focused validation green.
+- Current state: ready to commit/push/open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`.
+
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,16 +1,3 @@
-## 2026-06-04T17:15Z - opener (codex): issue #5432 localhost bind defaults
-
-- Repo/issue: `stranske/Trend_Model_Project` issue `#5432` (`T19a - Tighten default network bind to 127.0.0.1`).
-- Branch/worktree: `codex/issue-5432-localhost-bind-defaults` in `~/.codex/automations/pd-workloop-resume/worktrees/trend-5432-localhost-bind-defaults`.
-- Selection: raw opener cap was below 5. Scoped blockers refreshed for `#5343`, `#5389/#5440`, and LMS `#180`. Existing opener-owned PRs were classified as #5440 terminal/scoped strict-config decision, #5492 draining with green Gate/Followups evidence, and #5498 green Gate after closer recovery but still with non-required Claude review failure. #5432 was the oldest unlinked implementation candidate outside the scoped blockers and already-linked issues.
-- Implementation: changed repo-owned Streamlit proxy, LLM proxy, and API server entrypoint defaults from `0.0.0.0` to `127.0.0.1`, while preserving explicit `0.0.0.0` override support. Included the LLM proxy CLI default/help so the public entry point matches the server helper.
-- Tests: added `tests/test_server_bind_defaults.py` covering default localhost binds for Streamlit proxy CLI/helper, LLM proxy CLI/helper, and API server module entrypoint, plus explicit all-interface override coverage.
-- Validation: `PYTHONPATH=src python -m pytest tests/test_server_bind_defaults.py tests/test_proxy_cli_entrypoint.py tests/test_api_server_entrypoint.py tests/test_proxy_cli.py tests/test_proxy_server_additional.py::test_streamlit_proxy_start_invokes_uvicorn tests/test_proxy_server_additional.py::test_run_proxy_starts_and_closes tests/proxy/test_server.py::test_start_invokes_uvicorn tests/proxy/test_server.py::test_run_proxy_closes_on_start_failure tests/test_api_server.py::test_run_invokes_uvicorn -q` -> 18 passed, 1 existing runpy warning. Focused `ruff` passed. `git diff --check` passed.
-- Deliberate-break gate: temporarily restored `src/trend_analysis/proxy/cli.py` `--proxy-host` default to `0.0.0.0`; `tests/test_server_bind_defaults.py::test_streamlit_proxy_default_bind_is_localhost` failed on the expected default-host assertion. Restored localhost default and reran focused validation green.
-- PR/routing: ready-for-review PR `#5499` opened at https://github.com/stranske/Trend_Model_Project/pull/5499, non-draft, closes `#5432`, with `agent:codex`, `agents:keepalive`, and `autofix`. Handoff `pr_opened` event recorded with `active.next_action=wait_for_keepalive`.
-- Post-open cap repair: initial cap-health classified `#5499` as `needs-dispatch-evidence`; `opener-repair-infra-stalls.py` added `agent:retry` and dispatched Gate Followups. Refreshed cap-health at 2026-06-04T17:09:36Z showed total_opener_owned=4/raw_cap_reached=false/non_drainable_cap_blocker=false and `#5499` as `draining` with active Gate evidence.
-- Current state: PR `#5499` is open and waiting on asynchronous Gate/keepalive checks. Next action belongs to keepalive/closer after checks settle.
-
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.


### PR DESCRIPTION
Closes #5432

## Summary
- Change repo-owned Streamlit proxy, LLM proxy, and API server entrypoint defaults from `0.0.0.0` to `127.0.0.1`.
- Keep explicit `0.0.0.0` override support for proxy helpers and API server runs.
- Add focused bind-default regression tests for the Streamlit proxy, LLM proxy, and API server entrypoint.

## Validation
- `PYTHONPATH=src python -m pytest tests/test_server_bind_defaults.py tests/test_proxy_cli_entrypoint.py tests/test_api_server_entrypoint.py tests/test_proxy_cli.py tests/test_proxy_server_additional.py::test_streamlit_proxy_start_invokes_uvicorn tests/test_proxy_server_additional.py::test_run_proxy_starts_and_closes tests/proxy/test_server.py::test_start_invokes_uvicorn tests/proxy/test_server.py::test_run_proxy_closes_on_start_failure tests/test_api_server.py::test_run_invokes_uvicorn -q`
- `python -m ruff check src/trend_analysis/proxy/cli.py src/trend_analysis/proxy/server.py src/trend_analysis/llm_proxy/cli.py src/trend_analysis/llm_proxy/server.py src/trend_analysis/api_server/__main__.py tests/test_server_bind_defaults.py tests/test_proxy_cli_entrypoint.py tests/test_api_server_entrypoint.py`
- `git diff --check`

## Deliberate-break gate
- Temporarily restored `src/trend_analysis/proxy/cli.py` `--proxy-host` default to `0.0.0.0`; `tests/test_server_bind_defaults.py::test_streamlit_proxy_default_bind_is_localhost` failed on the expected localhost assertion. Restored the default and reran focused validation green.