### PR TITLE
Tighten Streamlit theme verifier coverage

### DIFF
--- a/streamlit_app/pages/1_Data.py
+++ b/streamlit_app/pages/1_Data.py
@@ -31,11 +31,12 @@ from streamlit_app.components.upload_guard import (
     guard_and_buffer_upload,
     hash_path,
 )
-from streamlit_app.theme import apply_ds_theme
+from streamlit_app.theme import apply_density_compact, apply_ds_theme
 from trend.input_validation import InputValidationError
 from trend_analysis.io.market_data import MarketDataValidationError
 
 apply_ds_theme()
+apply_density_compact()
 
 DATE_COLUMN = "Date"
 REQUIRED_UPLOAD_COLUMNS = (DATE_COLUMN,)
@@ -57,18 +58,26 @@ def _ensure_fund_table_state(
     table_key = _fund_table_state_key(data_key)
     existing = st.session_state.get(table_key)
 
-    if isinstance(existing, pd.DataFrame) and {"Include", "Fund Name"}.issubset(existing.columns):
+    if isinstance(existing, pd.DataFrame) and {"Include", "Fund Name"}.issubset(
+        existing.columns
+    ):
         df_existing = existing[["Include", "Fund Name"]].copy()
         df_existing["Fund Name"] = df_existing["Fund Name"].astype(str)
-        df_existing["Include"] = df_existing["Include"].astype("boolean").fillna(False).astype(bool)
+        df_existing["Include"] = (
+            df_existing["Include"].astype("boolean").fillna(False).astype(bool)
+        )
         if df_existing["Fund Name"].tolist() == list(available_funds):
             st.session_state[table_key] = df_existing
             return table_key
 
-        include_map = dict(zip(df_existing["Fund Name"].tolist(), df_existing["Include"].tolist()))
+        include_map = dict(
+            zip(df_existing["Fund Name"].tolist(), df_existing["Include"].tolist())
+        )
         st.session_state[table_key] = pd.DataFrame(
             {
-                "Include": [bool(include_map.get(fund, False)) for fund in available_funds],
+                "Include": [
+                    bool(include_map.get(fund, False)) for fund in available_funds
+                ],
                 "Fund Name": [str(fund) for fund in available_funds],
             }
         )
@@ -174,9 +183,9 @@ def _store_dataset(
         selected_bench = st.session_state.get("selected_benchmark")
         system_cols = {selected_rf, selected_bench, "Date"} - {None}
         fund_cols = [c for c in all_columns if c not in system_cols]
-        restored_funds = st.session_state.get("analysis_fund_columns") or st.session_state.get(
-            "fund_columns"
-        )
+        restored_funds = st.session_state.get(
+            "analysis_fund_columns"
+        ) or st.session_state.get("fund_columns")
         if isinstance(restored_funds, list):
             selected_funds = [c for c in restored_funds if c in fund_cols]
         else:
@@ -248,7 +257,9 @@ def _render_date_correction_ui(message: str, correction: DateCorrectionNeeded) -
         )
 
     if correction.unfixable:
-        st.error(f"⚠️ {len(correction.unfixable)} date(s) cannot be automatically corrected:")
+        st.error(
+            f"⚠️ {len(correction.unfixable)} date(s) cannot be automatically corrected:"
+        )
         for idx, val in correction.unfixable[:5]:
             st.write(f"• Row {idx + 1}: `{val}`")
         if len(correction.unfixable) > 5:
@@ -498,7 +509,9 @@ def render_data_page() -> None:
     options.append("Upload your own")
 
     requested_source = st.session_state.get("data_source", "Sample dataset")
-    default_index = options.index(requested_source) if requested_source in options else 0
+    default_index = (
+        options.index(requested_source) if requested_source in options else 0
+    )
     source = st.radio("Data source", options, index=default_index)
     st.session_state["data_source"] = source
 
@@ -522,7 +535,9 @@ def render_data_page() -> None:
                 _render_validation(meta)
                 st.dataframe(df.head(20))
     else:
-        upload_widget_key = f"upload_returns::{st.session_state.get('upload_widget_version', 0)}"
+        upload_widget_key = (
+            f"upload_returns::{st.session_state.get('upload_widget_version', 0)}"
+        )
         uploaded = st.file_uploader(
             "Upload returns (CSV or Excel with a Date column)",
             type=["csv", "xlsx", "xls"],
@@ -532,7 +547,9 @@ def render_data_page() -> None:
         if uploaded is not None:
             _load_uploaded_dataset(uploaded)
         elif not app_state.has_valid_upload():
-            st.info("No dataset loaded yet. Switch to the sample tab for a quick start.")
+            st.info(
+                "No dataset loaded yet. Switch to the sample tab for a quick start."
+            )
 
     if app_state.has_valid_upload():
         df, meta = app_state.get_uploaded_data()
@@ -563,7 +580,9 @@ def render_data_page() -> None:
 
                 def on_rf_change():
                     val = st.session_state["_widget_rf"]
-                    st.session_state["selected_risk_free"] = None if val == "(None)" else val
+                    st.session_state["selected_risk_free"] = (
+                        None if val == "(None)" else val
+                    )
 
                 st.selectbox(
                     "Risk-Free Rate Column",
@@ -589,7 +608,9 @@ def render_data_page() -> None:
 
                 def on_bench_change():
                     val = st.session_state["_widget_bench"]
-                    st.session_state["selected_benchmark"] = None if val == "(None)" else val
+                    st.session_state["selected_benchmark"] = (
+                        None if val == "(None)" else val
+                    )
 
                 st.selectbox(
                     "Benchmark Column (optional)",
@@ -619,10 +640,12 @@ def render_data_page() -> None:
 
             # Default: select all non-index columns.
             # Index-like columns are inferred from benchmark/risk-free candidates.
-            index_candidates = set(st.session_state.get("benchmark_candidates", [])) | set(
-                st.session_state.get("risk_free_candidates", [])
-            )
-            default_selected_funds = [c for c in available_funds if c not in index_candidates]
+            index_candidates = set(
+                st.session_state.get("benchmark_candidates", [])
+            ) | set(st.session_state.get("risk_free_candidates", []))
+            default_selected_funds = [
+                c for c in available_funds if c not in index_candidates
+            ]
 
             _t_funds_derived = time.perf_counter()
 
@@ -641,11 +664,15 @@ def render_data_page() -> None:
                 else:
                     st.session_state["selected_fund_columns"] = list(available_funds)
             if "fund_columns" not in st.session_state:
-                st.session_state["fund_columns"] = list(st.session_state["selected_fund_columns"])
+                st.session_state["fund_columns"] = list(
+                    st.session_state["selected_fund_columns"]
+                )
 
             # Current valid selection (respect available funds)
             current_selection = [
-                f for f in st.session_state.get("selected_fund_columns", []) if f in available_funds
+                f
+                for f in st.session_state.get("selected_fund_columns", [])
+                if f in available_funds
             ]
 
             # Default: select all funds (everything except system/index columns).
@@ -694,7 +721,9 @@ def render_data_page() -> None:
 
             # Multi-select (range) — shift-click equivalent.
             with st.expander("Bulk add/remove (range select)", expanded=True):
-                st.caption("Select a start and end fund, then include/exclude the whole range.")
+                st.caption(
+                    "Select a start and end fund, then include/exclude the whole range."
+                )
 
                 range_cols = st.columns(4)
                 with range_cols[0]:
@@ -796,14 +825,18 @@ def render_data_page() -> None:
                 st.session_state["fund_columns"] = list(new_selection_list)
 
             # Keep downstream analysis aligned with the visible checkbox state.
-            sanitized_selection = [c for c in new_selection_list if c not in system_columns]
+            sanitized_selection = [
+                c for c in new_selection_list if c not in system_columns
+            ]
             previous_analysis_selection = st.session_state.get("analysis_fund_columns")
             if previous_analysis_selection != sanitized_selection:
                 st.session_state["analysis_fund_columns"] = list(sanitized_selection)
                 if previous_analysis_selection is not None:
                     analysis_runner.clear_cached_analysis()
             fund_label = "fund" if len(sanitized_selection) == 1 else "funds"
-            st.caption(f"Applied automatically for analysis: {len(sanitized_selection)} {fund_label}")
+            st.caption(
+                f"Applied automatically for analysis: {len(sanitized_selection)} {fund_label}"
+            )
 
             # Show current configuration summary
             st.markdown("---")
@@ -834,15 +867,23 @@ def render_data_page() -> None:
                     "range_funds_count": len(range_funds),
                     "defaults_seeded_count": len(defaults),
                     "perf_ms": {
-                        "derive_funds": round((_t_funds_derived - _t_fund_start) * 1000, 2),
-                        "seed_defaults": round((_t_seed_done - _t_seed_start) * 1000, 2),
-                        "render_checkboxes": round((_t_render_done - _t_render_start) * 1000, 2),
+                        "derive_funds": round(
+                            (_t_funds_derived - _t_fund_start) * 1000, 2
+                        ),
+                        "seed_defaults": round(
+                            (_t_seed_done - _t_seed_start) * 1000, 2
+                        ),
+                        "render_checkboxes": round(
+                            (_t_render_done - _t_render_start) * 1000, 2
+                        ),
                         "fund_total": round((_t_render_done - _t_fund_start) * 1000, 2),
                     },
                     "selected_fund_columns_count": len(
                         st.session_state.get("selected_fund_columns") or []
                     ),
-                    "fund_columns_count": len(st.session_state.get("fund_columns") or []),
+                    "fund_columns_count": len(
+                        st.session_state.get("fund_columns") or []
+                    ),
                 }
 
                 history = st.session_state.get("_debug_fund_history", [])
@@ -856,7 +897,9 @@ def render_data_page() -> None:
                         "latest": snapshot,
                         "history": st.session_state.get("_debug_fund_history", []),
                         "available_funds": available_funds,
-                        "selected_fund_columns": st.session_state.get("selected_fund_columns"),
+                        "selected_fund_columns": st.session_state.get(
+                            "selected_fund_columns"
+                        ),
                         "fund_columns": st.session_state.get("fund_columns"),
                         "checkbox_prefix": include_prefix,
                     }

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -40,7 +40,7 @@ from streamlit_app.components.progress_eta import (
     progress_ratio_and_remaining,
     update_eta_seconds,
 )
-from streamlit_app.theme import apply_ds_theme
+from streamlit_app.theme import apply_density_compact, apply_ds_theme
 from trend_analysis.config.patch import apply_config_patch, diff_configs
 from trend_analysis.llm import (
     ConfigPatchChain,
@@ -53,6 +53,7 @@ from trend_analysis.llm import (
 from trend_analysis.llm.schema import load_compact_schema
 
 apply_ds_theme()
+apply_density_compact()
 
 # Extended metric fields for ranking
 METRIC_FIELDS = [
@@ -169,7 +170,9 @@ def _chain_resource_signature(
     chain_cache_key: Mapping[str, Any],
     llm_cache_key: Mapping[str, Any],
 ) -> str:
-    return _chain_cache_signature({"chain": dict(chain_cache_key), "llm": dict(llm_cache_key)})
+    return _chain_cache_signature(
+        {"chain": dict(chain_cache_key), "llm": dict(llm_cache_key)}
+    )
 
 
 def _chain_cache_summary(
@@ -426,7 +429,9 @@ def _record_chain_cache_stats(
     stats["last_build_seconds"] = chain_build_seconds
     stats["last_reused"] = reused
     stats["last_miss_reason"] = chain_meta.get("chain_cache_miss_reason")
-    stats["last_invalidation_fields"] = chain_meta.get("chain_cache_invalidation_fields")
+    stats["last_invalidation_fields"] = chain_meta.get(
+        "chain_cache_invalidation_fields"
+    )
     stats["last_signature"] = chain_meta.get("chain_cache_signature")
     stats["timestamp"] = datetime.utcnow().isoformat(timespec="seconds") + "Z"
     st.session_state[_CONFIG_CHAIN_STATS_KEY] = stats
@@ -452,7 +457,9 @@ def _preview_timing_summary(
     build = _format_seconds(timings.get("chain_build_seconds"))
     lookup = _format_seconds(timings.get("chain_lookup_seconds"))
     run = _format_seconds(timings.get("run_seconds"))
-    total_value = total_seconds if total_seconds is not None else timings.get("total_seconds")
+    total_value = (
+        total_seconds if total_seconds is not None else timings.get("total_seconds")
+    )
     total = _format_seconds(total_value)
     return (
         "Preview timing: "
@@ -480,15 +487,23 @@ def _render_preview_timing_history() -> None:
         cache_reason_label = str(cache_reason) if cache_reason else "—"
         invalidation_fields = entry.get("cache_invalidation_fields")
         invalidation_label = (
-            ", ".join(invalidation_fields) if isinstance(invalidation_fields, list) else "—"
+            ", ".join(invalidation_fields)
+            if isinstance(invalidation_fields, list)
+            else "—"
         )
         llm_changed_fields = entry.get("cache_llm_changed_fields")
         llm_changed_label = (
-            ", ".join(llm_changed_fields) if isinstance(llm_changed_fields, list) else "—"
+            ", ".join(llm_changed_fields)
+            if isinstance(llm_changed_fields, list)
+            else "—"
         )
         settings_changed = entry.get("cache_settings_changed")
         settings_changed_label = (
-            "Yes" if settings_changed is True else "No" if settings_changed is False else "—"
+            "Yes"
+            if settings_changed is True
+            else "No"
+            if settings_changed is False
+            else "—"
         )
         cache_reset = entry.get("cache_session_reset")
         cache_reset_label = "Yes" if cache_reset else "No"
@@ -542,7 +557,11 @@ def _render_last_preview_metrics() -> None:
     )
     settings_changed = metrics.get("cache_settings_changed")
     settings_changed_label = (
-        "Yes" if settings_changed is True else "No" if settings_changed is False else "—"
+        "Yes"
+        if settings_changed is True
+        else "No"
+        if settings_changed is False
+        else "—"
     )
     cache_reset = metrics.get("cache_session_reset")
     cache_reset_label = "Yes" if cache_reset else "No"
@@ -909,7 +928,9 @@ def _resolve_llm_session_overrides() -> dict[str, str | None]:
         "provider": provider_override,
         "model": _normalize_cache_str(str(model)) if model else None,
         "base_url": _normalize_cache_str(str(base_url)) if base_url else None,
-        "organization": (_normalize_cache_str(str(organization)) if organization else None),
+        "organization": (
+            _normalize_cache_str(str(organization)) if organization else None
+        ),
     }
 
 
@@ -920,7 +941,9 @@ def _fallback_llm_provider_config() -> LLMProviderConfig:
     if provider not in {"openai", "anthropic", "ollama"}:
         provider = _DEFAULT_CONFIG_CHAT_PROVIDER
     model = (
-        overrides.get("model") or os.environ.get("TREND_LLM_MODEL") or _DEFAULT_CONFIG_CHAT_MODEL
+        overrides.get("model")
+        or os.environ.get("TREND_LLM_MODEL")
+        or _DEFAULT_CONFIG_CHAT_MODEL
     )
     base_url = overrides.get("base_url") or os.environ.get("TREND_LLM_BASE_URL")
     organization = overrides.get("organization") or os.environ.get("TREND_LLM_ORG")
@@ -967,7 +990,9 @@ def _maybe_reset_config_chat_cache(snapshot: Mapping[str, Any]) -> list[str]:
     previous_normalized = {key: previous.get(key) for key in normalized}
     if previous_normalized == normalized:
         return []
-    changed = [key for key in normalized if previous_normalized.get(key) != normalized.get(key)]
+    changed = [
+        key for key in normalized if previous_normalized.get(key) != normalized.get(key)
+    ]
     st.session_state[_LLM_OVERRIDE_SNAPSHOT_KEY] = normalized
     st.session_state.pop("config_chat_preview", None)
     st.session_state.pop("config_chat_last_instruction", None)
@@ -1033,7 +1058,8 @@ def _render_llm_status_panel() -> None:
     selected_provider = _normalize_cache_str(st.session_state.get("selected_provider"))
     selected_provider = (selected_provider or _DEFAULT_CONFIG_CHAT_PROVIDER).lower()
     selected_model = (
-        _normalize_cache_str(st.session_state.get("selected_model")) or _DEFAULT_CONFIG_CHAT_MODEL
+        _normalize_cache_str(st.session_state.get("selected_model"))
+        or _DEFAULT_CONFIG_CHAT_MODEL
     )
     provider_label = provider_labels.get(selected_provider, selected_provider)
     st.info(f"Active provider: {provider_label}")
@@ -1053,12 +1079,15 @@ def _render_llm_status_panel() -> None:
     if missing_vars:
         missing_list = ", ".join(missing_vars)
         st.warning(
-            f"Missing required environment variables for {provider_label}. " f"Set: {missing_list}."
+            f"Missing required environment variables for {provider_label}. "
+            f"Set: {missing_list}."
         )
 
 
 def _sync_llm_selection_from_overrides() -> None:
-    provider_override = _normalize_cache_str(st.session_state.get(_LLM_PROVIDER_OVERRIDE_KEY))
+    provider_override = _normalize_cache_str(
+        st.session_state.get(_LLM_PROVIDER_OVERRIDE_KEY)
+    )
     if provider_override:
         st.session_state["selected_provider"] = provider_override.lower()
     else:
@@ -1076,7 +1105,9 @@ def _sync_llm_selection_from_overrides() -> None:
 
 def _render_llm_session_overrides_panel() -> None:
     with st.expander("LLM Settings (Session Only)", expanded=False):
-        st.caption("Overrides apply only to this session and do not store or display API keys.")
+        st.caption(
+            "Overrides apply only to this session and do not store or display API keys."
+        )
         provider_options = [None, "openai", "anthropic", "ollama"]
         provider_labels = {
             None: "Use env default",
@@ -1123,7 +1154,9 @@ def _render_llm_session_overrides_panel() -> None:
             except (TypeError, ValueError):
                 st.warning("Temperature override must be a number; using env default.")
         _sync_llm_selection_from_overrides()
-        _maybe_reset_config_chat_cache(_current_chain_settings_snapshot(allow_missing_api_key=True))
+        _maybe_reset_config_chat_cache(
+            _current_chain_settings_snapshot(allow_missing_api_key=True)
+        )
 
 
 def _normalize_temperature(value: float) -> float:
@@ -1324,7 +1357,9 @@ def _build_nl_chain(
 ) -> tuple[ConfigPatchChain, dict[str, Any]]:
     config = _resolve_llm_provider_config()
     resolved_provider = (
-        _normalize_cache_str(provider) or _normalize_cache_str(config.provider) or "openai"
+        _normalize_cache_str(provider)
+        or _normalize_cache_str(config.provider)
+        or "openai"
     )
     resolved_model = (
         _normalize_cache_str(model)
@@ -1345,7 +1380,9 @@ def _build_nl_chain(
         temperature if temperature is not None else _resolve_llm_temperature()
     )
     resolved_timeout = timeout if timeout is not None else config.timeout
-    resolved_max_retries = max_retries if max_retries is not None else config.max_retries
+    resolved_max_retries = (
+        max_retries if max_retries is not None else config.max_retries
+    )
     resolved_payload = (
         extra_payload if extra_payload is not None else _serialize_extra(config.extra)
     )
@@ -1382,10 +1419,16 @@ def _build_nl_chain(
     previous_cache_key = cache_state.get("last_cache_key")
     previous_llm_cache_key = cache_state.get("last_llm_cache_key")
     previous_invalidation_key = None
-    if isinstance(previous_cache_key, Mapping) or isinstance(previous_llm_cache_key, Mapping):
-        previous_invalidation_key = _merge_cache_keys(previous_cache_key, previous_llm_cache_key)
+    if isinstance(previous_cache_key, Mapping) or isinstance(
+        previous_llm_cache_key, Mapping
+    ):
+        previous_invalidation_key = _merge_cache_keys(
+            previous_cache_key, previous_llm_cache_key
+        )
     current_invalidation_key = _merge_cache_keys(cache_key, llm_cache_key)
-    changed_fields = _cache_key_changes(previous_cache_key, cache_key, _CONFIG_CHAIN_CORE_FIELDS)
+    changed_fields = _cache_key_changes(
+        previous_cache_key, cache_key, _CONFIG_CHAIN_CORE_FIELDS
+    )
     llm_changed_fields = _cache_key_changes(
         previous_llm_cache_key,
         llm_cache_key,
@@ -1402,7 +1445,8 @@ def _build_nl_chain(
         or reset_fields
     )
     resource_changed = bool(
-        previous_resource_signature and previous_resource_signature != resource_signature
+        previous_resource_signature
+        and previous_resource_signature != resource_signature
     )
     session_reset = False
     if invalidation_fields:
@@ -1430,7 +1474,9 @@ def _build_nl_chain(
     if not reused:
         if settings_changed:
             if invalidation_fields:
-                cache_miss_reason = f"settings_changed: {', '.join(invalidation_fields)}"
+                cache_miss_reason = (
+                    f"settings_changed: {', '.join(invalidation_fields)}"
+                )
             elif changed_fields:
                 cache_miss_reason = f"settings_changed: {', '.join(changed_fields)}"
             else:
@@ -1534,8 +1580,12 @@ def _extract_metric_map(result: Any) -> dict[str, float | None]:
 
 
 def _build_variant_metrics_table(results: Mapping[str, Any]) -> pd.DataFrame:
-    metrics_by_label = {label: _extract_metric_map(result) for label, result in results.items()}
-    all_metrics = sorted({key for metrics in metrics_by_label.values() for key in metrics})
+    metrics_by_label = {
+        label: _extract_metric_map(result) for label, result in results.items()
+    }
+    all_metrics = sorted(
+        {key for metrics in metrics_by_label.values() for key in metrics}
+    )
 
     ordered_labels = [
         label for label in _VARIANT_LABEL_ORDER if label in metrics_by_label
@@ -1581,7 +1631,9 @@ def _generate_config_preview(
             "chain_resource_signature": chain_meta.get("chain_resource_signature"),
             "chain_cache_summary": chain_meta.get("chain_cache_summary"),
             "chain_cache_miss_reason": chain_meta.get("chain_cache_miss_reason"),
-            "chain_cache_invalidation_fields": chain_meta.get("chain_cache_invalidation_fields"),
+            "chain_cache_invalidation_fields": chain_meta.get(
+                "chain_cache_invalidation_fields"
+            ),
             "chain_settings_changed": chain_meta.get("chain_settings_changed"),
             "chain_llm_changed_fields": chain_meta.get("chain_llm_changed_fields"),
             "chain_cache_session_reset": chain_meta.get("chain_cache_session_reset"),
@@ -1651,7 +1703,9 @@ def _current_run_key(model_state: dict[str, Any], benchmark: str | None) -> str:
     selected_rf = st.session_state.get("selected_risk_free")
     selected_rf_key = selected_rf or "__none__"
     info_ratio_benchmark = (
-        model_state.get("info_ratio_benchmark") if isinstance(model_state, dict) else None
+        model_state.get("info_ratio_benchmark")
+        if isinstance(model_state, dict)
+        else None
     )
     regime_proxy = None
     if bool(model_state.get("regime_enabled", False)):
@@ -1764,7 +1818,9 @@ def _render_risky_change_dialog() -> None:
         cancel = st.button("Cancel", type="secondary")
         if confirm:
             st.session_state.pop("config_chat_pending_apply", None)
-            _apply_preview_state(preview, run_analysis=bool(pending.get("run_analysis")))
+            _apply_preview_state(
+                preview, run_analysis=bool(pending.get("run_analysis"))
+            )
         elif cancel:
             st.session_state.pop("config_chat_pending_apply", None)
 
@@ -1864,8 +1920,12 @@ def _render_unified_diff(diff_text: str) -> None:
     st.markdown(_diff_text_to_html(diff_text), unsafe_allow_html=True)
 
 
-def _render_side_by_side_diff(before: Mapping[str, Any], after: Mapping[str, Any]) -> None:
-    before_yaml = yaml.safe_dump(dict(before), sort_keys=False, default_flow_style=False)
+def _render_side_by_side_diff(
+    before: Mapping[str, Any], after: Mapping[str, Any]
+) -> None:
+    before_yaml = yaml.safe_dump(
+        dict(before), sort_keys=False, default_flow_style=False
+    )
     after_yaml = yaml.safe_dump(dict(after), sort_keys=False, default_flow_style=False)
     differ = difflib.HtmlDiff(tabsize=2, wrapcolumn=80)
     diff_table = differ.make_table(
@@ -1917,10 +1977,16 @@ def _render_config_diff_preview(model_state: Mapping[str, Any] | None) -> None:
         cache_signature_label = str(cache_signature)[:8] if cache_signature else "—"
         settings_changed = timings.get("chain_settings_changed")
         settings_changed_label = (
-            "Yes" if settings_changed is True else "No" if settings_changed is False else "—"
+            "Yes"
+            if settings_changed is True
+            else "No"
+            if settings_changed is False
+            else "—"
         )
         cache_miss_reason = timings.get("chain_cache_miss_reason")
-        cache_miss_label = f" | Cache miss: {cache_miss_reason}" if cache_miss_reason else ""
+        cache_miss_label = (
+            f" | Cache miss: {cache_miss_reason}" if cache_miss_reason else ""
+        )
         invalidation_fields = timings.get("chain_cache_invalidation_fields")
         invalidation_label = (
             f" | Invalidated by: {', '.join(invalidation_fields)}"
@@ -2000,7 +2066,9 @@ def _render_config_chat_contents(model_state: Mapping[str, Any] | None) -> None:
             else "—"
         )
         cache_signature = (
-            _chain_cache_signature(cache_key)[:8] if isinstance(cache_key, Mapping) else "—"
+            _chain_cache_signature(cache_key)[:8]
+            if isinstance(cache_key, Mapping)
+            else "—"
         )
         st.caption(f"Current cache key: {cache_summary} | Sig: {cache_signature}")
     instruction = st.text_area(
@@ -2018,7 +2086,9 @@ def _render_config_chat_contents(model_state: Mapping[str, Any] | None) -> None:
             st.session_state["config_chat_last_instruction"] = trimmed
             st.success("Instruction captured. Preview coming next.")
     preview = st.session_state.get("config_chat_preview")
-    has_preview = isinstance(preview, Mapping) and isinstance(preview.get("after"), Mapping)
+    has_preview = isinstance(preview, Mapping) and isinstance(
+        preview.get("after"), Mapping
+    )
     action_cols = st.columns(4)
     with action_cols[0]:
         preview_clicked = st.button(
@@ -2150,7 +2220,9 @@ def _render_variant_what_if_panel(
         height=110,
         placeholder="e.g. Reduce turnover and tighten max weight while preserving returns.",
     )
-    run_clicked = st.button("Run What-if (3 variants)", key="what_if_run", type="primary")
+    run_clicked = st.button(
+        "Run What-if (3 variants)", key="what_if_run", type="primary"
+    )
 
     if run_clicked:
         st.session_state.pop("what_if_variant_results", None)
@@ -2169,7 +2241,9 @@ def _render_variant_what_if_panel(
             progress_bar = progress_slot.progress(0.0, text="Generating variants...")
             try:
                 chain, _ = _get_variant_chain()
-                variants = chain.run(current_config=dict(model_state), instruction=trimmed)
+                variants = chain.run(
+                    current_config=dict(model_state), instruction=trimmed
+                )
 
                 def _progress(label: str, idx: int, total: int) -> None:
                     progress_bar.progress(
@@ -2813,7 +2887,9 @@ def render_model_page() -> None:
             applied_funds = st.session_state.get("fund_columns")
 
         if isinstance(applied_funds, list) and applied_funds:
-            fund_cols = [c for c in applied_funds if c in df.columns and c not in system_cols]
+            fund_cols = [
+                c for c in applied_funds if c in df.columns and c not in system_cols
+            ]
         else:
             # Fallback: count only fund columns (exclude benchmarks/indices)
             fund_cols = [
@@ -2902,14 +2978,18 @@ def render_model_page() -> None:
                         else "Disabled until a duplicate name is entered."
                     ),
                 )
-                save_clicked = st.form_submit_button("Save Current Settings", type="primary")
+                save_clicked = st.form_submit_button(
+                    "Save Current Settings", type="primary"
+                )
 
             if save_clicked:
                 trimmed = save_name.strip()
                 if not trimmed:
                     st.error("Enter a name to save your configuration.")
                 elif overwrite_required and not overwrite_confirmed:
-                    st.warning("This name already exists. Check 'Confirm overwrite' to replace it.")
+                    st.warning(
+                        "This name already exists. Check 'Confirm overwrite' to replace it."
+                    )
                 else:
                     app_state.save_model_state(trimmed, st.session_state["model_state"])
                     app_state.save_config_wrapper(
@@ -2925,7 +3005,9 @@ def render_model_page() -> None:
         with manage_col:
             st.markdown("**Load or manage saved configurations**")
             if not saved_names:
-                st.info("No saved configurations yet. Save one to enable loading and export.")
+                st.info(
+                    "No saved configurations yet. Save one to enable loading and export."
+                )
             else:
                 selected_index = 0
                 active_saved_name = st.session_state.get("active_saved_model_name")
@@ -2938,7 +3020,9 @@ def render_model_page() -> None:
                     key="saved_configuration_selector",
                 )
 
-                if st.button("Load selected configuration", key="load_saved_config_button"):
+                if st.button(
+                    "Load selected configuration", key="load_saved_config_button"
+                ):
                     wrapper = app_state.load_saved_config_wrapper(selected_saved)
                     if isinstance(wrapper, Mapping):
                         _apply_config_wrapper(wrapper)
@@ -2966,12 +3050,18 @@ def render_model_page() -> None:
 
                 if rename_clicked:
                     try:
-                        app_state.rename_saved_model_state(selected_saved, rename_target)
+                        app_state.rename_saved_model_state(
+                            selected_saved, rename_target
+                        )
                     except (KeyError, ValueError) as exc:
                         st.error(str(exc))
                     else:
-                        st.session_state["active_saved_model_name"] = rename_target.strip()
-                        st.success(f"Renamed configuration to '{rename_target.strip()}'.")
+                        st.session_state["active_saved_model_name"] = (
+                            rename_target.strip()
+                        )
+                        st.success(
+                            f"Renamed configuration to '{rename_target.strip()}'."
+                        )
                         st.rerun()
 
                 if st.button(
@@ -2980,7 +3070,10 @@ def render_model_page() -> None:
                     type="secondary",
                 ):
                     app_state.delete_saved_model_state(selected_saved)
-                    if st.session_state.get("active_saved_model_name") == selected_saved:
+                    if (
+                        st.session_state.get("active_saved_model_name")
+                        == selected_saved
+                    ):
                         st.session_state.pop("active_saved_model_name", None)
                     st.success(f"Deleted configuration '{selected_saved}'.")
                     st.rerun()
@@ -2990,7 +3083,9 @@ def render_model_page() -> None:
         # Quick download of current configuration (without saving)
         st.markdown("**Download Current Configuration**")
         current_wrapper = _build_config_wrapper(st.session_state["model_state"])
-        current_payload = json.dumps(current_wrapper, indent=2, sort_keys=True, default=str)
+        current_payload = json.dumps(
+            current_wrapper, indent=2, sort_keys=True, default=str
+        )
         # Use active saved name if set, else uploaded filename, else "config"
         config_name = (
             st.session_state.get("active_saved_model_name")
@@ -3017,7 +3112,9 @@ def render_model_page() -> None:
             if saved_names:
                 export_index = 0
                 if st.session_state.get("active_saved_model_name") in saved_names:
-                    export_index = saved_names.index(st.session_state["active_saved_model_name"])
+                    export_index = saved_names.index(
+                        st.session_state["active_saved_model_name"]
+                    )
                 export_target = st.selectbox(
                     "Choose configuration to export",
                     saved_names,
@@ -3045,7 +3142,9 @@ def render_model_page() -> None:
 
         with import_col:
             st.markdown("**Import configuration from JSON**")
-            import_name = st.text_input("Name for imported configuration", key="import_config_name")
+            import_name = st.text_input(
+                "Name for imported configuration", key="import_config_name"
+            )
             uploaded_config = st.file_uploader(
                 "Upload JSON file",
                 type=["json"],
@@ -3056,7 +3155,9 @@ def render_model_page() -> None:
                 try:
                     raw_value = uploaded_config.getvalue()
                     if isinstance(raw_value, bytes):
-                        st.session_state["import_config_payload"] = raw_value.decode("utf-8-sig")
+                        st.session_state["import_config_payload"] = raw_value.decode(
+                            "utf-8-sig"
+                        )
                     else:
                         st.session_state["import_config_payload"] = str(raw_value)
                 except UnicodeDecodeError:
@@ -3065,26 +3166,38 @@ def render_model_page() -> None:
                         "Please upload a UTF-8 encoded JSON file."
                     )
                 except (AttributeError, TypeError):
-                    st.error("Unable to read uploaded JSON file due to an unexpected file format.")
+                    st.error(
+                        "Unable to read uploaded JSON file due to an unexpected file format."
+                    )
                 except OSError as exc:
                     st.error(f"Unable to read uploaded file: {exc}")
-            import_payload = st.text_area("Paste JSON to import", key="import_config_payload")
+            import_payload = st.text_area(
+                "Paste JSON to import", key="import_config_payload"
+            )
             if st.button("Import JSON configuration", key="import_config_button"):
                 if not import_payload.strip():
                     st.error("Paste a JSON payload to import a configuration.")
                 else:
                     try:
-                        imported_state = app_state.import_model_state(import_name, import_payload)
+                        imported_state = app_state.import_model_state(
+                            import_name, import_payload
+                        )
                     except ValueError as exc:
                         st.error(str(exc))
                     else:
-                        st.session_state["active_saved_model_name"] = import_name.strip()
-                        wrapper = app_state.load_saved_config_wrapper(import_name.strip())
+                        st.session_state["active_saved_model_name"] = (
+                            import_name.strip()
+                        )
+                        wrapper = app_state.load_saved_config_wrapper(
+                            import_name.strip()
+                        )
                         if isinstance(wrapper, Mapping):
                             _apply_config_wrapper(wrapper)
                         else:
                             st.session_state["model_state"] = imported_state
-                            st.session_state["last_loaded_model_state"] = dict(imported_state)
+                            st.session_state["last_loaded_model_state"] = dict(
+                                imported_state
+                            )
                             _reset_model_widget_state()
                             _sync_model_widgets_from_state(imported_state)
                         analysis_runner.clear_cached_analysis()
@@ -3124,7 +3237,9 @@ def render_model_page() -> None:
                     saved_model_states[config_b_name],
                 )
                 if not diffs:
-                    st.success("No differences found. The selected configurations match.")
+                    st.success(
+                        "No differences found. The selected configurations match."
+                    )
                 else:
                     diff_rows = []
                     for entry in diffs:
@@ -3244,7 +3359,9 @@ def render_model_page() -> None:
                 import datetime
 
                 original_end_str = current_end
-                current_end = datetime.datetime.strptime(current_end[:7] + "-01", "%Y-%m-%d").date()
+                current_end = datetime.datetime.strptime(
+                    current_end[:7] + "-01", "%Y-%m-%d"
+                ).date()
             except (ValueError, TypeError):
                 current_end = max_date
         elif current_end is None:
@@ -3271,10 +3388,14 @@ def render_model_page() -> None:
             )
             # Show warning if date was auto-corrected
             if start_was_corrected and original_start_str:
-                st.caption(f"⚠️ Adjusted from {original_start_str[:10]} to nearest available date")
+                st.caption(
+                    f"⚠️ Adjusted from {original_start_str[:10]} to nearest available date"
+                )
             # Update model state
             if sim_start_date:
-                st.session_state["model_state"]["start_date"] = sim_start_date.strftime("%Y-%m-%d")
+                st.session_state["model_state"]["start_date"] = sim_start_date.strftime(
+                    "%Y-%m-%d"
+                )
 
         with date_col2:
             sim_end_date = st.date_input(
@@ -3287,10 +3408,14 @@ def render_model_page() -> None:
             )
             # Show warning if date was auto-corrected
             if end_was_corrected and original_end_str:
-                st.caption(f"⚠️ Adjusted from {original_end_str[:10]} to nearest available date")
+                st.caption(
+                    f"⚠️ Adjusted from {original_end_str[:10]} to nearest available date"
+                )
             # Update model state
             if sim_end_date:
-                st.session_state["model_state"]["end_date"] = sim_end_date.strftime("%Y-%m-%d")
+                st.session_state["model_state"]["end_date"] = sim_end_date.strftime(
+                    "%Y-%m-%d"
+                )
 
         # Validate date range
         if sim_start_date and sim_end_date and sim_start_date > sim_end_date:
@@ -3302,7 +3427,9 @@ def render_model_page() -> None:
                     sim_end_date.month - sim_start_date.month
                 )
                 if months_span > 600:  # 50 years * 12 months
-                    st.warning("Date range exceeds 50 years - please verify your selection.")
+                    st.warning(
+                        "Date range exceeds 50 years - please verify your selection."
+                    )
                 else:
                     st.info(
                         (
@@ -3419,7 +3546,9 @@ def render_model_page() -> None:
 
     # Show description for selected weighting scheme (updates dynamically)
     with st.expander("ℹ️ About this weighting scheme", expanded=False):
-        st.markdown(WEIGHTING_DESCRIPTIONS.get(weighting_value, "No description available."))
+        st.markdown(
+            WEIGHTING_DESCRIPTIONS.get(weighting_value, "No description available.")
+        )
 
     # Update model_state if weighting changed
     if weighting_value != current_weighting:
@@ -3549,7 +3678,9 @@ def render_model_page() -> None:
         # =====================================================================
         st.divider()
         st.subheader("📋 Fund Selection & Time Windows")
-        st.caption("Configure time windows for fund evaluation and walk-forward analysis.")
+        st.caption(
+            "Configure time windows for fund evaluation and walk-forward analysis."
+        )
 
         # Row 1: Frequency (sets the period unit for all time windows)
         # Note: This is inside the form, so labels won't update until form is submitted.
@@ -3613,7 +3744,9 @@ def render_model_page() -> None:
                 min_value=1,
                 max_value=20,
                 value=int(
-                    model_state.get("min_history_periods", model_state.get("lookback_periods", 3))
+                    model_state.get(
+                        "min_history_periods", model_state.get("lookback_periods", 3)
+                    )
                 ),
                 help=HELP_TEXT.get(
                     "min_history",
@@ -3725,7 +3858,9 @@ def render_model_page() -> None:
                 "🎲 **Random Mode**: Metric weights are not used for selection in random mode. "
                 "Funds are selected randomly. Metrics are still calculated for reporting purposes."
             )
-        st.caption("Relative importance of each metric when ranking funds for selection.")
+        st.caption(
+            "Relative importance of each metric when ranking funds for selection."
+        )
 
         metric_weights: dict[str, float] = {}
         # Create two rows for the 6 metrics
@@ -3750,7 +3885,9 @@ def render_model_page() -> None:
                     min_value=0.0,
                     value=float(model_state.get("metric_weights", {}).get(code, 1.0)),
                     step=0.1,
-                    help=HELP_TEXT.get(help_key, "Weight for this metric in fund ranking."),
+                    help=HELP_TEXT.get(
+                        help_key, "Weight for this metric in fund ranking."
+                    ),
                     key=f"metric_{code}",
                 )
 
@@ -3765,9 +3902,13 @@ def render_model_page() -> None:
                     metric_weights[code] = st.number_input(
                         label,
                         min_value=0.0,
-                        value=float(model_state.get("metric_weights", {}).get(code, 1.0)),
+                        value=float(
+                            model_state.get("metric_weights", {}).get(code, 1.0)
+                        ),
                         step=0.1,
-                        help=HELP_TEXT.get(help_key, "Weight for this metric in fund ranking."),
+                        help=HELP_TEXT.get(
+                            help_key, "Weight for this metric in fund ranking."
+                        ),
                         key=f"metric_{code}",
                     )
 
@@ -3783,7 +3924,9 @@ def render_model_page() -> None:
         # Benchmark selector for Info Ratio - always show when info_ratio weight > 0
         # Check both form value AND saved state for info_ratio weight
         info_ratio_weight = metric_weights.get("info_ratio", 0)
-        saved_info_ratio_weight = model_state.get("metric_weights", {}).get("info_ratio", 0)
+        saved_info_ratio_weight = model_state.get("metric_weights", {}).get(
+            "info_ratio", 0
+        )
         show_benchmark_selector = info_ratio_weight > 0 or saved_info_ratio_weight > 0
 
         info_ratio_benchmark = model_state.get("info_ratio_benchmark", "")
@@ -3921,7 +4064,9 @@ def render_model_page() -> None:
                     options=decay_methods,
                     format_func=lambda x: decay_labels.get(x, x),
                     index=(
-                        decay_methods.index(current_decay) if current_decay in decay_methods else 0
+                        decay_methods.index(current_decay)
+                        if current_decay in decay_methods
+                        else 0
                     ),
                     help=HELP_TEXT["vol_window_decay"],
                     disabled=not vol_adj_enabled,
@@ -4077,10 +4222,10 @@ def render_model_page() -> None:
             with reg_c2:
                 # Use benchmark columns as regime proxy options
                 regime_proxy_options = ["SPX", "TSX", "MSCI", "ACWI"] + [
-                    c for c in benchmark_options if c.upper() not in ["SPX", "TSX", "MSCI", "ACWI"]
-                ][
-                    :10
-                ]  # Limit to 14 options
+                    c
+                    for c in benchmark_options
+                    if c.upper() not in ["SPX", "TSX", "MSCI", "ACWI"]
+                ][:10]  # Limit to 14 options
                 current_regime_proxy = model_state.get("regime_proxy", "SPX")
                 regime_proxy = st.selectbox(
                     "Regime Proxy Index",
@@ -4240,7 +4385,9 @@ def render_model_page() -> None:
                         help=HELP_TEXT["sticky_add_periods"],
                         disabled=not mp_enabled_state,
                     )
-                    st.caption(f"Fund must rank in top-K for {sticky_add_periods} period(s).")
+                    st.caption(
+                        f"Fund must rank in top-K for {sticky_add_periods} period(s)."
+                    )
 
                 with rank_c2:
                     sticky_drop_periods = st.number_input(
@@ -4251,7 +4398,9 @@ def render_model_page() -> None:
                         help=HELP_TEXT["sticky_drop_periods"],
                         disabled=not mp_enabled_state,
                     )
-                    st.caption(f"Fund must fall out of top-K for {sticky_drop_periods} period(s).")
+                    st.caption(
+                        f"Fund must fall out of top-K for {sticky_drop_periods} period(s)."
+                    )
             elif is_random_mode:
                 # Random mode: no ranking stability needed
                 st.info(
@@ -4317,7 +4466,9 @@ def render_model_page() -> None:
                     help="Fund must fail threshold for this many consecutive periods.",
                     disabled=not mp_enabled_state,
                 )
-                st.caption(f"Score ≤ {z_exit_soft:.2f}σ for {soft_strikes} period(s) to exit.")
+                st.caption(
+                    f"Score ≤ {z_exit_soft:.2f}σ for {soft_strikes} period(s) to exit."
+                )
 
             st.markdown("**Underweight Exit (Weight-based)**")
             min_weight_strikes = st.number_input(
@@ -4350,7 +4501,9 @@ def render_model_page() -> None:
                     "Hard Entry Z-Score",
                     min_value=0.0,
                     max_value=5.0,
-                    value=float(z_entry_hard_val if z_entry_hard_val is not None else 2.0),
+                    value=float(
+                        z_entry_hard_val if z_entry_hard_val is not None else 2.0
+                    ),
                     step=0.25,
                     format="%.2f",
                     help=HELP_TEXT["z_entry_hard"],
@@ -4375,7 +4528,9 @@ def render_model_page() -> None:
                     "Hard Exit Z-Score",
                     min_value=-5.0,
                     max_value=0.0,
-                    value=float(z_exit_hard_val if z_exit_hard_val is not None else -2.0),
+                    value=float(
+                        z_exit_hard_val if z_exit_hard_val is not None else -2.0
+                    ),
                     step=0.25,
                     format="%.2f",
                     help=HELP_TEXT["z_exit_hard"],
@@ -4458,14 +4613,18 @@ def render_model_page() -> None:
                     help=HELP_TEXT["bottom_k"],
                 )
                 if bottom_k > 0:
-                    st.caption(f"Bottom {bottom_k} ranked funds will always be excluded.")
+                    st.caption(
+                        f"Bottom {bottom_k} ranked funds will always be excluded."
+                    )
 
         # =====================================================================
         # Reporting Options
         # =====================================================================
         st.markdown("---")
         with st.expander("📊 Reporting Options", expanded=False):
-            st.markdown("Configure what additional information to include in the Results page.")
+            st.markdown(
+                "Configure what additional information to include in the Results page."
+            )
 
             report_c1, report_c2 = st.columns(2)
             with report_c1:
@@ -4593,14 +4752,18 @@ def render_model_page() -> None:
                 "report_attribution": show_attribution,
                 "report_rolling_metrics": show_rolling_metrics,
             }
-            errors = _validate_model(candidate_state, len(fund_cols) if fund_cols else 0)
+            errors = _validate_model(
+                candidate_state, len(fund_cols) if fund_cols else 0
+            )
             if errors:
                 _render_validation_errors(errors)
             else:
                 st.session_state["model_state"] = candidate_state
                 analysis_runner.clear_cached_analysis()
                 app_state.clear_analysis_results()
-                st.success("✅ Model configuration saved. Go to Results to run analysis.")
+                st.success(
+                    "✅ Model configuration saved. Go to Results to run analysis."
+                )
 
 
 def _should_auto_render() -> bool:

--- a/streamlit_app/pages/3_Results.py
+++ b/streamlit_app/pages/3_Results.py
@@ -20,11 +20,12 @@ from streamlit_app.components import (
     comparison_llm,
     explain_results,
 )
-from streamlit_app.theme import apply_ds_theme
+from streamlit_app.theme import apply_density_compact, apply_ds_theme
 from trend_analysis.diagnostics import PipelineReasonCode
 from trend_analysis.util.weights import normalize_weights
 
 apply_ds_theme()
+apply_density_compact()
 
 # =============================================================================
 # Formatting Helpers

--- a/streamlit_app/pages/5_Monte_Carlo.py
+++ b/streamlit_app/pages/5_Monte_Carlo.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from streamlit_app.monte_carlo_page import render
-from streamlit_app.theme import apply_ds_theme
+from streamlit_app.theme import apply_density_compact, apply_ds_theme
 
 
 apply_ds_theme()
+apply_density_compact()
 render()

--- a/streamlit_app/pages/8_Validation.py
+++ b/streamlit_app/pages/8_Validation.py
@@ -32,9 +32,10 @@ st.set_page_config(
 
 from streamlit_app import state as app_state  # noqa: E402
 from streamlit_app.components import analysis_runner  # noqa: E402
-from streamlit_app.theme import apply_ds_theme  # noqa: E402
+from streamlit_app.theme import apply_density_compact, apply_ds_theme  # noqa: E402
 
 apply_ds_theme()
+apply_density_compact()
 
 # =============================================================================
 # Setting Definitions
@@ -433,7 +434,9 @@ def extract_key_metrics(result: Any) -> dict[str, Any]:
         metrics["num_funds"] = len(pos_weights)
         metrics["selected_funds"] = sorted(pos_weights.index.tolist())[:5]
         metrics["max_weight"] = float(result.weights.max())
-        metrics["min_weight"] = float(pos_weights.min()) if len(pos_weights) > 0 else 0.0
+        metrics["min_weight"] = (
+            float(pos_weights.min()) if len(pos_weights) > 0 else 0.0
+        )
         metrics["weight_std"] = float(result.weights.std())
 
     # Multi-period results
@@ -487,7 +490,8 @@ def extract_key_metrics(result: Any) -> dict[str, Any]:
     except (TypeError, ValueError) as e:
         # Log serialization issues while preserving existing fallback behavior
         print(
-            "Error computing _result_hash in extract_key_metrics " f"(serialization issue): {e!r}"
+            "Error computing _result_hash in extract_key_metrics "
+            f"(serialization issue): {e!r}"
         )
         metrics["_result_hash"] = "error"
     except Exception as e:
@@ -759,7 +763,10 @@ def render_validation_page() -> None:
                     _apply_inclusion_approach_special_handling(test_state)
                 test_result = run_test_analysis(returns, test_state)
 
-                if baseline_result["status"] == "success" and test_result["status"] == "success":
+                if (
+                    baseline_result["status"] == "success"
+                    and test_result["status"] == "success"
+                ):
                     baseline_metrics = extract_key_metrics(baseline_result["result"])
                     test_metrics = extract_key_metrics(test_result["result"])
 
@@ -791,7 +798,11 @@ def render_validation_page() -> None:
             st.dataframe(results_df, use_container_width=True)
 
             # Summary
-            wired = sum(1 for r in results if "WIRED" in r["Status"] and "NOT" not in r["Status"])
+            wired = sum(
+                1
+                for r in results
+                if "WIRED" in r["Status"] and "NOT" not in r["Status"]
+            )
             not_wired = sum(1 for r in results if "NOT WIRED" in r["Status"])
             errors = sum(1 for r in results if "ERROR" in r["Status"])
 
@@ -843,7 +854,10 @@ def render_validation_page() -> None:
 
                 test_result = run_test_analysis(returns, test_state)
 
-                if baseline_result["status"] == "success" and test_result["status"] == "success":
+                if (
+                    baseline_result["status"] == "success"
+                    and test_result["status"] == "success"
+                ):
                     baseline_metrics = extract_key_metrics(baseline_result["result"])
                     test_metrics = extract_key_metrics(test_result["result"])
 

--- a/streamlit_app/theme.py
+++ b/streamlit_app/theme.py
@@ -20,3 +20,25 @@ def apply_ds_theme() -> None:
     import ds_streamlit
 
     ds_streamlit.inject_theme()
+
+
+def apply_density_compact() -> None:
+    """Tighten Streamlit table spacing on data-dense screens."""
+
+    _ensure_design_system_on_path()
+    import streamlit as st
+
+    st.markdown(
+        """<style>
+        /* density-compact: Streamlit table/dataframe adaptation. */
+        [data-testid="stDataFrame"] {
+            font-size: 0.86rem;
+        }
+        [data-testid="stDataFrame"] [role="gridcell"],
+        [data-testid="stDataFrame"] [role="columnheader"] {
+            padding-top: 0.25rem;
+            padding-bottom: 0.25rem;
+        }
+        </style>""",
+        unsafe_allow_html=True,
+    )

--- a/tests/test_design_system_theme.py
+++ b/tests/test_design_system_theme.py
@@ -5,15 +5,18 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-STREAMLIT_ENTRYPOINTS = (
-    REPO_ROOT / "streamlit_app" / "app.py",
-    REPO_ROOT / "streamlit_app" / "pages" / "1_Data.py",
-    REPO_ROOT / "streamlit_app" / "pages" / "2_Model.py",
-    REPO_ROOT / "streamlit_app" / "pages" / "3_Results.py",
-    REPO_ROOT / "streamlit_app" / "pages" / "4_Help.py",
-    REPO_ROOT / "streamlit_app" / "pages" / "5_Monte_Carlo.py",
-    REPO_ROOT / "streamlit_app" / "pages" / "8_Validation.py",
+DATA_DENSE_ENTRYPOINTS = (
+    "streamlit_app/pages/1_Data.py",
+    "streamlit_app/pages/2_Model.py",
+    "streamlit_app/pages/3_Results.py",
+    "streamlit_app/pages/5_Monte_Carlo.py",
+    "streamlit_app/pages/8_Validation.py",
 )
+
+
+def _streamlit_entrypoints() -> tuple[Path, ...]:
+    pages = sorted((REPO_ROOT / "streamlit_app" / "pages").glob("*.py"))
+    return (REPO_ROOT / "streamlit_app" / "app.py", *pages)
 
 
 def test_theme_adopted() -> None:
@@ -25,7 +28,26 @@ def test_theme_adopted() -> None:
 
     missing = [
         str(path.relative_to(REPO_ROOT))
-        for path in STREAMLIT_ENTRYPOINTS
+        for path in _streamlit_entrypoints()
         if "apply_ds_theme()" not in path.read_text()
     ]
     assert not missing, f"Streamlit entrypoints missing apply_ds_theme(): {missing}"
+
+
+def test_streamlit_entrypoint_discovery_covers_every_page() -> None:
+    discovered = {str(path.relative_to(REPO_ROOT)) for path in _streamlit_entrypoints()}
+    assert "streamlit_app/app.py" in discovered
+    assert "streamlit_app/pages/8_Validation.py" in discovered
+    assert not any("pages/6_" in path or "pages/7_" in path for path in discovered)
+
+
+def test_data_dense_entrypoints_apply_compact_density() -> None:
+    adapter = (REPO_ROOT / "streamlit_app" / "theme.py").read_text()
+    assert "density-compact" in adapter
+
+    missing = [
+        path
+        for path in DATA_DENSE_ENTRYPOINTS
+        if "apply_density_compact()" not in (REPO_ROOT / path).read_text()
+    ]
+    assert not missing, f"Data-dense entrypoints missing compact density: {missing}"


### PR DESCRIPTION
Closes #5658

## Summary
- add a Streamlit `density-compact` adaptation helper for table-heavy pages
- apply compact density on Data, Model, Results, Monte Carlo, and Validation entrypoints
- make the theme adoption test discover every numbered page dynamically and assert the data-dense entrypoints use compact density

## Verification
- `UV_CACHE_DIR=/tmp/trend-uv-cache uv run pytest tests/test_design_system_theme.py -q --no-cov`
- `UV_CACHE_DIR=/tmp/trend-uv-cache uv run ruff check streamlit_app/theme.py streamlit_app/pages/1_Data.py streamlit_app/pages/2_Model.py streamlit_app/pages/3_Results.py streamlit_app/pages/5_Monte_Carlo.py streamlit_app/pages/8_Validation.py tests/test_design_system_theme.py`
- `UV_CACHE_DIR=/tmp/trend-uv-cache uv run ruff format --check streamlit_app/theme.py streamlit_app/pages/1_Data.py streamlit_app/pages/2_Model.py streamlit_app/pages/3_Results.py streamlit_app/pages/5_Monte_Carlo.py streamlit_app/pages/8_Validation.py tests/test_design_system_theme.py`
- `git diff --check`

Follow-up for the #5659 Provider Comparison CONCERNS around page coverage evidence and density-compact adoption.