### PR TITLE
Issue #5439: share CLI helper implementations

### DIFF
--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -78,14 +78,18 @@ from trend_analysis.presets import (
     get_trend_preset,
     list_preset_slugs,
 )
+from trend.cli_helpers import (
+    _apply_trend_spec_preset,
+    _apply_universe_mask,
+    _attach_universe_paths,
+)
 from trend_analysis.reporting.portfolio_series import select_primary_portfolio_series
 from trend_analysis.reporting.run_artifacts import write_run_artifacts
 from trend_analysis.signal_presets import (
-    TrendSpecPreset,
     get_trend_spec_preset,
     list_trend_spec_presets,
 )
-from trend_analysis.universe_catalog import NamedUniverse, load_universe
+from trend_analysis.universe_catalog import load_universe
 from trend_analysis.util.hash import working_run_id
 from trend_analysis.viz.artifacts import extract_bundle_zip
 from trend_model.spec import ensure_run_spec
@@ -133,110 +137,6 @@ def _report_legacy_pipeline_diagnostic(
         reason_code=diagnostic.reason_code,
         **safe_fields,
     )
-
-
-def _apply_trend_spec_preset(cfg: Any, preset: TrendSpecPreset) -> None:
-    """Merge TrendSpec preset parameters into ``cfg`` in-place."""
-
-    payload = preset.as_signal_config()
-    if isinstance(cfg, dict):
-        existing = cfg.get("signals")
-        merged = dict(existing) if isinstance(existing, Mapping) else {}
-        merged.update(payload)
-        cfg["signals"] = merged
-        cfg["trend_spec_preset"] = preset.name
-        return
-
-    existing = getattr(cfg, "signals", None)
-    if isinstance(existing, Mapping):
-        merged = dict(existing)
-        merged.update(payload)
-    else:
-        merged = dict(payload)
-
-    try:
-        setattr(cfg, "signals", merged)
-    except ValueError:
-        object.__setattr__(cfg, "signals", merged)
-    try:
-        setattr(cfg, "trend_spec_preset", preset.name)
-    except ValueError:
-        object.__setattr__(cfg, "trend_spec_preset", preset.name)
-
-
-def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: str) -> pd.DataFrame:
-    """Apply a time-varying membership mask to returns data."""
-
-    if mask.empty:
-        return df
-    working = df.copy()
-    lookup = {str(col).lower(): col for col in working.columns}
-    try:
-        date_col = lookup[date_column.lower()]
-    except KeyError as exc:  # pragma: no cover - defensive guard
-        raise KeyError(f"Date column '{date_column}' is missing from the returns data") from exc
-
-    working[date_col] = pd.to_datetime(working[date_col])
-    working = working.set_index(date_col)
-    aligned_mask = mask.reindex(index=working.index, fill_value=False)
-
-    missing = [col for col in aligned_mask.columns if col not in working.columns]
-    if missing:
-        preview = ", ".join(missing[:3])
-        raise KeyError(
-            "Universe members missing from returns data: "
-            f"{preview}" + ("..." if len(missing) > 3 else "")
-        )
-
-    masked = working.copy()
-    masked.loc[:, aligned_mask.columns] = masked.loc[:, aligned_mask.columns].where(aligned_mask)
-    masked.reset_index(inplace=True)
-    return masked
-
-
-def _attach_universe_paths(cfg: Any, spec: NamedUniverse, *, csv_path: str | None) -> None:
-    """Persist the selected universe paths onto ``cfg.data`` when possible."""
-
-    membership_value = str(spec.membership_path)
-    csv_value = csv_path
-    data_section = getattr(cfg, "data", None)
-    if isinstance(data_section, Mapping):
-        merged = dict(data_section)
-        merged["universe_membership_path"] = membership_value
-        if csv_value:
-            merged.setdefault("csv_path", csv_value)
-        try:
-            setattr(cfg, "data", merged)
-        except Exception:
-            object.__setattr__(cfg, "data", merged)
-        return
-
-    if data_section is None:
-        payload: dict[str, str] = {"universe_membership_path": membership_value}
-        if csv_value:
-            payload["csv_path"] = csv_value
-        try:
-            setattr(cfg, "data", payload)
-        except Exception:
-            object.__setattr__(cfg, "data", payload)
-        return
-
-    try:
-        setattr(data_section, "universe_membership_path", membership_value)
-    except Exception:
-        try:
-            object.__setattr__(data_section, "universe_membership_path", membership_value)
-        except Exception:
-            data_section = None
-
-    if csv_value and data_section is not None:
-        try:
-            setattr(data_section, "csv_path", csv_value)
-        except Exception:
-            try:
-                object.__setattr__(data_section, "csv_path", csv_value)
-            except Exception:
-                pass
 
 
 def _run_environment_check() -> int:

