### PR TITLE
[codex] Modernize IO typing syntax

### DIFF
--- a/src/trend_analysis/io/market_data.py
+++ b/src/trend_analysis/io/market_data.py
@@ -12,18 +12,11 @@ import calendar
 import enum
 import logging
 import re
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import (
     Any,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Tuple,
     cast,
 )
 
@@ -215,22 +208,24 @@ class MarketDataMetadata(BaseModel):
     start: datetime
     end: datetime
     rows: int
-    columns: List[str] = Field(default_factory=list)
-    symbols: List[str] = Field(default_factory=list)
+    columns: list[str] = Field(default_factory=list)
+    symbols: list[str] = Field(default_factory=list)
     missing_policy: str = Field(default=_DEFAULT_MISSING_POLICY)
-    missing_policy_limit: Optional[int] = None
-    missing_policy_overrides: Dict[str, str] = Field(default_factory=dict)
-    missing_policy_limits: Dict[str, Optional[int]] = Field(default_factory=dict)
-    missing_policy_filled: Dict[str, MissingPolicyFillDetails] = Field(default_factory=dict)
-    missing_policy_dropped: List[str] = Field(default_factory=list)
-    missing_policy_summary: Optional[str] = None
+    missing_policy_limit: int | None = None
+    missing_policy_overrides: dict[str, str] = Field(default_factory=dict)
+    missing_policy_limits: dict[str, int | None] = Field(default_factory=dict)
+    missing_policy_filled: dict[str, MissingPolicyFillDetails] = Field(
+        default_factory=dict
+    )
+    missing_policy_dropped: list[str] = Field(default_factory=list)
+    missing_policy_summary: str | None = None
 
     @property
-    def date_range(self) -> Tuple[str, str]:
+    def date_range(self) -> tuple[str, str]:
         return self.start.strftime("%Y-%m-%d"), self.end.strftime("%Y-%m-%d")
 
     @model_validator(mode="after")
-    def _sync_symbols(self) -> "MarketDataMetadata":
+    def _sync_symbols(self) -> MarketDataMetadata:
         """Keep the ``columns`` and ``symbols`` fields aligned."""
 
         if not self.symbols and self.columns:
@@ -282,11 +277,13 @@ def _normalise_policy_value(value: str | None) -> str:
     policy = (value or _DEFAULT_MISSING_POLICY).strip().lower()
     if policy not in _VALID_MISSING_POLICIES:
         allowed = ", ".join(sorted(_VALID_MISSING_POLICIES))
-        raise ValueError(f"Unknown missing-data policy '{value}'. Choose one of {allowed}.")
+        raise ValueError(
+            f"Unknown missing-data policy '{value}'. Choose one of {allowed}."
+        )
     return policy
 
 
-def _coerce_limit_value(value: Any) -> Optional[int]:
+def _coerce_limit_value(value: Any) -> int | None:
     if value is None or value == "":
         return None
     try:
