### PR TITLE
fix(mc): align per-path analysis windows to the simulated horizon

### DIFF
--- a/config/scenarios/monte_carlo/hf_diversified_5y.yml
+++ b/config/scenarios/monte_carlo/hf_diversified_5y.yml
@@ -5,6 +5,13 @@ scenario:
 
 base_config: config/defaults.yml
 
+# Simulated paths are forward projections that carry no explicitly-configured
+# risk-free column, so enable the opt-in fallback for the per-path score-frame
+# and portfolio stats (matches cost_regime_example.yml). CASH injection stays
+# gated separately by metrics.rf_override_enabled.
+data:
+  allow_risk_free_fallback: true
+
 monte_carlo:
   mode: two_layer
   n_paths: 300

--- a/scripts/reproduce_ui_run.py
+++ b/scripts/reproduce_ui_run.py
@@ -43,10 +43,10 @@ from streamlit_app.components.data_cache import (  # noqa: E402
     load_dataset_from_bytes,
     load_dataset_from_path,
 )
+from trend_analysis.api import run_simulation  # noqa: E402
 from trend_analysis.io.date_correction import (  # noqa: E402
     apply_date_corrections,
 )
-from trend_analysis.api import run_simulation  # noqa: E402
 
 
 def _norm_cdf(z: float) -> float:

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -19,6 +19,11 @@ import numpy as np
 import pandas as pd
 import yaml
 
+from trend.cli_helpers import (
+    _apply_trend_spec_preset,
+    _apply_universe_mask,
+    _attach_universe_paths,
+)
 from trend.config_schema import CoreConfigError, load_core_config
 from trend.diagnostics import DiagnosticPayload, DiagnosticResult
 from trend.reporting import generate_unified_report
@@ -77,11 +82,6 @@ from trend_analysis.presets import (
     apply_trend_preset,
     get_trend_preset,
     list_preset_slugs,
-)
-from trend.cli_helpers import (
-    _apply_trend_spec_preset,
-    _apply_universe_mask,
-    _attach_universe_paths,
 )
 from trend_analysis.reporting.portfolio_series import select_primary_portfolio_series
 from trend_analysis.reporting.run_artifacts import write_run_artifacts

--- a/src/trend_analysis/api.py
+++ b/src/trend_analysis/api.py
@@ -27,8 +27,8 @@ from trend.validation import (
 )
 
 from .diagnostics import PipelineReasonCode, coerce_pipeline_result
-from .logging import log_step as _log_step  # lightweight import
 from .llm.analysis_fleet import record_analysis_run
+from .logging import log_step as _log_step  # lightweight import
 from .pipeline import (
     _build_trend_spec,
     _policy_from_config,

--- a/src/trend_analysis/backtesting/harness.py
+++ b/src/trend_analysis/backtesting/harness.py
@@ -13,9 +13,10 @@ import pandas as pd
 
 from backtest import shift_by_execution_lag
 
-from ..metrics.turnover import linear_turnover_cost
 from ..metrics import sortino_ratio
-from ..schedules import normalize_frequency, rebalance_calendar as _rebalance_calendar
+from ..metrics.turnover import linear_turnover_cost
+from ..schedules import normalize_frequency
+from ..schedules import rebalance_calendar as _rebalance_calendar
 from ..universe import MembershipTable, build_membership_mask
 from ..util.frequency import infer_periods_per_year as _infer_periods_per_year
 

--- a/src/trend_analysis/cli.py
+++ b/src/trend_analysis/cli.py
@@ -16,13 +16,13 @@ from typing import Any, Callable, cast
 import numpy as np
 import pandas as pd
 
-from trend.config_schema import CoreConfigError, validate_core_config
-from trend.diagnostics import DiagnosticPayload
 from trend.cli_helpers import (
     _apply_trend_spec_preset,
     _apply_universe_mask,
     _attach_universe_paths,
 )
+from trend.config_schema import CoreConfigError, validate_core_config
+from trend.diagnostics import DiagnosticPayload
 
 from . import export, pipeline
 from . import logging as run_logging

--- a/src/trend_analysis/engine/walkforward.py
+++ b/src/trend_analysis/engine/walkforward.py
@@ -9,7 +9,9 @@ import numpy as np
 import pandas as pd
 
 from trend_analysis.metrics import information_ratio
-from trend_analysis.util.frequency import infer_periods_per_year as _infer_periods_per_year
+from trend_analysis.util.frequency import (
+    infer_periods_per_year as _infer_periods_per_year,
+)
 
 
 @dataclass

--- a/src/trend_analysis/export/bundle.py
+++ b/src/trend_analysis/export/bundle.py
@@ -12,13 +12,13 @@ import matplotlib
 import pandas as pd
 
 from trend_analysis.backtesting import BacktestResult, CostModel, bootstrap_equity
+from trend_analysis.util.git import git_hash
 from trend_analysis.util.hash import (
     content_run_id,
     normalise_for_json,
     sha256_config,
     sha256_file,
 )
-from trend_analysis.util.git import git_hash
 
 
 def _git_hash() -> str:

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -1174,8 +1174,9 @@ class MonteCarloRunner:
         ratio = 0.7
         existing = merged.get("sample_split")
         if isinstance(existing, Mapping) and str(existing.get("method", "")).lower() == "ratio":
+            ratio_value = existing.get("ratio")
             try:
-                candidate = float(existing.get("ratio"))
+                candidate = float(ratio_value) if ratio_value is not None else None
             except (TypeError, ValueError):
                 candidate = None
             if candidate is not None and 0.0 < candidate < 1.0:
@@ -1276,9 +1277,12 @@ class MonteCarloRunner:
             return
         window = vol_adjust.get("window")
         if isinstance(window, Mapping):
+            window_length = window.get("length")
             try:
-                length = int(window.get("length"))
+                length = int(window_length) if window_length is not None else None
             except (TypeError, ValueError):
+                return
+            if length is None:
                 return
             if length > max_window:
                 new_window = dict(window)
@@ -1303,6 +1307,8 @@ class MonteCarloRunner:
         if not isinstance(signals, Mapping):
             return
         window = signals.get("window")
+        if window is None:
+            return
         try:
             length = int(window)
         except (TypeError, ValueError):
@@ -1314,7 +1320,7 @@ class MonteCarloRunner:
             effective_window = max_window
         min_periods = signals.get("min_periods")
         try:
-            min_length = int(min_periods)
+            min_length = int(min_periods) if min_periods is not None else None
         except (TypeError, ValueError):
             min_length = None
         if min_length is not None and min_length > effective_window:

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -1184,9 +1184,7 @@ class MonteCarloRunner:
         self._fit_vol_adjust_window(merged, max_window)
         self._fit_signal_window(merged, max_window)
 
-    def _align_multi_period(
-        self, merged: dict[str, Any], context: _PathContext | None
-    ) -> None:
+    def _align_multi_period(self, merged: dict[str, Any], context: _PathContext | None) -> None:
         """Re-base ``multi_period`` onto the path span, keeping it only if viable.
 
         The base config's multi-period window is expressed in absolute historical
@@ -1471,9 +1469,7 @@ class MonteCarloRunner:
         """Backward-compatible alias for cash injection behavior."""
         return self._apply_cash_handling(returns)
 
-    def _extract_portfolio_metrics(
-        self, run_result: Any
-    ) -> tuple[dict[str, float], str | None]:
+    def _extract_portfolio_metrics(self, run_result: Any) -> tuple[dict[str, float], str | None]:
         """Return per-path metrics for the evaluated strategy's portfolio.
 
         The single-period ``run_simulation`` metrics frame is indexed *per

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -632,8 +632,21 @@ class MonteCarloRunner:
         returns = np.expm1(log_returns)
         returns_df = self._returns_with_date(returns)
         returns_df = self._apply_cash_handling(returns_df)
-        score_frame = self._compute_score_frame(returns_df)
         path_hash = self._hash_frame(prices)
+        score_context = _PathContext(
+            fold_id=fold_id,
+            fold_label=fold_label,
+            path_id=path_id,
+            prices=prices,
+            returns=returns_df,
+            score_frame=pd.DataFrame(),
+            path_hash=path_hash,
+            seed=seed,
+        )
+        score_frame = self._compute_score_frame(
+            returns_df,
+            config_data=self._path_aligned_base_config(score_context),
+        )
         return _PathContext(
             fold_id=fold_id,
             fold_label=fold_label,
@@ -1138,6 +1151,11 @@ class MonteCarloRunner:
             merged["seed"] = int(seed)
         return Config(**merged)
 
+    def _path_aligned_base_config(self, context: _PathContext) -> dict[str, Any]:
+        merged = dict(self._base_config)
+        self._align_path_windows(merged, context)
+        return merged
+
     def _align_path_windows(
         self, merged: dict[str, Any], context: _PathContext | None = None
     ) -> None:
@@ -1390,9 +1408,11 @@ class MonteCarloRunner:
         _coerce_turnover_guard(guard_value)
         return None
 
-    def _compute_score_frame(self, returns: pd.DataFrame) -> pd.DataFrame:
+    def _compute_score_frame(
+        self, returns: pd.DataFrame, config_data: Mapping[str, Any] | None = None
+    ) -> pd.DataFrame:
         try:
-            config = Config(**self._base_config)
+            config = Config(**(config_data or self._base_config))
         except (TypeError, ValueError) as exc:
             self._logger.warning("Failed to parse base config for score frame: %s", exc)
             return pd.DataFrame()

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -651,10 +651,10 @@ class MonteCarloRunner:
         context: _PathContext,
     ) -> StrategyEvaluation:
         strategy_seed = self._strategy_seed(context.path_id, strategy.name)
-        config = self._build_strategy_config(strategy, strategy_seed)
+        config = self._build_strategy_config(strategy, strategy_seed, context)
         self._apply_regime_turnover_caps(config, context)
         run_result = run_simulation(config, context.returns)
-        metrics, source = self._extract_metrics(run_result.metrics)
+        metrics, source = self._extract_portfolio_metrics(run_result)
         cost_payload = self._maybe_sample_costs(run_result, context, strategy)
         if cost_payload is not None:
             metrics = dict(metrics)
@@ -1124,13 +1124,159 @@ class MonteCarloRunner:
         ]
         return path_seeds, strategy_seeds
 
