### PR TITLE
Fix one-period Results tab gating

### DIFF
--- a/streamlit_app/pages/3_Results.py
+++ b/streamlit_app/pages/3_Results.py
@@ -2118,7 +2118,7 @@ def render_results_page() -> None:
             f"✅ Simulation complete: **{period_count} periods** from {sim_start} to {sim_end}"
         )
 
-    single_period_result = period_count <= 0
+    single_period_result = period_count <= 1
     tab_labels = [
         "📊 Summary",
         "🔬 Period Analysis",

--- a/streamlit_app/pages/3_Results.py
+++ b/streamlit_app/pages/3_Results.py
@@ -181,7 +181,9 @@ def _current_run_key(model_state: dict[str, Any], benchmark: str | None) -> str:
         applied_funds = []
 
     info_ratio_benchmark = (
-        model_state.get("info_ratio_benchmark") if isinstance(model_state, dict) else None
+        model_state.get("info_ratio_benchmark")
+        if isinstance(model_state, dict)
+        else None
     )
     prohibited = {selected_rf, benchmark, info_ratio_benchmark} - {None}
     sanitized_funds = [c for c in applied_funds if c not in prohibited]
@@ -707,13 +709,23 @@ def _render_manager_changes(result) -> None:
         )
         return
 
-    initial = len(changes_df[changes_df["Action"] == "Initial"]) if not changes_df.empty else 0
-    hired = len(changes_df[changes_df["Action"] == "Hired"]) if not changes_df.empty else 0
+    initial = (
+        len(changes_df[changes_df["Action"] == "Initial"])
+        if not changes_df.empty
+        else 0
+    )
+    hired = (
+        len(changes_df[changes_df["Action"] == "Hired"]) if not changes_df.empty else 0
+    )
     terminated = (
-        len(changes_df[changes_df["Action"] == "Terminated"]) if not changes_df.empty else 0
+        len(changes_df[changes_df["Action"] == "Terminated"])
+        if not changes_df.empty
+        else 0
     )
     skipped = (
-        len(decisions_df[decisions_df["Action"] == "Skipped"]) if not decisions_df.empty else 0
+        len(decisions_df[decisions_df["Action"] == "Skipped"])
+        if not decisions_df.empty
+        else 0
     )
 
     # Compute expected final count for sanity check
@@ -792,14 +804,20 @@ def _render_manager_changes(result) -> None:
     # Debug expander for period-by-period breakdown
     with st.expander("📊 Period-by-Period Diagnostic", expanded=False):
         # Show period breakdown
-        period_stats = changes_df.groupby("Date")["Action"].value_counts().unstack(fill_value=0)
+        period_stats = (
+            changes_df.groupby("Date")["Action"].value_counts().unstack(fill_value=0)
+        )
         st.caption("Changes by period:")
         st.dataframe(period_stats, use_container_width=True)
 
         # Show unique manager counts
-        unique_initial = changes_df[changes_df["Action"] == "Initial"]["Manager"].nunique()
+        unique_initial = changes_df[changes_df["Action"] == "Initial"][
+            "Manager"
+        ].nunique()
         unique_hired = changes_df[changes_df["Action"] == "Hired"]["Manager"].nunique()
-        unique_terminated = changes_df[changes_df["Action"] == "Terminated"]["Manager"].nunique()
+        unique_terminated = changes_df[changes_df["Action"] == "Terminated"][
+            "Manager"
+        ].nunique()
 
         st.caption(
             f"Unique managers: {unique_initial} initial, {unique_hired} ever hired, "
@@ -807,7 +825,9 @@ def _render_manager_changes(result) -> None:
         )
 
         # Check for managers hired multiple times
-        hire_counts = changes_df[changes_df["Action"] == "Hired"]["Manager"].value_counts()
+        hire_counts = changes_df[changes_df["Action"] == "Hired"][
+            "Manager"
+        ].value_counts()
         multi_hired = hire_counts[hire_counts > 1]
         if not multi_hired.empty:
             st.caption(f"Managers hired multiple times: {len(multi_hired)}")