@@ -302,7 +299,7 @@ def _build_policy_maps(
     columns: Iterable[Any],
     policy: str | Mapping[str, str] | None,
     limit: int | Mapping[str, int | None] | None,
-) -> tuple[Dict[str, str], str, Dict[str, Optional[int]], Optional[int]]:
+) -> tuple[dict[str, str], str, dict[str, int | None], int | None]:
     """Normalize per-column missing-data policy and limit inputs.
 
     Assumptions and limitations:
@@ -327,7 +324,8 @@ def _build_policy_maps(
         raw_policy = {str(k): v for k, v in policy.items()}
         default_policy = _normalise_policy_value(raw_policy.get("*"))
         policy_map = {
-            col: _normalise_policy_value(raw_policy.get(col, default_policy)) for col in cols
+            col: _normalise_policy_value(raw_policy.get(col, default_policy))
+            for col in cols
         }
     else:
         # Scalar input applies to every column, so the policy map is uniform.
@@ -340,7 +338,9 @@ def _build_policy_maps(
         # per-column map fully expanded (no "*" entries) for downstream metadata.
         raw_limit = {str(k): v for k, v in limit.items()}
         default_limit = _coerce_limit_value(raw_limit.get("*"))
-        limit_map = {col: _coerce_limit_value(raw_limit.get(col, default_limit)) for col in cols}
+        limit_map = {
+            col: _coerce_limit_value(raw_limit.get(col, default_limit)) for col in cols
+        }
     else:
         # Scalar limit applies to every column when no mapping is provided.
         default_limit = _coerce_limit_value(limit)
@@ -363,7 +363,7 @@ def apply_missing_policy(
     policy: str | Mapping[str, str] | None,
     *,
     limit: int | Mapping[str, int | None] | None = None,
-) -> tuple[pd.DataFrame, Dict[str, Any]]:
+) -> tuple[pd.DataFrame, dict[str, Any]]:
     if frame.empty:
         return frame.copy(), {
             "policy": _DEFAULT_MISSING_POLICY,
@@ -418,12 +418,16 @@ def apply_missing_policy(
                 dropped.append(column)
                 continue
             result[column] = filled_series
-            filled[column] = MissingPolicyFillDetails(method="ffill", count=missing_total)
+            filled[column] = MissingPolicyFillDetails(
+                method="ffill", count=missing_total
+            )
             continue
 
         if col_policy == "zero":
             result[column] = series.fillna(0.0)
-            filled[column] = MissingPolicyFillDetails(method="zero", count=missing_total)
+            filled[column] = MissingPolicyFillDetails(
+                method="zero", count=missing_total
+            )
             continue
 
         raise ValueError(f"Unhandled missing-data policy '{col_policy}'.")
@@ -450,7 +454,7 @@ def _summarise_missing_policy(info: Mapping[str, Any]) -> str:
     limit = info.get("limit")
     limit_text = f"limit={limit}" if limit is not None else "unlimited"
 
-    overrides: Dict[str, str] = {}
+    overrides: dict[str, str] = {}
     policy_map = cast(Mapping[str, str], info.get("policy_map", {}))
     default_policy = policy
     for column, value in policy_map.items():
@@ -482,7 +486,9 @@ def _summarise_missing_policy(info: Mapping[str, Any]) -> str:
 
     parts = [f"policy={policy}", limit_text]
     if overrides:
-        overrides_text = ", ".join(f"{col}:{val}" for col, val in sorted(overrides.items()))
+        overrides_text = ", ".join(
+            f"{col}:{val}" for col, val in sorted(overrides.items())
+        )
         parts.append(f"overrides={overrides_text}")
     if filled_chunks:
         parts.append("filled=" + ", ".join(sorted(filled_chunks)))
@@ -499,8 +505,8 @@ def _normalize_delta_days(delta_days: pd.Series) -> pd.Series:
 def classify_frequency(
     index: pd.DatetimeIndex,
     *,
-    max_gap_limit: Optional[int] = None,
-) -> Dict[str, Any]:
+    max_gap_limit: int | None = None,
+) -> dict[str, Any]:
     if not isinstance(index, pd.DatetimeIndex) or len(index) < 2:
         return {
             "canonical": "UNKNOWN",
@@ -672,7 +678,9 @@ def _resolve_datetime_index(
             preview = ", ".join(sample_values[:5])
             if len(sample_values) > 5:
                 preview += " …"
-            issues = [f"Found dates that could not be parsed. Examples: {preview or 'n/a'}."]
+            issues = [
+                f"Found dates that could not be parsed. Examples: {preview or 'n/a'}."
+            ]
             raise MarketDataValidationError(_format_issues(issues), issues) from exc
         if parsed.isna().any():
             bad_values = working.loc[parsed.isna(), date_col].astype(str).tolist()
@@ -736,13 +744,13 @@ def _check_monotonic_index(index: pd.DatetimeIndex) -> list[str]:
 def _infer_frequency(
     index: pd.DatetimeIndex,
     *,
-    max_gap_limit: Optional[int] = None,
-) -> Tuple[str, str, Dict[str, Any]]:
+    max_gap_limit: int | None = None,
+) -> tuple[str, str, dict[str, Any]]:
     info = classify_frequency(index, max_gap_limit=max_gap_limit)
     return info["canonical"], info["label"], info
 
 
-def _strip_percent(series: pd.Series) -> Tuple[pd.Series, bool]:
+def _strip_percent(series: pd.Series) -> tuple[pd.Series, bool]:
     """Strip trailing '%' from string values and divide by 100 if needed.
 
     Returns
@@ -767,7 +775,7 @@ def _strip_percent(series: pd.Series) -> Tuple[pd.Series, bool]:
     return result, True
 
 
-def _coerce_numeric(df: pd.DataFrame) -> Tuple[pd.DataFrame, list[str]]:
+def _coerce_numeric(df: pd.DataFrame) -> tuple[pd.DataFrame, list[str]]:
     numeric = pd.DataFrame(index=df.index)
     issues: list[str] = []
 
