### PR TITLE
chore: refresh consumer CI config (llm_slots bump + drop double-CI trigger)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, phase-3]
   workflow_dispatch:
 
 jobs:

--- a/config/llm_slots.json
+++ b/config/llm_slots.json
@@ -3,12 +3,12 @@
     {
       "name": "slot1",
       "provider": "openai",
-      "model": "gpt-5.2"
+      "model": "gpt-5.4"
     },
     {
       "name": "slot2",
       "provider": "anthropic",
-      "model": "claude-sonnet-4-5-20250929"
+      "model": "claude-sonnet-4-6"
     },
     {
       "name": "slot3",


### PR DESCRIPTION
Fleet-hygiene fixes from the Workflows audit §4. Fixes applied: llm_slots(→gpt-5.4/sonnet-4-6) ci.yml(+phase-3). llm_slots was frozen at 2-gen-old models (create_only sync); the prohibited `pull_request:` trigger double-ran CI (the reusable Gate already covers PRs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Branch trigger and default LLM model IDs only; no auth, data, or core runtime logic changes.
> 
> **Overview**
> Extends the standalone **CI** workflow so pushes to **`phase-3`** run the same reusable Python CI as **`main`**, while PRs remain covered by the Gate workflow per existing comments.
> 
> Updates **`config/llm_slots.json`** default models: OpenAI slot **gpt-5.2 → gpt-5.4**, Anthropic slot **claude-sonnet-4-5-20250929 → claude-sonnet-4-6**; slot3 is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d541116cc3bfc1a96e5937c998460b671ab4d44d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->