### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,11 +5,11 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.14
+RUFF_VERSION=0.15.17
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.1.0
-PYTEST_VERSION=9.0.3
+PYTEST_VERSION=9.1.0
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0
-COVERAGE_VERSION=7.14.0
+COVERAGE_VERSION=7.14.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,18 +112,18 @@ notebooks = [
 dev = [
     "pre-commit==4.6.0",
     "black>=26.5.1",
-    "ruff>=0.15.14",
+    "ruff==0.15.17",
     "isort==8.0.1",
     "docformatter>=1.7.8",
     "mypy>=2.1.0",
     "flake8==7.3.0",
-    "pytest==9.0.3",
+    "pytest==9.1.0",
     "pytest-cov==7.1.0",
     "pytest-regressions==2.11.0",
     # Shared app behavior baseline harness (also pulls pytest-regressions). Pinned to
     # the Workflows default branch; move to a tagged ref once the package is versioned.
     "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit",
-    "coverage>=7.14.0",
+    "coverage==7.14.1",
     "pytest-rerunfailures==16.3",
     "pytest-xdist==3.8.0",
     "packaging==26.2",

--- a/requirements.lock
+++ b/requirements.lock
@@ -64,7 +64,7 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage==7.14.0
+coverage==7.14.1
     # via
     #   trend-model (pyproject.toml)
     #   pytest-cov
@@ -389,7 +389,7 @@ pygments==2.20.0
     #   pytest
 pyparsing==3.3.2
     # via matplotlib
-pytest==9.0.3
+pytest==9.1.0
     # via
     #   trend-model (pyproject.toml)
     #   app-baseline-kit
@@ -455,7 +455,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.14
+ruff==0.15.17
     # via trend-model (pyproject.toml)
 scipy==1.17.1
     # via trend-model (pyproject.toml)


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 6 version updates:
  - ruff: >=0.15.14 -> ==0.15.17
  - pytest: ==9.0.3 -> ==9.1.0
  - coverage: >=7.14.0 -> ==7.14.1
  - requirements.lock:coverage: 7.14.0 -> ==7.14.1
  - requirements.lock:pytest: 9.0.3 -> ==9.1.0
  - requirements.lock:ruff: 0.15.14 -> ==0.15.17

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`