### PR TITLE
Issue #5438: ignore equal numeric model-state types

### DIFF
--- a/streamlit_app/state.py
+++ b/streamlit_app/state.py
@@ -313,11 +313,15 @@ def _stringify_value(value: Any) -> str:
         return str(value)
 
 
+def _is_numeric_value(value: Any) -> bool:
+    return isinstance(value, numbers.Number) and not isinstance(value, bool)
+
+
 def _values_equal(left: Any, right: Any, float_tol: float) -> bool:
+    if _is_numeric_value(left) and _is_numeric_value(right):
+        return math.isclose(left, right, rel_tol=float_tol, abs_tol=float_tol)
     if type(left) is not type(right):
         return False
-    if isinstance(left, numbers.Number) and isinstance(right, numbers.Number):
-        return math.isclose(left, right, rel_tol=float_tol, abs_tol=float_tol)
     if isinstance(left, Mapping) and isinstance(right, Mapping):
         if set(left.keys()) != set(right.keys()):
             return False

--- a/tests/app/test_streamlit_state.py
+++ b/tests/app/test_streamlit_state.py
@@ -331,6 +331,18 @@ def test_diff_model_states_flags_type_changes_and_float_tolerance() -> None:
     assert diffs[0].type_changed is True
 
 
+def test_diff_model_states_ignores_equal_int_float_numbers() -> None:
+    assert state._values_equal(10, 10.0, 1e-9) is True
+    assert state.diff_model_states({"k": 10}, {"k": 10.0}) == []
+
+    string_diff = state.diff_model_states({"k": 10}, {"k": "10"})
+
+    assert len(string_diff) == 1
+    assert string_diff[0].path == "k"
+    assert string_diff[0].change_type == "changed"
+    assert string_diff[0].type_changed is True
+
+
 def test_format_model_state_diff_returns_copy_ready_text() -> None:
     diffs = [
         state.ModelStateDiff(

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,13 @@
+## 2026-06-05T01:06Z - opener (codex): issue #5438 numeric state diff
+
+- Repo/issue: `stranske/Trend_Model_Project` #5438 (`int/float model-state diff phantom change`).
+- Branch/worktree: `codex/issue-5438-numeric-state-diff` in `~/.codex/automations/pd-workloop-resume/worktrees/trend-5438-numeric-state-diff`.
+- Selection: raw opener cap was below 5 after cap/drain sweep. Scoped blockers remained LMS #180, Trend #5343, and Trend #5389/#5440. Trend #5436/#5504 had stale `agent:needs-attention` removed after direct evidence showed the review-path concern was fixed and Gate was green; cap-health then classified #5504 as draining. #5437 is linked to merged PR #5505 and awaiting verifier/source-issue disposition, so #5438 was the oldest unlinked implementation candidate outside blockers.
+- Implementation: moved numeric comparison before strict type equality in `streamlit_app/state.py` while excluding booleans from numeric equivalence, so `10` and `10.0` compare equal but real type changes still report. Added regression coverage for `_values_equal(10, 10.0)` and `diff_model_states({"k": 10}, {"k": 10.0}) == []`, plus string-vs-int type-change preservation.
+- Validation: `.venv/bin/python -m pytest tests/app/test_streamlit_state.py -q` was unavailable because `.venv/bin/python` does not exist in this worktree. `PYTHONPATH=src python -m pytest tests/app/test_streamlit_state.py -q` -> 22 passed with 2 existing protobuf deprecation warnings. `python -m ruff check streamlit_app/state.py tests/app/test_streamlit_state.py` -> passed. `git diff --check` -> passed.
+- Deliberate-break gate: temporarily restored the early `if type(left) is not type(right): return False` before the numeric branch; `tests/app/test_streamlit_state.py::test_diff_model_states_ignores_equal_int_float_numbers` failed on `_values_equal(10, 10.0)`. Restored the fix and reran focused validation green.
+- Current state: ready to commit, push, and open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; post-open action is asynchronous Gate/keepalive.
+
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,13 +1,3 @@
-## 2026-06-05T01:06Z - opener (codex): issue #5438 numeric state diff
-
-- Repo/issue: `stranske/Trend_Model_Project` #5438 (`int/float model-state diff phantom change`).
-- Branch/worktree: `codex/issue-5438-numeric-state-diff` in `~/.codex/automations/pd-workloop-resume/worktrees/trend-5438-numeric-state-diff`.
-- Selection: raw opener cap was below 5 after cap/drain sweep. Scoped blockers remained LMS #180, Trend #5343, and Trend #5389/#5440. Trend #5436/#5504 had stale `agent:needs-attention` removed after direct evidence showed the review-path concern was fixed and Gate was green; cap-health then classified #5504 as draining. #5437 is linked to merged PR #5505 and awaiting verifier/source-issue disposition, so #5438 was the oldest unlinked implementation candidate outside blockers.
-- Implementation: moved numeric comparison before strict type equality in `streamlit_app/state.py` while excluding booleans from numeric equivalence, so `10` and `10.0` compare equal but real type changes still report. Added regression coverage for `_values_equal(10, 10.0)` and `diff_model_states({"k": 10}, {"k": 10.0}) == []`, plus string-vs-int type-change preservation.
-- Validation: `.venv/bin/python -m pytest tests/app/test_streamlit_state.py -q` was unavailable because `.venv/bin/python` does not exist in this worktree. `PYTHONPATH=src python -m pytest tests/app/test_streamlit_state.py -q` -> 22 passed with 2 existing protobuf deprecation warnings. `python -m ruff check streamlit_app/state.py tests/app/test_streamlit_state.py` -> passed. `git diff --check` -> passed.
-- Deliberate-break gate: temporarily restored the early `if type(left) is not type(right): return False` before the numeric branch; `tests/app/test_streamlit_state.py::test_diff_model_states_ignores_equal_int_float_numbers` failed on `_values_equal(10, 10.0)`. Restored the fix and reran focused validation green.
-- Current state: ready to commit, push, and open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; post-open action is asynchronous Gate/keepalive.
-
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.


### PR DESCRIPTION
Closes #5438

## Summary
- compare non-bool numeric state values with numeric tolerance before strict type checks
- keep real type changes, including string-vs-int values, reported as changed
- add regression coverage for int/float JSON round-trip phantom diffs

## Validation
- .venv/bin/python -m pytest tests/app/test_streamlit_state.py -q (unavailable: .venv/bin/python missing in this worktree)
- PYTHONPATH=src python -m pytest tests/app/test_streamlit_state.py -q
- python -m ruff check streamlit_app/state.py tests/app/test_streamlit_state.py
- git diff --check

## Deliberate-break Gate
- Temporarily restored the early type(left) is not type(right) guard before numeric comparison; tests/app/test_streamlit_state.py::test_diff_model_states_ignores_equal_int_float_numbers failed on _values_equal(10, 10.0). Restored the fix and reran focused validation green.