### PR TITLE
Define lognormal Monte Carlo cost means in bps

### DIFF
--- a/config/scenarios/monte_carlo/cost_regime_example.yml
+++ b/config/scenarios/monte_carlo/cost_regime_example.yml
@@ -37,16 +37,16 @@ costs:
     # Baseline all-in trading cost in basis points (bps) in normal markets.
     trade_cost_bps:
       kind: lognormal
-      mean: 5
-      sigma: 0.20
+      mean: 5      # arithmetic mean cost in bps; converted to log-space for sampling
+      sigma: 0.20  # log-space volatility
     # Multiplies modeled slippage under calm liquidity conditions.
     slippage_multiplier: 1.0
   stress:
     # Elevated all-in trading cost in basis points (bps) during stress regimes.
     trade_cost_bps:
       kind: lognormal
-      mean: 20
-      sigma: 0.35
+      mean: 20     # arithmetic mean cost in bps; converted to log-space for sampling
+      sigma: 0.35  # log-space volatility
     # Multiplies modeled slippage when liquidity worsens in stress.
     slippage_multiplier: 1.8
 

--- a/config/scenarios/monte_carlo/hf_equity_ls_10y.yml
+++ b/config/scenarios/monte_carlo/hf_equity_ls_10y.yml
@@ -19,13 +19,13 @@ costs:
   calm:
     trade_cost_bps:
       kind: lognormal
-      mean: 6
-      sigma: 0.25
+      mean: 6      # arithmetic mean cost in bps; converted to log-space for sampling
+      sigma: 0.25  # log-space volatility
   stress:
     trade_cost_bps:
       kind: lognormal
-      mean: 18
-      sigma: 0.35
+      mean: 18     # arithmetic mean cost in bps; converted to log-space for sampling
+      sigma: 0.35  # log-space volatility
     slippage_multiplier: 1.5
 
 strategy_set:

--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -373,6 +373,7 @@ Canonical schema (required):
 - `kind`: Must be `regime_stochastic`.
 - `trade_cost_bps`: Required under each regime; defines the basis-point cost distribution.
 - Top-level regime blocks: regime names (for example `calm`, `stress`) are direct keys under `costs`, and each regime block must include `trade_cost_bps`.
+- For `kind: lognormal`, `mean` is the target arithmetic mean in basis points. The runner converts it to NumPy's log-space `mu` internally before sampling. Use `mu` or `log_mean` only for explicit log-space configuration.
 
 Concrete canonical example:
 
@@ -383,13 +384,13 @@ costs:
   calm:
     trade_cost_bps:
       kind: lognormal
-      mean: 6
-      sigma: 0.25
+      mean: 6      # arithmetic mean all-in cost, in bps
+      sigma: 0.25  # log-space volatility
   stress:
     trade_cost_bps:
       kind: lognormal