-    def _build_strategy_config(self, strategy: StrategyVariant, seed: int | None) -> ConfigType:
+    def _build_strategy_config(
+        self,
+        strategy: StrategyVariant,
+        seed: int | None,
+        context: _PathContext | None = None,
+    ) -> ConfigType:
         merged = strategy.apply_to(self._base_config)
         self._apply_strategy_guards(merged)
         self._apply_turnover_guard_distribution(merged, strategy, seed)
+        self._align_path_windows(merged, context)
         if seed is not None:
             merged["seed"] = int(seed)
         return Config(**merged)
+
+    def _align_path_windows(
+        self, merged: dict[str, Any], context: _PathContext | None = None
+    ) -> None:
+        """Align a simulated path's analysis windows to the path's own dates.
+
+        A Monte Carlo path is a *forward* projection over the simulation horizon
+        (e.g. ``2025``..``2026``), so the windows used to score and evaluate it
+        must be derived from the path itself. The historical windows baked into
+        ``base_config`` -- the ``multi_period`` schedule (e.g. ``1990``..
+        ``2024``) and a fixed-date ``sample_split`` (e.g. ``2017-12-31``) -- do
+        not overlap the simulated horizon, so every in/out window comes back
+        empty: the multi-period engine returns no periods (no NAV paths) and the
+        single-period split yields no metrics.
+
+        We therefore:
+
+        * Replace ``sample_split`` with a data-relative *ratio* split, which
+          derives the in/out boundary from whatever returns ``run_simulation``
+          receives and so always lands inside the simulated horizon. An existing
+          ratio split's ratio is preserved; otherwise it defaults to 0.7.
+        * Re-base ``multi_period`` onto the simulated path's dates and keep it
+          only when its schedule still yields at least one window over that span
+          (see :meth:`_align_multi_period`); a long historical schedule that
+          cannot fit the horizon is dropped so the ratio split takes over.
+        * Cap the rolling lookbacks ``vol_adjust.window`` and the trend
+          ``signals.window`` -- tuned for long real history (defaults.yml and
+          the UI both use 63 periods) -- at half the horizon. Left uncapped they
+          never fill on a short path, the volatility estimate / trend signal is
+          all-NaN, and the weights collapse to a 100% cash portfolio (flat NAV,
+          NaN Sharpe). Windows that already fit are untouched.
+        """
+        ratio = 0.7
+        existing = merged.get("sample_split")
+        if isinstance(existing, Mapping) and str(existing.get("method", "")).lower() == "ratio":
+            try:
+                candidate = float(existing.get("ratio"))
+            except (TypeError, ValueError):
+                candidate = None
+            if candidate is not None and 0.0 < candidate < 1.0:
+                ratio = candidate
+        merged["sample_split"] = {"method": "ratio", "ratio": ratio}
+        self._align_multi_period(merged, context)
+        max_window = max(2, self._compute_n_periods() // 2)
+        self._fit_vol_adjust_window(merged, max_window)
+        self._fit_signal_window(merged, max_window)
+
+    def _align_multi_period(
+        self, merged: dict[str, Any], context: _PathContext | None
+    ) -> None:
+        """Re-base ``multi_period`` onto the path span, keeping it only if viable.
+
+        The base config's multi-period window is expressed in absolute historical
+        dates. Re-base its ``start``/``end`` onto the simulated path's date span
+        and keep the schedule only when it still produces at least one rolling
+        window there (e.g. a monthly 2-in/2-out schedule over a 6-month path). A
+        long schedule that cannot fit the horizon (e.g. defaults.yml's annual
+        3-in/1-out over a sub-2-year path) is dropped so the data-relative ratio
+        split drives a single in/out evaluation instead.
+        """
+        multi_period = merged.get("multi_period")
+        if not isinstance(multi_period, Mapping):
+            merged.pop("multi_period", None)
+            return
+        span = self._path_period_span(context)
+        if span is None:
+            merged.pop("multi_period", None)
+            return
+        start, end = span
+        rewritten = {**multi_period, "start": start, "end": end}
+        from ..multi_period.scheduler import generate_periods
+
+        try:
+            periods = generate_periods({"multi_period": rewritten})
+        except Exception as exc:  # pragma: no cover - defensive
+            self._logger.debug("multi_period re-base failed; dropping for path eval: %s", exc)
+            periods = []
+        if periods:
+            merged["multi_period"] = rewritten
+        else:
+            merged.pop("multi_period", None)
+
+    @staticmethod
+    def _path_period_span(context: _PathContext | None) -> tuple[str, str] | None:
+        """Return the (start, end) ``YYYY-MM`` span of a path's simulated dates."""
+        if context is None:
+            return None
+        returns = getattr(context, "returns", None)
+        if not isinstance(returns, pd.DataFrame) or "Date" not in returns.columns:
+            return None
+        dates = pd.to_datetime(returns["Date"], errors="coerce").dropna()
+        if dates.empty:
+            return None
+        return dates.min().strftime("%Y-%m"), dates.max().strftime("%Y-%m")
+
+    def _fit_vol_adjust_window(self, merged: dict[str, Any], max_window: int) -> None:
+        """Cap an over-long vol-adjust rolling window at ``max_window``.
+
+        See :meth:`_align_path_windows`: a window longer than the simulated
+        horizon leaves the rolling volatility estimate all-NaN, collapsing the
+        vol-scaled weights to a 100% cash portfolio.
+        """
+        vol_adjust = merged.get("vol_adjust")
+        if not isinstance(vol_adjust, Mapping) or not vol_adjust.get("enabled", False):
+            return
+        window = vol_adjust.get("window")
+        if isinstance(window, Mapping):
+            try:
+                length = int(window.get("length"))
+            except (TypeError, ValueError):
+                return
+            if length > max_window:
+                new_window = dict(window)
+                new_window["length"] = max_window
+                merged["vol_adjust"] = {**vol_adjust, "window": new_window}
+        elif window is not None:
+            try:
+                length = int(window)
+            except (TypeError, ValueError):
+                return
+            if length > max_window:
+                merged["vol_adjust"] = {**vol_adjust, "window": max_window}
+
+    def _fit_signal_window(self, merged: dict[str, Any], max_window: int) -> None:
+        """Cap an over-long trend ``signals.window`` at ``max_window``.
+
+        See :meth:`_align_path_windows`: the UI builds a ``tsmom`` signal with a
+        63-period window, which is entirely NaN on a short simulated in-sample
+        so no fund earns a position and the portfolio is 100% cash.
+        """
+        signals = merged.get("signals")
+        if not isinstance(signals, Mapping):
+            return
+        window = signals.get("window")
+        try:
+            length = int(window)
+        except (TypeError, ValueError):
+            return
+        if length > max_window:
+            merged["signals"] = {**signals, "window": max_window}
 
     def _apply_strategy_guards(self, merged: dict[str, Any]) -> None:
         strategy_set = self._strategy_set()
@@ -1324,6 +1470,50 @@ class MonteCarloRunner:
     def _inject_cash_returns(self, returns: pd.DataFrame) -> pd.DataFrame:
         """Backward-compatible alias for cash injection behavior."""
         return self._apply_cash_handling(returns)
+
+    def _extract_portfolio_metrics(
+        self, run_result: Any
+    ) -> tuple[dict[str, float], str | None]:
+        """Return per-path metrics for the evaluated strategy's portfolio.
+
+        The single-period ``run_simulation`` metrics frame is indexed *per
+        fund*, so ``_extract_metrics`` (written for the multi-period frame keyed
+        by weighting scheme) falls through to its first row -- an arbitrary
+        constituent fund rather than the strategy. For the Monte Carlo summary
+        and Sharpe distribution we want the out-of-sample *portfolio* stats, so
+        prefer the user-weighted result, then the equal-weighted fallback, and
+        only then the metrics frame for callers/tests that populate just that.
+        """
+        details = getattr(run_result, "details", None)
+        if isinstance(details, Mapping):
+            for key in ("out_user_stats", "out_ew_stats"):
+                metrics = self._stats_to_metrics(details.get(key))
+                if metrics:
+                    return metrics, key
+        return self._extract_metrics(getattr(run_result, "metrics", None))
+
+    @staticmethod
+    def _stats_to_metrics(stats: Any) -> dict[str, float]:
+        """Coerce a portfolio stats object/mapping into a flat float metrics dict."""
+        if stats is None:
+            return {}
+        if isinstance(stats, Mapping):
+            items: Iterable[tuple[Any, Any]] = stats.items()
+        elif hasattr(stats, "__dict__"):
+            items = vars(stats).items()
+        else:
+            return {}
+        metrics: dict[str, float] = {}
+        for key, value in items:
+            if value is None or isinstance(value, bool):
+                continue
+            if not isinstance(value, (int, float, np.floating, np.integer)):
+                continue
+            numeric = float(value)
+            if math.isnan(numeric):
+                continue
+            metrics[str(key)] = numeric
+        return metrics
 
     def _extract_metrics(self, metrics_df: pd.DataFrame) -> tuple[dict[str, float], str | None]:
         if metrics_df is None or metrics_df.empty:

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -1201,7 +1201,11 @@ class MonteCarloRunner:
                 ratio = candidate
         merged["sample_split"] = {"method": "ratio", "ratio": ratio}
         multi_period_max_window = self._align_multi_period(merged, context)
-        max_window = multi_period_max_window or max(2, self._compute_n_periods() // 2)
+        horizon_rows = self._compute_n_periods()
+        if context is not None and isinstance(context.returns, pd.DataFrame):
+            horizon_rows = max(1, len(context.returns))
+        fallback_window = min(max(2, horizon_rows // 2), horizon_rows)
+        max_window = multi_period_max_window or fallback_window
         self._fit_vol_adjust_window(merged, max_window)
         self._fit_signal_window(merged, max_window)
 
@@ -1566,8 +1570,11 @@ class MonteCarloRunner:
         """Coerce a portfolio stats object/mapping into a flat float metrics dict."""
         if stats is None:
             return {}
-        if isinstance(stats, Mapping):
-            items: Iterable[tuple[Any, Any]] = stats.items()
+        items: Iterable[tuple[Any, Any]]
+        if isinstance(stats, pd.Series):
+            items = stats.items()
+        elif isinstance(stats, Mapping):
+            items = stats.items()
         elif hasattr(stats, "__dict__"):
             items = vars(stats).items()
         else:

--- a/src/trend_analysis/monte_carlo/runner.py
+++ b/src/trend_analysis/monte_carlo/runner.py
@@ -1164,10 +1164,12 @@ class MonteCarloRunner:
           cannot fit the horizon is dropped so the ratio split takes over.
         * Cap the rolling lookbacks ``vol_adjust.window`` and the trend
           ``signals.window`` -- tuned for long real history (defaults.yml and
-          the UI both use 63 periods) -- at half the horizon. Left uncapped they
-          never fill on a short path, the volatility estimate / trend signal is
-          all-NaN, and the weights collapse to a 100% cash portfolio (flat NAV,
-          NaN Sharpe). Windows that already fit are untouched.
+          the UI both use 63 periods) -- at the active multi-period in-sample
+          span when one is retained, otherwise at half the horizon. Left
+          uncapped they never fill on a short path, the volatility estimate /
+          trend signal is all-NaN, and the weights collapse to a 100% cash
+          portfolio (flat NAV, NaN Sharpe). Windows that already fit are
+          untouched.
         """
         ratio = 0.7
         existing = merged.get("sample_split")
@@ -1179,12 +1181,14 @@ class MonteCarloRunner:
             if candidate is not None and 0.0 < candidate < 1.0:
                 ratio = candidate
         merged["sample_split"] = {"method": "ratio", "ratio": ratio}
-        self._align_multi_period(merged, context)
-        max_window = max(2, self._compute_n_periods() // 2)
+        multi_period_max_window = self._align_multi_period(merged, context)
+        max_window = multi_period_max_window or max(2, self._compute_n_periods() // 2)
         self._fit_vol_adjust_window(merged, max_window)
         self._fit_signal_window(merged, max_window)
 
-    def _align_multi_period(self, merged: dict[str, Any], context: _PathContext | None) -> None:
+    def _align_multi_period(
+        self, merged: dict[str, Any], context: _PathContext | None
+    ) -> int | None:
         """Re-base ``multi_period`` onto the path span, keeping it only if viable.
 
         The base config's multi-period window is expressed in absolute historical
@@ -1198,11 +1202,11 @@ class MonteCarloRunner:
         multi_period = merged.get("multi_period")
         if not isinstance(multi_period, Mapping):
             merged.pop("multi_period", None)
-            return
+            return None
         span = self._path_period_span(context)
         if span is None:
             merged.pop("multi_period", None)
-            return
+            return None
         start, end = span
         rewritten = {**multi_period, "start": start, "end": end}
         from ..multi_period.scheduler import generate_periods
@@ -1214,8 +1218,38 @@ class MonteCarloRunner:
             periods = []
         if periods:
             merged["multi_period"] = rewritten
+            return self._multi_period_in_sample_cap(context, periods)
         else:
             merged.pop("multi_period", None)
+        return None
+
+    @staticmethod
+    def _multi_period_in_sample_cap(
+        context: _PathContext | None, periods: Sequence[Any]
+    ) -> int | None:
+        """Return the shortest retained in-sample row count for path windows."""
+        if context is None:
+            return None
+        returns = getattr(context, "returns", None)
+        if not isinstance(returns, pd.DataFrame) or "Date" not in returns.columns:
+            return None
+        dates = pd.to_datetime(returns["Date"], errors="coerce").dropna()
+        if dates.empty:
+            return None
+        caps: list[int] = []
+        for period in periods:
+            in_start = getattr(period, "in_start", None)
+            in_end = getattr(period, "in_end", None)
+            if in_start is None or in_end is None:
+                continue
+            start = pd.to_datetime(in_start, errors="coerce")
+            end = pd.to_datetime(in_end, errors="coerce")
+            if pd.isna(start) or pd.isna(end):
+                continue
+            count = int(((dates >= start) & (dates <= end)).sum())
+            if count > 0:
+                caps.append(count)
+        return max(1, min(caps)) if caps else None
 
     @staticmethod
     def _path_period_span(context: _PathContext | None) -> tuple[str, str] | None:
@@ -1273,8 +1307,21 @@ class MonteCarloRunner:
             length = int(window)
         except (TypeError, ValueError):
             return
+        updated: dict[str, Any] | None = None
+        effective_window = length
         if length > max_window:
-            merged["signals"] = {**signals, "window": max_window}
+            updated = {**signals, "window": max_window}
+            effective_window = max_window
+        min_periods = signals.get("min_periods")
+        try:
+            min_length = int(min_periods)
+        except (TypeError, ValueError):
+            min_length = None
+        if min_length is not None and min_length > effective_window:
+            updated = {**signals} if updated is None else updated
+            updated["min_periods"] = effective_window
+        if updated is not None:
+            merged["signals"] = updated
 
     def _apply_strategy_guards(self, merged: dict[str, Any]) -> None:
         strategy_set = self._strategy_set()
@@ -1506,7 +1553,7 @@ class MonteCarloRunner:
             if not isinstance(value, (int, float, np.floating, np.integer)):
                 continue
             numeric = float(value)
-            if math.isnan(numeric):
+            if not math.isfinite(numeric):
                 continue
             metrics[str(key)] = numeric
         return metrics

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -86,6 +86,10 @@ def _stable_period_seed(base_seed: int, *parts: object, modulo: int = 10000) -> 
     return abs(int(base_seed)) + (int.from_bytes(digest, "big") % modulo)
 
 
+def _seed_or_default(seed: Any, default: int = 42) -> int:
+    return default if seed is None else int(seed)
+
+
 SHIFT_DETECTION_MAX_STEPS_DEFAULT = 10
 _DEFAULT_LOAD_CSV = load_csv
 
@@ -1173,7 +1177,7 @@ def run_schedule(
             if prev_weights is None:
                 prev_weights = target_weights["weight"].astype(float)
             # For random mode, seed varies per period to get different selections
-            period_seed = _stable_period_seed(seed or 42, str(date))
+            period_seed = _stable_period_seed(_seed_or_default(seed), str(date))
             prev_weights = rebalancer.apply_triggers(
                 cast(pd.Series, prev_weights),
                 sf,
@@ -2699,7 +2703,7 @@ def _run_threshold_hold_multi_periods(
         # In random mode, shuffle candidates randomly instead of ranking by zscore.
         # Use a period-specific seed so different periods get different shuffles.
         if is_random_mode:
-            period_seed_base = getattr(cfg, "seed", 42) or 42
+            period_seed_base = _seed_or_default(getattr(cfg, "seed", None))
             period_seed = _stable_period_seed(period_seed_base, str(pt))
             rng = np.random.default_rng(period_seed)
             rng.shuffle(candidates)
@@ -2904,7 +2908,9 @@ def _run_threshold_hold_multi_periods(
                     holdings = []
                 else:
                     # Seed varies per period to get different selections
-                    period_seed = _stable_period_seed(getattr(cfg, "seed", 42) or 42, str(pt))
+                    period_seed = _stable_period_seed(
+                        _seed_or_default(getattr(cfg, "seed", None)), str(pt)
+                    )
                     rng = np.random.default_rng(period_seed)
                     n_select = max(1, min(target_n, len(available)))
                     holdings = list(rng.choice(available, size=n_select, replace=False))
@@ -2934,7 +2940,9 @@ def _run_threshold_hold_multi_periods(
                     holdings = []
                 elif buy_hold_initial == "random":
                     # Random initial selection
-                    period_seed = _stable_period_seed(getattr(cfg, "seed", 42) or 42, str(pt))
+                    period_seed = _stable_period_seed(
+                        _seed_or_default(getattr(cfg, "seed", None)), str(pt)
+                    )
                     rng = np.random.default_rng(period_seed)
                     n_select = max(1, min(buy_hold_n, len(available)))
                     holdings = list(rng.choice(available, size=n_select, replace=False))
@@ -3291,7 +3299,9 @@ def _run_threshold_hold_multi_periods(
 
                     if buy_hold_initial == "random":
                         # Random replacement
-                        period_seed = _stable_period_seed(getattr(cfg, "seed", 42) or 42, str(pt))
+                        period_seed = _stable_period_seed(
+                            _seed_or_default(getattr(cfg, "seed", None)), str(pt)
+                        )
                         rng = np.random.default_rng(period_seed)
                         rng.shuffle(available)
                         replacements: list[str] = []
@@ -3377,7 +3387,9 @@ def _run_threshold_hold_multi_periods(
                 # each period. This is essential to avoid survivorship bias - we select
                 # from the available universe at each point in time, not funds we know
                 # will survive.
-                period_seed = _stable_period_seed(getattr(cfg, "seed", 42) or 42, str(pt))
+                period_seed = _stable_period_seed(
+                    _seed_or_default(getattr(cfg, "seed", None)), str(pt)
+                )
                 rebased = rebalancer.apply_triggers(
                     prev_weights.astype(float),
                     sf,
@@ -3586,7 +3598,9 @@ def _run_threshold_hold_multi_periods(
                 candidates = _filter_entry_candidates(candidates, sf)
                 if candidates:
                     if is_random_mode:
-                        period_seed = _stable_period_seed(getattr(cfg, "seed", 42) or 42, str(pt))
+                        period_seed = _stable_period_seed(
+                            _seed_or_default(getattr(cfg, "seed", None)), str(pt)
+                        )
                         rng = np.random.default_rng(period_seed)
                         rng.shuffle(candidates)
                         ranked = candidates
@@ -3622,7 +3636,7 @@ def _run_threshold_hold_multi_periods(
 
                 def _random_key(mgr: str) -> float:
                     # For random mode: use a seeded random value for stable ordering
-                    base_seed = getattr(cfg, "seed", 42) or 42
+                    base_seed = _seed_or_default(getattr(cfg, "seed", None))
                     safe_seed = _stable_period_seed(base_seed, str(pt), mgr, modulo=2**32 - 1)
                     rng = np.random.default_rng(safe_seed)
                     return rng.random()

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -80,7 +80,8 @@ from .scheduler import generate_periods
 MultiPeriodPeriodResult = Dict[str, Any]
 
 
-def _stable_period_seed(base_seed: int, period_key: str, *, modulo: int = 10000) -> int:
+def _stable_period_seed(base_seed: int, *parts: object, modulo: int = 10000) -> int:
+    period_key = "|".join(str(part) for part in parts)
     digest = hashlib.blake2b(period_key.encode("utf-8"), digest_size=8).digest()
     return abs(int(base_seed)) + (int.from_bytes(digest, "big") % modulo)
 
@@ -1172,7 +1173,7 @@ def run_schedule(
             if prev_weights is None:
                 prev_weights = target_weights["weight"].astype(float)
             # For random mode, seed varies per period to get different selections
-            period_seed = abs((seed or 42) + hash(str(date)) % 10000)
+            period_seed = _stable_period_seed(seed or 42, str(date))
             prev_weights = rebalancer.apply_triggers(
                 cast(pd.Series, prev_weights),
                 sf,
@@ -3621,11 +3622,8 @@ def _run_threshold_hold_multi_periods(
 
                 def _random_key(mgr: str) -> float:
                     # For random mode: use a seeded random value for stable ordering
-                    # Make the seed period-specific by incorporating the score frame.
-                    # Use abs() to ensure non-negative seed (hash can be negative).
                     base_seed = getattr(cfg, "seed", 42) or 42
-                    combined_seed = (base_seed, id(sf), mgr)
-                    safe_seed = abs(hash(combined_seed))
+                    safe_seed = _stable_period_seed(base_seed, str(pt), mgr, modulo=2**32 - 1)
                     rng = np.random.default_rng(safe_seed)
                     return rng.random()
 
@@ -3949,10 +3947,14 @@ def _run_threshold_hold_multi_periods(
             need = max(0, desired_after_low_weight - len(holdings))
             if need > 0:
                 candidates = [
-                    c for c in sf.index if c not in holdings and _eligible_sticky_add(str(c))
+                    str(c)
+                    for c in sf.index
+                    if str(c) not in {str(h) for h in holdings}
+                    and _eligible_sticky_add(str(c))
                 ]
                 if cooldown_periods > 0 and cooldown_book:
                     candidates = [c for c in candidates if str(c) not in cooldown_book]
+                candidates = _filter_entry_candidates(candidates, sf)
                 add_from = sf.loc[candidates].sort_values("zscore", ascending=False).index.tolist()
                 for f in add_from:
                     if len(holdings) >= desired_after_low_weight:
@@ -4018,9 +4020,7 @@ def _run_threshold_hold_multi_periods(
         # Preserve the intended holdings for manual pipeline selection.
         # Use the holdings list so newly hired funds are included even if
         # their weights were altered by turnover/bounds logic.
-        manual_holdings = (
-            [str(x) for x in holdings] if holdings else [str(x) for x in bounded_w.index.tolist()]
-        )
+        manual_holdings = [str(x) for x in holdings]
 
         turnover_cost = _apply_turnover_and_cost(
             bounded_weights=bounded_w,

--- a/src/trend_analysis/multi_period/loaders.py
+++ b/src/trend_analysis/multi_period/loaders.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import logging
 import inspect
+import logging
 from pathlib import Path
 from typing import Any, Mapping
 

--- a/src/trend_analysis/pipeline_entrypoints.py
+++ b/src/trend_analysis/pipeline_entrypoints.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import logging
 import inspect
+import logging
 from dataclasses import dataclass
 from typing import Any, Mapping, cast
 

--- a/streamlit_app/monte_carlo_page.py
+++ b/streamlit_app/monte_carlo_page.py
@@ -14,6 +14,7 @@ from typing import Any, Iterable, Mapping
 import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
+
 from streamlit_app.components.data_cache import cache_key_for_frame
 from streamlit_app.components.guardrails import infer_frequency
 from streamlit_app.components.progress_eta import progress_ratio_and_remaining

--- a/streamlit_app/monte_carlo_page.py
+++ b/streamlit_app/monte_carlo_page.py
@@ -90,6 +90,15 @@ def _analysis_frame_from_session(
     sanitized_funds = [
         c for c in applied_funds if c in returns.columns and c not in prohibited
     ]
+    if not sanitized_funds:
+        # The one-click demo (and any flow that never visited the Data page)
+        # leaves no explicit fund selection in session. Without this fallback
+        # ``keep_cols`` would contain only the benchmark, so Monte Carlo would
+        # run on a single non-investable column, select zero funds, and produce
+        # empty NAV paths plus a Sharpe "distribution" that is really the path
+        # index. Default to the full investable universe (every column that is
+        # not the benchmark / risk-free / regime proxy) instead.
+        sanitized_funds = [c for c in returns.columns if c not in prohibited]
     keep_cols = list(sanitized_funds)
     for extra in (selected_rf, benchmark, regime_proxy):
         if extra and extra in returns.columns and extra not in keep_cols:

--- a/streamlit_app/pages/1_Data.py
+++ b/streamlit_app/pages/1_Data.py
@@ -22,10 +22,6 @@ from streamlit_app.components.data_schema import (
     infer_benchmarks,
     infer_risk_free_candidates,
 )
-from trend_analysis.io.date_correction import (
-    apply_date_corrections,
-    format_corrections_for_display,
-)
 from streamlit_app.components.upload_guard import (
     UploadViolation,
     guard_and_buffer_upload,
@@ -33,6 +29,10 @@ from streamlit_app.components.upload_guard import (
 )
 from streamlit_app.theme import apply_density_compact, apply_ds_theme
 from trend.input_validation import InputValidationError
+from trend_analysis.io.date_correction import (
+    apply_date_corrections,
+    format_corrections_for_display,
+)
 from trend_analysis.io.market_data import MarketDataValidationError
 
 apply_ds_theme()

--- a/tests/app/test_fund_selection_commit.py
+++ b/tests/app/test_fund_selection_commit.py
@@ -6,7 +6,8 @@ from types import ModuleType
 import pandas as pd
 import pytest
 
-from tests.app.test_data_page import DummyStreamlit, data_page as _shared_data_page
+from tests.app.test_data_page import DummyStreamlit
+from tests.app.test_data_page import data_page as _shared_data_page
 
 
 @pytest.fixture(name="data_page")

--- a/tests/baseline/test_coverage_manifest.py
+++ b/tests/baseline/test_coverage_manifest.py
@@ -10,7 +10,6 @@ issue automation can later read to raise "untested input element" issues.
 
 from __future__ import annotations
 
-
 from . import manifest
 from .conftest import load_catalog
 from .harness import REPO_ROOT

--- a/tests/baseline/test_rank_fund_count_limits.py
+++ b/tests/baseline/test_rank_fund_count_limits.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import pandas as pd
-from trend.diagnostics import DiagnosticResult
 
+from trend.diagnostics import DiagnosticResult
 from trend_analysis.config import load
 from trend_analysis.multi_period import engine as mp_engine
 from trend_analysis.multi_period import run_from_config

--- a/tests/monte_carlo/test_runner.py
+++ b/tests/monte_carlo/test_runner.py
@@ -162,7 +162,7 @@ def _stub_mixture_path_evaluation(
     monkeypatch.setattr(
         runner,
         "_compute_score_frame",
-        lambda _returns: pd.DataFrame({"score": [1.0]}, index=["AssetA"]),
+        lambda _returns, config_data=None: pd.DataFrame({"score": [1.0]}, index=["AssetA"]),
     )
 
     def _fake_evaluate_strategy(

--- a/tests/monte_carlo/test_runner_path_window_alignment.py
+++ b/tests/monte_carlo/test_runner_path_window_alignment.py
@@ -1,0 +1,217 @@
+"""Regression tests for per-path analysis-window alignment in the MC runner.
+
+These guard the demo Monte Carlo fixes: a simulated path is a short forward
+projection, so the runner must evaluate it against windows derived from the
+path itself rather than the historical windows baked into ``base_config``.
+Without this, every in/out window is empty and the demo produces no NAV paths,
+an empty summary, and a Sharpe "distribution" that is really the path index.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from trend_analysis.api import RunResult
+from trend_analysis.monte_carlo.runner import MonteCarloRunner, _PathContext
+from trend_analysis.monte_carlo.scenario import MonteCarloScenario
+from trend_analysis.monte_carlo.strategy import StrategyVariant
+
+
+def _demo_like_config() -> dict[str, Any]:
+    """A defaults.yml-shaped config that degenerates without window alignment.
+
+    It carries a historical ``multi_period`` window, a fixed historical
+    ``sample_split`` date, and 63-period rolling lookbacks for both
+    ``vol_adjust`` and the trend ``signals`` -- the exact combination that
+    leaves a short simulated path 100% cash with empty NAV paths.
+    """
+    return {
+        "version": "1",
+        "data": {
+            "date_column": "Date",
+            "frequency": "M",
+            "allow_risk_free_fallback": True,
+        },
+        "preprocessing": {},
+        "vol_adjust": {
+            "enabled": True,
+            "target_vol": 0.10,
+            "floor_vol": 0.015,
+            "window": {"length": 63, "decay": "ewma", "lambda": 0.94},
+        },
+        "sample_split": {"method": "date", "date": "2017-12-31"},
+        "portfolio": {"selection_mode": "all", "weighting_scheme": "equal"},
+        "benchmarks": {},
+        "metrics": {"registry": ["annual_return", "volatility", "sharpe_ratio"]},
+        "regime": {},
+        "export": {},
+        "run": {"monthly_cost": 0.0},
+        "signals": {"kind": "tsmom", "window": 63, "lag": 1, "vol_adjust": False},
+        "multi_period": {
+            "frequency": "A",
+            "in_sample_len": 3,
+            "out_sample_len": 1,
+            "start": "1990-01",
+            "end": "2024-12",
+        },
+    }
+
+
+def _price_history(n: int = 60) -> pd.DataFrame:
+    dates = pd.date_range("2018-01-31", periods=n, freq="ME")
+    rng = np.random.default_rng(7)
+    rets = pd.DataFrame(
+        rng.normal(0.01, 0.03, size=(n, 3)),
+        index=dates,
+        columns=["AssetA", "AssetB", "AssetC"],
+    )
+    return (1.0 + rets).cumprod() * 100.0
+
+
+def _scenario(horizon_years: float = 2.0, n_paths: int = 4) -> MonteCarloScenario:
+    return MonteCarloScenario(
+        name="window_alignment_test",
+        base_config="base.yml",
+        monte_carlo={
+            "mode": "two_layer",
+            "n_paths": n_paths,
+            "horizon_years": horizon_years,
+            "frequency": "M",
+            "seed": 11,
+        },
+        return_model={"kind": "stationary_bootstrap", "params": {"mean_block_len": 2}},
+        enable_fold_runs=False,
+    )
+
+
+def _context(dates: pd.DatetimeIndex) -> _PathContext:
+    returns = pd.DataFrame({"Date": dates, "AssetA": 0.01, "AssetB": 0.02})
+    return _PathContext(
+        path_id=0,
+        prices=pd.DataFrame({"AssetA": [1.0], "AssetB": [1.0]}),
+        returns=returns,
+        score_frame=pd.DataFrame(),
+        path_hash="hash",
+        seed=1,
+    )
+
+
+def _runner(horizon_years: float = 2.0, n_paths: int = 4) -> MonteCarloRunner:
+    return MonteCarloRunner(
+        _scenario(horizon_years=horizon_years, n_paths=n_paths),
+        base_config=_demo_like_config(),
+        price_history=_price_history(),
+    )
+
+
+def test_align_path_windows_neutralises_historical_windows() -> None:
+    runner = _runner(horizon_years=2.0)  # n_periods=24 -> max_window=12
+    merged = dict(_demo_like_config())
+    dates = pd.date_range("2025-01-31", periods=24, freq="ME")
+    runner._align_path_windows(merged, _context(dates))
+
+    # Single-period data-relative split replaces the fixed historical date.
+    assert merged["sample_split"] == {"method": "ratio", "ratio": 0.7}
+    # Annual 3-in/1-out cannot fit a 2-year path -> multi_period dropped.
+    assert "multi_period" not in merged
+    # Over-long rolling lookbacks capped at half the horizon.
+    assert merged["vol_adjust"]["window"]["length"] == 12
+    assert merged["signals"]["window"] == 12
+
+
+def test_align_multi_period_keeps_fitting_schedule_rebased_to_path() -> None:
+    runner = _runner(horizon_years=0.5)  # n_periods=6
+    merged = {
+        "multi_period": {
+            "frequency": "M",
+            "in_sample_len": 2,
+            "out_sample_len": 2,
+            "start": "1990-01",
+            "end": "1990-06",
+        }
+    }
+    dates = pd.date_range("2025-01-31", periods=6, freq="ME")
+    runner._align_multi_period(merged, _context(dates))
+
+    assert "multi_period" in merged
+    # Re-based onto the simulated path's span, not the original historical dates.
+    assert merged["multi_period"]["start"] == "2025-01"
+    assert merged["multi_period"]["end"] == "2025-06"
+    assert merged["multi_period"]["in_sample_len"] == 2
+
+
+def test_align_multi_period_dropped_without_context() -> None:
+    runner = _runner()
+    merged = {"multi_period": {"frequency": "A", "in_sample_len": 3, "out_sample_len": 1}}
+    runner._align_multi_period(merged, None)
+    assert "multi_period" not in merged
+
+
+def test_fit_windows_leave_fitting_lookbacks_untouched() -> None:
+    runner = _runner(horizon_years=2.0)  # max_window=12
+    merged = {
+        "vol_adjust": {"enabled": True, "window": {"length": 6}},
+        "signals": {"kind": "tsmom", "window": 4},
+    }
+    runner._fit_vol_adjust_window(merged, 12)
+    runner._fit_signal_window(merged, 12)
+    assert merged["vol_adjust"]["window"]["length"] == 6
+    assert merged["signals"]["window"] == 4
+
+
+def test_extract_portfolio_metrics_prefers_out_user_stats() -> None:
+    runner = _runner()
+
+    class _Stats:
+        def __init__(self, sharpe: float) -> None:
+            self.cagr = 0.1
+            self.vol = 0.05
+            self.sharpe = sharpe
+            self.is_avg_corr = None  # non-numeric fields are skipped
+
+    per_fund = pd.DataFrame({"sharpe": [0.1, 0.2]}, index=["FundA", "FundB"])
+    run_result = RunResult(
+        metrics=per_fund,
+        details={"out_user_stats": _Stats(1.5), "out_ew_stats": _Stats(1.2)},
+        seed=0,
+        environment={},
+    )
+    metrics, source = runner._extract_portfolio_metrics(run_result)
+    assert source == "out_user_stats"
+    assert metrics["sharpe"] == 1.5
+    assert "is_avg_corr" not in metrics
+
+
+def test_extract_portfolio_metrics_falls_back_to_metrics_frame() -> None:
+    runner = _runner()
+    per_scheme = pd.DataFrame({"sharpe": [0.7]}, index=["equal_weight"])
+    run_result = RunResult(metrics=per_scheme, details={}, seed=0, environment={})
+    metrics, source = runner._extract_portfolio_metrics(run_result)
+    assert source == "equal_weight"
+    assert metrics["sharpe"] == 0.7
+
+
+def test_runner_produces_real_sharpe_and_nav_paths_for_demo_like_config() -> None:
+    """End-to-end guard for both reported symptoms on a demo-like config."""
+    runner = _runner(horizon_years=2.0, n_paths=6)
+    results = runner.run(jobs=1)
+
+    rf = results.results_frame
+    assert not rf.empty
+    # Symptom 2: a real Sharpe column exists with finite values (not path ids).
+    assert "sharpe" in rf.columns
+    assert np.isfinite(rf["sharpe"].to_numpy()).any()
+    # Metrics come from the portfolio, not an arbitrary fund row.
+    assert set(rf["metric_source"].dropna()) <= {"out_user_stats", "out_ew_stats"}
+    assert not results.summary_frame.empty
+
+    # Symptom 1: NAV paths are populated over the simulated horizon and vary.
+    nav_paths = results.metadata.get("nav_paths")
+    assert isinstance(nav_paths, pd.DataFrame)
+    assert not nav_paths.empty
+    assert isinstance(nav_paths.index, pd.DatetimeIndex)
+    final_row = nav_paths.iloc[-1].to_numpy()
+    assert np.nanstd(final_row) > 0.0

--- a/tests/monte_carlo/test_runner_path_window_alignment.py
+++ b/tests/monte_carlo/test_runner_path_window_alignment.py
@@ -142,6 +142,29 @@ def test_align_multi_period_keeps_fitting_schedule_rebased_to_path() -> None:
     assert merged["multi_period"]["in_sample_len"] == 2
 
 
+def test_align_path_windows_caps_to_retained_multi_period_in_sample_span() -> None:
+    runner = _runner(horizon_years=0.5)  # n_periods=6, half-horizon cap would be 3
+    merged = {
+        "sample_split": {"method": "date", "date": "2017-12-31"},
+        "vol_adjust": {"enabled": True, "window": {"length": 63}},
+        "signals": {"kind": "tsmom", "window": 63, "min_periods": 63},
+        "multi_period": {
+            "frequency": "M",
+            "in_sample_len": 2,
+            "out_sample_len": 2,
+            "start": "1990-01",
+            "end": "1990-06",
+        },
+    }
+    dates = pd.date_range("2025-01-31", periods=6, freq="ME")
+    runner._align_path_windows(merged, _context(dates))
+
+    assert merged["multi_period"]["start"] == "2025-01"
+    assert merged["vol_adjust"]["window"]["length"] == 2
+    assert merged["signals"]["window"] == 2
+    assert merged["signals"]["min_periods"] == 2
+
+
 def test_align_multi_period_dropped_without_context() -> None:
     runner = _runner()
     merged = {"multi_period": {"frequency": "A", "in_sample_len": 3, "out_sample_len": 1}}

--- a/tests/monte_carlo/test_runner_path_window_alignment.py
+++ b/tests/monte_carlo/test_runner_path_window_alignment.py
@@ -165,6 +165,21 @@ def test_align_path_windows_caps_to_retained_multi_period_in_sample_span() -> No
     assert merged["signals"]["min_periods"] == 2
 
 
+def test_align_path_windows_clamps_fallback_cap_to_path_length() -> None:
+    runner = _runner(horizon_years=2.0)
+    merged = {
+        "sample_split": {"method": "date", "date": "2017-12-31"},
+        "vol_adjust": {"enabled": True, "window": {"length": 63}},
+        "signals": {"kind": "tsmom", "window": 63, "min_periods": 63},
+    }
+    dates = pd.date_range("2025-01-31", periods=1, freq="ME")
+    runner._align_path_windows(merged, _context(dates))
+
+    assert merged["vol_adjust"]["window"]["length"] == 1
+    assert merged["signals"]["window"] == 1
+    assert merged["signals"]["min_periods"] == 1
+
+
 def test_path_context_score_frame_uses_path_aligned_windows(
     monkeypatch: Any,
 ) -> None:
@@ -251,6 +266,26 @@ def test_extract_portfolio_metrics_prefers_out_user_stats() -> None:
     assert source == "out_user_stats"
     assert metrics["sharpe"] == 1.5
     assert "is_avg_corr" not in metrics
+
+
+def test_extract_portfolio_metrics_accepts_series_stats() -> None:
+    runner = _runner()
+    per_fund = pd.DataFrame({"sharpe": [0.1, 0.2]}, index=["FundA", "FundB"])
+    run_result = RunResult(
+        metrics=per_fund,
+        details={
+            "out_user_stats": pd.Series(
+                {"sharpe": 1.5, "bad_inf": np.inf, "is_avg_corr": True}
+            )
+        },
+        seed=0,
+        environment={},
+    )
+
+    metrics, source = runner._extract_portfolio_metrics(run_result)
+
+    assert source == "out_user_stats"
+    assert metrics == {"sharpe": 1.5}
 
 
 def test_extract_portfolio_metrics_falls_back_to_metrics_frame() -> None:

--- a/tests/monte_carlo/test_runner_path_window_alignment.py
+++ b/tests/monte_carlo/test_runner_path_window_alignment.py
@@ -17,7 +17,6 @@ import pandas as pd
 from trend_analysis.api import RunResult
 from trend_analysis.monte_carlo.runner import MonteCarloRunner, _PathContext
 from trend_analysis.monte_carlo.scenario import MonteCarloScenario
-from trend_analysis.monte_carlo.strategy import StrategyVariant
 
 
 def _demo_like_config() -> dict[str, Any]:

--- a/tests/monte_carlo/test_runner_path_window_alignment.py
+++ b/tests/monte_carlo/test_runner_path_window_alignment.py
@@ -9,7 +9,7 @@ an empty summary, and a Sharpe "distribution" that is really the path index.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Mapping
 
 import numpy as np
 import pandas as pd
@@ -163,6 +163,52 @@ def test_align_path_windows_caps_to_retained_multi_period_in_sample_span() -> No
     assert merged["vol_adjust"]["window"]["length"] == 2
     assert merged["signals"]["window"] == 2
     assert merged["signals"]["min_periods"] == 2
+
+
+def test_path_context_score_frame_uses_path_aligned_windows(
+    monkeypatch: Any,
+) -> None:
+    runner = _runner(horizon_years=0.5)
+    dates = pd.date_range("2025-01-31", periods=6, freq="ME")
+    returns = pd.DataFrame(
+        {
+            "AssetA": [0.01, 0.02, -0.01, 0.03, 0.01, 0.02],
+            "AssetB": [0.02, -0.01, 0.01, 0.02, 0.03, -0.01],
+        },
+        index=dates,
+    )
+
+    class _PathResult:
+        prices = (1.0 + returns).cumprod() * 100.0
+        log_returns = np.log1p(returns)
+
+    captured: dict[str, Mapping[str, Any] | None] = {}
+
+    def fake_score_frame(
+        _returns: pd.DataFrame,
+        config_data: Mapping[str, Any] | None = None,
+    ) -> pd.DataFrame:
+        captured["config"] = config_data
+        return pd.DataFrame({"sharpe_ratio": [1.0]}, index=["AssetA"])
+
+    monkeypatch.setattr(runner, "_compute_score_frame", fake_score_frame)
+
+    context = runner._generate_path_context(
+        path_id=0,
+        seed=1,
+        model=None,
+        n_periods=6,
+        path_result=_PathResult(),
+        fold_id=None,
+        fold_label=None,
+    )
+
+    score_config = captured["config"]
+    assert isinstance(score_config, Mapping)
+    assert score_config["sample_split"] == {"method": "ratio", "ratio": 0.7}
+    assert "multi_period" not in score_config
+    assert not context.score_frame.empty
+    assert "sharpe_ratio" in context.score_frame.columns
 
 
 def test_align_multi_period_dropped_without_context() -> None:

--- a/tests/streamlit/test_mc_page.py
+++ b/tests/streamlit/test_mc_page.py
@@ -915,6 +915,7 @@ def test_analysis_frame_defaults_to_full_universe_when_no_selection(
 
     expected_managers = [c for c in returns.columns if c.startswith("Mgr_")]
     assert set(expected_managers).issubset(frame.columns), "all managers must be kept"
+    assert "SPX" in frame.columns, "benchmark must be retained for analysis"
     assert frame.shape[1] > 1, "frame must not collapse to the benchmark alone"
 
 

--- a/tests/streamlit/test_mc_page.py
+++ b/tests/streamlit/test_mc_page.py
@@ -913,7 +913,8 @@ def test_analysis_frame_defaults_to_full_universe_when_no_selection(
 
     frame = page._analysis_frame_from_session(returns, {}, "SPX")
 
-    assert [c for c in frame.columns if c.startswith("Mgr_")], "managers must be kept"
+    expected_managers = [c for c in returns.columns if c.startswith("Mgr_")]
+    assert set(expected_managers).issubset(frame.columns), "all managers must be kept"
     assert frame.shape[1] > 1, "frame must not collapse to the benchmark alone"
 
 

--- a/tests/streamlit/test_mc_page.py
+++ b/tests/streamlit/test_mc_page.py
@@ -889,3 +889,43 @@ def test_empty_filtered_results_short_circuits(monkeypatch: pytest.MonkeyPatch) 
     assert any("No results available" in message for message in stub.warning_messages)
     assert not stub.dataframes
     assert not stub.downloads
+
+
+def _universe_returns() -> pd.DataFrame:
+    idx = pd.date_range("2015-01-31", periods=24, freq="ME")
+    cols = {f"Mgr_{i:02d}": [0.01] * len(idx) for i in range(1, 6)}
+    cols["SPX"] = [0.008] * len(idx)
+    cols["RF"] = [0.001] * len(idx)
+    return pd.DataFrame(cols, index=idx)
+
+
+def test_analysis_frame_defaults_to_full_universe_when_no_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One-click demo sets no fund_columns; MC must still use the fund universe.
+
+    Without the fallback the frame would contain only the benchmark column, so
+    Monte Carlo selects zero funds (empty NAV paths, path-index Sharpe axis).
+    """
+    page, stub = _load_page(monkeypatch)
+    returns = _universe_returns()
+    stub.session_state.clear()  # emulate a fresh one-click demo session
+
+    frame = page._analysis_frame_from_session(returns, {}, "SPX")
+
+    assert [c for c in frame.columns if c.startswith("Mgr_")], "managers must be kept"
+    assert frame.shape[1] > 1, "frame must not collapse to the benchmark alone"
+
+
+def test_analysis_frame_respects_explicit_fund_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page, stub = _load_page(monkeypatch)
+    returns = _universe_returns()
+    stub.session_state.clear()
+    stub.session_state["fund_columns"] = ["Mgr_01", "Mgr_02"]
+
+    frame = page._analysis_frame_from_session(returns, {}, "SPX")
+
+    fund_cols = [c for c in frame.columns if c.startswith("Mgr_")]
+    assert fund_cols == ["Mgr_01", "Mgr_02"]

--- a/tests/test_analysis_fleet.py
+++ b/tests/test_analysis_fleet.py
@@ -7,7 +7,10 @@ import pandas as pd
 
 from trend_analysis import api
 from trend_analysis.config import Config
-from trend_analysis.config.coverage import ConfigCoverageTracker, wrap_config_for_coverage
+from trend_analysis.config.coverage import (
+    ConfigCoverageTracker,
+    wrap_config_for_coverage,
+)
 from trend_analysis.llm.analysis_fleet import _config_fingerprint
 from trend_analysis.llm.tracing import load_fleet_records
 

--- a/tests/test_date_column_main_path.py
+++ b/tests/test_date_column_main_path.py
@@ -2,8 +2,8 @@ from types import SimpleNamespace
 
 import pandas as pd
 import pytest
-from trend.diagnostics import DiagnosticResult
 
+from trend.diagnostics import DiagnosticResult
 from trend_analysis import pipeline_entrypoints
 from trend_analysis.data import load_csv
 from trend_analysis.io.market_data import MarketDataValidationError

--- a/tests/test_infer_periods_per_year.py
+++ b/tests/test_infer_periods_per_year.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import pandas as pd
 
-from trend_analysis.backtesting.harness import _infer_periods_per_year as harness_periods
+from trend_analysis.backtesting.harness import (
+    _infer_periods_per_year as harness_periods,
+)
 from trend_analysis.engine.walkforward import _infer_periods_per_year as engine_periods
 from trend_analysis.util.frequency import infer_periods_per_year
 

--- a/tests/test_multi_period_engine_price_frames.py
+++ b/tests/test_multi_period_engine_price_frames.py
@@ -173,6 +173,16 @@ def test_stable_period_seed_does_not_use_python_hash_randomization() -> None:
     assert mp_engine._stable_period_seed(-123, period) == 123 + expected_offset
 
 
+def test_seed_or_default_preserves_explicit_zero_seed() -> None:
+    period = "2020-01/2020-02"
+
+    assert mp_engine._seed_or_default(0) == 0
+    assert mp_engine._seed_or_default(None) == 42
+    assert mp_engine._stable_period_seed(mp_engine._seed_or_default(0), period) != (
+        mp_engine._stable_period_seed(mp_engine._seed_or_default(None), period)
+    )
+
+
 def test_run_requires_csv_path_when_frame_not_provided() -> None:
     cfg = DummyConfig()
     cfg.data = {}

--- a/tests/test_prompt_injection_guard.py
+++ b/tests/test_prompt_injection_guard.py
@@ -10,7 +10,10 @@ pytest.importorskip("langchain_core")
 
 from langchain_core.runnables import RunnableLambda  # noqa: E402
 
-from trend_analysis.llm.chain import ConfigPatchChain, ConfigPatchVariantsChain  # noqa: E402
+from trend_analysis.llm.chain import (  # noqa: E402
+    ConfigPatchChain,
+    ConfigPatchVariantsChain,
+)
 from trend_analysis.llm.injection import (  # noqa: E402
     DEFAULT_BLOCK_SUMMARY,
     detect_prompt_injection,

--- a/tests/test_util_missing_additional.py
+++ b/tests/test_util_missing_additional.py
@@ -8,8 +8,10 @@ import pandas as pd
 import pytest
 
 from trend_analysis.data import load_csv
-from trend_analysis.io.market_data import MarketDataValidationError
-from trend_analysis.io.market_data import _normalise_policy_value
+from trend_analysis.io.market_data import (
+    MarketDataValidationError,
+    _normalise_policy_value,
+)
 from trend_analysis.util import missing
 
 

--- a/tests/test_weighting_resolution.py
+++ b/tests/test_weighting_resolution.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import pytest
 
 from trend_analysis.multi_period.engine import _resolve_portfolio_weighting
-from trend_analysis.weighting import EqualWeight
-from trend_analysis.weighting import ScorePropSimple
+from trend_analysis.weighting import EqualWeight, ScorePropSimple
 from trend_analysis.weights.risk_parity import RiskParity
 
 

--- a/tests/workflows/test_autofix_repo_regressions.py
+++ b/tests/workflows/test_autofix_repo_regressions.py
@@ -7,10 +7,10 @@ import numpy as np
 import pandas as pd
 import yaml
 
+from tests.workflows.fixtures.automation_multifailure import aggregate_numbers
 from trend_analysis.constants import NUMERICAL_TOLERANCE_MEDIUM
 from trend_analysis.selector import RankSelector
 from trend_analysis.weighting import EqualWeight
-from tests.workflows.fixtures.automation_multifailure import aggregate_numbers
 
 EXPECTED_AUTOFIX_SELECTED_FUNDS = 2
 EXPECTED_AGGREGATE_OUTPUT = "1 | 2 | 3"


### PR DESCRIPTION
## Problem

Running the Streamlit demo Monte Carlo scenario (`Run Demo` -> Monte Carlo -> `hf_diversified_5y` -> Run) produced degenerate results: empty NAV paths / fan chart, an empty summary, and a Sharpe histogram whose axis was path ids rather than Sharpe values.

Two upstream causes were found:

1. The one-click demo did not set `fund_columns`, so `_analysis_frame_from_session` fed the runner a benchmark-only frame.
2. The runner evaluated short, forward-dated simulated paths against historical static windows (`multi_period`, fixed-date `sample_split`, and 63-period rolling lookbacks) that did not overlap or fit the simulated horizon.

## Fix

- Default the MC analysis frame to the full investable universe when no explicit fund selection exists.
- Rebase each path's `multi_period` schedule onto the simulated path span and drop it only when it cannot produce a viable schedule.
- Replace fixed-date `sample_split` with a path-relative ratio split.
- Cap `vol_adjust.window`, `signals.window`, and `signals.min_periods` to the retained multi-period in-sample span when present, otherwise to the short path horizon.
- Report portfolio-level OOS metrics rather than falling back to an arbitrary constituent fund row.
- Use deterministic digest-based seeds in the remaining multi-period random paths.
- Apply entry eligibility filtering to low-weight replacements and preserve intentional empty holdings in the manual pipeline.

## Review Status

Review feedback has been addressed through commit `2e80866c`.

Merge condition: this PR should be mergeable once the post-push CI checks finish green and review bots do not raise new actionable findings. There is no remaining owner-held "do not merge" condition on the PR.

## Verification

- `uv run ruff check src/trend_analysis/monte_carlo/runner.py src/trend_analysis/multi_period/engine.py tests/streamlit/test_mc_page.py tests/monte_carlo/test_runner_path_window_alignment.py`
- `uv run mypy --config-file pyproject.toml --exclude .workflows-lib src/trend_analysis/monte_carlo/runner.py src/trend_analysis/multi_period/engine.py`
- `uv run pytest tests/streamlit/test_mc_page.py tests/monte_carlo/test_runner_path_window_alignment.py tests/test_multi_period_engine_price_frames.py::test_stable_period_seed_does_not_use_python_hash_randomization tests/test_multi_period_engine_price_frames.py::test_seed_or_default_preserves_explicit_zero_seed tests/test_multi_period_exits_cooldown.py::test_threshold_hold_new_hires_survive_manual_pipeline tests/test_multi_period_engine_additional.py::test_run_threshold_hold_low_weight_replacement tests/test_multi_period_engine_threshold_edgecases.py::test_threshold_hold_drops_low_weight_and_replenishes tests/test_engine_run_refactor_parity.py`

## Separate Follow-Up Areas

- WASM chart rendering version skew remains separate from the data fix.
- Regular demo analysis / Results-page fund selection remains separate from this MC-focused PR.
- Sibling MC scenarios may still need standalone risk-free config parity, but the UI config path covered here now enables the fallback.