@@ -885,7 +893,9 @@ def validate_market_data(
         raise MarketDataValidationError(_format_issues(issues), issues)
 
     limit_candidates = [
-        value for value in policy_info.get("limit_map", {}).values() if value is not None
+        value
+        for value in policy_info.get("limit_map", {}).values()
+        if value is not None
     ]
     max_gap_limit = max(limit_candidates) if limit_candidates else None
 
@@ -992,7 +1002,11 @@ def attach_metadata(frame: pd.DataFrame, metadata: MarketDataMetadata) -> pd.Dat
             "missing_policy_overrides": dict(metadata.missing_policy_overrides),
             "missing_policy_limits": dict(metadata.missing_policy_limits),
             "missing_policy_filled": {
-                column: (details.model_dump() if hasattr(details, "model_dump") else dict(details))
+                column: (
+                    details.model_dump()
+                    if hasattr(details, "model_dump")
+                    else dict(details)
+                )
                 for column, details in metadata.missing_policy_filled.items()
             },
             "missing_policy_dropped": list(metadata.missing_policy_dropped),

--- a/src/trend_analysis/io/ui_ingest.py
+++ b/src/trend_analysis/io/ui_ingest.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import csv
 import io
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any
 
 import pandas as pd
 
@@ -168,7 +169,9 @@ def _raise_date_issue(result: DateCorrectionResult, *, auto_fix_dates: bool) -> 
     if total_fixable > 0:
         issues.append(f"{total_fixable} row(s) can be auto-corrected.")
     if result.unfixable:
-        preview = ", ".join(f"row {row + 1}: {val!r}" for row, val in result.unfixable[:3])
+        preview = ", ".join(
+            f"row {row + 1}: {val!r}" for row, val in result.unfixable[:3]
+        )
         issues.append(f"Unfixable dates detected ({preview}).")
 
     if auto_fix_dates:

--- a/src/trend_analysis/io/validators.py
+++ b/src/trend_analysis/io/validators.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import io
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, Iterator, List, Tuple
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -28,11 +29,13 @@ class _ValidationSummary:
     metadata: MarketDataMetadata
     frame: pd.DataFrame
 
-    def warnings(self) -> List[str]:
+    def warnings(self) -> list[str]:
         warnings: list[str] = []
         rows = self.metadata.rows
         if rows < 12:
-            warnings.append(f"Dataset is quite small ({rows} periods) – consider a longer history.")
+            warnings.append(
+                f"Dataset is quite small ({rows} periods) – consider a longer history."
+            )
         for column in self.frame.columns:
             valid = self.frame[column].notna().sum()
             if rows and valid / rows <= 0.5:
@@ -56,7 +59,9 @@ class _ValidationSummary:
             or bool(self.metadata.missing_policy_filled)
             or bool(self.metadata.missing_policy_dropped)
         ):
-            warnings.append(f"Missing-data policy applied: {self.metadata.missing_policy_summary}.")
+            warnings.append(
+                f"Missing-data policy applied: {self.metadata.missing_policy_summary}."
+            )
         return warnings
 
 
@@ -70,7 +75,7 @@ class ValidationResult:
         issues: Iterable[str] | None,
         warnings: Iterable[str] | None,
         frequency: str | None = None,
-        date_range: Tuple[str, str] | None = None,
+        date_range: tuple[str, str] | None = None,
         metadata: MarketDataMetadata | None = None,
     ) -> None:
         self.is_valid = is_valid
@@ -88,7 +93,9 @@ class ValidationResult:
             if self.frequency:
                 lines.append(f"📊 Detected frequency: {self.frequency}")
             if self.date_range:
-                lines.append(f"📅 Date range: {self.date_range[0]} to {self.date_range[1]}")
+                lines.append(
+                    f"📅 Date range: {self.date_range[0]} to {self.date_range[1]}"
+                )
             if self.mode:
                 lines.append(f"📈 Detected mode: {self.mode.value}")
             if (
@@ -100,7 +107,9 @@ class ValidationResult:
                     or bool(self.metadata.missing_policy_dropped)
                 )
             ):
-                lines.append(f"🧹 Missing data policy: {self.metadata.missing_policy_summary}")
+                lines.append(
+                    f"🧹 Missing data policy: {self.metadata.missing_policy_summary}"
+                )
         else:
             lines.append("❌ Schema validation failed!")
 
@@ -172,7 +181,7 @@ def validate_returns_schema(df: pd.DataFrame) -> ValidationResult:
     return _build_result(validated)
 
 
-def _read_uploaded_file(file_like: Any) -> Tuple[pd.DataFrame, str]:
+def _read_uploaded_file(file_like: Any) -> tuple[pd.DataFrame, str]:
     name = getattr(file_like, "name", None)
     lower_name = name.lower() if isinstance(name, str) else ""
 
@@ -211,9 +220,13 @@ def _read_uploaded_file(file_like: Any) -> Tuple[pd.DataFrame, str]:
     except FileNotFoundError:
         raise ValueError(f"File not found: '{lower_name or file_like}'")
     except PermissionError:
-        raise ValueError(f"Permission denied accessing file: '{lower_name or file_like}'")
+        raise ValueError(
+            f"Permission denied accessing file: '{lower_name or file_like}'"
+        )
     except IsADirectoryError:
