### PR TITLE
Mark single-period demo-only Results tabs

### DIFF
--- a/streamlit_app/pages/3_Results.py
+++ b/streamlit_app/pages/3_Results.py
@@ -683,7 +683,10 @@ def _render_manager_changes(result) -> None:
     decisions_df = _extract_manager_decisions(result)
 
     if changes_df.empty and decisions_df.empty:
-        st.caption("No manager changes during simulation period.")
+        st.caption(
+            "Manager change history is not included in this sample run; use a custom "
+            "multi-period analysis to review hiring and termination decisions."
+        )
         return
 
     initial = len(changes_df[changes_df["Action"] == "Initial"]) if not changes_df.empty else 0
@@ -949,7 +952,10 @@ def _render_fund_holdings(result) -> None:
     summary_df, risk_df = _compute_fund_holding_periods(result)
 
     if summary_df.empty:
-        st.caption("No fund holding data available.")
+        st.caption(
+            "Holding-period detail is not included in this sample run; use a custom "
+            "multi-period analysis to inspect manager tenure and holdings."
+        )
         return
 
     # Format summary
@@ -1663,7 +1669,9 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
             mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         )
     else:
-        st.caption("Run a multi-period analysis to enable workbook export.")
+        st.caption(
+            "Run a multi-period analysis from the Model page to enable workbook export."
+        )
 
     # CSV equivalent of the Excel workbook
     st.divider()
@@ -1834,7 +1842,7 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
             mime="application/zip",
         )
     else:
-        st.caption("Run a multi-period analysis to enable CSV export.")
+        st.caption("Run a multi-period analysis from the Model page to enable CSV export.")
 
 
 # =============================================================================
@@ -2092,17 +2100,32 @@ def render_results_page() -> None:
             f"✅ Simulation complete: **{period_count} periods** from {sim_start} to {sim_end}"
         )
 
