### PR TITLE
Issue #5436: reject missing policy aliases

### DIFF
--- a/src/trend_analysis/data.py
+++ b/src/trend_analysis/data.py
@@ -36,10 +36,6 @@ def _normalise_policy_alias(value: str | None) -> str:
     policy = value.strip().lower()
     if not policy:
         return DEFAULT_POLICY_FALLBACK
-    if policy in {"both", "bfill", "backfill"}:
-        return "ffill"
-    if policy in {"zeros", "zero_fill", "fillzero"}:
-        return "zero"
     return policy
 
 
@@ -340,13 +336,15 @@ def _validate_payload(
             missing_policy=policy_param,
             missing_limit=limit_param,
         )
-    except MarketDataValidationError as exc:
+    except (MarketDataValidationError, ValueError) as exc:
         if errors == "raise":
-            raise
-        msg_lower = exc.user_message.lower()
-        message = exc.user_message
+            if isinstance(exc, MarketDataValidationError):
+                raise
+            raise MarketDataValidationError(str(exc)) from exc
+        message = exc.user_message if isinstance(exc, MarketDataValidationError) else str(exc)
+        msg_lower = message.lower()
         if "could not be parsed" in msg_lower or "unable to parse" in msg_lower:
-            message = f"{exc.user_message}\nUnable to parse Date values in {origin}"
+            message = f"{message}\nUnable to parse Date values in {origin}"
         logger.error("Validation failed (%s): %s", origin, message)
         return None
 

--- a/src/trend_analysis/util/missing.py
+++ b/src/trend_analysis/util/missing.py
@@ -72,10 +72,6 @@ class MissingPolicyResult(Mapping[str, Any]):
 
 def _coerce_policy(policy: str | None) -> str:
     value = (policy or "drop").strip().lower()
-    if value in {"both", "bfill", "backfill"}:
-        value = "ffill"
-    if value in {"zeros", "zero_fill", "fillzero"}:
-        value = "zero"
     if value not in {"drop", "ffill", "zero"}:
         raise ValueError(f"Unsupported missing-data policy: {policy!r}")
     return value

--- a/tests/soft_coverage/test_data_soft.py
+++ b/tests/soft_coverage/test_data_soft.py
@@ -58,9 +58,9 @@ def sample_metadata() -> MarketDataMetadata:
 def test_normalise_policy_alias_variants() -> None:
     assert _normalise_policy_alias(None) == DEFAULT_POLICY_FALLBACK
     assert _normalise_policy_alias("  ") == DEFAULT_POLICY_FALLBACK
-    assert _normalise_policy_alias("both") == "ffill"
-    assert _normalise_policy_alias("Backfill") == "ffill"
-    assert _normalise_policy_alias("zeros") == "zero"
+    assert _normalise_policy_alias("both") == "both"
+    assert _normalise_policy_alias("Backfill") == "backfill"
+    assert _normalise_policy_alias("zeros") == "zeros"
     assert _normalise_policy_alias("Custom") == "custom"
 
 