-        raise ValueError(f"Path is a directory, not a file: '{lower_name or file_like}'")
+        raise ValueError(
+            f"Path is a directory, not a file: '{lower_name or file_like}'"
+        )
     except pd.errors.EmptyDataError:
         raise ValueError(f"File contains no data: '{lower_name or file_like}'")
     except pd.errors.ParserError:
@@ -230,9 +243,13 @@ def _read_uploaded_file(file_like: Any) -> Tuple[pd.DataFrame, str]:
         except FileNotFoundError:
             raise ValueError(f"File not found: '{lower_name or file_like}'")
         except PermissionError:
-            raise ValueError(f"Permission denied accessing file: '{lower_name or file_like}'")
+            raise ValueError(
+                f"Permission denied accessing file: '{lower_name or file_like}'"
+            )
         except IsADirectoryError:
-            raise ValueError(f"Path is a directory, not a file: '{lower_name or file_like}'")
+            raise ValueError(
+                f"Path is a directory, not a file: '{lower_name or file_like}'"
+            )
         except pd.errors.EmptyDataError:
             raise ValueError(f"File contains no data: '{lower_name or file_like}'")
         except pd.errors.ParserError:
@@ -240,12 +257,14 @@ def _read_uploaded_file(file_like: Any) -> Tuple[pd.DataFrame, str]:
                 f"Failed to parse file (corrupted or invalid format): '{lower_name or file_like}'"
             )
         except Exception as exc:
-            raise ValueError(f"Failed to read file: '{lower_name or file_like}'") from exc
+            raise ValueError(
+                f"Failed to read file: '{lower_name or file_like}'"
+            ) from exc
 
     raise ValueError("Unsupported upload source")
 
 
-def load_and_validate_upload(file_like: Any) -> Tuple[pd.DataFrame, Dict[str, Any]]:
+def load_and_validate_upload(file_like: Any) -> tuple[pd.DataFrame, dict[str, Any]]:
     """Load uploaded content, validate it, and attach metadata."""
 
     frame, source = _read_uploaded_file(file_like)
@@ -256,7 +275,7 @@ def load_and_validate_upload(file_like: Any) -> Tuple[pd.DataFrame, Dict[str, An
 
     attach_metadata(validated.frame, validated.metadata)
     result = _build_result(validated)
-    meta: Dict[str, Any] = {
+    meta: dict[str, Any] = {
         "metadata": validated.metadata.model_dump(mode="json"),
         "validation": result,
         "n_rows": validated.metadata.rows,
@@ -273,7 +292,7 @@ def create_sample_template() -> pd.DataFrame:
 
     dates = pd.date_range(start="2023-01-31", periods=12, freq="ME")
     rng = np.random.default_rng(42)
-    data: Dict[str, Any] = {"Date": dates}
+    data: dict[str, Any] = {"Date": dates}
     for idx in range(1, 6):
         data[f"Fund_{idx:02d}"] = rng.normal(0.008, 0.03, len(dates))
     data["SPX_Benchmark"] = rng.normal(0.007, 0.025, len(dates))


### PR DESCRIPTION
## Summary
- apply a scoped codemod-lane pyupgrade campaign to `src/trend_analysis/io`
- replace legacy `typing` aliases with Python 3.12 builtin generics / `collections.abc` imports
- format only the three touched IO source files after the mechanical rewrite

## Orchestrator
- exercised the `codemod_lane.py` path for backlog item D
- Vibe authored the campaign JSON; `codemod_lane.py --validate` accepted it
- local integration applied the campaign in an isolated clone based on `phase-3`

## Validation
- `uv run ruff check --select UP006,UP007,UP035,UP037,UP045 src/trend_analysis/io`
- `uv run ruff check src/trend_analysis/io tests/test_market_data_validation_additional.py tests/test_io_validators_extra.py tests/test_io_validators_additional.py tests/test_validators_branch_coverage.py tests/test_validators.py tests/test_io_utils.py`
- `uv run ruff format --check src/trend_analysis/io/market_data.py src/trend_analysis/io/validators.py src/trend_analysis/io/ui_ingest.py`
- `uv run pytest tests/test_market_data_validation_additional.py tests/test_io_validators_extra.py tests/test_io_validators_additional.py tests/test_validators_branch_coverage.py tests/test_validators.py tests/test_io_utils.py --no-cov`

No issue reference; this is a scoped Orchestrator codemod-lane exercise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized type annotations across data handling and validation modules for consistency with current Python standards and improved code clarity.
  * Updated internal module imports for cleaner, more organized code structure.

* **Style**
  * Reformatted code blocks, error messages, and validation output throughout the data processing pipeline for enhanced readability and long-term maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->