### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/actions/agent-run-base/action.yml
+++ b/.github/actions/agent-run-base/action.yml
@@ -66,7 +66,7 @@ runs:
     - name: Mint GitHub App token
       id: app_token
       continue-on-error: true
-      uses: actions/create-github-app-token@v3
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
       with:
         app-id: ${{ inputs.workflows_app_id || '0' }}
         private-key: ${{ inputs.workflows_app_private_key || 'dummy' }}
@@ -109,7 +109,7 @@ runs:
         printf 'Checkout auth: %s; push permitted with app token: %s.\n' "$source" "$push_allowed"
 
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
         ref: ${{ inputs.checkout_ref || github.ref }}
@@ -132,7 +132,7 @@ runs:
         github_token: ${{ inputs.github_token }}
 
     - name: Checkout Workflows scripts
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: stranske/Workflows
         ref: ${{ inputs.workflows_ref }}

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -43,7 +43,7 @@ SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 EVIDENCE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#@-]{0,255}$")
 SECRET_LIKE_EVIDENCE_PREFIXES = ("ghp_", "github_pat_", "sk-")
 SECRET_LIKE_EVIDENCE_SEGMENT_RE = re.compile(
-    r"(?:^|[:/])(?:" + "|".join(SECRET_LIKE_EVIDENCE_PREFIXES) + r")",
+    r"(?:^|[:/#@])(?:" + "|".join(SECRET_LIKE_EVIDENCE_PREFIXES) + r")",
     re.IGNORECASE,
 )
 SUPERVISION_MODES = {

--- a/tools/discover_model_catalog.py
+++ b/tools/discover_model_catalog.py
@@ -16,12 +16,19 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-
-import requests
+from urllib.error import URLError
+from urllib.request import Request, urlopen
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_REGISTRY_PATH = _REPO_ROOT / "config" / "model_registry.json"
 PROVIDERS = ("openai", "anthropic", "github-models")
+CATALOG_URLS = frozenset(
+    {
+        "https://models.github.ai/catalog/models",
+        "https://api.openai.com/v1/models",
+        "https://api.anthropic.com/v1/models?limit=1000",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -31,9 +38,11 @@ class CatalogModel:
 
 
 def _request_json(url: str, headers: dict[str, str]) -> Any:
-    response = requests.get(url, headers=headers, timeout=30)
-    response.raise_for_status()
-    return response.json()
+    if url not in CATALOG_URLS:
+        raise ValueError(f"unsupported catalog URL: {url}")
+    request = Request(url, headers=headers)
+    with urlopen(request, timeout=30) as response:  # noqa: S310 - validated static catalog URL
+        return json.load(response)
 
 
 def _parse_timestamp(value: object) -> dt.datetime | None:
@@ -131,7 +140,7 @@ def fetch_provider(provider: str) -> tuple[list[CatalogModel] | None, str | None
         else:  # pragma: no cover - argparse constrains values
             raise ValueError(f"unsupported provider: {provider}")
         return parse_catalog(provider, payload), None
-    except (OSError, ValueError, requests.RequestException) as exc:
+    except (OSError, URLError, ValueError) as exc:
         return None, str(exc)
 
 

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -286,7 +286,9 @@ def configured_model_for_provider(
                     slot_profile,
                     slot_provider,
                 )
-                return ""
+                # A malformed slot must not mask a later valid slot or the
+                # provider-level reviewed selection/fallback.
+                continue
             if explicit_model and explicit_model != model:
                 logger.warning(
                     "Ignoring slot model pin %s/%s; reviewed %s selection is %s",


### PR DESCRIPTION
## Sync Summary

### Files Updated
- runner_lib/ (1 files): Shared runner prompt assembly, output parsing, and dispatch debounce helpers
- llm_registry.py: LLM model registry helper - shared slot/model selection and blocked-model enforcement
- discover_model_catalog.py: Advisory provider-catalog discovery - proposes new model candidates without changing reviewed selections
- agent-run-base/ (1 files): Shared agent runner setup action - required by reusable-codex-run.yml and reusable-claude-run.yml

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- AGENTS.md: Repo keeps historical Agents.md casing to avoid case-only path conflicts
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `6e6c92979287018064fbd77d6a6a348303de653b`
**Template hash:** `6545e3aa7885`
**Sync branch:** `sync/workflows-6545e3aa7885`
**Consumer repo:** `stranske/Trend_Model_Project`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Trend_Model_Project","source_repository":"stranske/Workflows","source_sha":"6e6c92979287018064fbd77d6a6a348303de653b","template_hash":"6545e3aa7885","sync_branch":"sync/workflows-6545e3aa7885","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"29408267192","run_attempt":"1","changes_count":4} -->