### PR TITLE
Follow-ups: fix A29 Model-page parity test gate (#5545) + document single-period transaction_cost_bps (#5544)

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -331,6 +331,10 @@ realistic implementation:
    subtract these costs when computing risk/return figures. When a nested
    `portfolio.cost_model.bps_per_trade` value is supplied it overrides this
    top-level field so configs can keep transaction costs and slippage together.
+   **Single-period note:** this turnover-based cost is charged only by the
+   multi-period engine. On a single-period run it is ignored (the app emits a
+   `UserWarning`); use `run.monthly_cost`, or run multi-period, to model costs
+   for a single-period analysis.
 - `portfolio.cost_model.slippage_bps` – optional extra spread per turnover
    event to mimic fill slippage. Defaults to `0`. Positive values reduce the
    first post-rebalance return by the specified number of basis points.

--- a/docs/config.md
+++ b/docs/config.md
@@ -56,6 +56,9 @@ model is constructed:
 - `portfolio.transaction_cost_bps` and every linear `cost_model` field (bps per
   trade, slippage, per-trade bps, half-spread) remain non-negative and must
   round-trip unchanged through `CoreConfig.to_payload()` into `TrendConfig`.
+  Note: `transaction_cost_bps` is a turnover-based lever charged only by the
+  multi-period engine; single-period runs ignore it and emit a `UserWarning`
+  (use `run.monthly_cost` for single-period cost modeling).
 - `run.monthly_cost` is a flat decimal per-period fee. It is subtracted from
   every fund return before statistics are calculated and is not scaled by
   turnover or exposure.

--- a/tests/app/test_model_page_config_parity.py
+++ b/tests/app/test_model_page_config_parity.py
@@ -215,6 +215,7 @@ def rendered_model(monkeypatch: pytest.MonkeyPatch):
     stub.cache_data = _passthrough_decorator
     stub.cache_resource = _passthrough_decorator
     stub.expander = lambda *_args, **_kwargs: Context()
+    stub.container = lambda *_args, **_kwargs: Context()
     stub.sidebar = Context()
     stub.dialog = lambda *_args, **_kwargs: Context()
     stub.form = lambda *_args, **_kwargs: Context()


### PR DESCRIPTION
Implements the two low-risk audit follow-ups.

**#5545 (A29 follow-up)** — `tests/app/test_model_page_config_parity.py` errored at collection (`SimpleNamespace` had no `container`) because `render_model_page()` reaches `nl_operation_viewer` which calls `st.container(border=True)`. Adds the missing `container` stub so the 4 parity tests run and the deliberate-break gate is live.

**#5544 (A14 follow-up)** — documents that `portfolio.transaction_cost_bps` is a turnover-based, multi-period-only lever (single-period runs ignore it and emit a `UserWarning`) in `docs/UserGuide.md` and `docs/config.md`, completing the "note it in the config docs" half of A14.

Docs + test-only; no production code change.

Closes #5544
Closes #5545

🤖 Generated with [Claude Code](https://claude.com/claude-code)