### PR TITLE
Issue #5437: tolerate missing risk-free dates

### DIFF
--- a/scripts/run_real_model.py
+++ b/scripts/run_real_model.py
@@ -27,6 +27,17 @@ def _ensure_dir(path: str | Path) -> None:
     Path(path).mkdir(parents=True, exist_ok=True)
 
 
+def _align_risk_free_to_portfolio(
+    rf_series: pd.Series | None,
+    portfolio_index: pd.Index,
+) -> pd.Series | float:
+    if rf_series is None:
+        return 0.0
+    # Missing RF observations should not crash or leak NaNs into Sharpe.
+    # Treat absent dates as a zero risk-free baseline for the stitched OOS series.
+    return rf_series.reindex(portfolio_index).fillna(0.0)
+
+
 def main(cfg_path: str = "config/long_backtest.yml") -> int:
     setup_script_logging(app_name="real-model", module_file=__file__)
     cfg: ConfigProtocol = load(cfg_path)
@@ -118,9 +129,9 @@ def main(cfg_path: str = "config/long_backtest.yml") -> int:
         from trend_analysis.metrics import annual_return, sharpe_ratio, volatility
 
         rf_series = df_all.get("Risk-Free Rate")
-        rf_aligned = rf_series.loc[portfolio.index] if rf_series is not None else 0.0
         cagr = annual_return(portfolio)
         vol = volatility(portfolio)
+        rf_aligned = _align_risk_free_to_portfolio(rf_series, portfolio.index)
         sr = sharpe_ratio(portfolio, rf_aligned)
         msg = f"OOS CAGR: {cagr * 100:.2f}%  Vol: {vol * 100:.2f}%  Sharpe: {sr:.2f}"
         print(msg)