-    # Create main tabs for organized navigation
-    main_tabs = st.tabs(
-        [
+    single_period_result = period_count <= 0
+    tab_labels = [
+        "📊 Summary",
+        "🔬 Period Analysis",
+        "📈 Visualizations",
+        "📋 Fund Details",
+        "💾 Export",
+        "🆚 Compare",
+    ]
+    if single_period_result:
+        st.info(
+            "Single-period demo results include Summary and Visualizations. "
+            "Run a multi-period analysis to enable Period Analysis, Fund Details, Export, "
+            "and Compare."
+        )
+        tab_labels = [
             "📊 Summary",
-            "🔬 Period Analysis",
+            "🔬 Period Analysis — multi-period only",
             "📈 Visualizations",
-            "📋 Fund Details",
-            "💾 Export",
-            "🆚 Compare",
+            "📋 Fund Details — multi-period/custom only",
+            "💾 Export — multi-period only",
+            "🆚 Compare — needs saved configs",
         ]
-    )
+
+    # Create main tabs for organized navigation
+    main_tabs = st.tabs(tab_labels)
 
     # ==========================================================================
     # TAB 1: SUMMARY - Total portfolio performance
@@ -2158,7 +2181,10 @@ def render_results_page() -> None:
         if period_count > 0:
             _render_period_breakdown(result)
         else:
-            st.info("Single-period analysis does not have period breakdown.")
+            st.info(
+                "Set Lookback/periods above 1 on the Model page for a period-by-period "
+                "breakdown."
+            )
             # Show single period data if available
             if details:
                 score_frame = details.get("score_frame")
@@ -2304,7 +2330,9 @@ def render_results_page() -> None:
         saved_names = sorted(saved_states)
 
         if len(saved_names) < 2:
-            st.info("Save at least two configurations on the Model page to enable A/B comparison.")
+            st.info(
+                "Save at least two configurations on the Model page to enable A/B comparison."
+            )
         else:
             col_a, col_b = st.columns(2)
             with col_a:

--- a/streamlit_app/pages/3_Results.py
+++ b/streamlit_app/pages/3_Results.py
@@ -150,6 +150,24 @@ def _portfolio_series_from_details(details: dict[str, Any]) -> pd.Series:
     return pd.Series(dtype=float)
 
 
+def _result_period_count(result: Any, details: dict[str, Any]) -> int:
+    """Return the best available count of analyzed periods."""
+    raw_count = getattr(result, "period_count", None)
+    if raw_count is None:
+        raw_count = details.get("period_count", 0)
+
+    try:
+        period_count = int(raw_count or 0)
+    except (TypeError, ValueError):
+        period_count = 0
+
+    period_results = details.get("period_results")
+    if isinstance(period_results, list):
+        period_count = max(period_count, len(period_results))
+
+    return period_count
+
+
 def _current_run_key(model_state: dict[str, Any], benchmark: str | None) -> str:
     fingerprint = st.session_state.get("data_fingerprint", "unknown")
     model_blob = json.dumps(model_state, sort_keys=True, default=str)
@@ -2087,7 +2105,7 @@ def render_results_page() -> None:
             returns = _portfolio_series_from_details(details)
 
     # Multi-period info
-    period_count = getattr(result, "period_count", 0) or details.get("period_count", 0)
+    period_count = _result_period_count(result, details)
     sim_start, sim_end = _get_simulation_date_range(result)
 
     # ==========================================================================

--- a/tests/app/test_results_page.py
+++ b/tests/app/test_results_page.py
@@ -30,6 +30,7 @@ class DummyStreamlit:
         self.dataframes: list[pd.DataFrame] = []
         self.metrics: list[tuple[str, object]] = []
         self.checkbox_labels: list[str] = []
+        self.tab_groups: list[list[str]] = []
 
     # Basic UI primitives -------------------------------------------------
     def title(self, _text: str) -> None:  # pragma: no cover - trivial
@@ -82,6 +83,7 @@ class DummyStreamlit:
         self.caption_messages.append(message)
 
     def tabs(self, labels: list[str]):
+        self.tab_groups.append(list(labels))
         return [ColumnContext(self) for _ in labels]
 
     def metric(self, label: str, value: object) -> None:
@@ -594,3 +596,65 @@ def test_demo_run_renders_results_end_to_end(
 
     assert rerun_columns == ["FundA", "FundB", "RF"]
     assert rerun_model_states[-1]["risk_free_column"] == "RF"
+
+
+def test_demo_run_marks_or_hides_inapplicable_tabs(
+    monkeypatch: pytest.MonkeyPatch, results_page
+) -> None:
+    page, stub = results_page
+    returns = _sample_returns()
+    result = SimpleNamespace(
+        metrics=pd.DataFrame({"Sharpe": [1.23]}),
+        details={
+            "portfolio_equal_weight_combined": returns["FundA"],
+            "risk_diagnostics": {
+                "turnover": pd.Series([0.1, 0.2], index=returns.index[:2]),
+                "final_weights": pd.Series({"FundA": 0.6, "FundB": 0.4}),
+            },
+        },
+        fallback_info=None,
+        portfolio=returns["FundA"],
+        weights=pd.Series({"FundA": 0.6, "FundB": 0.4}),
+    )
+
+    from streamlit_app.components import demo_runner
+
+    setup = demo_runner.DemoSetup(
+        config_state={"preset_name": "Balanced"},
+        sim_config={"preset_name": "Balanced"},
+        pipeline_config=SimpleNamespace(),
+        benchmark=None,
+    )
+    demo_runner._update_session_state(stub, setup, returns, {})
+    demo_runner._store_demo_result_state(stub, setup, returns, result)
+
+    for chart in [
+        "equity_chart",
+        "drawdown_chart",
+        "rolling_sharpe_chart",
+        "turnover_chart",
+        "exposure_chart",
+    ]:
+        monkeypatch.setattr(
+            getattr(page, "charts"), chart, lambda *_args, chart_name=chart: chart_name
+        )
+    monkeypatch.setattr(
+        page.explain_results, "render_explain_results", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(stub, "button", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        page.analysis_runner,
+        "run_analysis",
+        lambda *_args, **_kwargs: pytest.fail("demo result should be reused"),
+    )
+
+    page.render_results_page()
+
+    labels = stub.tab_groups[-1]
+    assert any("Summary" in label for label in labels)
+    assert any("Visualizations" in label for label in labels)
+    assert any("Period Analysis" in label and "multi-period only" in label for label in labels)
+    assert any("Fund Details" in label and "multi-period/custom only" in label for label in labels)
+    assert any("Export" in label and "multi-period only" in label for label in labels)
+    assert any("Compare" in label and "needs saved configs" in label for label in labels)
+    assert any("Run a multi-period analysis to enable" in msg for msg in stub.info_messages)

--- a/tests/app/test_results_page.py
+++ b/tests/app/test_results_page.py
@@ -658,3 +658,20 @@ def test_demo_run_marks_or_hides_inapplicable_tabs(
     assert any("Export" in label and "multi-period only" in label for label in labels)
     assert any("Compare" in label and "needs saved configs" in label for label in labels)
     assert any("Run a multi-period analysis to enable" in msg for msg in stub.info_messages)
+
+
+def test_period_count_uses_period_results_when_explicit_count_missing(results_page) -> None:
+    page, _stub = results_page
+
+    result = SimpleNamespace(
+        details={
+            "period_count": 0,
+            "period_results": [
+                {"period": ("2024-01-01", "2024-01-31", "2024-02-01", "2024-02-29")},
+                {"period": ("2024-02-01", "2024-02-29", "2024-03-01", "2024-03-31")},
+            ],
+        },
+        period_count=0,
+    )
+
+    assert page._result_period_count(result, result.details) == 2


### PR DESCRIPTION
Closes #5629

## Summary
- Mark Results tabs that are unavailable for single-period demo runs with prerequisite labels.
- Add upfront guidance for single-period demo Results and route empty-state copy toward multi-period/custom runs.
- Add a focused regression that records tab labels and fails on unmarked six-tab demo behavior.

## Validation
- MPLCONFIGDIR=/tmp/mplconfig pytest tests/app/test_results_page.py::test_demo_run_marks_or_hides_inapplicable_tabs -q
- Deliberate break: removed the single-period tab markers and confirmed the named test failed, then restored the fix.
- MPLCONFIGDIR=/tmp/mplconfig pytest tests/app/test_results_page.py::test_demo_run_marks_or_hides_inapplicable_tabs tests/app/test_results_page.py::test_demo_run_renders_results_end_to_end tests/app/test_results_page.py -q
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Results page UI now adapts to available period data: single-period demo runs show only Summary and Visualizations, with an informational prompt to enable multi-period analysis.
  * Export and A/B Comparison empty states now clearly explain when multi-period analysis and saving configurations are required.
* **Bug Fixes**
  * Corrected effective period count handling by deriving it from period breakdown data when an explicit count is missing.
* **Tests**
  * Added end-to-end coverage for the demo/tab behavior and the period-count derivation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->