@@ -919,7 +939,10 @@ def _compute_fund_holding_periods(result) -> tuple[pd.DataFrame, pd.DataFrame]:
                     }
                     fund_returns[manager] = []
             elif action == "dropped":
-                if manager in fund_tenures and fund_tenures[manager]["Exit Date"] is None:
+                if (
+                    manager in fund_tenures
+                    and fund_tenures[manager]["Exit Date"] is None
+                ):
                     fund_tenures[manager]["Exit Date"] = out_start
 
         # Accumulate returns for funds held this period
@@ -978,7 +1001,9 @@ def _render_fund_holdings(result) -> None:
 
     # Format summary
     display_summary = summary_df.copy()
-    display_summary["Years Held"] = display_summary["Years Held"].apply(lambda x: f"{x:.1f}")
+    display_summary["Years Held"] = display_summary["Years Held"].apply(
+        lambda x: f"{x:.1f}"
+    )
 
     def highlight_current(row):
         if row["Exit"] == "Current":
@@ -1016,7 +1041,9 @@ def _get_selection_config(result) -> dict[str, Any]:
 
     # Portfolio sizing source of truth (multi-period runs): mp_min_funds/mp_max_funds.
     # Avoid legacy/duplicate sizing knobs here.
-    max_funds = int(model_state.get("mp_max_funds") or model_state.get("selection_count") or 10)
+    max_funds = int(
+        model_state.get("mp_max_funds") or model_state.get("selection_count") or 10
+    )
     min_funds = int(model_state.get("mp_min_funds") or 0)
 
     config = {
@@ -1069,7 +1096,9 @@ def _render_selection_criteria(result) -> None:
         st.markdown("**Time Parameters**")
         st.markdown(f"- Rebalance frequency: **{freq}**")
         st.markdown(f"- In-sample (lookback): **{config['lookback_periods']}** periods")
-        st.markdown(f"- Out-of-sample (eval): **{config['evaluation_periods']}** period(s)")
+        st.markdown(
+            f"- Out-of-sample (eval): **{config['evaluation_periods']}** period(s)"
+        )
 
 
 def _build_period_detail(res: dict[str, Any], period_num: int) -> dict[str, Any]:
@@ -1131,10 +1160,16 @@ def _render_single_period(period_data: dict[str, Any]) -> None:
     """Render detailed view for a single period."""
     pn = period_data["period_num"]
 
-    st.markdown(f"### Period {pn}: {period_data['out_start']} to {period_data['out_end']}")
-    st.caption(f"In-sample window: {period_data['in_start']} to {period_data['in_end']}")
+    st.markdown(
+        f"### Period {pn}: {period_data['out_start']} to {period_data['out_end']}"
+    )
+    st.caption(
+        f"In-sample window: {period_data['in_start']} to {period_data['in_end']}"
+    )
 
-    tabs = st.tabs(["📊 In-Sample Metrics", "✅ Selection", "📈 Out-of-Sample", "💰 Period Return"])
+    tabs = st.tabs(
+        ["📊 In-Sample Metrics", "✅ Selection", "📈 Out-of-Sample", "💰 Period Return"]
+    )
 
     with tabs[0]:
         # In-sample metrics (score frame)
@@ -1156,7 +1191,9 @@ def _render_single_period(period_data: dict[str, Any]) -> None:
                 return [""] * len(row)
 
             # Sort by zscore if available, else by first column
-            sort_col = "zscore" if "zscore" in sf_display.columns else sf_display.columns[0]
+            sort_col = (
+                "zscore" if "zscore" in sf_display.columns else sf_display.columns[0]
+            )
             sf_sorted = sf_display.sort_values(sort_col, ascending=False)
 
             # Format numeric columns
@@ -1180,7 +1217,9 @@ def _render_single_period(period_data: dict[str, Any]) -> None:
                         lambda x: _fmt_pct(x, 1) if pd.notna(x) else "—"
                     )
 
