### PR TITLE
Issue #5434: fix UI theme and widget imports

### DIFF
--- a/src/trend_analysis/gui/app.py
+++ b/src/trend_analysis/gui/app.py
@@ -804,7 +804,7 @@ def launch() -> widgets.Widget:
         store.dirty = True
         theme_val = change["new"]
         js = cast(Any, Javascript)(
-            f"document.documentElement.style.setProperty(" f"' --trend-theme','{theme_val}')"
+            f"document.documentElement.style.setProperty('--trend-theme','{theme_val}')"
         )
         cast(Any, display)(js)
 

--- a/src/trend_analysis/ui/rank_widgets.py
+++ b/src/trend_analysis/ui/rank_widgets.py
@@ -10,8 +10,8 @@ from ..core.rank_selection import METRIC_REGISTRY
 from ..data import ensure_datetime, load_csv
 from ..export import Formatter
 
-if TYPE_CHECKING:  # pragma: no cover
-    import ipywidgets as widgets
+if TYPE_CHECKING:
+    import ipywidgets as ipyw
 
 # ===============================================================
 #  UI SCAFFOLD (very condensed – Codex expands)
@@ -21,12 +21,12 @@ if TYPE_CHECKING:  # pragma: no cover
 def _load_widgets() -> Any:
     try:
         import ipywidgets as widgets
-    except ImportError as exc:  # pragma: no cover - covered via mocked import
+    except ImportError as exc:
         raise ImportError("ipywidgets is required for rank widget UI") from exc
     return widgets
 
 
-def build_ui() -> widgets.VBox:  # pragma: no cover - UI wiring exercised manually
+def build_ui() -> ipyw.VBox:  # pragma: no cover - UI wiring exercised manually
     widgets = _load_widgets()
 
     # -------------------- Step 1: data source & periods --------------------
@@ -66,7 +66,7 @@ def build_ui() -> widgets.VBox:  # pragma: no cover - UI wiring exercised manual
         ]
     )
 
-    def _load_action(_btn: widgets.Button) -> None:
+    def _load_action(_btn: ipyw.Button) -> None:
         with load_out:
             load_out.clear_output()
             try:
@@ -198,8 +198,8 @@ def build_ui() -> widgets.VBox:  # pragma: no cover - UI wiring exercised manual
     # -------------------- Step 3: manual override --------------------
     manual_box = widgets.VBox()
     manual_scores_html = widgets.HTML()
-    manual_checks: list[widgets.Checkbox] = []
-    manual_weights: list[widgets.FloatText] = []
+    manual_checks: list[ipyw.Checkbox] = []
+    manual_weights: list[ipyw.FloatText] = []
     manual_total_lbl = widgets.Label("Total weight: 0 %")
 
     def _update_manual() -> None:
@@ -224,7 +224,7 @@ def build_ui() -> widgets.VBox:  # pragma: no cover - UI wiring exercised manual
             scores = res.value["scores"]
             manual_checks.clear()
             manual_weights.clear()
-            rows: list[widgets.Widget] = []
+            rows: list[ipyw.Widget] = []
             manual_funds: list[str] = []
             for f, score in scores.items():
                 chk = widgets.Checkbox(value=False, description=f)
@@ -295,7 +295,7 @@ def build_ui() -> widgets.VBox:  # pragma: no cover - UI wiring exercised manual
     def _on_manual_change(_change: dict[str, Any]) -> None:
         _collect_manual_weights()
 
-    def _on_next(_: widgets.Button) -> None:
+    def _on_next(_: ipyw.Button) -> None:
         _collect_manual_weights()
         _update_manual()
 
@@ -306,7 +306,7 @@ def build_ui() -> widgets.VBox:  # pragma: no cover - UI wiring exercised manual
 
     next_btn_1.on_click(_on_next)
 
-    def _run_action(_btn: widgets.Button) -> None:
+    def _run_action(_btn: ipyw.Button) -> None:
         manual_funds.clear()
         custom_weights.clear()
         for chk, wt in zip(manual_checks, manual_weights):

--- a/src/trend_analysis/ui/rank_widgets.py
+++ b/src/trend_analysis/ui/rank_widgets.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import io
-from typing import Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 
-import ipywidgets as widgets
 import pandas as pd
 
 from .. import export, pipeline