--- a/tests/test_run_real_model.py
+++ b/tests/test_run_real_model.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+from scripts.run_real_model import _align_risk_free_to_portfolio
+from trend_analysis.metrics import sharpe_ratio
+
+
+def test_align_risk_free_reindexes_missing_portfolio_dates_without_nan() -> None:
+    portfolio = pd.Series(
+        [0.01, 0.02, 0.03],
+        index=pd.to_datetime(["2020-01-31", "2020-02-29", "2020-03-31"]),
+    )
+    rf_series = pd.Series(
+        [0.001, 0.002],
+        index=pd.to_datetime(["2020-01-31", "2020-02-29"]),
+        name="Risk-Free Rate",
+    )
+
+    aligned = _align_risk_free_to_portfolio(rf_series, portfolio.index)
+
+    assert isinstance(aligned, pd.Series)
+    pd.testing.assert_index_equal(aligned.index, portfolio.index)
+    assert aligned.tolist() == [0.001, 0.002, 0.0]
+    assert not aligned.isna().any()
+    assert math.isfinite(sharpe_ratio(portfolio, aligned))

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,15 @@
+## 2026-06-05T00:08Z - opener (codex): issue #5437 risk-free alignment
+
+- Repo: `stranske/Trend_Model_Project`
+- Issue: `#5437` (`Risk-Free Rate` alignment in `scripts/run_real_model.py` can crash when stitched OOS dates exceed RF coverage)
+- Branch/worktree: `codex/issue-5437-rf-alignment` in `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/trend-5437-rf-alignment`
+- Selection: raw opener cap was below 5 after cap-drain preflight. Existing opener PRs were classified as: #5440 scoped/terminal on strict-config product decision, #5492 draining follow-up refactor lane, and #5504 active-moving after infra repair dispatched Gate Followups. #5437 was the oldest unlinked implementation candidate outside scoped blockers and existing linked PRs.
+- Implementation: added `_align_risk_free_to_portfolio()` in `scripts/run_real_model.py` and replaced label-based `rf_series.loc[portfolio.index]` with `rf_series.reindex(portfolio.index).fillna(0.0)`, documenting missing RF dates as a zero risk-free baseline so Sharpe inputs remain finite.
+- Validation: `PYTHONPATH=src python -m pytest tests/test_run_real_model.py -q` -> 1 passed. `python -m ruff check scripts/run_real_model.py tests/test_run_real_model.py` -> passed. `git diff --check` -> passed.
+- Deliberate-break gate: temporarily restored `.loc[portfolio_index]`; `tests/test_run_real_model.py::test_align_risk_free_reindexes_missing_portfolio_dates_without_nan` failed with `KeyError` for missing `2020-03-31`, then the reindex/fill behavior was restored and the focused test reran green.
+- PR/routing: ready-for-review PR #5505 opened at https://github.com/stranske/Trend_Model_Project/pull/5505, non-draft, closing #5437, with `agent:codex`, `agents:keepalive`, and `autofix`. Handoff event `pr_opened active.source_repo=stranske/Trend_Model_Project active.source_issue=5437 active.source_pr=5505 active.next_action=wait_for_keepalive` was recorded.
+- Current state: post-open cap-health/infra repair should verify Gate Followups evidence for #5505 and add `agent:retry`/dispatch if needed. Next action belongs to async Gate/keepalive/closer after checks settle.
+
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,15 +1,3 @@
-## 2026-06-05T00:08Z - opener (codex): issue #5437 risk-free alignment
-
-- Repo: `stranske/Trend_Model_Project`
-- Issue: `#5437` (`Risk-Free Rate` alignment in `scripts/run_real_model.py` can crash when stitched OOS dates exceed RF coverage)
-- Branch/worktree: `codex/issue-5437-rf-alignment` in `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/trend-5437-rf-alignment`
-- Selection: raw opener cap was below 5 after cap-drain preflight. Existing opener PRs were classified as: #5440 scoped/terminal on strict-config product decision, #5492 draining follow-up refactor lane, and #5504 active-moving after infra repair dispatched Gate Followups. #5437 was the oldest unlinked implementation candidate outside scoped blockers and existing linked PRs.
-- Implementation: added `_align_risk_free_to_portfolio()` in `scripts/run_real_model.py` and replaced label-based `rf_series.loc[portfolio.index]` with `rf_series.reindex(portfolio.index).fillna(0.0)`, documenting missing RF dates as a zero risk-free baseline so Sharpe inputs remain finite.
-- Validation: `PYTHONPATH=src python -m pytest tests/test_run_real_model.py -q` -> 1 passed. `python -m ruff check scripts/run_real_model.py tests/test_run_real_model.py` -> passed. `git diff --check` -> passed.
-- Deliberate-break gate: temporarily restored `.loc[portfolio_index]`; `tests/test_run_real_model.py::test_align_risk_free_reindexes_missing_portfolio_dates_without_nan` failed with `KeyError` for missing `2020-03-31`, then the reindex/fill behavior was restored and the focused test reran green.
-- PR/routing: ready-for-review PR #5505 opened at https://github.com/stranske/Trend_Model_Project/pull/5505, non-draft, closing #5437, with `agent:codex`, `agents:keepalive`, and `autofix`. Handoff event `pr_opened active.source_repo=stranske/Trend_Model_Project active.source_issue=5437 active.source_pr=5505 active.next_action=wait_for_keepalive` was recorded.
-- Current state: post-open cap-health/infra repair should verify Gate Followups evidence for #5505 and add `agent:retry`/dispatch if needed. Next action belongs to async Gate/keepalive/closer after checks settle.
-
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.


### PR DESCRIPTION
Closes #5437

## Summary
- add a script-local risk-free alignment helper that reindexes RF observations to the stitched OOS portfolio dates
- treat missing RF observations as a zero risk-free baseline so Sharpe inputs stay finite
- add regression coverage for portfolio dates outside the RF series range

## Validation
- PYTHONPATH=src python -m pytest tests/test_run_real_model.py -q
- python -m ruff check scripts/run_real_model.py tests/test_run_real_model.py
- git diff --check

## Deliberate-break Gate
- Temporarily restored label-based rf_series.loc[portfolio_index]; tests/test_run_real_model.py::test_align_risk_free_reindexes_missing_portfolio_dates_without_nan failed with KeyError for the missing 2020-03-31 date. Restored reindex/fill behavior and reran green.