@@ -191,7 +191,7 @@ def test_validate_payload_normalises_inputs(
     assert result["FundA"].tolist() == [10.0, -2.0, 0.5]
     assert captured["source"] == "upload.csv"
     assert captured["policy"] == {
-        "FundA": "ffill",
+        "FundA": "both",
         "FundB": DEFAULT_POLICY_FALLBACK,
     }
     assert captured["limit"] == {"FundA": 7, "FundB": None, "*": 2}

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -123,8 +123,8 @@ def test_identify_risk_free_fund_no_numeric() -> None:
 
 def test_normalise_policy_alias_variants() -> None:
     assert data_mod._normalise_policy_alias(None) == "drop"
-    assert data_mod._normalise_policy_alias("  BOTH  ") == "ffill"
-    assert data_mod._normalise_policy_alias("zeros") == "zero"
+    assert data_mod._normalise_policy_alias("  BOTH  ") == "both"
+    assert data_mod._normalise_policy_alias("zeros") == "zeros"
     assert data_mod._normalise_policy_alias("custom") == "custom"
 
 
@@ -251,7 +251,7 @@ def test_validate_payload_coerces_policy_and_limit(
     def fake_validate(payload: pd.DataFrame, **kwargs: Any) -> ValidatedMarketData:
         recorded.update(kwargs)
         assert isinstance(kwargs["missing_policy"], dict)
-        assert kwargs["missing_policy"]["A"] == "ffill"
+        assert kwargs["missing_policy"]["A"] == "both"
         assert kwargs["missing_policy"]["B"] == "drop"
         assert kwargs["missing_policy"]["C"] == "2"
         assert kwargs["missing_policy"]["*"] == "drop"

--- a/tests/test_trend_analysis_data.py
+++ b/tests/test_trend_analysis_data.py
@@ -73,11 +73,11 @@ class ValidationProbe:
         return ValidatedMarketData(frame=frame, metadata=metadata)
 
 
-def test_normalise_policy_alias_handles_aliases() -> None:
+def test_normalise_policy_alias_strips_without_aliasing() -> None:
     assert _normalise_policy_alias(None) == DEFAULT_POLICY_FALLBACK
     assert _normalise_policy_alias("") == DEFAULT_POLICY_FALLBACK
-    assert _normalise_policy_alias(" backfill ") == "ffill"
-    assert _normalise_policy_alias("zeros") == "zero"
+    assert _normalise_policy_alias(" backfill ") == "backfill"
+    assert _normalise_policy_alias("zeros") == "zeros"
     assert _normalise_policy_alias("drop") == "drop"
 
 
@@ -194,7 +194,7 @@ def test_validate_payload_normalises_strings_and_applies_defaults(
     assert probe.calls
     call = probe.calls[-1]
     assert call["source"] == "input.csv"
-    assert call["missing_policy"] == {"Rate": "ffill", "*": DEFAULT_POLICY_FALLBACK}
+    assert call["missing_policy"] == {"Rate": "backfill", "*": DEFAULT_POLICY_FALLBACK}
     assert call["missing_limit"] == {"Rate": 10, "*": None}
 
 
@@ -210,7 +210,7 @@ def test_validate_payload_accepts_scalar_policy_and_limit(
         origin="payload",
         errors="log",
         include_date_column=True,
-        missing_policy=" zeros ",
+        missing_policy=" zero ",
         missing_limit="5",
     )
 
@@ -319,7 +319,7 @@ def test_load_csv_reads_file_and_applies_legacy_kwargs(
 
     result = load_csv(
         str(csv_path),
-        nan_policy="zeros",
+        nan_policy="zero",
         nan_limit="7",
     )
 
@@ -601,7 +601,7 @@ def test_load_parquet_applies_legacy_kwargs(
 
     result = load_parquet(
         str(parquet_path),
-        nan_policy={"Value": "BackFill"},
+        nan_policy={"Value": "ffill"},
         nan_limit={"Value": "4"},
     )
 

--- a/tests/test_trend_analysis_data_keepalive.py
+++ b/tests/test_trend_analysis_data_keepalive.py
@@ -46,8 +46,8 @@ def sample_frame() -> pd.DataFrame:
 
 def test_normalise_policy_alias_variants() -> None:
     assert data_mod._normalise_policy_alias(None) == "drop"
-    assert data_mod._normalise_policy_alias("  BOTH  ") == "ffill"
-    assert data_mod._normalise_policy_alias("zeros") == "zero"
+    assert data_mod._normalise_policy_alias("  BOTH  ") == "both"
+    assert data_mod._normalise_policy_alias("zeros") == "zeros"
     assert data_mod._normalise_policy_alias(" custom ") == "custom"
 
 
@@ -169,7 +169,7 @@ def test_validate_payload_builds_policy_and_limit_maps(
 
     assert result is not None
     assert isinstance(result, pd.DataFrame)
-    assert captured["missing_policy"] == {"Fund": "ffill", "*": "zero"}
+    assert captured["missing_policy"] == {"Fund": "both", "*": "zeros"}
     assert captured["missing_limit"] == {"Fund": 5, "*": None}
     assert list(result.columns) == ["Date", "Fund"]
 

--- a/tests/test_trend_analysis_data_module.py
+++ b/tests/test_trend_analysis_data_module.py
@@ -48,9 +48,9 @@ def _build_metadata(index: pd.DatetimeIndex) -> MarketDataMetadata:
 def test_normalise_policy_alias_variants():
     assert _normalise_policy_alias(None) == DEFAULT_POLICY_FALLBACK
     assert _normalise_policy_alias(" ") == DEFAULT_POLICY_FALLBACK
-    assert _normalise_policy_alias("both") == "ffill"
-    assert _normalise_policy_alias("BackFill") == "ffill"
-    assert _normalise_policy_alias("zero_fill") == "zero"
+    assert _normalise_policy_alias("both") == "both"
+    assert _normalise_policy_alias("BackFill") == "backfill"
+    assert _normalise_policy_alias("zero_fill") == "zero_fill"
     assert _normalise_policy_alias("custom") == "custom"
 
 
@@ -136,7 +136,7 @@ def test_validate_payload_success(monkeypatch):
         origin="fixture.csv",
         errors="log",
         include_date_column=False,
-        missing_policy={"alpha": "both", "*": None},
+        missing_policy={"alpha": "ffill", "*": None},
         missing_limit={"alpha": "10", "beta": "none"},
     )
 
@@ -234,7 +234,7 @@ def test_load_csv_validates_payload(tmp_path, monkeypatch):
 
     result = data_module.load_csv(
         str(path),
-        nan_policy="zeros",
+        nan_policy="zero",
         nan_limit="3",
         missing_limit=None,
     )

--- a/tests/test_util_missing_additional.py
+++ b/tests/test_util_missing_additional.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pandas as pd
 import pytest
 
+from trend_analysis.data import load_csv
+from trend_analysis.io.market_data import MarketDataValidationError
 from trend_analysis.io.market_data import _normalise_policy_value
 from trend_analysis.util import missing
 
@@ -62,6 +66,20 @@ def test_missing_policy_layers_reject_undocumented_aliases(value: str) -> None:
 
     with pytest.raises(ValueError, match="Unknown missing-data policy"):
         _normalise_policy_value(value)
+
+
+@pytest.mark.parametrize("value", ["bfill", "backfill", "both", "zero_fill", "zeros"])
+def test_load_csv_rejects_undocumented_missing_policy_aliases(
+    tmp_path: Path, value: str
+) -> None:
+    csv_path = tmp_path / "returns.csv"
+    csv_path.write_text(
+        "Date,Fund\n2024-01-31,1.0\n2024-02-29,\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(MarketDataValidationError, match="Unknown missing-data policy"):
+        load_csv(str(csv_path), errors="raise", missing_policy=value)
 
 
 @pytest.mark.parametrize("limit", [-1, -5])

--- a/tests/test_util_missing_additional.py
+++ b/tests/test_util_missing_additional.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
+from trend_analysis.io.market_data import _normalise_policy_value
 from trend_analysis.util import missing
 
 
@@ -40,13 +41,27 @@ def test_missing_policy_result_get_returns_default() -> None:
     assert result.get("missing", "fallback") == "fallback"
 
 
-@pytest.mark.parametrize("value", ["invalid", "", None])
+@pytest.mark.parametrize(
+    "value",
+    ["invalid", "bfill", "backfill", "both", "zero_fill", "zeros", "fillzero"],
+)
 def test_coerce_policy_rejects_unknown(value: str | None) -> None:
-    if value in {"", None}:
-        assert missing._coerce_policy(value) == "drop"
-    else:
-        with pytest.raises(ValueError, match="Unsupported missing-data policy"):
-            missing._coerce_policy(value)
+    with pytest.raises(ValueError, match="Unsupported missing-data policy"):
+        missing._coerce_policy(value)
+
+
+@pytest.mark.parametrize("value", ["", None])
+def test_coerce_policy_defaults_empty_to_drop(value: str | None) -> None:
+    assert missing._coerce_policy(value) == "drop"
+
+
+@pytest.mark.parametrize("value", ["bfill", "backfill", "both", "zero_fill"])
+def test_missing_policy_layers_reject_undocumented_aliases(value: str) -> None:
+    with pytest.raises(ValueError, match="Unsupported missing-data policy"):
+        missing._coerce_policy(value)
+
+    with pytest.raises(ValueError, match="Unknown missing-data policy"):
+        _normalise_policy_value(value)
 
 
 @pytest.mark.parametrize("limit", [-1, -5])

--- a/tests/trend_analysis/test_data.py
+++ b/tests/trend_analysis/test_data.py
@@ -58,8 +58,8 @@ def validated_payload(sample_metadata: MarketDataMetadata) -> ValidatedMarketDat
 def test_normalise_policy_alias_variants():
     assert data._normalise_policy_alias(None) == data.DEFAULT_POLICY_FALLBACK
     assert data._normalise_policy_alias("  ") == data.DEFAULT_POLICY_FALLBACK
-    assert data._normalise_policy_alias("Both") == "ffill"
-    assert data._normalise_policy_alias("zero_fill") == "zero"
+    assert data._normalise_policy_alias("Both") == "both"
+    assert data._normalise_policy_alias("zero_fill") == "zero_fill"
     assert data._normalise_policy_alias("DROP") == "drop"
 
 
@@ -235,7 +235,7 @@ def test_validate_payload_success(monkeypatch, validated_payload):
     ) -> ValidatedMarketData:
         assert source == "origin.csv"
         assert isinstance(missing_policy, dict)
-        assert missing_policy["AAA"] == "ffill"
+        assert missing_policy["AAA"] == "bfill"
         assert missing_policy["*"] == data.DEFAULT_POLICY_FALLBACK
         assert isinstance(missing_limit, dict)
         assert missing_limit["AAA"] is None
@@ -326,7 +326,7 @@ def test_validate_payload_missing_policy_string(monkeypatch, validated_payload):
     payload = pd.DataFrame({"Date": ["2024-01-01"], "AAA": ["3"]})
 
     def fake_validate(frame: pd.DataFrame, *, source: str, **kwargs):
-        assert kwargs["missing_policy"] == "ffill"
+        assert kwargs["missing_policy"] == "both"
         assert kwargs["missing_limit"] == 2
         return validated_payload
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,13 +1,3 @@
-## 2026-06-04T23:10Z - opener (codex): issue #5436 missing-policy aliases
-
-- Repo/issue: `stranske/Trend_Model_Project` #5436 (`# Why`, missing-policy alias divergence).
-- Branch/worktree: `codex/issue-5436-missing-policy` in `~/.codex/automations/pd-workloop-resume/worktrees/trend-5436-missing-policy`.
-- Selection: raw opener cap below 5. Scoped blockers remained Trend #5343, LMS #180, and Trend #5389/#5440. Trend #5435 is already linked to merged PR #5503 and awaiting verifier disposition; Trend #5422 is linked to active PR #5492. #5436 was the oldest unlinked implementation candidate outside scoped blockers.
-- Implementation: removed undocumented `_coerce_policy` alias coercions for `both`/`bfill`/`backfill` -> `ffill` and `zeros`/`zero_fill`/`fillzero` -> `zero`, leaving only documented `drop`/`ffill`/`zero` plus empty/None defaulting to `drop`. Added util/io cross-layer regression coverage for alias rejection.
-- Validation: `PYTHONPATH=src python -m pytest tests/test_util_missing_additional.py -q` -> 22 passed. `python -m ruff check src/trend_analysis/util/missing.py tests/test_util_missing_additional.py` -> passed. `git diff --check` -> passed. `.venv/bin/python` was unavailable in this worktree, so the focused pytest used the available project Python with `PYTHONPATH=src`.
-- Deliberate-break gate: temporarily restored the `bfill`/`backfill`/`both` -> `ffill` branch; `tests/test_util_missing_additional.py::test_missing_policy_layers_reject_undocumented_aliases` failed for those aliases, then the temporary alias was removed and the focused suite reran green.
-- Current state: ready to commit, push, and open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; post-open action is cap-health/infra repair if dispatch evidence is missing.
-
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,13 @@
+## 2026-06-04T23:10Z - opener (codex): issue #5436 missing-policy aliases
+
+- Repo/issue: `stranske/Trend_Model_Project` #5436 (`# Why`, missing-policy alias divergence).
+- Branch/worktree: `codex/issue-5436-missing-policy` in `~/.codex/automations/pd-workloop-resume/worktrees/trend-5436-missing-policy`.
+- Selection: raw opener cap below 5. Scoped blockers remained Trend #5343, LMS #180, and Trend #5389/#5440. Trend #5435 is already linked to merged PR #5503 and awaiting verifier disposition; Trend #5422 is linked to active PR #5492. #5436 was the oldest unlinked implementation candidate outside scoped blockers.
+- Implementation: removed undocumented `_coerce_policy` alias coercions for `both`/`bfill`/`backfill` -> `ffill` and `zeros`/`zero_fill`/`fillzero` -> `zero`, leaving only documented `drop`/`ffill`/`zero` plus empty/None defaulting to `drop`. Added util/io cross-layer regression coverage for alias rejection.
+- Validation: `PYTHONPATH=src python -m pytest tests/test_util_missing_additional.py -q` -> 22 passed. `python -m ruff check src/trend_analysis/util/missing.py tests/test_util_missing_additional.py` -> passed. `git diff --check` -> passed. `.venv/bin/python` was unavailable in this worktree, so the focused pytest used the available project Python with `PYTHONPATH=src`.
+- Deliberate-break gate: temporarily restored the `bfill`/`backfill`/`both` -> `ffill` branch; `tests/test_util_missing_additional.py::test_missing_policy_layers_reject_undocumented_aliases` failed for those aliases, then the temporary alias was removed and the focused suite reran green.
+- Current state: ready to commit, push, and open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; post-open action is cap-health/infra repair if dispatch evidence is missing.
+
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.


### PR DESCRIPTION
Closes #5436

## Summary
- remove undocumented missing-policy alias coercions from util missing-policy validation
- keep empty/None defaulting to drop while restricting valid explicit values to drop, ffill, and zero
- add util/io cross-layer regression tests proving undocumented aliases are rejected consistently

## Validation
- PYTHONPATH=src python -m pytest tests/test_util_missing_additional.py -q
- python -m ruff check src/trend_analysis/util/missing.py tests/test_util_missing_additional.py
- git diff --check

## Deliberate-break Gate
- Temporarily restored the bfill/backfill/both -> ffill alias branch; tests/test_util_missing_additional.py::test_missing_policy_layers_reject_undocumented_aliases failed for those aliases, then the temporary alias was removed and the focused suite reran green.

Note: .venv/bin/python is not present in this worktree, so the focused pytest used the available project Python with PYTHONPATH=src.