### PR TITLE
fix(demo): bundle design-system/ds_streamlit so the offline demo boots

### DIFF
--- a/scripts/build_wasm_demo.py
+++ b/scripts/build_wasm_demo.py
@@ -122,6 +122,7 @@ ENTRYPOINT = "streamlit_app/app.py"
 #: Source directories whose ``*.py`` files are loaded into the browser FS.
 SOURCE_DIRS = (
     "streamlit_app",
+    "design-system",  # ds_streamlit.py — theme.apply_ds_theme() imports it
     "analysis",
     "src/trend_analysis",
     "src/trend",

--- a/tests/wasm/test_demo_no_external_cdn.py
+++ b/tests/wasm/test_demo_no_external_cdn.py
@@ -260,3 +260,20 @@ def test_monte_carlo_scenario_configs_are_bundled() -> None:
     # actually exist and are non-empty.
     for rel in sorted(required | set(scenario_files)):
         _assert_non_empty(REPO_ROOT / rel)
+
+
+def test_design_system_theme_module_is_bundled() -> None:
+    """Every Streamlit entry point calls ``theme.apply_ds_theme()``, which adds
+    ``design-system/`` to ``sys.path`` and imports the first-party ``ds_streamlit``
+    module. ``ds_streamlit`` is not a PyPI package, so vendoring wheels does not
+    cover it -- the ``design-system`` source must be bundled into the browser FS
+    or the demo crashes at startup with ``ModuleNotFoundError: No module named
+    'ds_streamlit'`` before any page renders."""
+    manifest = _manifest()
+    files = set(manifest["files"])
+    assert "design-system/ds_streamlit.py" in files, (
+        "ds_streamlit theme module is not bundled; the offline demo crashes at "
+        "startup (theme.apply_ds_theme imports it). Add 'design-system' to "
+        "SOURCE_DIRS in scripts/build_wasm_demo.py."
+    )
+    _assert_non_empty(REPO_ROOT / "design-system" / "ds_streamlit.py")


### PR DESCRIPTION
## Context

You asked me to complete the offline-vendoring effort so the stlite/Pyodide demo boots and the Monte Carlo charts work offline.

**Most of that work had already merged into `phase-3` during the session** via [#5655](https://github.com/stranske/Trend_Model_Project/pull/5655) ("Complete offline stlite demo"): it vendors the full ~37-wheel Pyodide closure (protobuf, fastparquet, altair, jsonschema, pillow, cramjam, …), vendors **plotly 6.8.0** under `vendor/pypi/`, **bumps narwhals to 1.15.1** in the lock (so plotly 6.x works), adds `fetch_offline_runtime.py`, and wires plotly wheel-URLs in `index.html`.

But **merged ≠ works**: when I built and ran it in a real browser, the demo still **crashed at startup**:

```
ModuleNotFoundError: No module named 'ds_streamlit'
  File ".../streamlit_app/app.py", line 35, in <module>
    apply_ds_theme()
  File ".../streamlit_app/theme.py", line 20, in apply_ds_theme
    import ds_streamlit
```

Every entry point calls `theme.apply_ds_theme()`, which adds the repo's `design-system/` to `sys.path` and imports `ds_streamlit` — but `design-system` wasn't in the demo's `SOURCE_DIRS`, so that first-party module was never bundled into the browser FS. It's not a PyPI package, so the wheel vendoring doesn't cover it.

## Fix

Add `design-system` to `SOURCE_DIRS` in `scripts/build_wasm_demo.py` so `ds_streamlit.py` is bundled. Plus a regression test asserting the theme module is bundled.

## Verified end-to-end in a real browser (offline, local static server, zero external CDN fetches)

- ✅ Demo **boots** — home page renders with the Ink & Air theme
- ✅ Monte Carlo page **loads** (plotly vendored)
- ✅ MC **Plotly charts render** — Sharpe histogram, path distribution, risk-return, CDF all draw with the modebar (plotly 6.8.0 + narwhals 1.15.1, no `from_native(... 'pass_through')` crash)
- ✅ Downloads render (CSV / parquet / ZIP; graceful "Kaleido not installed" PNG-skip)

`tests/wasm/test_demo_no_external_cdn.py` green (10 passed); the new guard fails if `design-system` is dropped from `SOURCE_DIRS` again (verified).

## Out of scope (separate, pre-existing)

The MC results are still **degenerate** (empty NAV paths, path-index-like Sharpe values) — the multi-period-window mismatch a concurrent effort is addressing on `fix/mc-demo-degenerate-results`. The charts *render* correctly; only the underlying data is degenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The offline WASM demo now bundles the design-system theme module for complete offline functionality.
* **Tests**
  * Added test to verify the design-system theme module is properly included in the offline demo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->