### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ dev = [
     # Shared app behavior baseline harness (also pulls pytest-regressions). Pinned to
     # the Workflows default branch; move to a tagged ref once the package is versioned.
     "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit",
-    "coverage==7.14.1",
+    "coverage==7.14.2",
     "pytest-rerunfailures==16.3",
     "pytest-xdist==3.8.0",
     "packaging==26.2",

--- a/requirements.lock
+++ b/requirements.lock
@@ -64,7 +64,7 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage==7.14.1
+coverage==7.14.2
     # via
     #   trend-model (pyproject.toml)
     #   pytest-cov


### PR DESCRIPTION
Automated follow-up to the Maint52 dev-tool sync wave.

The original Maint52 PR also changed `.github/workflows/autofix-versions.env`, but that env pin has already landed on `main` via the focused coverage env sync. This replacement starts from current `main` and keeps the remaining canonical coverage pin updates in `pyproject.toml` and `requirements.lock`.

Supersedes the conflicting `deps/sync-dev-versions-d45bcd3be592` PR.