### PR TITLE
fix(results): hide pre-run prompt + 'Run analysis' CTA once results exist (#5628)

### DIFF
--- a/streamlit_app/pages/3_Results.py
+++ b/streamlit_app/pages/3_Results.py
@@ -2035,8 +2035,16 @@ def render_results_page() -> None:
 
     data_hash = _data_hash_for_analysis(df_for_analysis)
 
-    st.markdown("Run the analysis to generate performance and risk diagnostics.")
-    run_clicked = st.button("Run analysis", type="primary")
+    # P2 (design-system presentation pattern): show the pre-run prompt + primary
+    # "Run analysis" CTA ONLY when there is no result yet. When results are already
+    # present, surface a completed-state caption + an explicit "Re-run" control
+    # instead of a prompt that reads as if nothing has run (issue #5628).
+    if result is None:
+        st.markdown("Run the analysis to generate performance and risk diagnostics.")
+        run_clicked = st.button("Run analysis", type="primary")
+    else:
+        st.caption("Analysis complete. Adjust the settings above and re-run to refresh these results.")
+        run_clicked = st.button("Re-run analysis", type="secondary")
 
     if run_clicked or result is None:
         with st.spinner("Running analysis…"):

--- a/tests/app/test_results_page.py
+++ b/tests/app/test_results_page.py
@@ -675,3 +675,72 @@ def test_period_count_uses_period_results_when_explicit_count_missing(results_pa
     )
 
     assert page._result_period_count(result, result.details) == 2
+
+
+def test_results_hides_prerun_prompt_when_result_present(
+    monkeypatch: pytest.MonkeyPatch, results_page
+) -> None:
+    """P2 / issue #5628: once a completed result is present, the page must not
+    show the pre-run 'Run the analysis to generate...' prompt + primary CTA; it
+    shows a completed-state caption + an explicit re-run instead (and does not
+    recompute when re-run is not clicked)."""
+    page, stub = results_page
+    returns = _sample_returns()
+    stub.session_state.update(
+        {
+            "model_state": {
+                "trend_spec": {"window": 63, "lag": 1},
+                "metric_weights": {"sharpe": 1.0},
+            },
+            "selected_benchmark": "BenchA",
+            "data_fingerprint": "abc123",
+            "returns_df": returns,
+            "schema_meta": {},
+            "upload_status": "success",
+        }
+    )
+
+    run_calls: list[bool] = []
+
+    def fake_run(df, model_state, benchmark, **_kwargs):
+        run_calls.append(True)
+        return SimpleNamespace(
+            metrics=pd.DataFrame({"Sharpe": [1.23]}),
+            details={
+                "portfolio_equal_weight_combined": df["FundA"],
+                "risk_diagnostics": {
+                    "turnover": pd.Series([0.1, 0.2], index=returns.index[:2]),
+                    "final_weights": pd.Series({"FundA": 0.6, "FundB": 0.4}),
+                },
+            },
+            fallback_info=None,
+        )
+
+    for chart in [
+        "equity_chart",
+        "drawdown_chart",
+        "rolling_sharpe_chart",
+        "turnover_chart",
+        "exposure_chart",
+    ]:
+        monkeypatch.setattr(
+            getattr(page, "charts"), chart, lambda *_args, chart_name=chart: chart_name
+        )
+    monkeypatch.setattr(page.analysis_runner, "run_analysis", fake_run)
+
+    # First render: click "Run analysis" -> result + key get cached.
+    stub.button_responses = [True]
+    page.render_results_page()
+    assert stub.session_state.get("analysis_result_key")
+    assert run_calls == [True]
+
+    # Second render: re-run NOT clicked -> the cached result is reused, the
+    # completed-state caption shows, and there is no recompute.
+    stub.button_responses = [False]
+    stub.caption_messages.clear()
+    run_calls.clear()
+    page.render_results_page()
+
+    captions = " ".join(stub.caption_messages)
+    assert "Analysis complete" in captions
+    assert run_calls == []


### PR DESCRIPTION
Closes #5628 by adopting **design-system presentation pattern P2** (empty-state shows only when there is no result).

Before: the Results page rendered 'Run the analysis to generate performance and risk diagnostics.' + a primary 'Run analysis' button **above** already-rendered demo results — reading as if nothing had run.
After: when a result is present it shows a completed-state caption ('Analysis complete. Adjust the settings above and re-run to refresh…') + an explicit secondary 'Re-run analysis' control; the pre-run prompt + primary CTA appear only when no result exists.

This is the first per-app application of the fleet design-system rollout (see Workflows #2508 + design-system/PRESENTATION_PATTERNS.md). Verified live in the browser, and gated by `tests/app/test_results_page.py::test_results_hides_prerun_prompt_when_result_present` (passes; fails when reverted — deliberate-break checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Results page now displays context-aware UI based on analysis state. Shows initial prompt with 'Run analysis' button when no analysis exists, and displays completion confirmation with 'Re-run analysis' option once analysis is complete. Analysis results are cached for faster re-renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->