--- a/src/trend/cli_helpers.py
+++ b/src/trend/cli_helpers.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping
+
+import pandas as pd
+
+
+def _apply_trend_spec_preset(cfg: Any, preset: Any) -> None:
+    """Merge TrendSpec preset parameters into ``cfg`` in-place."""
+
+    payload = preset.as_signal_config()
+    if isinstance(cfg, dict):
+        existing = cfg.get("signals")
+        merged = dict(existing) if isinstance(existing, Mapping) else {}
+        merged.update(payload)
+        cfg["signals"] = merged
+        cfg["trend_spec_preset"] = preset.name
+        return
+
+    existing = getattr(cfg, "signals", None)
+    if isinstance(existing, Mapping):
+        merged = dict(existing)
+        merged.update(payload)
+    else:
+        merged = dict(payload)
+
+    try:
+        setattr(cfg, "signals", merged)
+    except ValueError:
+        object.__setattr__(cfg, "signals", merged)
+    try:
+        setattr(cfg, "trend_spec_preset", preset.name)
+    except ValueError:
+        object.__setattr__(cfg, "trend_spec_preset", preset.name)
+
+
+def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: str) -> pd.DataFrame:
+    """Apply a time-varying membership mask to returns data."""
+
+    if mask.empty:
+        return df
+    working = df.copy()
+    lookup = {str(col).lower(): col for col in working.columns}
+    try:
+        date_col = lookup[date_column.lower()]
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise KeyError(f"Date column '{date_column}' is missing from the returns data") from exc
+
+    working[date_col] = pd.to_datetime(working[date_col])
+    working = working.set_index(date_col)
+    aligned_mask = mask.reindex(index=working.index, fill_value=False)
+
+    missing = [col for col in aligned_mask.columns if col not in working.columns]
+    if missing:
+        preview = ", ".join(missing[:3])
+        raise KeyError(
+            "Universe members missing from returns data: "
+            f"{preview}" + ("..." if len(missing) > 3 else "")
+        )
+
+    masked = working.copy()
+    masked.loc[:, aligned_mask.columns] = masked.loc[:, aligned_mask.columns].where(aligned_mask)
+    masked.reset_index(inplace=True)
+    return masked
+
+
+def _attach_universe_paths(cfg: Any, spec: Any, *, csv_path: str | None) -> None:
+    """Persist the selected universe paths onto ``cfg.data`` when possible."""
+
+    logger = logging.getLogger(__name__)
+    membership_value = str(spec.membership_path)
+    csv_value = csv_path
+    data_section = getattr(cfg, "data", None)
+    if isinstance(data_section, Mapping):
+        merged = dict(data_section)
+        merged["universe_membership_path"] = membership_value
+        if csv_value:
+            merged.setdefault("csv_path", csv_value)
+        try:
+            setattr(cfg, "data", merged)
+        except (AttributeError, TypeError, ValueError):
+            object.__setattr__(cfg, "data", merged)
+        return
+
+    if data_section is None:
+        payload: dict[str, str] = {"universe_membership_path": membership_value}
+        if csv_value:
+            payload["csv_path"] = csv_value
+        try:
+            setattr(cfg, "data", payload)
+        except (AttributeError, TypeError, ValueError):
+            object.__setattr__(cfg, "data", payload)
+        return
+
+    try:
+        setattr(data_section, "universe_membership_path", membership_value)
+    except (AttributeError, TypeError, ValueError) as exc:
+        logger.debug(
+            "Unable to attach universe membership path with setattr; trying object.__setattr__: %s",
+            exc,
+        )
+        try:
+            object.__setattr__(data_section, "universe_membership_path", membership_value)
+        except (AttributeError, TypeError, ValueError) as fallback_exc:
+            logger.debug(
+                "Unable to attach universe membership path to config data section: %s",
+                fallback_exc,
+            )
+            data_section = None
+
+    if csv_value and data_section is not None:
+        try:
+            setattr(data_section, "csv_path", csv_value)
+        except (AttributeError, TypeError, ValueError) as exc:
+            logger.debug(
+                "Unable to attach universe csv path with setattr; trying object.__setattr__: %s",
+                exc,
+            )
+            try:
+                object.__setattr__(data_section, "csv_path", csv_value)
+            except (AttributeError, TypeError, ValueError) as fallback_exc:
+                logger.debug(
+                    "Unable to attach universe csv path to config data section: %s",
+                    fallback_exc,
+                )

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -18,6 +18,11 @@ import pandas as pd
 
 from trend.config_schema import CoreConfigError, validate_core_config
 from trend.diagnostics import DiagnosticPayload
