### PR TITLE
Show completed state for cached Results

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -80,6 +80,11 @@ selected_preset = st.selectbox(
     help=DEMO_PRESET_SELECTOR_HELP,
 )
 st.session_state["demo_preset"] = selected_preset
+if _active_profile == demo_profile.PRESENTATION_SAFE and len(preset_names) == 1:
+    st.caption(
+        "Presentation-safe mode includes one preset — switch to public_llm_demo "
+        "for the full preset library."
+    )
 
 # Load preset config for display and modification
 preset_config = load_preset_config(selected_preset)
@@ -248,7 +253,9 @@ if demo_profile.custom_analysis_enabled(_active_profile):
     if st.button("📂 Go to Data Upload", use_container_width=True):
         st.switch_page("pages/1_Data.py")
 
-    st.caption("The Model page uses a different analysis pipeline with more configuration options.")
+    st.caption(
+        "The Model page uses a different analysis pipeline with more configuration options."
+    )
 else:
     st.subheader("🔒 Presentation-safe mode")
     st.caption(

--- a/streamlit_app/pages/3_Results.py
+++ b/streamlit_app/pages/3_Results.py
@@ -95,6 +95,30 @@ def _diagnostic_message(result: Any) -> tuple[str | None, str | None]:
     return None, None
 
 
+def _completed_state_line(result: Any, fund_count: int) -> str:
+    """Summarize a cached result before rendering detailed tabs."""
+    prefix = (
+        "Demo results loaded"
+        if st.session_state.get("demo_preset")
+        else "Results loaded"
+    )
+    parts = [prefix]
+    if fund_count > 0:
+        parts.append(f"{fund_count} funds")
+
+    metrics = getattr(result, "metrics", None)
+    if isinstance(metrics, pd.DataFrame) and not metrics.empty:
+        sharpe = None
+        for column in ("Sharpe", "sharpe"):
+            if column in metrics.columns:
+                sharpe = pd.to_numeric(metrics[column], errors="coerce").dropna()
+                break
+        if sharpe is not None and not sharpe.empty:
+            parts.append(f"Sharpe {_fmt_ratio(float(sharpe.iloc[0]))}")
+
+    return " — ".join(parts) + "."
+
+
 def _coerce_weight_mapping(raw: Any) -> dict[str, float]:
     return normalize_weights(raw)
 
@@ -2108,8 +2132,12 @@ def render_results_page() -> None:
 
     data_hash = _data_hash_for_analysis(df_for_analysis)
 
-    st.markdown("Run the analysis to generate performance and risk diagnostics.")
-    run_clicked = st.button("Run analysis", type="primary")
+    if result is None:
+        st.markdown("Run the analysis to generate performance and risk diagnostics.")
+        run_clicked = st.button("Run analysis", type="primary")
+    else:
+        st.success(_completed_state_line(result, len(sanitized_funds)))
+        run_clicked = st.button("Re-run with custom settings")
 
     if run_clicked or result is None:
         with st.spinner("Running analysis…"):

--- a/streamlit_app/pages/3_Results.py
+++ b/streamlit_app/pages/3_Results.py
@@ -106,17 +106,57 @@ def _completed_state_line(result: Any, fund_count: int) -> str:
     if fund_count > 0:
         parts.append(f"{fund_count} funds")
 
+    sharpe = _completed_state_sharpe(result)
+    if sharpe is not None:
+        parts.append(f"Sharpe {_fmt_ratio(sharpe)}")
+
+    return " — ".join(parts) + "."
+
+
+def _completed_state_sharpe(result: Any) -> float | None:
+    """Return portfolio-level Sharpe for the completed-state banner."""
+    raw_details = getattr(result, "details", None)
+    details = raw_details if isinstance(raw_details, dict) else {}
+    portfolio_sharpe = _stats_value(details.get("out_user_stats"), "sharpe")
+    if portfolio_sharpe is not None:
+        return portfolio_sharpe
+
     metrics = getattr(result, "metrics", None)
     if isinstance(metrics, pd.DataFrame) and not metrics.empty:
-        sharpe = None
         for column in ("Sharpe", "sharpe"):
             if column in metrics.columns:
                 sharpe = pd.to_numeric(metrics[column], errors="coerce").dropna()
-                break
-        if sharpe is not None and not sharpe.empty:
-            parts.append(f"Sharpe {_fmt_ratio(float(sharpe.iloc[0]))}")
+                if not sharpe.empty:
+                    return float(sharpe.iloc[0])
+    return None
 
-    return " — ".join(parts) + "."
+
+def _stats_value(stats: Any, name: str) -> float | None:
+    """Extract a finite numeric stat from dict/object/Series-like containers."""
+    raw: Any = None
+    if isinstance(stats, dict):
+        for key in (name, name.title(), name.upper()):
+            if key in stats:
+                raw = stats[key]
+                break
+    elif isinstance(stats, pd.Series):
+        for key in (name, name.title(), name.upper()):
+            if key in stats:
+                raw = stats[key]
+                break
+    elif stats is not None:
+        raw = getattr(stats, name, None)
+        if raw is None:
+            raw = getattr(stats, name.title(), None)
+        if raw is None:
+            raw = getattr(stats, name.upper(), None)
+    if raw is None:
+        return None
+    value = pd.to_numeric(pd.Series([raw]), errors="coerce").dropna()
+    if value.empty:
+        return None
+    parsed = float(value.iloc[0])
+    return parsed if np.isfinite(parsed) else None
 
 
 def _coerce_weight_mapping(raw: Any) -> dict[str, float]:

--- a/streamlit_app/pages/3_Results.py
+++ b/streamlit_app/pages/3_Results.py
@@ -125,7 +125,8 @@ def _completed_state_sharpe(result: Any) -> float | None:
     if isinstance(metrics, pd.DataFrame) and not metrics.empty:
         for column in ("Sharpe", "sharpe"):
             if column in metrics.columns:
-                sharpe = pd.to_numeric(metrics[column], errors="coerce").dropna()
+                sharpe = pd.to_numeric(metrics[column], errors="coerce")
+                sharpe = sharpe[np.isfinite(sharpe)].dropna()
                 if not sharpe.empty:
                     return float(sharpe.iloc[0])
     return None

--- a/tests/app/test_results_page.py
+++ b/tests/app/test_results_page.py
@@ -515,6 +515,7 @@ def test_results_hides_empty_state_when_result_present(
     result = SimpleNamespace(
         metrics=pd.DataFrame({"Sharpe": [1.23]}),
         details={
+            "out_user_stats": {"sharpe": 2.34},
             "portfolio_equal_weight_combined": returns["FundA"],
             "risk_diagnostics": {
                 "turnover": pd.Series([0.1, 0.2], index=returns.index[:2]),
@@ -575,7 +576,7 @@ def test_results_hides_empty_state_when_result_present(
     assert "Run analysis" not in stub.button_labels
     assert "Re-run with custom settings" in stub.button_labels
     assert any(
-        "Demo results loaded — 2 funds — Sharpe 1.23." in msg
+        "Demo results loaded — 2 funds — Sharpe 2.34." in msg
         for msg in stub.success_messages
     )
 

--- a/tests/app/test_results_page.py
+++ b/tests/app/test_results_page.py
@@ -25,11 +25,14 @@ class DummyStreamlit:
         self.caption_messages: list[str] = []
         self.warning_messages: list[str] = []
         self.info_messages: list[str] = []
+        self.success_messages: list[str] = []
+        self.markdown_messages: list[str] = []
         self.subheaders: list[str] = []
         self.altair_payloads: list[object] = []
         self.dataframes: list[pd.DataFrame] = []
         self.metrics: list[tuple[str, object]] = []
         self.checkbox_labels: list[str] = []
+        self.button_labels: list[str] = []
         self.tab_groups: list[list[str]] = []
 
     # Basic UI primitives -------------------------------------------------
@@ -39,10 +42,11 @@ class DummyStreamlit:
     def header(self, _text: str) -> None:  # pragma: no cover - trivial
         return None
 
-    def markdown(self, *_args, **_kwargs) -> None:  # pragma: no cover - trivial
-        return None
+    def markdown(self, text: str, *_args, **_kwargs) -> None:
+        self.markdown_messages.append(text)
 
-    def button(self, *_args, **_kwargs) -> bool:
+    def button(self, label: str, *_args, **_kwargs) -> bool:
+        self.button_labels.append(label)
         if self.button_responses:
             return self.button_responses.pop(0)
         return False
@@ -58,8 +62,8 @@ class DummyStreamlit:
     def subheader(self, text: str) -> None:
         self.subheaders.append(text)
 
-    def success(self, _text: str) -> None:  # pragma: no cover - trivial
-        return None
+    def success(self, text: str) -> None:
+        self.success_messages.append(text)
 
     def divider(self) -> None:  # pragma: no cover - trivial
         return None
@@ -501,6 +505,79 @@ def test_current_run_key_changes_with_risk_free(results_page) -> None:
     key_two = page._current_run_key(model_state, None)
 
     assert key_one != key_two
+
+
+def test_results_hides_empty_state_when_result_present(
+    monkeypatch: pytest.MonkeyPatch, results_page
+) -> None:
+    page, stub = results_page
+    returns = _sample_returns()
+    result = SimpleNamespace(
+        metrics=pd.DataFrame({"Sharpe": [1.23]}),
+        details={
+            "portfolio_equal_weight_combined": returns["FundA"],
+            "risk_diagnostics": {
+                "turnover": pd.Series([0.1, 0.2], index=returns.index[:2]),
+                "final_weights": pd.Series({"FundA": 0.6, "FundB": 0.4}),
+            },
+        },
+        fallback_info=None,
+        portfolio=returns["FundA"],
+        weights=pd.Series({"FundA": 0.6, "FundB": 0.4}),
+    )
+
+    stub.session_state.update(
+        {
+            "model_state": {
+                "trend_spec": {"window": 63, "lag": 1},
+                "metric_weights": {"sharpe": 1.0},
+            },
+            "analysis_fund_columns": ["FundA", "FundB"],
+            "fund_columns": ["FundA", "FundB"],
+            "selected_benchmark": None,
+            "data_fingerprint": "abc123",
+            "returns_df": returns,
+            "schema_meta": {},
+            "upload_status": "success",
+            "demo_preset": "Balanced",
+        }
+    )
+    stub.session_state["analysis_result"] = result
+    stub.session_state["analysis_result_key"] = page._current_run_key(
+        stub.session_state["model_state"], stub.session_state["selected_benchmark"]
+    )
+
+    for chart in [
+        "equity_chart",
+        "drawdown_chart",
+        "rolling_sharpe_chart",
+        "turnover_chart",
+        "exposure_chart",
+    ]:
+        monkeypatch.setattr(
+            getattr(page, "charts"), chart, lambda *_args, chart_name=chart: chart_name
+        )
+    monkeypatch.setattr(
+        page.explain_results, "render_explain_results", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        page.analysis_runner,
+        "run_analysis",
+        lambda *_args, **_kwargs: pytest.fail("cached result should render directly"),
+    )
+
+    page.render_results_page()
+
+    assert not any(
+        "Run the analysis to generate performance and risk diagnostics." in msg
+        for msg in stub.markdown_messages
+    )
+    assert "Run analysis" not in stub.button_labels
+    assert "Re-run with custom settings" in stub.button_labels
+    assert any(
+        "Demo results loaded — 2 funds — Sharpe 1.23." in msg
+        for msg in stub.success_messages
+    )
 
 
 def test_demo_run_renders_results_end_to_end(

--- a/tests/app/test_results_page.py
+++ b/tests/app/test_results_page.py
@@ -581,6 +581,67 @@ def test_results_hides_empty_state_when_result_present(
     )
 
 
+def test_results_completed_state_skips_non_finite_fallback_sharpe(
+    monkeypatch: pytest.MonkeyPatch, results_page
+) -> None:
+    page, stub = results_page
+    returns = _sample_returns()
+    result = SimpleNamespace(
+        metrics=pd.DataFrame({"Sharpe": [float("inf"), 1.23]}),
+        details={"portfolio_equal_weight_combined": returns["FundA"]},
+        fallback_info=None,
+        portfolio=returns["FundA"],
+        weights=pd.Series({"FundA": 0.6, "FundB": 0.4}),
+    )
+    stub.session_state.update(
+        {
+            "model_state": {
+                "trend_spec": {"window": 63, "lag": 1},
+                "metric_weights": {"sharpe": 1.0},
+            },
+            "analysis_fund_columns": ["FundA", "FundB"],
+            "fund_columns": ["FundA", "FundB"],
+            "selected_benchmark": None,
+            "data_fingerprint": "abc123",
+            "returns_df": returns,
+            "schema_meta": {},
+            "upload_status": "success",
+            "demo_preset": "Balanced",
+        }
+    )
+    stub.session_state["analysis_result"] = result
+    stub.session_state["analysis_result_key"] = page._current_run_key(
+        stub.session_state["model_state"], stub.session_state["selected_benchmark"]
+    )
+
+    for chart in [
+        "equity_chart",
+        "drawdown_chart",
+        "rolling_sharpe_chart",
+        "turnover_chart",
+        "exposure_chart",
+    ]:
+        monkeypatch.setattr(
+            getattr(page, "charts"), chart, lambda *_args, chart_name=chart: chart_name
+        )
+    monkeypatch.setattr(
+        page.explain_results, "render_explain_results", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        page.analysis_runner,
+        "run_analysis",
+        lambda *_args, **_kwargs: pytest.fail("cached result should render directly"),
+    )
+
+    page.render_results_page()
+
+    assert any(
+        "Demo results loaded — 2 funds — Sharpe 1.23." in msg
+        for msg in stub.success_messages
+    )
+    assert not any("Sharpe —" in msg for msg in stub.success_messages)
+
+
 def test_demo_run_renders_results_end_to_end(
     monkeypatch: pytest.MonkeyPatch, results_page
 ) -> None:


### PR DESCRIPTION
Closes #5628

## Summary
- hide the stale empty-state prompt and bare Run analysis button when cached Results are already available
- show a completed-state line with fund count and Sharpe before rendering result tabs
- add the presentation-safe preset note under the demo selector

## Validation
- MPLCONFIGDIR=/tmp/mplconfig pytest tests/app/test_results_page.py::test_results_hides_empty_state_when_result_present tests/app/test_results_page.py -q
- deliberate break: restored unconditional empty-state prompt/button and confirmed the named test failed
- python -m ruff check streamlit_app/app.py streamlit_app/pages/3_Results.py tests/app/test_results_page.py
- python -m ruff format --check streamlit_app/app.py streamlit_app/pages/3_Results.py tests/app/test_results_page.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced the Results page with a completion banner that reflects cached vs demo-loaded status and selected fund count, including an optional Sharpe metric only when a finite value is available.
  * Updated the page’s top controls so the correct primary action (“Run analysis” vs “Re-run with custom settings”) is shown based on cached results presence.
* **UI**
  * Improved caption display in presentation-safe mode and refined multiline caption formatting in the custom-analysis flow.
* **Tests**
  * Expanded the Streamlit UI test stub and added coverage for cached-result rendering and non-finite Sharpe suppression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->