-            st.markdown("**All candidates ranked by in-sample metrics** (green = selected)")
+            st.markdown(
+                "**All candidates ranked by in-sample metrics** (green = selected)"
+            )
             styled = sf_sorted.style.apply(highlight_selected, axis=1)
             st.dataframe(styled, use_container_width=True, height=300)
         else:
@@ -1246,9 +1285,16 @@ def _render_single_period(period_data: dict[str, Any]) -> None:
                         expected = pd.period_range(out_start, out_end, freq="M")
                         expected_labels = [str(p) for p in expected]
                         actual_labels = sorted(
-                            {str(p) for p in pd.to_datetime(out_df.index).to_period("M").tolist()}
+                            {
+                                str(p)
+                                for p in pd.to_datetime(out_df.index)
+                                .to_period("M")
+                                .tolist()
+                            }
                         )
-                        missing = [m for m in expected_labels if m not in set(actual_labels)]
+                        missing = [
+                            m for m in expected_labels if m not in set(actual_labels)
+                        ]
                         if missing:
                             st.warning(
                                 "Missing months inside this out-of-sample window: "
@@ -1328,7 +1374,9 @@ def _render_single_period(period_data: dict[str, Any]) -> None:
                 # Show raw returns in expander
                 with st.expander("View monthly returns detail"):
                     display_oos = out_df[cols_to_show].copy()
-                    display_oos.index = pd.to_datetime(display_oos.index).strftime("%Y-%m")
+                    display_oos.index = pd.to_datetime(display_oos.index).strftime(
+                        "%Y-%m"
+                    )
                     for col in display_oos.columns:
                         display_oos[col] = display_oos[col].apply(
                             lambda x: _fmt_pct(x, 2) if pd.notna(x) else "—"
@@ -1385,7 +1433,9 @@ def _render_period_breakdown(result) -> None:
         return
 
     # Build period data
-    periods_data = [_build_period_detail(res, i + 1) for i, res in enumerate(period_results)]
+    periods_data = [
+        _build_period_detail(res, i + 1) for i, res in enumerate(period_results)
+    ]
 
     # Show weights across all rebalance dates (sub-period visibility)
     try:
@@ -1407,7 +1457,8 @@ def _render_period_breakdown(result) -> None:
 
     # Period selector
     period_options = [
-        f"Period {p['period_num']}: {p['out_start']} to {p['out_end']}" for p in periods_data
+        f"Period {p['period_num']}: {p['out_start']} to {p['out_end']}"
+        for p in periods_data
     ]
 
     selected_period = st.selectbox(
@@ -1765,13 +1816,19 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
             col_lower = col.lower()
 
             # Check column type
-            is_already_pct = col in already_pct_cols or any(p in col for p in already_pct_patterns)
+            is_already_pct = col in already_pct_cols or any(
+                p in col for p in already_pct_patterns
+            )
             is_raw_pct = col in raw_pct_cols
             is_ratio = (
-                col in ratio_cols or any(p in col for p in ratio_patterns) or ir_pattern in col
+                col in ratio_cols
+                or any(p in col for p in ratio_patterns)
+                or ir_pattern in col
             )
             is_decimal_1 = col in decimal_1_cols
-            is_decimal_2 = col in decimal_2_cols or any(p in col_lower for p in decimal_2_patterns)
+            is_decimal_2 = col in decimal_2_cols or any(
+                p in col_lower for p in decimal_2_patterns
+            )
             is_int = col in int_cols or any(p in col for p in int_patterns)
 
             if is_already_pct and not is_ratio:
@@ -1779,7 +1836,9 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
                 out[col] = out[col].apply(
                     lambda x: (
                         f"{float(x):.1f}%"
-                        if pd.notna(x) and isinstance(x, (int, float)) and np.isfinite(x)
+                        if pd.notna(x)
+                        and isinstance(x, (int, float))
+                        and np.isfinite(x)
                         else ""
                     )
                 )
@@ -1788,7 +1847,9 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
                 out[col] = out[col].apply(
                     lambda x: (
                         f"{float(x) * 100:.1f}%"
-                        if pd.notna(x) and isinstance(x, (int, float)) and np.isfinite(x)
+                        if pd.notna(x)
+                        and isinstance(x, (int, float))
+                        and np.isfinite(x)
                         else ""
                     )
                 )
@@ -1796,7 +1857,9 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
                 out[col] = out[col].apply(
                     lambda x: (
                         f"{float(x):.2f}"
-                        if pd.notna(x) and isinstance(x, (int, float)) and np.isfinite(x)
+                        if pd.notna(x)
+                        and isinstance(x, (int, float))
+                        and np.isfinite(x)
                         else ""
                     )
                 )
@@ -1804,7 +1867,9 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
                 out[col] = out[col].apply(
                     lambda x: (
                         f"{float(x):.1f}"
-                        if pd.notna(x) and isinstance(x, (int, float)) and np.isfinite(x)
+                        if pd.notna(x)
+                        and isinstance(x, (int, float))
+                        and np.isfinite(x)
                         else ""
                     )
                 )
@@ -1812,7 +1877,9 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
                 out[col] = out[col].apply(
                     lambda x: (
                         f"{float(x):.2f}"
-                        if pd.notna(x) and isinstance(x, (int, float)) and np.isfinite(x)
+                        if pd.notna(x)
+                        and isinstance(x, (int, float))
+                        and np.isfinite(x)
                         else ""
                     )
                 )
@@ -1820,7 +1887,9 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
                 out[col] = out[col].apply(
                     lambda x: (
                         f"{int(x)}"
-                        if pd.notna(x) and isinstance(x, (int, float)) and np.isfinite(x)
+                        if pd.notna(x)
+                        and isinstance(x, (int, float))
+                        and np.isfinite(x)
                         else ""
                     )
                 )
@@ -1860,7 +1929,9 @@ def _render_download_section(result, *, include_narrative: bool = True) -> None:
             mime="application/zip",
         )
     else:
-        st.caption("Run a multi-period analysis from the Model page to enable CSV export.")
+        st.caption(
+            "Run a multi-period analysis from the Model page to enable CSV export."
+        )
 
 
 # =============================================================================
@@ -2010,7 +2081,9 @@ def render_results_page() -> None:
 
     # Policy: benchmark/index columns (including Info Ratio benchmark) and RF
     # are never investable funds.
-    sanitized_funds = [c for c in applied_funds if c in df.columns and c not in prohibited]
+    sanitized_funds = [
+        c for c in applied_funds if c in df.columns and c not in prohibited
+    ]
     removed = [c for c in applied_funds if c in df.columns and c in prohibited]
     keep_cols = list(sanitized_funds)
     for extra in (selected_rf, benchmark, regime_proxy):
@@ -2118,7 +2191,12 @@ def render_results_page() -> None:
             f"✅ Simulation complete: **{period_count} periods** from {sim_start} to {sim_end}"
         )
 
-    single_period_result = period_count <= 1
+    period_results = details.get("period_results")
+    single_period_result = (
+        period_count == 1
+        and isinstance(period_results, list)
+        and len(period_results) == 1
+    )
     tab_labels = [
         "📊 Summary",
         "🔬 Period Analysis",
@@ -2196,7 +2274,17 @@ def render_results_page() -> None:
             "Out-of-sample returns → Period performance"
         )
 
-        if period_count > 0:
+        if single_period_result:
+            st.info(
+                "Period Analysis requires a multi-period run. Use the Model page to run "
+                "more than one analysis period."
+            )
+            if details:
+                score_frame = details.get("score_frame")
+                if isinstance(score_frame, pd.DataFrame) and not score_frame.empty:
+                    st.subheader("In-Sample Metrics (All Candidates)")
+                    st.dataframe(score_frame, use_container_width=True)
+        elif period_count > 0:
             _render_period_breakdown(result)
         else:
             st.info(
@@ -2223,15 +2311,21 @@ def render_results_page() -> None:
     with main_tabs[3]:
         st.header("Fund Details")
 
-        # Manager changes
-        st.subheader("🔄 Manager Hiring & Termination Timeline")
-        _render_manager_changes(result)
+        if single_period_result:
+            st.info(
+                "Fund Details require a multi-period or custom analysis run with fund "
+                "holding history."
+            )
+        else:
+            # Manager changes
+            st.subheader("🔄 Manager Hiring & Termination Timeline")
+            _render_manager_changes(result)
 
-        st.divider()
+            st.divider()
 
-        # Fund holding periods with risk stats
-        st.subheader("📋 Fund Holdings & Out-of-Sample Performance")
-        _render_fund_holdings(result)
+            # Fund holding periods with risk stats
+            st.subheader("📋 Fund Holdings & Out-of-Sample Performance")
+            _render_fund_holdings(result)
 
     # ==========================================================================
     # TAB 5: EXPORT - Download data
@@ -2240,110 +2334,138 @@ def render_results_page() -> None:
         st.header("Export Data")
         st.caption("Download detailed data for external analysis and verification")
 
-        include_narrative = st.checkbox(
-            "Generate Summary",
-            value=st.session_state.get("export_generate_summary", True),
-            key="export_generate_summary",
-            help="Include auto-generated narrative summaries in Excel and text exports.",
-        )
-        _render_download_section(result, include_narrative=include_narrative)
+        if single_period_result:
+            st.info(
+                "Export requires a multi-period analysis with period-level result data."
+            )
+        else:
+            include_narrative = st.checkbox(
+                "Generate Summary",
+                value=st.session_state.get("export_generate_summary", True),
+                key="export_generate_summary",
+                help="Include auto-generated narrative summaries in Excel and text exports.",
+            )
+            _render_download_section(result, include_narrative=include_narrative)
 
-        # Additional: Full period data export
-        st.divider()
-        st.subheader("📄 Complete Period Data")
+            # Additional: Full period data export
+            st.divider()
+            st.subheader("📄 Complete Period Data")
 
-        if period_count > 0:
-            period_results = details.get("period_results", [])
+            if period_count > 0:
+                period_results = details.get("period_results", [])
 
-            # Build comprehensive export
-            all_period_data = []
-            for i, res in enumerate(period_results):
-                period = res.get("period", ("", "", "", ""))
-                score_frame = res.get("score_frame")
-                selected = res.get("selected_funds", [])
-                weights = res.get("fund_weights", {})
+                # Build comprehensive export
+                all_period_data = []
+                for i, res in enumerate(period_results):
+                    period = res.get("period", ("", "", "", ""))
+                    score_frame = res.get("score_frame")
+                    selected = res.get("selected_funds", [])
+                    weights = res.get("fund_weights", {})
 
-                if isinstance(score_frame, pd.DataFrame) and not score_frame.empty:
-                    for fund in score_frame.index:
-                        weight_value = float(weights.get(fund, 0.0) or 0.0)
-                        row = {
-                            "Period": i + 1,
-                            "In-Sample Start": period[0] if len(period) > 0 else "",
-                            "In-Sample End": period[1] if len(period) > 1 else "",
-                            "Out-Sample Start": period[2] if len(period) > 2 else "",
-                            "Out-Sample End": period[3] if len(period) > 3 else "",
-                            "Fund": fund,
-                            "Selected": "Yes" if fund in selected else "No",
-                            # Keep numeric weights for exports; format at display time.
-                            "Weight": weight_value,
-                        }
-                        # Add all score columns
-                        for col in score_frame.columns:
-                            row[f"InSample_{col}"] = score_frame.loc[fund, col]
-                        all_period_data.append(row)
+                    if isinstance(score_frame, pd.DataFrame) and not score_frame.empty:
+                        for fund in score_frame.index:
+                            weight_value = float(weights.get(fund, 0.0) or 0.0)
+                            row = {
+                                "Period": i + 1,
+                                "In-Sample Start": period[0] if len(period) > 0 else "",
+                                "In-Sample End": period[1] if len(period) > 1 else "",
+                                "Out-Sample Start": period[2]
+                                if len(period) > 2
+                                else "",
+                                "Out-Sample End": period[3] if len(period) > 3 else "",
+                                "Fund": fund,
+                                "Selected": "Yes" if fund in selected else "No",
+                                # Keep numeric weights for exports; format at display time.
+                                "Weight": weight_value,
+                            }
+                            # Add all score columns
+                            for col in score_frame.columns:
+                                row[f"InSample_{col}"] = score_frame.loc[fund, col]
+                            all_period_data.append(row)
 
-            if all_period_data:
-                full_df = pd.DataFrame(all_period_data)
-                base_cols = [
-                    "Period",
-                    "In-Sample Start",
-                    "In-Sample End",
-                    "Out-Sample Start",
-                    "Out-Sample End",
-                    "Fund",
-                    "Selected",
-                    "Weight",
-                ]
-                metric_cols = [c for c in full_df.columns if c.startswith("InSample_")]
-                ordered_cols = [c for c in base_cols if c in full_df.columns] + metric_cols
-                full_df = full_df.loc[:, ordered_cols]
+                if all_period_data:
+                    full_df = pd.DataFrame(all_period_data)
+                    base_cols = [
+                        "Period",
+                        "In-Sample Start",
+                        "In-Sample End",
+                        "Out-Sample Start",
+                        "Out-Sample End",
+                        "Fund",
+                        "Selected",
+                        "Weight",
+                    ]
+                    metric_cols = [
+                        c for c in full_df.columns if c.startswith("InSample_")
+                    ]
+                    ordered_cols = [
+                        c for c in base_cols if c in full_df.columns
+                    ] + metric_cols
+                    full_df = full_df.loc[:, ordered_cols]
 
-                # Format the DataFrame to match Excel styling
-                export_df = full_df.copy()
-                # Format Weight as percentage
-                if "Weight" in export_df.columns:
-                    export_df["Weight"] = export_df["Weight"].apply(
-                        lambda x: (f"{x * 100:.1f}%" if pd.notna(x) and np.isfinite(x) else "")
+                    # Format the DataFrame to match Excel styling
+                    export_df = full_df.copy()
+                    # Format Weight as percentage
+                    if "Weight" in export_df.columns:
+                        export_df["Weight"] = export_df["Weight"].apply(
+                            lambda x: (
+                                f"{x * 100:.1f}%"
+                                if pd.notna(x) and np.isfinite(x)
+                                else ""
+                            )
+                        )
+                    # Format metric columns based on their names
+                    for col in metric_cols:
+                        col_lower = col.lower()
+                        if any(
+                            p in col_lower for p in ["cagr", "vol", "maxdd", "max_dd"]
+                        ):
+                            # Percentage format
+                            export_df[col] = export_df[col].apply(
+                                lambda x: (
+                                    f"{float(x) * 100:.1f}%"
+                                    if pd.notna(x)
+                                    and isinstance(x, (int, float))
+                                    and np.isfinite(x)
+                                    else ""
+                                )
+                            )
+                        elif any(p in col_lower for p in ["sharpe", "sortino", "ir"]):
+                            # Ratio format
+                            export_df[col] = export_df[col].apply(
+                                lambda x: (
+                                    f"{float(x):.2f}"
+                                    if pd.notna(x)
+                                    and isinstance(x, (int, float))
+                                    and np.isfinite(x)
+                                    else ""
+                                )
+                            )
+
+                    csv = export_df.to_csv(index=False)
+                    st.download_button(
+                        "📊 Download Complete Period Analysis (CSV)",
+                        csv,
+                        "complete_period_analysis.csv",
+                        "text/csv",
                     )
-                # Format metric columns based on their names
-                for col in metric_cols:
-                    col_lower = col.lower()
-                    if any(p in col_lower for p in ["cagr", "vol", "maxdd", "max_dd"]):
-                        # Percentage format
-                        export_df[col] = export_df[col].apply(
-                            lambda x: (
-                                f"{float(x) * 100:.1f}%"
-                                if pd.notna(x) and isinstance(x, (int, float)) and np.isfinite(x)
-                                else ""
-                            )
-                        )
-                    elif any(p in col_lower for p in ["sharpe", "sortino", "ir"]):
-                        # Ratio format
-                        export_df[col] = export_df[col].apply(
-                            lambda x: (
-                                f"{float(x):.2f}"
-                                if pd.notna(x) and isinstance(x, (int, float)) and np.isfinite(x)
-                                else ""
-                            )
-                        )
-
-                csv = export_df.to_csv(index=False)
-                st.download_button(
-                    "📊 Download Complete Period Analysis (CSV)",
-                    csv,
-                    "complete_period_analysis.csv",
-                    "text/csv",
-                )
-                st.caption(
-                    "Contains in-sample metrics for all candidates in all periods, "
-                    "with selection status and weights."
-                )
+                    st.caption(
+                        "Contains in-sample metrics for all candidates in all periods, "
+                        "with selection status and weights."
+                    )
 
     # ==========================================================================
     # TAB 6: A/B COMPARISON - Compare saved configurations
     # ==========================================================================
     with main_tabs[5]:
         st.header("A/B Comparison (Saved Configurations)")
+        if single_period_result:
+            st.info(
+                "Compare requires saved multi-period configurations. Save at least two "
+                "Model page configurations after running a multi-period analysis."
+            )
+            return
+
         saved_states = app_state.get_saved_model_states()
         saved_names = sorted(saved_states)
 

--- a/tests/app/test_results_page.py
+++ b/tests/app/test_results_page.py
@@ -92,7 +92,9 @@ class DummyStreamlit:
     def expander(self, *_args, **_kwargs) -> "ColumnContext":
         return ColumnContext(self)
 
-    def checkbox(self, label: str, value: bool = False, key: str | None = None, **_kwargs) -> bool:
+    def checkbox(
+        self, label: str, value: bool = False, key: str | None = None, **_kwargs
+    ) -> bool:
         self.checkbox_labels.append(label)
         if key is None:
             return bool(value)
@@ -652,7 +654,12 @@ def test_demo_run_marks_or_hides_inapplicable_tabs(
     monkeypatch.setattr(
         page.explain_results, "render_explain_results", lambda *_args, **_kwargs: None
     )
-    monkeypatch.setattr(page, "_render_download_section", lambda *_args, **_kwargs: None)
+    download_calls: list[tuple[object, dict[str, object]]] = []
+
+    def render_download_spy(*args, **kwargs):
+        download_calls.append((args, kwargs))
+
+    monkeypatch.setattr(page, "_render_download_section", render_download_spy)
     monkeypatch.setattr(stub, "button", lambda *_args, **_kwargs: False)
     monkeypatch.setattr(
         page.analysis_runner,
@@ -665,14 +672,29 @@ def test_demo_run_marks_or_hides_inapplicable_tabs(
     labels = stub.tab_groups[-1]
     assert any("Summary" in label for label in labels)
     assert any("Visualizations" in label for label in labels)
-    assert any("Period Analysis" in label and "multi-period only" in label for label in labels)
-    assert any("Fund Details" in label and "multi-period/custom only" in label for label in labels)
+    assert any(
+        "Period Analysis" in label and "multi-period only" in label for label in labels
+    )
+    assert any(
+        "Fund Details" in label and "multi-period/custom only" in label
+        for label in labels
+    )
     assert any("Export" in label and "multi-period only" in label for label in labels)
-    assert any("Compare" in label and "needs saved configs" in label for label in labels)
-    assert any("Run a multi-period analysis to enable" in msg for msg in stub.info_messages)
+    assert any(
+        "Compare" in label and "needs saved configs" in label for label in labels
+    )
+    assert any(
+        "Run a multi-period analysis to enable" in msg for msg in stub.info_messages
+    )
+    assert any(
+        "Export requires a multi-period analysis" in msg for msg in stub.info_messages
+    )
+    assert not download_calls
 
 
-def test_period_count_uses_period_results_when_explicit_count_missing(results_page) -> None:
+def test_period_count_uses_period_results_when_explicit_count_missing(
+    results_page,
+) -> None:
     page, _stub = results_page
 
     result = SimpleNamespace(

--- a/tests/app/test_results_page.py
+++ b/tests/app/test_results_page.py
@@ -606,12 +606,23 @@ def test_demo_run_marks_or_hides_inapplicable_tabs(
     result = SimpleNamespace(
         metrics=pd.DataFrame({"Sharpe": [1.23]}),
         details={
+            "period_count": 1,
+            "period_results": [
+                {
+                    "period": ("2024-01-01", "2024-01-31", "2024-02-01", "2024-02-29"),
+                    "in_sample_scaled": returns.iloc[:2],
+                    "out_sample_scaled": returns.iloc[2:],
+                    "ew_weights": {"FundA": 0.5, "FundB": 0.5},
+                    "fund_weights": {"FundA": 0.6, "FundB": 0.4},
+                }
+            ],
             "portfolio_equal_weight_combined": returns["FundA"],
             "risk_diagnostics": {
                 "turnover": pd.Series([0.1, 0.2], index=returns.index[:2]),
                 "final_weights": pd.Series({"FundA": 0.6, "FundB": 0.4}),
             },
         },
+        period_count=1,
         fallback_info=None,
         portfolio=returns["FundA"],
         weights=pd.Series({"FundA": 0.6, "FundB": 0.4}),
@@ -641,6 +652,7 @@ def test_demo_run_marks_or_hides_inapplicable_tabs(
     monkeypatch.setattr(
         page.explain_results, "render_explain_results", lambda *_args, **_kwargs: None
     )
+    monkeypatch.setattr(page, "_render_download_section", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(stub, "button", lambda *_args, **_kwargs: False)
     monkeypatch.setattr(
         page.analysis_runner,


### PR DESCRIPTION
## Summary
- treat one-period demo results as single-period for Results tab availability markers
- extend the tab-label regression to cover a concrete `period_count == 1` result
- isolates the tab-label test from export workbook generation so it verifies the UI gate directly

Closes #5629

## Validation
- `MPLCONFIGDIR=/tmp/mplconfig pytest tests/app/test_results_page.py::test_demo_run_marks_or_hides_inapplicable_tabs tests/app/test_results_page.py::test_period_count_uses_period_results_when_explicit_count_missing tests/app/test_results_page.py -q` -> 10 passed
- `git diff --check`

## Verifier follow-up
This addresses the post-merge provider comparison concern on PR #5633 that `single_period_result = period_count <= 0` missed true one-period runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected which Results tabs appear for single-period runs. The app now treats a run as single-period only when there is exactly one period available, ensuring the Period Analysis, Fund Details, Export, and Compare tabs render the appropriate guidance and content (including skipping export/compare UI when not applicable).
* **Tests**
  * Added/updated coverage to verify period-count handling when explicit counts are missing and to confirm the download section is not rendered in single-period scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->