### PR TITLE
fix(mc): degrade Monte Carlo page gracefully when Plotly is absent (offline demo)

### DIFF
--- a/streamlit_app/pages/5_Monte_Carlo.py
+++ b/streamlit_app/pages/5_Monte_Carlo.py
@@ -2,9 +2,35 @@
 
 from __future__ import annotations
 
-from streamlit_app.monte_carlo_page import render
+import streamlit as st
+
 from streamlit_app.theme import apply_ds_theme
 
-
 apply_ds_theme()
-render()
+
+# The Monte Carlo page renders Plotly charts and imports Plotly transitively
+# (monte_carlo_page -> viz adapters / chart export bundle). Plotly is
+# intentionally excluded from the lean offline demo bundle (the stlite/Pyodide
+# vendoring ships numpy/pandas only), so importing the page there raises
+# ModuleNotFoundError and the whole page crashes with a red traceback.
+# Degrade gracefully: when Plotly is unavailable, show a clear message instead
+# of crashing. When Plotly is present (the full app or a Plotly-enabled build)
+# the page behaves exactly as before.
+try:
+    import plotly.graph_objects  # noqa: F401  (availability probe only)
+
+    _PLOTLY_AVAILABLE = True
+except ModuleNotFoundError:
+    _PLOTLY_AVAILABLE = False
+
+if _PLOTLY_AVAILABLE:
+    from streamlit_app.monte_carlo_page import render
+
+    render()
+else:
+    st.title("Monte Carlo Simulation")
+    st.info(
+        "The Monte Carlo page requires Plotly, which isn't included in this "
+        "offline demo build. Run the full app (or a Plotly-enabled build) to "
+        "use Monte Carlo simulations and charts."
+    )

--- a/tests/streamlit/test_mc_page.py
+++ b/tests/streamlit/test_mc_page.py
@@ -779,3 +779,44 @@ def test_empty_filtered_results_short_circuits(monkeypatch: pytest.MonkeyPatch) 
     assert any("No results available" in message for message in stub.warning_messages)
     assert not stub.dataframes
     assert not stub.downloads
+
+
+def test_monte_carlo_entrypoint_degrades_without_plotly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The numbered MC entrypoint must not crash when Plotly is unavailable.
+
+    Plotly is intentionally excluded from the lean offline (stlite/Pyodide) demo
+    bundle, so importing ``monte_carlo_page`` -- which pulls Plotly transitively
+    via the viz adapters / chart export bundle -- raises ModuleNotFoundError
+    there and the whole page crashes with a red traceback. The entrypoint must
+    detect the missing Plotly and show a clear message instead.
+    """
+    import importlib.util
+
+    stub = _install_streamlit_stub(monkeypatch)
+
+    # Stub the theme module the entrypoint imports.
+    theme_module = ModuleType("streamlit_app.theme")
+    theme_module.apply_ds_theme = lambda: None
+    monkeypatch.setitem(sys.modules, "streamlit_app.theme", theme_module)
+
+    # Simulate Plotly being absent from the bundle.
+    monkeypatch.setitem(sys.modules, "plotly", None)
+    monkeypatch.setitem(sys.modules, "plotly.graph_objects", None)
+
+    entrypoint = (
+        Path(__file__).resolve().parents[2]
+        / "streamlit_app"
+        / "pages"
+        / "5_Monte_Carlo.py"
+    )
+    spec = importlib.util.spec_from_file_location("_mc_entrypoint_under_test", entrypoint)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+
+    # Must not raise -- no ModuleNotFoundError surfacing to the user.
+    spec.loader.exec_module(module)
+
+    assert module._PLOTLY_AVAILABLE is False
+    assert any("Plotly" in message for message in stub.info_messages)


### PR DESCRIPTION
## Problem

In the offline stlite/Pyodide demo, navigating to **Monte Carlo** crashes the page with a red traceback:

```
ModuleNotFoundError: No module named 'plotly'
  File ".../streamlit_app/monte_carlo_page.py", line 14, in <module>
    import plotly.graph_objects as go
```

`monte_carlo_page` imports Plotly directly **and** transitively (via `trend_analysis.viz` adapters and the chart export bundle). Plotly is intentionally **excluded** from the lean offline demo bundle (the vendored runtime ships `numpy`/`pandas` only), so importing the page there fails and the whole page dies.

## Fix

Guard the numbered entrypoint [`streamlit_app/pages/5_Monte_Carlo.py`](streamlit_app/pages/5_Monte_Carlo.py) — the **sole** importer of `monte_carlo_page`:

- Probe for Plotly. If unavailable, show a clear "requires Plotly, not in this offline build" message instead of importing the Plotly-dependent page.
- If Plotly **is** present (the full app, or any Plotly-enabled build), the page behaves exactly as before.

Contained entirely to the entrypoint — no changes to `monte_carlo_page`, the shared `viz`/chart modules, or `export_bundle`.

## Tests

Adds `test_monte_carlo_entrypoint_degrades_without_plotly` — executes the real entrypoint file with Plotly stubbed absent and asserts it shows the message instead of raising. Full `tests/streamlit/test_mc_page.py` green (17 passed).

## Verification status

- ✅ **Unit-verified**: the entrypoint executes gracefully (message, no exception) with Plotly absent.
- ⚠️ **Browser end-to-end not verifiable on `phase-3` yet** — see below.

## Separate pre-existing issue found (out of scope here)

While verifying, I found the offline demo on `phase-3` **does not boot at all**: streamlit's Pyodide closure isn't fully vendored. The web-worker access log 404s on `protobuf`, `narwhals`, `fastparquet`, `altair`, `jsonschema`, `pillow`, `cramjam`, … — the `vendor/` dir ships only ~9 of the ~20 required wheels (the initial [#5649](https://github.com/stranske/Trend_Model_Project/pull/5649) vendoring; the closure-completion work isn't merged). Boot fails with `ModuleNotFoundError: protobuf` before any page renders. That's a larger, separate effort (vendor the full closure) and is why this fix is unit-verified rather than browser-verified end-to-end. This guard is still correct and kicks in as soon as the demo boots (or on any plotly-absent build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Monte Carlo page now gracefully handles missing Plotly dependency instead of crashing. Users will see an informational message explaining the requirement when Plotly is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->