### PR TITLE
Fix presentation-safe demo fund selection

### DIFF
--- a/streamlit_app/components/demo_runner.py
+++ b/streamlit_app/components/demo_runner.py
@@ -174,6 +174,7 @@ def _build_pipeline_config(
     }
 
     portfolio = {
+        "indices_list": [benchmark] if benchmark else [],
         "selection_mode": "rank",
         "rank": {
             "inclusion_approach": "top_n",

--- a/tests/test_streamlit_demo_runner.py
+++ b/tests/test_streamlit_demo_runner.py
@@ -56,6 +56,21 @@ def test_run_one_click_demo_updates_state(monkeypatch):
     assert state["demo_show_export_prompt"] is True
 
 
+def test_demo_presentation_safe_yields_results():
+    df, _ = demo_runner._load_demo_returns()
+    setup = demo_runner._prepare_demo_setup(df)
+    returns = df.reset_index().rename(columns={df.index.name or "index": "Date"})
+
+    result = demo_runner.run_simulation(setup.pipeline_config, returns)
+    selected_funds = result.details.get("selected_funds", [])
+
+    assert result.diagnostic is None
+    assert result.metrics.shape[0] >= 1
+    assert selected_funds
+    assert any(str(fund).startswith("Mgr_") for fund in selected_funds)
+    assert "SPX" not in selected_funds
+
+
 def test_app_demo_button_triggers_navigation(monkeypatch):
     class MockStreamlit(ModuleType):
         def __init__(self) -> None:  # noqa: D401 - helper

--- a/tests/test_streamlit_demo_runner.py
+++ b/tests/test_streamlit_demo_runner.py
@@ -67,7 +67,7 @@ def test_demo_presentation_safe_yields_results():
     assert result.diagnostic is None
     assert result.metrics.shape[0] >= 1
     assert selected_funds
-    assert any(str(fund).startswith("Mgr_") for fund in selected_funds)
+    assert all(str(fund).startswith("Mgr_") for fund in selected_funds)
     assert "SPX" not in selected_funds
 
 


### PR DESCRIPTION
Closes #5619

## Summary
- exclude the detected benchmark column from the demo pipeline portfolio universe
- add a presentation-safe Balanced demo regression test over demo/demo_returns.csv

## Validation
- MPLCONFIGDIR=/tmp/mplconfig pytest tests/test_streamlit_demo_runner.py -q

## Notes
- On the current phase-3 base the original zero-fund diagnostic no longer reproduced; this preserves the non-empty demo result and fixes the adjacent benchmark-as-holding leak.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Portfolio simulation configuration now carries benchmark index scoping, improving how benchmark-related indices are applied during runs.

* **Tests**
  * Added an end-to-end demo simulation test to confirm the simulation completes successfully, generates metrics, and returns a valid set of selected funds without including the benchmark symbol.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->