### PR TITLE
Enforce shrinkage wiring under robust fixture (#5538)

### DIFF
--- a/tests/baseline/README.md
+++ b/tests/baseline/README.md
@@ -22,6 +22,10 @@ scenario or toggle there; no Python changes needed. Each Tier-1 scenario runs a
   used while we're still confirming what "sensible" means, or when the current
   demo config doesn't exercise that knob.
 
+Tier-2 toggles default to `config/demo.yml`, but can name a more sensitive
+`config` plus an optional `base` patch when the default demo fixture cannot
+exercise the flag.
+
 **`invariants.py`** holds the always-true economic rules (weights sum/cap,
 long-only, vol ≥ 0, Sharpe soft-band ≤ 5, etc.). Edit the bounds there.
 
@@ -73,6 +77,7 @@ test_coverage_manifest.py # emits coverage.md; guards catalog quality
 | 5 | Fund weights sum to ~0.95 | **Not a bug** — intentional cash allocation, tracked as `cash_weight` (portfolio.py:558). |
 | 6 | Model page crashes on cold render | **FIXED 2026-05-30** (caught by AppTest) — nested-expander crash inside the "Config Chat" expander. Demoted the timing/NL-log expanders in `2_Model.py` AND the Replay expanders in `components/nl_operation_viewer.py` to `st.container`. (The state-dependent second pair was missed on the first pass; the AppTest guard now covers it.) Passing regression guard. |
 | 7 | `portfolio.weighting_scheme` (risk_parity) was a no-op in the demo fixture | **FIXED 2026-06-11 (#5537)** — `weighting_scheme` is correctly wired, but the `weighting_risk_parity` scenario inherited the demo fixture's pinned `portfolio.custom_weights`, which takes precedence: the weight engine only runs when `custom_weights is None` (`src/trend_analysis/stages/portfolio.py:288`). Clearing `custom_weights` in the scenario base makes equal vs risk_parity diverge (`max_weight` 0.2565 → 0.3176; `min_weight` 0.1532 → 0.1133); scenario now `enforce: true` (`tests/baseline/catalog.yaml:93-107`). Not a wiring gap — a fixture-precedence artifact. |
+| 8 | `portfolio.robustness.shrinkage.enabled` toggle is a no-op in the default demo fixture | **FIXED 2026-06-11 (#5538)** — the default demo uses equal/manual weighting, so shrinkage cannot affect output. The Tier-2 toggle now runs against `config/robust_demo.yml`, whose `portfolio.weighting_scheme: robust_mv` flows through `weight_engine_params_from_robustness` into `RobustMeanVariance` shrinkage; shrinkage on/off changes allocation and is enforced. |
 
 ### Harness refinements queued (from findings)
 - rf check should read the *reported* Sharpe, not the rf=0 derived one (Finding 3).

--- a/tests/baseline/catalog.yaml
+++ b/tests/baseline/catalog.yaml
@@ -133,8 +133,9 @@ toggles:
     enforce: false
   - id: shrinkage_toggle
     flag: portfolio.robustness.shrinkage.enabled
-    description: Toggling covariance shrinkage must change output.
-    enforce: false   # may be a no-op on the small, well-conditioned demo set
+    config: config/robust_demo.yml
+    description: Toggling covariance shrinkage under robust mean-variance must change output.
+    enforce: true
 
 # Priority parameters (the confirmed top-impact set). The coverage manifest
 # asserts each is exercised by at least one scenario or toggle above.

--- a/tests/baseline/manifest.py
+++ b/tests/baseline/manifest.py
@@ -79,6 +79,7 @@ def catalog_touched_keys(
         if scen.get("param"):
             raw.add(scen["param"])
     for tog in catalog.get("toggles", []) or []:
+        raw.update((tog.get("base") or {}).keys())
         if tog.get("flag"):
             raw.add(tog["flag"])
 

--- a/tests/baseline/test_harness_manifest_unit.py
+++ b/tests/baseline/test_harness_manifest_unit.py
@@ -119,12 +119,18 @@ def test_catalog_touched_keys_collects_scenarios_and_toggles() -> None:
                 "param": "selection.selection_count",
             }
         ],
-        "toggles": [{"flag": "vol_adjust.enabled"}],
+        "toggles": [
+            {
+                "base": {"portfolio.weighting_scheme": "robust_mv"},
+                "flag": "vol_adjust.enabled",
+            }
+        ],
     }
 
     touched = manifest.catalog_touched_keys(catalog)
     assert "portfolio.constraints.max_weight" in touched
     assert "selection.selection_count" in touched
+    assert "portfolio.weighting_scheme" in touched
     assert "vol_adjust.enabled" in touched
 
 

--- a/tests/baseline/test_wiring.py
+++ b/tests/baseline/test_wiring.py
@@ -37,8 +37,10 @@ def _outputs_differ(a, b, tol: float = 1e-8) -> bool:
 @pytest.mark.parametrize("tog", _TOGGLES, ids=_TOG_IDS)
 def test_flag_is_wired(tog):
     flag = tog["flag"]
-    out_on = run_scenario("config/demo.yml", {flag: True})
-    out_off = run_scenario("config/demo.yml", {flag: False})
+    config_path = tog.get("config", "config/demo.yml")
+    base_patch = tog.get("base") or {}
+    out_on = run_scenario(config_path, {**base_patch, flag: True})
+    out_off = run_scenario(config_path, {**base_patch, flag: False})
     differ = _outputs_differ(out_on, out_off)
     msg = f"{flag} produced identical output on/off -> appears UNWIRED"
     if tog.get("enforce", True):

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,23 @@
+## 2026-06-11T12:11Z - opener (codex): issue #5538 shrinkage wiring PR materializing
+
+- Repo/issue: `stranske/Trend_Model_Project` issue `#5538` (`Verify multi-period shrinkage wiring under robust weighting fixture`).
+- Branch/worktree: `codex/issue-5538-shrinkage-wiring` in `~/.codex/automations/pd-workloop-resume/worktrees/trend-5538-shrinkage-wiring`, based on `origin/phase-3`.
+- Selection: raw opener cap was below 5. Cap-health found only PR `#5540` as opener-owned and actively draining on a fresh Gate run. Scoped blockers remain Trend `#5343` and LMS `#180`; Workflows `#2242` is an operational alert; trip-planner `#1306` is an epic; Trend `#5537` is already linked to PR `#5540`. `#5538` was the highest-priority unlinked implementation candidate.
+- Implementation: `shrinkage_toggle` now runs against `config/robust_demo.yml` with `enforce: true`, and Tier-2 toggle execution can use a per-toggle `config` plus optional `base` patch. This verifies `portfolio.robustness.shrinkage.enabled` where `portfolio.weighting_scheme: robust_mv` flows through `weight_engine_params_from_robustness` into the robust mean-variance engine instead of the insensitive equal/manual demo fixture. The README records the fixture limitation and fix.
+- Validation: `PYTHONPATH=src python -m pytest tests/baseline/test_wiring.py tests/baseline/test_harness_manifest_unit.py tests/baseline/test_coverage_manifest.py -q -rA` -> 10 passed, 1 expected report-only skip for `regime_toggle`. `python -m ruff check tests/baseline/test_wiring.py tests/baseline/test_harness_manifest_unit.py tests/baseline/manifest.py` passed. `git diff --check origin/phase-3..HEAD` passed.
+- Current state: implementation commit `c5cbdea0` exists and is ready to push with this state entry, then open a ready-for-review PR with `agent:codex`, `agents:keepalive`, `autofix`, `repo-review-approved`, and `priority:normal`; post-open action belongs to Gate/keepalive unless cap-health needs a mechanical dispatch repair.
+
+## 2026-06-11T12:04Z - opener (codex): issue #5538 -> PR #5541 (new_issue)
+
+- Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5538`, PR `#5541`, branch `codex/issue-5538-shrinkage-wiring`, base `phase-3`.
+- Lane: opener materialization from neutral Code workspace. Worktree `~/.codex/automations/pd-workloop-resume/worktrees/trend-5538-shrinkage-wiring`.
+- Discovery: raw opener cap was below 5. The only opener-owned PR before selection was `#5540`, classified by cap-health as `draining` with an active Gate run. Liveness candidates were scoped blockers `#5343`/LMS `#180`, policy-excluded trip-planner epic `#1306`, linked issue `#5537` via PR `#5540`, and unlinked implementation issue `#5538`; selected `#5538`.
+- Finding: `portfolio.robustness.shrinkage.enabled` was report-only because the default demo fixture uses equal/manual weighting, so shrinkage settings cannot reach a robust weight engine. `config/robust_demo.yml` uses `portfolio.weighting_scheme: robust_mv`, and shrinkage on/off changes allocation there.
+- Change: Tier-2 wiring toggles now accept optional `config` and `base` fixture fields; `shrinkage_toggle` runs against `config/robust_demo.yml` with `enforce: true`. `catalog_touched_keys` includes toggle base patches, README Finding #7 documents the fixture resolution, and `docs/reports/baseline-coverage.md` was regenerated.
+- Validation: `MPLCONFIGDIR=/private/tmp/mpl-cache PYTHONPATH=src python -m pytest tests/baseline/test_wiring.py tests/baseline/test_coverage_manifest.py tests/baseline/test_harness_manifest_unit.py -q -rA` -> 10 passed, 1 skipped. Broader `tests/baseline/{test_directional,test_wiring,test_coverage_manifest,test_harness_manifest_unit,test_invariants}.py -q -rA` -> 26 passed, 2 skipped (existing `regime.enabled` fixture gap and `weighting_risk_parity` on base `phase-3`; the latter is separately covered by PR #5540). `python -m ruff check tests/baseline/test_wiring.py tests/baseline/manifest.py tests/baseline/test_harness_manifest_unit.py` passed. `git diff --check` passed.
+- PR/routing: PR `#5541` is non-draft, closes `#5538`, and has labels `agent:codex`, `agents:keepalive`, `autofix`, `repo-review-approved`, and `priority:normal`.
+- Current state: push this state-note commit, then keepalive/Gate owns PR `#5541`; opener should not duplicate `#5538`.
+
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,25 +1,3 @@
-## 2026-06-11T12:11Z - opener (codex): issue #5538 shrinkage wiring PR materializing
-
-- Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5538`, PR `#5541` (`Enforce shrinkage wiring under robust fixture (#5538)`).
-- Branch/worktree: `codex/issue-5538-shrinkage-wiring` in `~/.codex/automations/pd-workloop-resume/worktrees/trend-5538-shrinkage-wiring`, based on `origin/phase-3`.
-- Selection: raw opener cap was below 5. Cap-health found only PR `#5540` as opener-owned and actively draining on a fresh Gate run. Scoped blockers remain Trend `#5343` and LMS `#180`; Workflows `#2242` is an operational alert; trip-planner `#1306` is an epic; Trend `#5537` is already linked to PR `#5540`. `#5538` was the highest-priority unlinked implementation candidate.
-- Implementation: `shrinkage_toggle` now runs against `config/robust_demo.yml` with `enforce: true`, and Tier-2 toggle execution can use a per-toggle `config` plus optional `base` patch. This verifies `portfolio.robustness.shrinkage.enabled` where `portfolio.weighting_scheme: robust_mv` flows through `weight_engine_params_from_robustness` into the robust mean-variance engine instead of the insensitive equal/manual demo fixture. The README records the fixture limitation and fix.
-- Validation: `PYTHONPATH=src python -m pytest tests/baseline/test_wiring.py tests/baseline/test_harness_manifest_unit.py tests/baseline/test_coverage_manifest.py -q -rA` -> 10 passed, 1 expected report-only skip for `regime_toggle`. `python -m ruff check tests/baseline/test_wiring.py tests/baseline/test_harness_manifest_unit.py tests/baseline/manifest.py` passed. `git diff --check origin/phase-3..HEAD` passed.
-- PR/routing: ready-for-review PR `#5541` opened from `codex/issue-5538-shrinkage-wiring`, non-draft, closing `#5538`, with labels `agent:codex`, `agents:keepalive`, `autofix`, `repo-review-approved`, and `priority:normal`. Recorded `pr_opened active.source_pr=5541 active.next_action=wait_for_keepalive`.
-- Post-open cap hygiene: initial post-open cap-health found `#5540` needing dispatch evidence after a failed Gate; `opener-repair-infra-stalls.py --json` added `agent:retry` and dispatched Gate Followups. Final cap-health at `2026-06-11T12:06:00Z` showed `#5540` and `#5541` both `draining`, `raw_cap_reached=false`, `non_drainable_count=0`.
-- Current state: PR `#5541` is open and waiting on asynchronous Gate/keepalive checks. Next action belongs to keepalive/closer unless a later run finds a bounded branch-local failure.
-
-## 2026-06-11T12:04Z - opener (codex): issue #5538 -> PR #5541 (new_issue)
-
-- Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5538`, PR `#5541`, branch `codex/issue-5538-shrinkage-wiring`, base `phase-3`.
-- Lane: opener materialization from neutral Code workspace. Worktree `~/.codex/automations/pd-workloop-resume/worktrees/trend-5538-shrinkage-wiring`.
-- Discovery: raw opener cap was below 5. The only opener-owned PR before selection was `#5540`, classified by cap-health as `draining` with an active Gate run. Liveness candidates were scoped blockers `#5343`/LMS `#180`, policy-excluded trip-planner epic `#1306`, linked issue `#5537` via PR `#5540`, and unlinked implementation issue `#5538`; selected `#5538`.
-- Finding: `portfolio.robustness.shrinkage.enabled` was report-only because the default demo fixture uses equal/manual weighting, so shrinkage settings cannot reach a robust weight engine. `config/robust_demo.yml` uses `portfolio.weighting_scheme: robust_mv`, and shrinkage on/off changes allocation there.
-- Change: Tier-2 wiring toggles now accept optional `config` and `base` fixture fields; `shrinkage_toggle` runs against `config/robust_demo.yml` with `enforce: true`. `catalog_touched_keys` includes toggle base patches, README Finding #7 documents the fixture resolution, and `docs/reports/baseline-coverage.md` was regenerated.
-- Validation: `MPLCONFIGDIR=/private/tmp/mpl-cache PYTHONPATH=src python -m pytest tests/baseline/test_wiring.py tests/baseline/test_coverage_manifest.py tests/baseline/test_harness_manifest_unit.py -q -rA` -> 10 passed, 1 skipped. Broader `tests/baseline/{test_directional,test_wiring,test_coverage_manifest,test_harness_manifest_unit,test_invariants}.py -q -rA` -> 26 passed, 2 skipped (existing `regime.enabled` fixture gap and `weighting_risk_parity` on base `phase-3`; the latter is separately covered by PR #5540). `python -m ruff check tests/baseline/test_wiring.py tests/baseline/manifest.py tests/baseline/test_harness_manifest_unit.py` passed. `git diff --check` passed.
-- PR/routing: PR `#5541` is non-draft, closes `#5538`, and has labels `agent:codex`, `agents:keepalive`, `autofix`, `repo-review-approved`, and `priority:normal`.
-- Current state: push this state-note commit, then keepalive/Gate owns PR `#5541`; opener should not duplicate `#5538`.
-
 ## 2026-06-04T10:18Z - closer (codex): PR #5490 full-suite stale test repair
 
 - Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5423`, PR `#5490`, branch `codex/issue-5423-legacy-runners`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,11 +1,13 @@
 ## 2026-06-11T12:11Z - opener (codex): issue #5538 shrinkage wiring PR materializing
 
-- Repo/issue: `stranske/Trend_Model_Project` issue `#5538` (`Verify multi-period shrinkage wiring under robust weighting fixture`).
+- Repo/issue/PR: `stranske/Trend_Model_Project` issue `#5538`, PR `#5541` (`Enforce shrinkage wiring under robust fixture (#5538)`).
 - Branch/worktree: `codex/issue-5538-shrinkage-wiring` in `~/.codex/automations/pd-workloop-resume/worktrees/trend-5538-shrinkage-wiring`, based on `origin/phase-3`.
 - Selection: raw opener cap was below 5. Cap-health found only PR `#5540` as opener-owned and actively draining on a fresh Gate run. Scoped blockers remain Trend `#5343` and LMS `#180`; Workflows `#2242` is an operational alert; trip-planner `#1306` is an epic; Trend `#5537` is already linked to PR `#5540`. `#5538` was the highest-priority unlinked implementation candidate.
 - Implementation: `shrinkage_toggle` now runs against `config/robust_demo.yml` with `enforce: true`, and Tier-2 toggle execution can use a per-toggle `config` plus optional `base` patch. This verifies `portfolio.robustness.shrinkage.enabled` where `portfolio.weighting_scheme: robust_mv` flows through `weight_engine_params_from_robustness` into the robust mean-variance engine instead of the insensitive equal/manual demo fixture. The README records the fixture limitation and fix.
 - Validation: `PYTHONPATH=src python -m pytest tests/baseline/test_wiring.py tests/baseline/test_harness_manifest_unit.py tests/baseline/test_coverage_manifest.py -q -rA` -> 10 passed, 1 expected report-only skip for `regime_toggle`. `python -m ruff check tests/baseline/test_wiring.py tests/baseline/test_harness_manifest_unit.py tests/baseline/manifest.py` passed. `git diff --check origin/phase-3..HEAD` passed.
-- Current state: implementation commit `c5cbdea0` exists and is ready to push with this state entry, then open a ready-for-review PR with `agent:codex`, `agents:keepalive`, `autofix`, `repo-review-approved`, and `priority:normal`; post-open action belongs to Gate/keepalive unless cap-health needs a mechanical dispatch repair.
+- PR/routing: ready-for-review PR `#5541` opened from `codex/issue-5538-shrinkage-wiring`, non-draft, closing `#5538`, with labels `agent:codex`, `agents:keepalive`, `autofix`, `repo-review-approved`, and `priority:normal`. Recorded `pr_opened active.source_pr=5541 active.next_action=wait_for_keepalive`.
+- Post-open cap hygiene: initial post-open cap-health found `#5540` needing dispatch evidence after a failed Gate; `opener-repair-infra-stalls.py --json` added `agent:retry` and dispatched Gate Followups. Final cap-health at `2026-06-11T12:06:00Z` showed `#5540` and `#5541` both `draining`, `raw_cap_reached=false`, `non_drainable_count=0`.
+- Current state: PR `#5541` is open and waiting on asynchronous Gate/keepalive checks. Next action belongs to keepalive/closer unless a later run finds a bounded branch-local failure.
 
 ## 2026-06-11T12:04Z - opener (codex): issue #5538 -> PR #5541 (new_issue)
 


### PR DESCRIPTION
## Summary

Closes #5538. The shrinkage wiring check was report-only because the default demo fixture uses equal/manual weighting, so `portfolio.robustness.shrinkage.enabled` never reaches a robust weight engine.

This PR makes Tier-2 wiring toggles able to name a fixture config and points only `shrinkage_toggle` at `config/robust_demo.yml`, where `portfolio.weighting_scheme: robust_mv` flows through `weight_engine_params_from_robustness` into `RobustMeanVariance` shrinkage. Shrinkage on/off now changes allocation and is enforced.

Relevant paths:
- `tests/baseline/catalog.yaml` promotes `shrinkage_toggle` with `config: config/robust_demo.yml` and `enforce: true`.
- `tests/baseline/test_wiring.py` applies optional toggle `config` and `base` fixture fields.
- `src/trend_analysis/weights/robust_config.py:53-73` maps shrinkage settings to robust mean-variance engine params.
- `src/trend_analysis/multi_period/engine.py:2368-2378` forwards portfolio robustness config into weighting resolution.

## Acceptance criteria

- [x] `portfolio.robustness.shrinkage.enabled` is enforced by a passing robust-weighting wiring scenario.
- [x] Result cites the relevant robustness, multi-period, and baseline lines.

## Validation

```
MPLCONFIGDIR=/private/tmp/mpl-cache PYTHONPATH=src python -m pytest tests/baseline/test_wiring.py tests/baseline/test_coverage_manifest.py tests/baseline/test_harness_manifest_unit.py -q -rA
# 10 passed, 1 skipped

MPLCONFIGDIR=/private/tmp/mpl-cache PYTHONPATH=src python -m pytest tests/baseline/test_directional.py tests/baseline/test_wiring.py tests/baseline/test_coverage_manifest.py tests/baseline/test_harness_manifest_unit.py tests/baseline/test_invariants.py -q -rA
# 26 passed, 2 skipped

python -m ruff check tests/baseline/test_wiring.py tests/baseline/manifest.py tests/baseline/test_harness_manifest_unit.py
# All checks passed

git diff --check
```

Notes: the remaining skips are the existing `regime.enabled` fixture gap and `weighting_risk_parity` on base `phase-3`; the latter is separately addressed by active PR #5540.