@@ -11,12 +10,25 @@ from ..core.rank_selection import METRIC_REGISTRY
 from ..data import ensure_datetime, load_csv
 from ..export import Formatter
 
+if TYPE_CHECKING:  # pragma: no cover
+    import ipywidgets as widgets
+
 # ===============================================================
 #  UI SCAFFOLD (very condensed – Codex expands)
 # ===============================================================
 
 
+def _load_widgets() -> Any:
+    try:
+        import ipywidgets as widgets
+    except ImportError as exc:  # pragma: no cover - covered via mocked import
+        raise ImportError("ipywidgets is required for rank widget UI") from exc
+    return widgets
+
+
 def build_ui() -> widgets.VBox:  # pragma: no cover - UI wiring exercised manually
+    widgets = _load_widgets()
+
     # -------------------- Step 1: data source & periods --------------------
     source_tb = widgets.ToggleButtons(
         options=["Path/URL", "Browse"],

--- a/tests/test_app_coverage.py
+++ b/tests/test_app_coverage.py
@@ -1395,6 +1395,8 @@ def test_launch_interactions(monkeypatch, tmp_path):
 
     theme.set_value("dark")
     assert store.theme == "dark" and theme_calls
+    assert "setProperty('--trend-theme','dark')" in theme_calls[-1]
+    assert "' --trend-theme'" not in theme_calls[-1]
 
     run_btn.click()
     assert json_calls and save_calls and not store.dirty

--- a/tests/test_rank_widgets_headless_import.py
+++ b/tests/test_rank_widgets_headless_import.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+def test_rank_widgets_imports_without_ipywidgets(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delitem(sys.modules, "trend_analysis.ui.rank_widgets", raising=False)
+    monkeypatch.delitem(sys.modules, "ipywidgets", raising=False)
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if name == "ipywidgets" or name.startswith("ipywidgets."):
+            raise ImportError("ipywidgets deliberately hidden")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    module = importlib.import_module("trend_analysis.ui.rank_widgets")
+
+    assert module.__name__ == "trend_analysis.ui.rank_widgets"
+
+
+def test_build_ui_still_requires_ipywidgets(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delitem(sys.modules, "trend_analysis.ui.rank_widgets", raising=False)
+    monkeypatch.delitem(sys.modules, "ipywidgets", raising=False)
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if name == "ipywidgets" or name.startswith("ipywidgets."):
+            raise ImportError("ipywidgets deliberately hidden")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    module = importlib.import_module("trend_analysis.ui.rank_widgets")
+
+    with pytest.raises(ImportError, match="ipywidgets is required"):
+        module.build_ui()

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,13 +1,3 @@
-## 2026-06-04T20:08Z - opener (codex): issue #5434 UI correctness fixes
-
-- Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5434`, PR `#5502`, branch `codex/issue-5434-ui-correctness`.
-- Selection: raw opener cap was below 5 after required discovery. Scoped blockers remained LMS #180, Trend #5343, and Trend #5389/#5440. Existing opener PR #5492 was classified draining/keepalive-side with green Gate and non-required review noise; #5440 remains terminal/scoped on strict-config product decision. #5434 was the oldest unlinked implementation candidate outside blockers after prior issues were already linked/merged/source-disposition lanes.
-- Implementation: fixed the notebook theme toggle JavaScript to call `setProperty('--trend-theme', ...)` without the leading-space CSS custom-property typo; made `trend_analysis.ui.rank_widgets` import `ipywidgets` lazily inside `build_ui()` so the module imports in headless/CI environments; added headless import/build regression coverage and tightened the existing theme interaction assertion.
-- Validation: `PYTHONPATH=src python -m pytest tests/test_rank_widgets_headless_import.py tests/test_rank_widgets.py tests/test_app_coverage.py::test_launch_interactions tests/test_optional_notebook_deps.py::test_rank_ui_loader_requires_widgets -q` -> 6 passed, 2 existing warnings. `python -m ruff check src/trend_analysis/gui/app.py src/trend_analysis/ui/rank_widgets.py tests/test_rank_widgets_headless_import.py tests/test_app_coverage.py tests/test_optional_notebook_deps.py` passed. `git diff --check` passed.
-- Deliberate-break gate: temporarily restored a top-level `import ipywidgets as widgets`; `tests/test_rank_widgets_headless_import.py::test_rank_widgets_imports_without_ipywidgets` failed on the mocked missing dependency. Reverted the temporary import and reran focused validation green.
-- PR/routing: opened ready-for-review PR #5502 at https://github.com/stranske/Trend_Model_Project/pull/5502, non-draft, closes #5434, labels `agent:codex`, `agents:keepalive`, `autofix`. Post-open cap-health initially reported `needs-dispatch-evidence`; `opener-repair-infra-stalls.py` added `agent:retry` and dispatched Gate Followups. Fresh cap-health at 2026-06-04T20:07:37Z classifies #5502 as `draining` with active Gate evidence.
-- Current state: PR #5502 is waiting on asynchronous Gate/keepalive/guard checks after the repair dispatch/state update. Next action belongs to keepalive/closer after checks settle.
-
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,13 @@
+## 2026-06-04T20:08Z - opener (codex): issue #5434 UI correctness fixes
+
+- Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5434`, PR `#5502`, branch `codex/issue-5434-ui-correctness`.
+- Selection: raw opener cap was below 5 after required discovery. Scoped blockers remained LMS #180, Trend #5343, and Trend #5389/#5440. Existing opener PR #5492 was classified draining/keepalive-side with green Gate and non-required review noise; #5440 remains terminal/scoped on strict-config product decision. #5434 was the oldest unlinked implementation candidate outside blockers after prior issues were already linked/merged/source-disposition lanes.
+- Implementation: fixed the notebook theme toggle JavaScript to call `setProperty('--trend-theme', ...)` without the leading-space CSS custom-property typo; made `trend_analysis.ui.rank_widgets` import `ipywidgets` lazily inside `build_ui()` so the module imports in headless/CI environments; added headless import/build regression coverage and tightened the existing theme interaction assertion.
+- Validation: `PYTHONPATH=src python -m pytest tests/test_rank_widgets_headless_import.py tests/test_rank_widgets.py tests/test_app_coverage.py::test_launch_interactions tests/test_optional_notebook_deps.py::test_rank_ui_loader_requires_widgets -q` -> 6 passed, 2 existing warnings. `python -m ruff check src/trend_analysis/gui/app.py src/trend_analysis/ui/rank_widgets.py tests/test_rank_widgets_headless_import.py tests/test_app_coverage.py tests/test_optional_notebook_deps.py` passed. `git diff --check` passed.
+- Deliberate-break gate: temporarily restored a top-level `import ipywidgets as widgets`; `tests/test_rank_widgets_headless_import.py::test_rank_widgets_imports_without_ipywidgets` failed on the mocked missing dependency. Reverted the temporary import and reran focused validation green.
+- PR/routing: opened ready-for-review PR #5502 at https://github.com/stranske/Trend_Model_Project/pull/5502, non-draft, closes #5434, labels `agent:codex`, `agents:keepalive`, `autofix`. Post-open cap-health initially reported `needs-dispatch-evidence`; `opener-repair-infra-stalls.py` added `agent:retry` and dispatched Gate Followups. Fresh cap-health at 2026-06-04T20:07:37Z classifies #5502 as `draining` with active Gate evidence.
+- Current state: PR #5502 is waiting on asynchronous Gate/keepalive/guard checks after the repair dispatch/state update. Next action belongs to keepalive/closer after checks settle.
+
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.


### PR DESCRIPTION
Closes #5434

## Summary
- fix the notebook theme toggle to set the '--trend-theme' CSS property without a leading-space typo
- make rank widget UI imports lazy so the module imports in headless environments without ipywidgets
- add focused regression coverage for headless import behavior and theme JavaScript output

## Validation
- PYTHONPATH=src python -m pytest tests/test_rank_widgets_headless_import.py tests/test_rank_widgets.py tests/test_app_coverage.py::test_launch_interactions tests/test_optional_notebook_deps.py::test_rank_ui_loader_requires_widgets -q
- python -m ruff check src/trend_analysis/gui/app.py src/trend_analysis/ui/rank_widgets.py tests/test_rank_widgets_headless_import.py tests/test_app_coverage.py tests/test_optional_notebook_deps.py
- git diff --check

Deliberate-break gate: temporarily restored a top-level ipywidgets import in src/trend_analysis/ui/rank_widgets.py; tests/test_rank_widgets_headless_import.py::test_rank_widgets_imports_without_ipywidgets failed on the mocked missing dependency, then the temporary import was reverted.