### PR TITLE
Hide raw pipeline codes in Results summary

### DIFF
--- a/streamlit_app/pages/3_Results.py
+++ b/streamlit_app/pages/3_Results.py
@@ -20,6 +20,7 @@ from streamlit_app.components import (
     comparison_llm,
     explain_results,
 )
+from trend_analysis.diagnostics import PipelineReasonCode
 from trend_analysis.util.weights import normalize_weights
 
 # =============================================================================
@@ -84,12 +85,12 @@ def _diagnostic_message(result: Any) -> tuple[str | None, str | None]:
         message = getattr(diag, "message", None)
         code = getattr(diag, "reason_code", None)
         if message:
-            summary = (
-                f"Analysis did not produce results ({code})."
-                if code
-                else "Analysis did not produce results."
-            )
-            return summary, str(message)
+            detail = str(message)
+            if code == PipelineReasonCode.NO_FUNDS_SELECTED.value:
+                detail = (
+                    f"{detail} Try another preset, or adjust Customize Demo Settings."
+                )
+            return "Analysis did not produce results.", detail
 
     return None, None
 

--- a/tests/app/test_results_page.py
+++ b/tests/app/test_results_page.py
@@ -6,6 +6,8 @@ from types import ModuleType, SimpleNamespace
 import pandas as pd
 import pytest
 
+from trend_analysis.diagnostics import PipelineReasonCode, pipeline_failure
+
 
 class _ContextManager:
     def __enter__(self):
@@ -388,6 +390,19 @@ def test_results_page_reports_plain_language_error(
         "message": "We couldn't run the analysis with the current data or settings. Please review the configuration and try again.",
         "detail": "No returns available after filtering",
     }
+
+
+def test_results_error_summary_hides_reason_code(results_page) -> None:
+    page, _stub = results_page
+    result = pipeline_failure(PipelineReasonCode.NO_FUNDS_SELECTED)
+
+    summary, detail = page._diagnostic_message(result)
+
+    assert summary == "Analysis did not produce results."
+    assert "PIPELINE_NO_FUNDS_SELECTED" not in summary
+    assert detail is not None
+    assert "No investable funds satisfy the selection filters." in detail
+    assert "Try another preset, or adjust Customize Demo Settings." in detail
 
 
 def test_results_page_renders_explain_results(


### PR DESCRIPTION
Closes #5620

## Summary
- remove raw PIPELINE_* reason-code tokens from the primary Results diagnostic summary
- append a concrete operator next step for the no-funds diagnostic detail
- add a focused regression test for the Results diagnostic summary helper

## Validation
- MPLCONFIGDIR=/tmp/mplconfig pytest tests/app/test_results_page.py::test_results_error_summary_hides_reason_code -q
- Deliberate break: restored the raw-code summary and confirmed the named test failed, then reverted
- MPLCONFIGDIR=/tmp/mplconfig pytest tests/app/test_results_page.py -q
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when analysis fails due to missing fund selections. Users now receive clearer, more actionable guidance recommending they try alternative presets or adjust their demo settings configuration to resolve the issue. Technical error codes are hidden from user-facing messages to provide a cleaner, more intuitive overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->