### PR TITLE
Issue #5433: add shell parse lint

### DIFF
--- a/scripts/check_branch.sh
+++ b/scripts/check_branch.sh
@@ -219,7 +219,7 @@ if [[ "$FAST_MODE" == false ]]; then
     fi
 
     echo ""
-    if ! run_validation "Test coverage" "rm -f .coverage .coverage.* && pytest --cov=src --cov-report=term-missing --cov-fail-under=80 --cov-branch $XDIST_FLAG" ""; then then
+    if ! run_validation "Test coverage" "rm -f .coverage .coverage.* && pytest --cov=src --cov-report=term-missing --cov-fail-under=80 --cov-branch $XDIST_FLAG" ""; then
         VALIDATION_SUCCESS=false
         FAILED_CHECKS+=("Test coverage")
     fi

--- a/scripts/lint_shell.sh
+++ b/scripts/lint_shell.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Parse-check tracked shell scripts under scripts/.
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+failed=0
+count=0
+while IFS= read -r script; do
+  count=$((count + 1))
+  if ! bash -n "$script"; then
+    echo "Shell parse check failed: $script" >&2
+    failed=1
+  fi
+done < <(git ls-files 'scripts/*.sh' | sort)
+
+if [[ "$count" -eq 0 ]]; then
+  echo "No tracked scripts/*.sh files found."
+  exit 0
+fi
+
+if [[ "$failed" -ne 0 ]]; then
+  exit "$failed"
+fi
+
+echo "Shell parse check passed for $count tracked scripts/*.sh files."

--- a/scripts/test_health_retry.sh
+++ b/scripts/test_health_retry.sh
@@ -28,7 +28,6 @@ except ModuleNotFoundError:  # pragma: no cover - shell wrapper guard
     sys.exit(1)
 sys.exit(0)
 PY
-then
     echo "trend-portfolio-app package not installed. Run 'pip install -e .[app]' first." >&2
     exit 1
 fi

--- a/tests/scripts/test_lint_shell.py
+++ b/tests/scripts/test_lint_shell.py
@@ -1,0 +1,18 @@
+"""Regression tests for shell script parse linting."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_lint_shell_parse_checks_tracked_scripts() -> None:
+    result = subprocess.run(
+        ["bash", "scripts/lint_shell.sh"],
+        check=True,
+        cwd=Path(__file__).resolve().parents[2],
+        text=True,
+        capture_output=True,
+    )
+
+    assert "Shell parse check passed" in result.stdout

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,13 +1,3 @@
-## 2026-06-04T18:14Z - opener (codex): issue #5433 shell parse check
-
-- Repo/issue: `stranske/Trend_Model_Project` #5433 (`# Why`, shell syntax/parse-check issue).
-- Branch/worktree: `codex/issue-5433-shell-parse-check` in `~/.codex/automations/pd-workloop-resume/worktrees/trend-5433-shell-parse-check`.
-- Selection: raw opener cap was below 5. Approved queue items Inv-Man #524 and Trend #5500 were materialized then closed as already implemented/stale queue work with durable comments. Existing opener PRs #5492/#5499 were draining and #5440 remained scoped on the strict-config product decision, so #5433 was the oldest unlinked implementation issue outside blockers.
-- Implementation: removed the duplicated `then` from `scripts/check_branch.sh` coverage validation, fixed an existing here-doc `then` parse error in `scripts/test_health_retry.sh`, added `scripts/lint_shell.sh` to run `bash -n` over every tracked `scripts/*.sh`, and added `tests/scripts/test_lint_shell.py`.
-- Validation: `bash -n scripts/check_branch.sh` -> exit 0; `bash -n scripts/test_health_retry.sh` -> exit 0; `scripts/lint_shell.sh` -> passed for 26 tracked shell scripts; `PYTHONPATH=src python -m pytest tests/scripts/test_lint_shell.py -q` -> 1 passed; `git diff --check` -> passed.
-- Deliberate-break gate: temporarily reintroduced `; then then` on the original `scripts/check_branch.sh` coverage line; `scripts/lint_shell.sh` failed and named `scripts/check_branch.sh`; restored the line and reran the parse checker/test green.
-- Current state: ready to commit, push, and open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; post-open action is Gate Followups dispatch if cap-health needs fresh evidence.
-
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,13 @@
+## 2026-06-04T18:14Z - opener (codex): issue #5433 shell parse check
+
+- Repo/issue: `stranske/Trend_Model_Project` #5433 (`# Why`, shell syntax/parse-check issue).
+- Branch/worktree: `codex/issue-5433-shell-parse-check` in `~/.codex/automations/pd-workloop-resume/worktrees/trend-5433-shell-parse-check`.
+- Selection: raw opener cap was below 5. Approved queue items Inv-Man #524 and Trend #5500 were materialized then closed as already implemented/stale queue work with durable comments. Existing opener PRs #5492/#5499 were draining and #5440 remained scoped on the strict-config product decision, so #5433 was the oldest unlinked implementation issue outside blockers.
+- Implementation: removed the duplicated `then` from `scripts/check_branch.sh` coverage validation, fixed an existing here-doc `then` parse error in `scripts/test_health_retry.sh`, added `scripts/lint_shell.sh` to run `bash -n` over every tracked `scripts/*.sh`, and added `tests/scripts/test_lint_shell.py`.
+- Validation: `bash -n scripts/check_branch.sh` -> exit 0; `bash -n scripts/test_health_retry.sh` -> exit 0; `scripts/lint_shell.sh` -> passed for 26 tracked shell scripts; `PYTHONPATH=src python -m pytest tests/scripts/test_lint_shell.py -q` -> 1 passed; `git diff --check` -> passed.
+- Deliberate-break gate: temporarily reintroduced `; then then` on the original `scripts/check_branch.sh` coverage line; `scripts/lint_shell.sh` failed and named `scripts/check_branch.sh`; restored the line and reran the parse checker/test green.
+- Current state: ready to commit, push, and open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; post-open action is Gate Followups dispatch if cap-health needs fresh evidence.
+
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.


### PR DESCRIPTION
Closes #5433

## Summary
- remove the duplicated `then` that made `scripts/check_branch.sh` unparseable in full mode
- fix an existing here-doc parse error in `scripts/test_health_retry.sh` so all tracked shell scripts parse cleanly
- add `scripts/lint_shell.sh` plus a focused pytest regression for tracked `scripts/*.sh` parse checks

## Validation
- `bash -n scripts/check_branch.sh` -> exit 0
- `bash -n scripts/test_health_retry.sh` -> exit 0
- `scripts/lint_shell.sh` -> passed for 26 tracked scripts/*.sh files
- `PYTHONPATH=src python -m pytest tests/scripts/test_lint_shell.py -q` -> 1 passed
- `git diff --check`
- deliberate-break gate: reintroduced `; then then` on the original coverage line; `scripts/lint_shell.sh` failed and named `scripts/check_branch.sh`; restored and reran green