### PR TITLE
Document Monte Carlo flat output contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,11 @@ python scripts/walk_forward.py --config config/walk_forward.yml
 trend mc viz --bundle <path> --out <dir> --charts fan,path_dist,risk_return --html --json --png
 ```
 
-- `--bundle`: Path to the Monte Carlo bundle directory used as input.
+- `--bundle`: Path to the flat Monte Carlo bundle directory used as input. The
+  bundle root contains `manifest.json`, `results.<fmt>`, `summary.<fmt>`,
+  optional diagnostics/pooled summaries, aggregation files such as
+  `summary_quantiles.<fmt>` and `per_strategy_stats.<fmt>`, and root-level
+  `nav_paths.parquet` when NAV paths were exported.
 - `--out`: Output directory where `plots/` is created (for example `<out>/plots/`).
 - `--charts`: Comma-separated chart names to render, for example `fan,path_dist,risk_return`.
 - `--html`: Write HTML chart files to `<out>/plots/*.html`.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -179,15 +179,13 @@ Runtime overrides include `--data` for an alternate CSV/Parquet input,
 repeatable), `--n-paths`, `--jobs`, `--seed`, `--dry-run`, `--no-progress`, and
 `--registry`.
 
-`mc run` writes a flat bundle into the output directory. The canonical root-level
-files are `manifest.json`, `results.<fmt>`, `summary.<fmt>`, optional
-`diagnostics.<fmt>`, optional pooled/cross-fold summaries, and optional
-`nav_paths.parquet` or `nav_paths_fold_<id>.parquet` files. Aggregation exports
-also use root-level files: `path_summary.<fmt>`, `per_strategy_stats.<fmt>`,
-`per_strategy_path.<fmt>`, `quantiles.<fmt>`, `summary_quantiles.<fmt>`,
-`breach_probabilities.<fmt>`, and `expected_shortfall.<fmt>`. The manifest's
-`outputs.files` map is the file index for the bundle; no separate frozen
-scenario YAML file is produced.
+`mc run` writes a flat bundle into the output directory. The CLI-managed bundle
+contains `manifest.json`, `results.<fmt>`, and `summary.<fmt>` files at the root;
+the manifest's `outputs.files` map indexes those CLI exports. Scenario-configured
+runner exports may also write optional root-level diagnostics, pooled/cross-fold
+summaries, aggregation files such as `path_summary.<fmt>` and
+`summary_quantiles.<fmt>`, and `nav_paths.parquet` or
+`nav_paths_fold_<id>.parquet`. No separate frozen scenario YAML file is produced.
 
 ```bash
 python -m trend_analysis.cli mc run --scenario cost_regime_example \

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -179,6 +179,16 @@ Runtime overrides include `--data` for an alternate CSV/Parquet input,
 repeatable), `--n-paths`, `--jobs`, `--seed`, `--dry-run`, `--no-progress`, and
 `--registry`.
 
+`mc run` writes a flat bundle into the output directory. The canonical root-level
+files are `manifest.json`, `results.<fmt>`, `summary.<fmt>`, optional
+`diagnostics.<fmt>`, optional pooled/cross-fold summaries, and optional
+`nav_paths.parquet` or `nav_paths_fold_<id>.parquet` files. Aggregation exports
+also use root-level files: `path_summary.<fmt>`, `per_strategy_stats.<fmt>`,
+`per_strategy_path.<fmt>`, `quantiles.<fmt>`, `summary_quantiles.<fmt>`,
+`breach_probabilities.<fmt>`, and `expected_shortfall.<fmt>`. The manifest's
+`outputs.files` map is the file index for the bundle; no separate frozen
+scenario YAML file is produced.
+
 ```bash
 python -m trend_analysis.cli mc run --scenario cost_regime_example \
   --n-paths 500 --jobs 4 --seed 123

--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -652,11 +652,14 @@ valid values (`monte_carlo: null` fails validation).
 
 ### Output Bundle Structure
 
-`mc run` uses a flat output bundle. The exporter writes every result table into
-the bundle root and `manifest.json` records the exact file map under
-`outputs.files`. It does not write a separate frozen scenario YAML file; the
-manifest records scenario metadata, runtime overrides, data path, settings, row
-counts, and the exported filenames.
+`mc run` uses a flat output bundle. The CLI export writes `results.<fmt>` and
+`summary.<fmt>` into the bundle root, and `manifest.json` records that exact CLI
+file map under `outputs.files`. Scenario-configured runner exports may also
+write optional diagnostics, pooled/cross-fold summaries, aggregation files, and
+NAV-path artifacts into a root-level bundle. The command does not write a
+separate frozen scenario YAML file; the manifest records scenario metadata,
+runtime overrides, data path, settings, row counts, and the CLI-exported
+filenames.
 
 ```
 outputs/monte_carlo/hf_equity_ls_10y/2026-01-03_143052/

--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -652,23 +652,30 @@ valid values (`monte_carlo: null` fails validation).
 
 ### Output Bundle Structure
 
+`mc run` uses a flat output bundle. The exporter writes every result table into
+the bundle root and `manifest.json` records the exact file map under
+`outputs.files`. It does not write a separate frozen scenario YAML file; the
+manifest records scenario metadata, runtime overrides, data path, settings, row
+counts, and the exported filenames.
+
 ```
 outputs/monte_carlo/hf_equity_ls_10y/2026-01-03_143052/
 ├── manifest.json              # Run metadata + file index
-├── config_snapshot.yml        # Frozen scenario config
-├── distributions/
-│   ├── sharpe_dist.parquet   # Sharpe distribution by strategy
-│   ├── maxdd_dist.parquet    # Max drawdown distribution
-│   ├── terminal_wealth.parquet
-│   └── summary_quantiles.csv  # Human-readable summary
-├── paths/
-│   ├── nav_samples.parquet   # NAV for representative paths
-│   └── path_metadata.csv     # Path IDs + seeds
-├── strategies/
-│   ├── strategy_configs.json # All strategy definitions
-│   └── per_strategy_stats.parquet
-└── logs/
-    └── run.log
+├── results.csv                # Per-path, per-strategy simulation results
+├── summary.csv                # Strategy summary statistics
+├── diagnostics.csv            # Optional diagnostics table
+├── cross_fold_summary.csv     # Optional cross-fold summary table
+├── pooled_summary.csv         # Optional pooled summary table
+├── pooled_distributions.csv   # Optional pooled distribution table
+├── nav_paths.parquet          # Optional root-level NAV paths for mc viz
+├── nav_paths_fold_1.parquet   # Optional fold-specific NAV paths
+├── path_summary.csv           # Aggregation path summary
+├── per_strategy_stats.csv     # Backward-compatible path summary alias
+├── per_strategy_path.csv      # Backward-compatible path summary alias
+├── quantiles.csv              # Distribution quantiles
+├── summary_quantiles.csv      # Human-readable quantile summary
+├── breach_probabilities.csv   # Drawdown/metric breach probabilities
+└── expected_shortfall.csv     # Tail-risk expected shortfall
 ```
 
 ### Key Output Tables

--- a/tests/monte_carlo/test_output_contract.py
+++ b/tests/monte_carlo/test_output_contract.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import json
+
 import pandas as pd
 
+from trend_analysis.cli import _write_mc_manifest
 from trend_analysis.monte_carlo.aggregator import aggregate_monte_carlo_results
 from trend_analysis.monte_carlo.export import export_aggregation_results
 from trend_analysis.monte_carlo.results import (
@@ -9,6 +12,7 @@ from trend_analysis.monte_carlo.results import (
     build_summary_frame,
     export_results,
 )
+from trend_analysis.monte_carlo.scenario import MonteCarloScenario, MonteCarloSettings
 
 
 def test_export_results_writes_flat_bundle_contract(tmp_path) -> None:
@@ -44,6 +48,55 @@ def test_export_results_writes_flat_bundle_contract(tmp_path) -> None:
     assert not (tmp_path / "paths").exists()
     assert not (tmp_path / "strategies").exists()
     assert not (tmp_path / "logs").exists()
+
+
+def test_mc_manifest_indexes_cli_exported_results_only(tmp_path) -> None:
+    results_frame = pd.DataFrame(
+        [
+            {
+                "fold_id": 1,
+                "path_id": 1,
+                "strategy": "rank_12_equal",
+                "metric": 0.42,
+            }
+        ]
+    )
+    results = MonteCarloResults(
+        mode="two_layer",
+        evaluations=[],
+        errors=[],
+        results_frame=results_frame,
+        summary_frame=build_summary_frame(results_frame),
+        metadata={},
+    )
+    exported = export_results(results, tmp_path, formats=["csv"])
+    scenario = MonteCarloScenario(
+        name="flat_bundle_contract",
+        base_config="config/demo.yml",
+        monte_carlo=MonteCarloSettings(
+            mode="two_layer",
+            n_paths=1,
+            horizon_years=1.0,
+            frequency="M",
+        ),
+    )
+
+    manifest_path = _write_mc_manifest(
+        tmp_path,
+        scenario=scenario,
+        results=results,
+        overrides={"n_paths": 1},
+        exported_files=exported,
+        data_path=None,
+        jobs_used=1,
+    )
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["outputs"]["files"] == {
+        "results_csv": str(tmp_path / "results.csv"),
+        "summary_csv": str(tmp_path / "summary.csv"),
+    }
+    assert "path_summary_csv" not in manifest["outputs"]["files"]
 
 
 def test_export_aggregation_results_writes_flat_bundle_contract(tmp_path) -> None:

--- a/tests/monte_carlo/test_output_contract.py
+++ b/tests/monte_carlo/test_output_contract.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from trend_analysis.monte_carlo.aggregator import aggregate_monte_carlo_results
+from trend_analysis.monte_carlo.export import export_aggregation_results
+from trend_analysis.monte_carlo.results import (
+    MonteCarloResults,
+    build_summary_frame,
+    export_results,
+)
+
+
+def test_export_results_writes_flat_bundle_contract(tmp_path) -> None:
+    results_frame = pd.DataFrame(
+        [
+            {
+                "fold_id": 1,
+                "path_id": 1,
+                "strategy": "rank_12_equal",
+                "metric": 0.42,
+            }
+        ]
+    )
+    results = MonteCarloResults(
+        mode="two_layer",
+        evaluations=[],
+        errors=[],
+        results_frame=results_frame,
+        summary_frame=build_summary_frame(results_frame),
+        metadata={},
+    )
+
+    exported = export_results(results, tmp_path, formats=["csv"])
+
+    assert exported == {
+        "results_csv": tmp_path / "results.csv",
+        "summary_csv": tmp_path / "summary.csv",
+    }
+    assert (tmp_path / "results.csv").exists()
+    assert (tmp_path / "summary.csv").exists()
+    assert not (tmp_path / "config_snapshot.yml").exists()
+    assert not (tmp_path / "distributions").exists()
+    assert not (tmp_path / "paths").exists()
+    assert not (tmp_path / "strategies").exists()
+    assert not (tmp_path / "logs").exists()
+
+
+def test_export_aggregation_results_writes_flat_bundle_contract(tmp_path) -> None:
+    results_frame = pd.DataFrame(
+        [
+            {"path_id": 1, "strategy": "rank_12_equal", "metric": 0.42},
+            {"path_id": 2, "strategy": "rank_12_equal", "metric": 0.84},
+        ]
+    )
+    aggregation = aggregate_monte_carlo_results(
+        results_frame,
+        quantiles=[0.5],
+        breach_spec={"metric": [0.5]},
+        expected_shortfall_spec={"metric": 0.5},
+    )
+
+    exported = export_aggregation_results(aggregation, tmp_path, formats=["csv"])
+
+    assert exported == {
+        "path_summary_csv": tmp_path / "path_summary.csv",
+        "per_strategy_stats_csv": tmp_path / "per_strategy_stats.csv",
+        "per_strategy_path_csv": tmp_path / "per_strategy_path.csv",
+        "quantiles_csv": tmp_path / "quantiles.csv",
+        "summary_quantiles_csv": tmp_path / "summary_quantiles.csv",
+        "breach_probabilities_csv": tmp_path / "breach_probabilities.csv",
+        "expected_shortfall_csv": tmp_path / "expected_shortfall.csv",
+    }
+    for filename in (
+        "path_summary.csv",
+        "per_strategy_stats.csv",
+        "per_strategy_path.csv",
+        "quantiles.csv",
+        "summary_quantiles.csv",
+        "breach_probabilities.csv",
+        "expected_shortfall.csv",
+    ):
+        assert (tmp_path / filename).exists()
+    assert not (tmp_path / "distributions").exists()
+    assert not (tmp_path / "paths").exists()
+    assert not (tmp_path / "strategies").exists()

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,12 @@
+## 2026-06-11T06:09Z - opener (codex): issue #5529 Monte Carlo output contract
+
+- Repo/issue: `stranske/Trend_Model_Project` #5529 (`Reconcile Monte Carlo output bundle docs with flat exporter contract`).
+- Branch/worktree: `codex/issue-5529-mc-output-contract` in `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/trend-5529-mc-output-contract`, based on `origin/phase-3`.
+- Selection: raw opener cap was below 5 after repairing `Manager-Database#1154` with `agent:retry` plus Gate Followups dispatch. High-priority liveness candidates `Trend_Model_Project#5343` and `learning-management-system#180` are scoped owner/deployment-evidence blockers; open `Manager-Database` issues are linked/merged-awaiting-verifier; `trip-planner#1306` is an epic tracker. This was the first unmaterialized approved normal-priority implementation queue item.
+- Implementation: documented the existing flat Monte Carlo bundle as canonical in `docs/phase-3/MonteCarlo.md`, `docs/CLI.md`, and `README.md`; added `tests/monte_carlo/test_output_contract.py` asserting the root-level filenames from `export_results` and `export_aggregation_results`, and asserting the old hierarchy/config snapshot files are absent.
+- Validation: `PYTHONPATH=src python -m pytest tests/monte_carlo/test_output_contract.py -v` -> 2 passed. Deliberate-break gate temporarily renamed `results.{ext}` to `results_renamed.{ext}` and the contract test failed on the expected `results.csv` path mismatch; reverted and reran green. `PYTHONPATH=src python -m pytest tests/monte_carlo/test_results.py -v` -> 21 passed, 2 skipped for missing parquet engine. `python -m ruff check tests/monte_carlo/test_output_contract.py` and `git diff --check` passed. `rg "config_snapshot" docs/phase-3/MonteCarlo.md src/trend_analysis/cli.py` returned no matches.
+- Current state: ready to commit, push, and open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; post-open action belongs to Gate/keepalive.
+
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,12 +1,3 @@
-## 2026-06-11T06:09Z - opener (codex): issue #5529 Monte Carlo output contract
-
-- Repo/issue: `stranske/Trend_Model_Project` #5529 (`Reconcile Monte Carlo output bundle docs with flat exporter contract`).
-- Branch/worktree: `codex/issue-5529-mc-output-contract` in `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/trend-5529-mc-output-contract`, based on `origin/phase-3`.
-- Selection: raw opener cap was below 5 after repairing `Manager-Database#1154` with `agent:retry` plus Gate Followups dispatch. High-priority liveness candidates `Trend_Model_Project#5343` and `learning-management-system#180` are scoped owner/deployment-evidence blockers; open `Manager-Database` issues are linked/merged-awaiting-verifier; `trip-planner#1306` is an epic tracker. This was the first unmaterialized approved normal-priority implementation queue item.
-- Implementation: documented the existing flat Monte Carlo bundle as canonical in `docs/phase-3/MonteCarlo.md`, `docs/CLI.md`, and `README.md`; added `tests/monte_carlo/test_output_contract.py` asserting the root-level filenames from `export_results` and `export_aggregation_results`, and asserting the old hierarchy/config snapshot files are absent.
-- Validation: `PYTHONPATH=src python -m pytest tests/monte_carlo/test_output_contract.py -v` -> 2 passed. Deliberate-break gate temporarily renamed `results.{ext}` to `results_renamed.{ext}` and the contract test failed on the expected `results.csv` path mismatch; reverted and reran green. `PYTHONPATH=src python -m pytest tests/monte_carlo/test_results.py -v` -> 21 passed, 2 skipped for missing parquet engine. `python -m ruff check tests/monte_carlo/test_output_contract.py` and `git diff --check` passed. `rg "config_snapshot" docs/phase-3/MonteCarlo.md src/trend_analysis/cli.py` returned no matches.
-- Current state: ready to commit, push, and open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; post-open action belongs to Gate/keepalive.
-
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.


### PR DESCRIPTION
Closes #5529

## Summary
- document the current flat Monte Carlo bundle as the canonical output contract
- add output-contract tests for root-level export_results and export_aggregation_results filenames
- remove the stale hierarchical/config snapshot documentation from the Monte Carlo docs

## Validation
- PYTHONPATH=src python -m pytest tests/monte_carlo/test_output_contract.py -v
- deliberate-break gate: temporarily renamed results.{ext} to results_renamed.{ext}; test_output_contract failed on the expected results.csv mismatch; reverted and reran green
- PYTHONPATH=src python -m pytest tests/monte_carlo/test_results.py -v
- python -m ruff check tests/monte_carlo/test_output_contract.py
- git diff --check
- rg "config_snapshot" docs/phase-3/MonteCarlo.md src/trend_analysis/cli.py (no matches)