-      mean: 18
-      sigma: 0.35
+      mean: 18     # arithmetic mean all-in cost, in bps
+      sigma: 0.35  # log-space volatility
     slippage_multiplier: 1.5  # Optional
 ```
 
@@ -573,13 +574,13 @@ scenario:
     calm:
       trade_cost_bps:
         kind: lognormal
-        mean: 6
-        sigma: 0.25
+        mean: 6      # arithmetic mean all-in cost, in bps
+        sigma: 0.25  # log-space volatility
     stress:
       trade_cost_bps:
         kind: lognormal
-        mean: 18
-        sigma: 0.35
+        mean: 18     # arithmetic mean all-in cost, in bps
+        sigma: 0.35  # log-space volatility
       slippage_multiplier: 1.5
 
 # Reference to base pipeline config

--- a/src/trend_analysis/monte_carlo/costs.py
+++ b/src/trend_analysis/monte_carlo/costs.py
@@ -102,11 +102,17 @@ class NormalCostDistribution(CostDistribution):
 class LognormalCostDistribution(CostDistribution):
     mean: float = 0.0
     sigma: float = 1.0
+    log_mean: float | None = None
 
     def sample(self, rng: np.random.Generator, size: int) -> NDArray[np.float64]:
         if size <= 0:
             return np.array([], dtype=float)
-        values = rng.lognormal(mean=float(self.mean), sigma=float(self.sigma), size=size)
+        log_mean = (
+            float(self.log_mean)
+            if self.log_mean is not None
+            else _lognormal_mu_from_arithmetic_mean(float(self.mean), float(self.sigma))
+        )
+        values = rng.lognormal(mean=log_mean, sigma=float(self.sigma), size=size)
         return self._apply_clip(values)
 
 
@@ -190,8 +196,12 @@ class CostProcess:
             regimes[str(label)] = _parse_regime_spec(spec, name=str(label))
 
         if not regimes:
-            fallback_spec = config.get("default") or config.get("distribution") or config
-            regimes[default_regime] = _parse_regime_spec(fallback_spec, name=default_regime)
+            fallback_spec = (
+                config.get("default") or config.get("distribution") or config
+            )
+            regimes[default_regime] = _parse_regime_spec(
+                fallback_spec, name=default_regime
+            )
 
         return cls(regimes, default_regime=default_regime)
 
@@ -224,7 +234,9 @@ class CostProcess:
             total_cost_drag=total_cost_drag,
         )
 
-    def _sample_cost_bps(self, regime_series: pd.Series, rng: np.random.Generator) -> pd.Series:
+    def _sample_cost_bps(
+        self, regime_series: pd.Series, rng: np.random.Generator
+    ) -> pd.Series:
         values = np.empty(len(regime_series), dtype=float)
         for label in pd.unique(regime_series):
             spec = self._select_spec(label)
@@ -282,7 +294,9 @@ def _coerce_regime_series(
     return pd.Series(values, index=index, dtype="string")
 
 
-def _coerce_turnover_series(turnover: pd.Series | float | None, index: pd.Index) -> pd.Series:
+def _coerce_turnover_series(
+    turnover: pd.Series | float | None, index: pd.Index
+) -> pd.Series:
     if turnover is None:
         return pd.Series(0.0, index=index, name="turnover")
     if isinstance(turnover, pd.Series):
@@ -310,14 +324,18 @@ def _parse_distribution(spec: Any, *, regime: str) -> CostDistribution:
     if isinstance(spec, (int, float)) and not isinstance(spec, bool):
         return FixedCostDistribution(kind="fixed", value=float(spec))
     if not isinstance(spec, Mapping):
-        raise ValueError(f"distribution for regime '{regime}' must be a mapping or number")
+        raise ValueError(
+            f"distribution for regime '{regime}' must be a mapping or number"
+        )
     kind = str(spec.get("kind") or spec.get("dist") or "fixed").strip().lower()
     clip_min = _coerce_optional_float(spec.get("clip_min"), "clip_min")
     clip_max = _coerce_optional_float(spec.get("clip_max"), "clip_max")
 
     if kind == "fixed":
         value = _coerce_float(spec.get("value", spec.get("bps", 0.0)), "value")
-        return FixedCostDistribution(kind=kind, value=value, clip_min=clip_min, clip_max=clip_max)
+        return FixedCostDistribution(
+            kind=kind, value=value, clip_min=clip_min, clip_max=clip_max
+        )
 
     if kind == "normal":
         mean = _coerce_float(spec.get("mean", 0.0), "mean")
@@ -331,17 +349,29 @@ def _parse_distribution(spec: Any, *, regime: str) -> CostDistribution:
         )
 
     if kind == "lognormal":
-        mean = _coerce_float(spec.get("mean", 0.0), "mean")
+        mean = _coerce_float(spec.get("mean", 0.0), "mean", minimum=0.0)
         sigma = _coerce_float(spec.get("sigma", 1.0), "sigma", minimum=0.0)
+        if "mu" in spec or "log_mean" in spec:
+            log_mean = _coerce_float(spec.get("mu", spec.get("log_mean")), "log_mean")
+            mean = float(np.exp(log_mean + 0.5 * sigma * sigma))
+        else:
+            log_mean = _lognormal_mu_from_arithmetic_mean(mean, sigma)
         return LognormalCostDistribution(
             kind=kind,
             mean=mean,
             sigma=sigma,
+            log_mean=log_mean,
             clip_min=clip_min,
             clip_max=clip_max,
         )
 
     raise ValueError(f"Unsupported distribution kind '{kind}' for regime '{regime}'")
+
+
+def _lognormal_mu_from_arithmetic_mean(mean_bps: float, sigma: float) -> float:
+    if mean_bps <= 0.0:
+        raise ValueError("lognormal mean must be > 0 basis points")
+    return float(np.log(mean_bps) - 0.5 * sigma * sigma)
 
 
 def _extract_top_level_regimes(config: Mapping[str, Any]) -> dict[str, Any]:
@@ -360,7 +390,9 @@ def _extract_top_level_regimes(config: Mapping[str, Any]) -> dict[str, Any]:
         if not label or label in reserved:
             continue
         if isinstance(value, Mapping) and (
-            "trade_cost_bps" in value or "distribution" in value or "slippage_multiplier" in value
+            "trade_cost_bps" in value
+            or "distribution" in value
+            or "slippage_multiplier" in value
         ):
             top_level[label] = value
     return top_level

--- a/tests/monte_carlo/test_costs.py
+++ b/tests/monte_carlo/test_costs.py
@@ -78,7 +78,9 @@ def test_cost_process_fixed_distribution_applies_slippage() -> None:
 def test_cost_process_normal_distribution_reasonable_mean() -> None:
     config = {
         "default_regime": "base",
-        "regimes": {"base": {"distribution": {"kind": "normal", "mean": 8.0, "std": 0.5}}},
+        "regimes": {
+            "base": {"distribution": {"kind": "normal", "mean": 8.0, "std": 0.5}}
+        },
     }
     process = CostProcess.from_config(config)
     assert process is not None
@@ -96,7 +98,9 @@ def test_cost_process_lognormal_stress_higher_mean_and_variance() -> None:
         "default_regime": "calm",
         "regimes": {
             "calm": {"distribution": {"kind": "lognormal", "mean": 1.0, "sigma": 0.1}},
-            "stress": {"distribution": {"kind": "lognormal", "mean": 1.3, "sigma": 0.4}},
+            "stress": {
+                "distribution": {"kind": "lognormal", "mean": 1.3, "sigma": 0.4}
+            },
         },
     }
     process = CostProcess.from_config(config)
@@ -112,6 +116,42 @@ def test_cost_process_lognormal_stress_higher_mean_and_variance() -> None:
     assert calm.mean() > 0
     assert stress.mean() > calm.mean()
     assert stress.var() > calm.var()
+
+
+def test_cost_process_lognormal_mean_is_arithmetic_bps_target() -> None:
+    config = {
+        "default_regime": "base",
+        "regimes": {
+            "base": {"distribution": {"kind": "lognormal", "mean": 20.0, "sigma": 0.35}}
+        },
+    }
+    process = CostProcess.from_config(config)
+    assert process is not None
+
+    rng = np.random.default_rng(123)
+    regimes = pd.Series(["base"] * 20000)
+    output = process.sample(regimes=regimes, turnover=0.1, index=None, rng=rng)
+
+    mean = float(output.cost_bps.mean())
+    assert 19.5 < mean < 20.5
+    assert float(output.cost_bps.quantile(0.99)) < 50.0
+
+
+def test_cost_process_lognormal_rejects_non_positive_arithmetic_mean() -> None:
+    with np.testing.assert_raises_regex(ValueError, "lognormal mean must be > 0"):
+        CostProcess.from_config(
+            {
+                "regimes": {
+                    "base": {
+                        "distribution": {
+                            "kind": "lognormal",
+                            "mean": 0.0,
+                            "sigma": 0.35,
+                        }
+                    }
+                }
+            }
+        )
 
 
 def test_cost_process_canonical_regime_stochastic_trade_cost_bps_dist() -> None:
@@ -168,7 +208,9 @@ def test_runner_integration_records_costs(monkeypatch: Any) -> None:
         metrics = pd.DataFrame({"annual_return": [0.1]}, index=["user_weight"])
         out_index = pd.date_range("2021-01-31", periods=3, freq="ME")
         details = {
-            "out_sample_scaled": pd.DataFrame({"A": [0.01, 0.02, 0.03]}, index=out_index),
+            "out_sample_scaled": pd.DataFrame(
+                {"A": [0.01, 0.02, 0.03]}, index=out_index
+            ),
             "regime_labels_out": pd.Series(
                 ["calm", "stress", "calm"], index=out_index, dtype="string"
             ),
@@ -205,7 +247,9 @@ def test_runner_integration_records_costs(monkeypatch: Any) -> None:
     )
     expected_costs.name = transaction_costs.name
     pd.testing.assert_series_equal(transaction_costs, expected_costs)
-    total_cost_drag = pd.to_numeric(results.results_frame["total_cost_drag"], errors="coerce")
+    total_cost_drag = pd.to_numeric(
+        results.results_frame["total_cost_drag"], errors="coerce"
+    )
     assert total_cost_drag.notna().all()
     assert bool((total_cost_drag.abs() > 0.0).all())
 
@@ -263,13 +307,16 @@ def test_cost_regime_example_fixture_produces_exact_deterministic_outputs() -> N
     assert sampled.slippage_multiplier.tolist() == [1.0, 1.8, 1.0]
     np.testing.assert_allclose(
         sampled.cost_bps.to_numpy(dtype=float, copy=False),
-        np.array([126.64343064753369, 249828634.21277088, 155.7285234063499]),
+        np.array([4.1820996013544685, 9.686837945111462, 5.142565961196969]),
         rtol=0.0,
         atol=1e-12,
     )
+    assert float(sampled.cost_bps.max()) < 100.0
     np.testing.assert_allclose(
         sampled.transaction_costs.to_numpy(dtype=float, copy=False),
-        np.array([0.001266434306475337, 8993.830831659752, 0.004671855702190497]),
+        np.array(
+            [4.182099601354469e-05, 0.0003487261660240126, 0.00015427697883590907]
+        ),
         rtol=0.0,
         atol=1e-12,
     )
@@ -310,11 +357,15 @@ def test_runner_injects_cash_series_when_override_enabled(monkeypatch: Any) -> N
         cash_series = returns["CASH"]
         assert pd.api.types.is_numeric_dtype(cash_series)
         assert np.isfinite(cash_series.to_numpy(dtype=float, copy=False)).all()
-        expected = pd.Series(expected_periodic_rf, index=returns.index, name="CASH", dtype=float)
+        expected = pd.Series(
+            expected_periodic_rf, index=returns.index, name="CASH", dtype=float
+        )
         pd.testing.assert_series_equal(cash_series, expected)
 
 
-def test_inject_cash_warns_when_override_disabled(monkeypatch: Any, caplog: Any) -> None:
+def test_inject_cash_warns_when_override_disabled(
+    monkeypatch: Any, caplog: Any
+) -> None:
     """When rf_override_enabled is False the runner should log a skip warning."""
     scenario = load_scenario("cost_regime_example")
     scenario.monte_carlo.n_paths = 10
@@ -348,19 +399,23 @@ def test_inject_cash_warns_when_override_disabled(monkeypatch: Any, caplog: Any)
 
     assert captured_returns
     for returns in captured_returns:
-        assert (
-            "CASH" not in returns.columns
-        ), "CASH should not be injected when metrics.rf_override_enabled is False"
+        assert "CASH" not in returns.columns, (
+            "CASH should not be injected when metrics.rf_override_enabled is False"
+        )
 
-    warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
-    fallback_warnings = [m for m in warning_messages if "metrics.rf_override_enabled" in m]
-    assert (
-        fallback_warnings
-    ), f"Expected a warning about metrics.rf_override_enabled, got: {warning_messages}"
+    warning_messages = [
+        r.message for r in caplog.records if r.levelno >= logging.WARNING
+    ]
+    fallback_warnings = [
+        m for m in warning_messages if "metrics.rf_override_enabled" in m
+    ]
+    assert fallback_warnings, (
+        f"Expected a warning about metrics.rf_override_enabled, got: {warning_messages}"
+    )
     # P2 fix: The warning should be emitted only once, not per path.
-    assert (
-        len(fallback_warnings) == 1
-    ), f"Expected exactly 1 fallback warning but got {len(fallback_warnings)}"
+    assert len(fallback_warnings) == 1, (
+        f"Expected exactly 1 fallback warning but got {len(fallback_warnings)}"
+    )
 
 
 def test_scenario_data_and_metrics_overrides_merge_into_base_config() -> None:
@@ -379,9 +434,9 @@ def test_scenario_data_and_metrics_overrides_merge_into_base_config() -> None:
     )
 
     # The merged base config should now have the override applied.
-    assert (
-        runner.base_config["data"]["allow_risk_free_fallback"] is True
-    ), "Scenario-level data.allow_risk_free_fallback should override defaults"
+    assert runner.base_config["data"]["allow_risk_free_fallback"] is True, (
+        "Scenario-level data.allow_risk_free_fallback should override defaults"
+    )
     assert runner.base_config["metrics"]["rf_override_enabled"] is True
     assert abs(runner.base_config["metrics"]["rf_rate_annual"] - 0.03) < 1e-12
     frequency = str(runner.base_config["data"].get("frequency", "M"))


### PR DESCRIPTION
Closes #5634

## Summary
- make lognormal cost `mean` represent the arithmetic basis-point target and convert it to NumPy log-space before sampling
- support explicit `mu`/`log_mean` for intentional log-space configuration
- update Monte Carlo cost docs, scenario comments, and deterministic cost fixtures to use plausible bps-scale samples

## Validation
- `uv run python -m trend_analysis.cli mc validate config/scenarios/monte_carlo/cost_regime_example.yml`
- deliberate break: removed the lognormal arithmetic-mean conversion term and confirmed the mean-target/exact-fixture regressions failed, then restored it
- `uv run pytest tests/monte_carlo/test_costs.py tests/monte_carlo/test_monte_carlo_docs_schema.py tests/monte_carlo/test_registry.py tests/monte_carlo/test_seed.py -q`
- `uv run ruff check src/trend_analysis/monte_carlo/costs.py tests/monte_carlo/test_costs.py`
- `uv run ruff format --check src/trend_analysis/monte_carlo/costs.py tests/monte_carlo/test_costs.py`
- `git diff --check`