### PR TITLE
Reuse demo results on Results page

### DIFF
--- a/streamlit_app/components/demo_runner.py
+++ b/streamlit_app/components/demo_runner.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, MutableMapping, Tuple
@@ -349,6 +351,57 @@ def _update_session_state(
     state["selected_benchmark"] = setup.benchmark
 
 
+def _selected_funds_from_result(result: Any, df: pd.DataFrame, benchmark: str | None) -> list[str]:
+    selected: list[str] = []
+    for attr in ("weights", "exposures", "portfolio"):
+        series = getattr(result, attr, None)
+        if isinstance(series, pd.Series):
+            selected.extend(str(item) for item in series.index if str(item) in df.columns)
+    if not selected:
+        selected = [str(col) for col in df.columns]
+
+    excluded = {benchmark, None, ""}
+    return [fund for fund in dict.fromkeys(selected) if fund not in excluded]
+
+
+def _analysis_run_key(
+    state: Mapping[str, Any], model_state: Mapping[str, Any], benchmark: str | None
+) -> str:
+    fingerprint = state.get("data_fingerprint", "unknown")
+    model_blob = json.dumps(model_state, sort_keys=True, default=str)
+    bench = benchmark or "__none__"
+    selected_rf = state.get("selected_risk_free")
+    selected_rf_key = selected_rf or "__none__"
+    applied_funds = state.get("analysis_fund_columns")
+    if not isinstance(applied_funds, list):
+        applied_funds = state.get("fund_columns")
+    if not isinstance(applied_funds, list):
+        applied_funds = []
+
+    info_ratio_benchmark = model_state.get("info_ratio_benchmark")
+    prohibited = {selected_rf, benchmark, info_ratio_benchmark} - {None}
+    sanitized_funds = [c for c in applied_funds if c not in prohibited]
+    funds_blob = json.dumps(list(sanitized_funds), sort_keys=False, default=str)
+    funds_hash = hashlib.sha256(funds_blob.encode("utf-8")).hexdigest()[:12]
+    return f"{fingerprint}:{bench}:{selected_rf_key}:{funds_hash}:{model_blob}"
+
+
+def _store_demo_result_state(st_module: Any, setup: DemoSetup, df: pd.DataFrame, result: Any) -> None:
+    from streamlit_app.components.data_cache import cache_key_for_frame
+
+    state: MutableMapping[str, Any] = st_module.session_state
+    selected_funds = _selected_funds_from_result(result, df, setup.benchmark)
+    state["selected_fund_columns"] = list(selected_funds)
+    state["fund_columns"] = list(selected_funds)
+    state["analysis_fund_columns"] = list(selected_funds)
+    state["sim_results"] = result
+    state["analysis_result"] = result
+    state["data_fingerprint"] = cache_key_for_frame(df)
+    model_state = state.get("model_state")
+    if isinstance(model_state, Mapping):
+        state["analysis_result_key"] = _analysis_run_key(state, model_state, setup.benchmark)
+
+
 def run_one_click_demo(st_module: Any | None = None) -> bool:
     """Execute the demo pipeline and stash results in ``st.session_state``."""
 
@@ -378,13 +431,7 @@ def run_one_click_demo(st_module: Any | None = None) -> bool:
         return False
 
     _update_session_state(st_module, setup, df, meta)
-    st_module.session_state["sim_results"] = result
-    # Also store as analysis_result so Results page can display it directly
-    st_module.session_state["analysis_result"] = result
-    # Set a fingerprint for the data so cache key can match
-    from streamlit_app.components.data_cache import cache_key_for_frame
-
-    st_module.session_state["data_fingerprint"] = cache_key_for_frame(df)
+    _store_demo_result_state(st_module, setup, df, result)
     return True
 
 
@@ -544,11 +591,6 @@ def run_demo_with_overrides(
 
     # Update session state
     _update_session_state(st_module, setup, df, meta)
-    st_module.session_state["sim_results"] = result
-    st_module.session_state["analysis_result"] = result
-
-    from streamlit_app.components.data_cache import cache_key_for_frame
-
-    st_module.session_state["data_fingerprint"] = cache_key_for_frame(df)
+    _store_demo_result_state(st_module, setup, df, result)
 
     return True

--- a/streamlit_app/components/demo_runner.py
+++ b/streamlit_app/components/demo_runner.py
@@ -15,6 +15,7 @@ from streamlit_app.components.analysis_runner import ModelSettings
 from streamlit_app.components.data_schema import (
     SchemaMeta,
     infer_benchmarks,
+    infer_risk_free_candidates,
     load_and_validate_file,
 )
 from streamlit_app.components.policy_engine import MetricSpec, PolicyConfig
@@ -364,6 +365,13 @@ def _selected_funds_from_result(result: Any, df: pd.DataFrame, benchmark: str | 
     return [fund for fund in dict.fromkeys(selected) if fund not in excluded]
 
 
+def _selected_risk_free_from_demo(df: pd.DataFrame, benchmark: str | None) -> str | None:
+    for candidate in infer_risk_free_candidates(list(df.columns)):
+        if candidate != benchmark:
+            return candidate
+    return None
+
+
 def _analysis_run_key(
     state: Mapping[str, Any], model_state: Mapping[str, Any], benchmark: str | None
 ) -> str:
@@ -390,6 +398,8 @@ def _store_demo_result_state(st_module: Any, setup: DemoSetup, df: pd.DataFrame,
     from streamlit_app.components.data_cache import cache_key_for_frame
 
     state: MutableMapping[str, Any] = st_module.session_state
+    selected_rf = _selected_risk_free_from_demo(df, setup.benchmark)
+    state["selected_risk_free"] = selected_rf
     selected_funds = _selected_funds_from_result(result, df, setup.benchmark)
     state["selected_fund_columns"] = list(selected_funds)
     state["fund_columns"] = list(selected_funds)

--- a/tests/app/test_results_page.py
+++ b/tests/app/test_results_page.py
@@ -504,6 +504,7 @@ def test_demo_run_renders_results_end_to_end(
 ) -> None:
     page, stub = results_page
     returns = _sample_returns()
+    returns["RF"] = [0.001, 0.001, 0.001]
     result = SimpleNamespace(
         metrics=pd.DataFrame({"Sharpe": [1.23]}),
         details={
@@ -572,7 +573,24 @@ def test_demo_run_renders_results_end_to_end(
     assert render_run_keys[-1] == stub.session_state["analysis_result_key"]
     assert not recompute_calls
     assert stub.session_state["analysis_fund_columns"] == ["FundA", "FundB"]
+    assert stub.session_state["selected_risk_free"] == "RF"
     assert stub.session_state["analysis_result"] is result
     assert stub.session_state["analysis_result_key"] == expected_run_key
     assert any("Using 2 selected funds" in msg for msg in stub.caption_messages)
     assert not stub.error_messages
+
+    rerun_columns: list[str] = []
+    rerun_model_states: list[dict] = []
+
+    def record_rerun(df, model_state, _benchmark, **_kwargs):
+        rerun_columns.extend(list(df.columns))
+        rerun_model_states.append(dict(model_state))
+        return result
+
+    monkeypatch.setattr(page.analysis_runner, "run_analysis", record_rerun)
+    monkeypatch.setattr(stub, "button", lambda *_args, **_kwargs: True)
+
+    page.render_results_page()
+
+    assert rerun_columns == ["FundA", "FundB", "RF"]
+    assert rerun_model_states[-1]["risk_free_column"] == "RF"

--- a/tests/app/test_results_page.py
+++ b/tests/app/test_results_page.py
@@ -497,3 +497,82 @@ def test_current_run_key_changes_with_risk_free(results_page) -> None:
     key_two = page._current_run_key(model_state, None)
 
     assert key_one != key_two
+
+
+def test_demo_run_renders_results_end_to_end(
+    monkeypatch: pytest.MonkeyPatch, results_page
+) -> None:
+    page, stub = results_page
+    returns = _sample_returns()
+    result = SimpleNamespace(
+        metrics=pd.DataFrame({"Sharpe": [1.23]}),
+        details={
+            "portfolio_equal_weight_combined": returns["FundA"],
+            "risk_diagnostics": {
+                "turnover": pd.Series([0.1, 0.2], index=returns.index[:2]),
+                "final_weights": pd.Series({"FundA": 0.6, "FundB": 0.4}),
+            },
+        },
+        fallback_info=None,
+        portfolio=returns["FundA"],
+        weights=pd.Series({"FundA": 0.6, "FundB": 0.4}),
+    )
+
+    from streamlit_app.components import demo_runner
+
+    setup = demo_runner.DemoSetup(
+        config_state={"preset_name": "Balanced"},
+        sim_config={"preset_name": "Balanced"},
+        pipeline_config=SimpleNamespace(),
+        benchmark=None,
+    )
+    demo_runner._update_session_state(stub, setup, returns, {})
+    demo_runner._store_demo_result_state(stub, setup, returns, result)
+
+    for chart in [
+        "equity_chart",
+        "drawdown_chart",
+        "rolling_sharpe_chart",
+        "turnover_chart",
+        "exposure_chart",
+    ]:
+        monkeypatch.setattr(
+            getattr(page, "charts"), chart, lambda *_args, chart_name=chart: chart_name
+        )
+    monkeypatch.setattr(
+        page.explain_results, "render_explain_results", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(stub, "button", lambda *_args, **_kwargs: False)
+
+    recompute_calls: list[tuple[object, ...]] = []
+
+    def fail_recompute(*args, **_kwargs):
+        recompute_calls.append(args)
+        raise AssertionError("demo result should be reused without recomputing")
+
+    monkeypatch.setattr(page.analysis_runner, "run_analysis", fail_recompute)
+
+    original_current_run_key = page._current_run_key
+    render_run_keys: list[str] = []
+
+    def recording_run_key(model_state, benchmark):
+        key = original_current_run_key(model_state, benchmark)
+        render_run_keys.append(key)
+        return key
+
+    monkeypatch.setattr(page, "_current_run_key", recording_run_key)
+
+    expected_run_key = page._current_run_key(
+        stub.session_state["model_state"], stub.session_state["selected_benchmark"]
+    )
+    assert stub.session_state["analysis_result_key"] == expected_run_key
+
+    page.render_results_page()
+
+    assert render_run_keys[-1] == stub.session_state["analysis_result_key"]
+    assert not recompute_calls
+    assert stub.session_state["analysis_fund_columns"] == ["FundA", "FundB"]
+    assert stub.session_state["analysis_result"] is result
+    assert stub.session_state["analysis_result_key"] == expected_run_key
+    assert any("Using 2 selected funds" in msg for msg in stub.caption_messages)
+    assert not stub.error_messages


### PR DESCRIPTION
Closes #5625

## Summary
- populate Results-page fund selection keys after demo runs
- store the matching analysis result cache key so Run Demo reuses the computed result
- add an end-to-end Results page regression for the demo session-state handoff

## Validation
- MPLCONFIGDIR=/tmp/mplconfig pytest tests/app/test_results_page.py::test_demo_run_renders_results_end_to_end tests/app/test_demo_runner_component.py::test_run_one_click_demo_happy_path tests/app/test_demo_runner_component.py::test_update_session_state_populates_streamlit_state tests/app/test_results_page.py -q
- Deliberate break: cleared analysis_fund_columns in _store_demo_result_state and confirmed test_demo_run_renders_results_end_to_end failed, then reverted
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how demo simulation results are stored and keyed so cached analysis can be reliably reused on the results page, avoiding unnecessary recomputation.
  * Ensures risk-free options are handled correctly when rerunning the demo.

* **Tests**
  * Added an end-to-end test that verifies cached demo results are reused during rendering and that rerunning triggers recomputation with the expected risk-free data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->