+from trend.cli_helpers import (
+    _apply_trend_spec_preset,
+    _apply_universe_mask,
+    _attach_universe_paths,
+)
 
 from . import export, pipeline
 from . import logging as run_logging
@@ -61,7 +66,6 @@ from .presets import apply_trend_preset, get_trend_preset, list_preset_slugs
 from .reporting.portfolio_series import select_primary_portfolio_series
 from .reporting.run_artifacts import find_existing_run, write_run_artifacts
 from .signal_presets import (
-    TrendSpecPreset,
     get_trend_spec_preset,
     list_trend_spec_presets,
 )
@@ -191,35 +195,6 @@ def _report_pipeline_diagnostic(
     )
 
 
-def _apply_trend_spec_preset(cfg: Any, preset: TrendSpecPreset) -> None:
-    """Merge TrendSpec preset parameters into ``cfg`` in-place."""
-
-    payload = preset.as_signal_config()
-    if isinstance(cfg, dict):
-        existing = cfg.get("signals")
-        merged = dict(existing) if isinstance(existing, Mapping) else {}
-        merged.update(payload)
-        cfg["signals"] = merged
-        cfg["trend_spec_preset"] = preset.name
-        return
-
-    existing = getattr(cfg, "signals", None)
-    if isinstance(existing, Mapping):
-        merged = dict(existing)
-        merged.update(payload)
-    else:
-        merged = dict(payload)
-
-    try:
-        setattr(cfg, "signals", merged)
-    except ValueError:
-        object.__setattr__(cfg, "signals", merged)
-    try:
-        setattr(cfg, "trend_spec_preset", preset.name)
-    except ValueError:
-        object.__setattr__(cfg, "trend_spec_preset", preset.name)
-
-
 def _log_step(run_id: str, event: str, message: str, level: str = "INFO", **fields: Any) -> None:
     """Internal indirection for structured logging.
 
@@ -272,97 +247,6 @@ def _extract_cache_stats(payload: object) -> dict[str, int] | None:
 
     _visit(payload)
     return found[-1] if found else None
-
-
-def _apply_universe_mask(df: pd.DataFrame, mask: pd.DataFrame, *, date_column: str) -> pd.DataFrame:
-    """Apply a time-varying membership mask to returns data."""
-
-    if mask.empty:
-        return df
-    working = df.copy()
-    lookup = {str(col).lower(): col for col in working.columns}
-    try:
-        date_col = lookup[date_column.lower()]
-    except KeyError as exc:  # pragma: no cover - defensive guard
-        raise KeyError(f"Date column '{date_column}' is missing from the returns data") from exc
-
-    working[date_col] = pd.to_datetime(working[date_col])
-    working = working.set_index(date_col)
-    aligned_mask = mask.reindex(index=working.index, fill_value=False)
-
-    missing = [col for col in aligned_mask.columns if col not in working.columns]
-    if missing:
-        preview = ", ".join(missing[:3])
-        raise KeyError(
-            "Universe members missing from returns data: "
-            f"{preview}" + ("…" if len(missing) > 3 else "")
-        )
-
-    masked = working.copy()
-    masked.loc[:, aligned_mask.columns] = masked.loc[:, aligned_mask.columns].where(aligned_mask)
-    masked.reset_index(inplace=True)
-    return masked
-
-
-def _attach_universe_paths(cfg: Any, spec: NamedUniverse, *, csv_path: str | None) -> None:
-    """Persist the selected universe paths onto ``cfg.data`` when possible."""
-
-    logger = logging.getLogger(__name__)
-    membership_value = str(spec.membership_path)
-    csv_value = csv_path
-    data_section = getattr(cfg, "data", None)
-    if isinstance(data_section, Mapping):
-        merged = dict(data_section)
-        merged["universe_membership_path"] = membership_value
-        if csv_value:
-            merged.setdefault("csv_path", csv_value)
-        try:
-            setattr(cfg, "data", merged)
-        except (AttributeError, TypeError, ValueError):
-            object.__setattr__(cfg, "data", merged)
-        return
-
-    if data_section is None:
-        payload: dict[str, str] = {"universe_membership_path": membership_value}
-        if csv_value:
-            payload["csv_path"] = csv_value
-        try:
-            setattr(cfg, "data", payload)
-        except (AttributeError, TypeError, ValueError):
-            object.__setattr__(cfg, "data", payload)
-        return
-
-    try:
-        setattr(data_section, "universe_membership_path", membership_value)
-    except (AttributeError, TypeError, ValueError) as exc:
-        logger.debug(
-            "Unable to attach universe membership path with setattr; trying object.__setattr__: %s",
-            exc,
-        )
-        try:
-            object.__setattr__(data_section, "universe_membership_path", membership_value)
-        except (AttributeError, TypeError, ValueError) as fallback_exc:
-            logger.debug(
-                "Unable to attach universe membership path to config data section: %s",
-                fallback_exc,
-            )
-            data_section = None
-
-    if csv_value and data_section is not None:
-        try:
-            setattr(data_section, "csv_path", csv_value)
-        except (AttributeError, TypeError, ValueError) as exc:
-            logger.debug(
-                "Unable to attach universe csv path with setattr; trying object.__setattr__: %s",
-                exc,
-            )
-            try:
-                object.__setattr__(data_section, "csv_path", csv_value)
-            except (AttributeError, TypeError, ValueError) as fallback_exc:
-                logger.debug(
-                    "Unable to attach universe csv path to config data section: %s",
-                    fallback_exc,
-                )
 
 
 def _resolve_artifact_paths(

--- a/tests/test_cli_helpers_shared.py
+++ b/tests/test_cli_helpers_shared.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import trend.cli as unified_cli
+import trend_analysis.cli as legacy_cli
+
+
+def test_cli_helpers_are_shared_objects() -> None:
+    assert unified_cli._apply_trend_spec_preset is legacy_cli._apply_trend_spec_preset
+    assert unified_cli._apply_universe_mask is legacy_cli._apply_universe_mask
+    assert unified_cli._attach_universe_paths is legacy_cli._attach_universe_paths

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,16 +1,3 @@
-## 2026-06-05T02:14Z - opener (codex): issue #5439 shared CLI helpers
-
-- Repo/issue: `stranske/Trend_Model_Project` issue `#5439` (`T9 - Consolidate the 3 byte-equivalent CLI helpers`).
-- Branch/worktree: `codex/issue-5439-cli-helpers` in `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/trend-5439-cli-helpers`, based on `origin/phase-3` at `44cb93c0`.
-- Selection: required priority search found only scoped high-priority Trend #5343 and LMS #180; normal/low priority searches were empty. Liveness guard still had candidates, raw opener cap was below 5, and the approved queue's remaining Trend CLI-docs item was already closed/merged via #5476/#5477. #5439 was the oldest unlinked implementation candidate outside scoped blockers and existing linked/merged PRs.
-- Cap/drain preflight: cap-health after infra repair showed opener-owned PRs #5440 runner-failed/scoped on #5389 strict-config product decision, #5492 with green Gate/source-complete evidence and closer-drain candidate status, and #5506 draining after `opener-repair-infra-stalls.py` added `agent:retry` and dispatched Gate Followups.
-- Verification before touch: `_apply_trend_spec_preset`, `_apply_universe_mask`, and `_attach_universe_paths` were present in both `src/trend/cli.py` and `src/trend_analysis/cli.py`; the five named non-target helpers in `trend_analysis/cli.py` are already compatibility delegates into `trend.cli`. The three target helpers were functionally aligned, with minor defensive-diagnostics differences retained in the shared implementation.
-- Implementation: added `src/trend/cli_helpers.py`, imported the three shared helper objects from both CLI modules, removed the duplicate local bodies, and added `tests/test_cli_helpers_shared.py` identity coverage proving both CLIs expose the same function objects.
-- Validation: `PYTHONPATH=src python -m pytest tests/test_cli_helpers.py tests/test_cli_helpers_shared.py -q` -> 6 passed. `PYTHONPATH=src python -m pytest tests/test_cli.py tests/test_cli_module.py tests/test_cli_helpers_shared.py -q` -> 20 passed. Focused `ruff` and `git diff --check` passed.
-- Deliberate-break gate: temporarily reintroduced a local `_apply_universe_mask` in `trend_analysis/cli.py`; `tests/test_cli_helpers_shared.py::test_cli_helpers_are_shared_objects` failed on the identity assertion. Removed the temporary shadow and reran validation green.
-- Known validation limitation: literal old issue paths `tests/test_run_analysis_cli.py tests/test_run_multi_analysis_cli.py` are absent in this checkout; attempting them caused pytest to load conftest and hit the existing local NumPy 2.x/compiled-extension ABI warnings before reporting the missing files.
-- Current state: ready to commit, push, and open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; post-open action is cap-health/infra repair if Gate Followups evidence is missing.
-
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,16 @@
+## 2026-06-05T02:14Z - opener (codex): issue #5439 shared CLI helpers
+
+- Repo/issue: `stranske/Trend_Model_Project` issue `#5439` (`T9 - Consolidate the 3 byte-equivalent CLI helpers`).
+- Branch/worktree: `codex/issue-5439-cli-helpers` in `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/trend-5439-cli-helpers`, based on `origin/phase-3` at `44cb93c0`.
+- Selection: required priority search found only scoped high-priority Trend #5343 and LMS #180; normal/low priority searches were empty. Liveness guard still had candidates, raw opener cap was below 5, and the approved queue's remaining Trend CLI-docs item was already closed/merged via #5476/#5477. #5439 was the oldest unlinked implementation candidate outside scoped blockers and existing linked/merged PRs.
+- Cap/drain preflight: cap-health after infra repair showed opener-owned PRs #5440 runner-failed/scoped on #5389 strict-config product decision, #5492 with green Gate/source-complete evidence and closer-drain candidate status, and #5506 draining after `opener-repair-infra-stalls.py` added `agent:retry` and dispatched Gate Followups.
+- Verification before touch: `_apply_trend_spec_preset`, `_apply_universe_mask`, and `_attach_universe_paths` were present in both `src/trend/cli.py` and `src/trend_analysis/cli.py`; the five named non-target helpers in `trend_analysis/cli.py` are already compatibility delegates into `trend.cli`. The three target helpers were functionally aligned, with minor defensive-diagnostics differences retained in the shared implementation.
+- Implementation: added `src/trend/cli_helpers.py`, imported the three shared helper objects from both CLI modules, removed the duplicate local bodies, and added `tests/test_cli_helpers_shared.py` identity coverage proving both CLIs expose the same function objects.
+- Validation: `PYTHONPATH=src python -m pytest tests/test_cli_helpers.py tests/test_cli_helpers_shared.py -q` -> 6 passed. `PYTHONPATH=src python -m pytest tests/test_cli.py tests/test_cli_module.py tests/test_cli_helpers_shared.py -q` -> 20 passed. Focused `ruff` and `git diff --check` passed.
+- Deliberate-break gate: temporarily reintroduced a local `_apply_universe_mask` in `trend_analysis/cli.py`; `tests/test_cli_helpers_shared.py::test_cli_helpers_are_shared_objects` failed on the identity assertion. Removed the temporary shadow and reran validation green.
+- Known validation limitation: literal old issue paths `tests/test_run_analysis_cli.py tests/test_run_multi_analysis_cli.py` are absent in this checkout; attempting them caused pytest to load conftest and hit the existing local NumPy 2.x/compiled-extension ABI warnings before reporting the missing files.
+- Current state: ready to commit, push, and open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; post-open action is cap-health/infra repair if Gate Followups evidence is missing.
+
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.


### PR DESCRIPTION
Closes #5439

## Summary
- verified the three target CLI helper copies and the existing non-target delegators before touching the implementation
- moved `_apply_trend_spec_preset`, `_apply_universe_mask`, and `_attach_universe_paths` into `trend.cli_helpers`
- imported the same helper objects from both `trend.cli` and `trend_analysis.cli`, with identity coverage to prevent local-copy drift

## Validation
- `PYTHONPATH=src python -m pytest tests/test_cli_helpers.py tests/test_cli_helpers_shared.py -q` -> 6 passed
- `PYTHONPATH=src python -m pytest tests/test_cli.py tests/test_cli_module.py tests/test_cli_helpers_shared.py -q` -> 20 passed
- `python -m ruff check src/trend/cli_helpers.py src/trend/cli.py src/trend_analysis/cli.py tests/test_cli_helpers_shared.py` -> passed
- `git diff --check` -> passed
- Deliberate-break: temporarily reintroduced a local `_apply_universe_mask` in `trend_analysis/cli.py`; `tests/test_cli_helpers_shared.py::test_cli_helpers_are_shared_objects` failed on the identity assertion, then passed after restore

## Notes
- The issue body names old paths `tests/test_run_analysis_cli.py` and `tests/test_run_multi_analysis_cli.py`; those files are absent in this checkout. Attempting them loads pytest conftest and hits the known local NumPy 2.x compiled-extension warning path before reporting the missing files.
