### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,11 +5,11 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.20
+RUFF_VERSION=0.15.22
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
-MYPY_VERSION=2.1.0
+MYPY_VERSION=2.3.0
 PYTEST_VERSION=9.1.1
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0
-COVERAGE_VERSION=7.15.0
+COVERAGE_VERSION=7.15.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,19 +23,19 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 26.5.1
     hooks:
       - id: black
         language_version: python3
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.3
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: ["--fix"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v2.3.0
     hooks:
       - id: mypy
         name: mypy (core + app)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,11 +111,11 @@ notebooks = [
 ]
 dev = [
     "pre-commit==4.6.0",
-    "black>=26.5.1",
-    "ruff==0.15.20",
+    "black==26.5.1",
+    "ruff==0.15.22",
     "isort==8.0.1",
-    "docformatter>=1.7.8",
-    "mypy>=2.1.0",
+    "docformatter==1.7.8",
+    "mypy==2.3.0",
     "flake8==7.3.0",
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
@@ -123,7 +123,7 @@ dev = [
     # Shared app behavior baseline harness (also pulls pytest-regressions). Pinned to
     # the Workflows default branch; move to a tagged ref once the package is versioned.
     "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit",
-    "coverage==7.15.0",
+    "coverage==7.15.2",
     "pytest-rerunfailures==16.3",
     "pytest-xdist==3.8.0",
     "packaging==26.2",

--- a/requirements.lock
+++ b/requirements.lock
@@ -23,7 +23,7 @@ anyio==4.13.0
     #   starlette
     #   streamlit
     #   watchfiles
-ast-serialize==0.3.0
+ast-serialize==0.6.0
     # via mypy
 asttokens==3.0.1
     # via stack-data
@@ -234,7 +234,7 @@ langsmith==0.9.3
     #   langchain-classic
     #   langchain-community
     #   langchain-core
-librt==0.11.0
+librt==0.13.0
     # via mypy
 markupsafe==3.0.3
     # via jinja2

--- a/requirements.lock
+++ b/requirements.lock
@@ -58,7 +58,7 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage==7.15.0
+coverage==7.15.2
     # via
     #   trend-model (pyproject.toml)
     #   pytest-cov
@@ -250,7 +250,7 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==2.1.0
+mypy==2.3.0
     # via trend-model (pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -448,7 +448,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.20
+ruff==0.15.22
     # via trend-model (pyproject.toml)
 scipy==1.18.0
     # via trend-model (pyproject.toml)


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 8 version updates:
  - ruff: ==0.15.20 -> ==0.15.22
  - black: >=26.5.1 -> ==26.5.1
  - mypy: >=2.1.0 -> ==2.3.0
  - coverage: ==7.15.0 -> ==7.15.2
  - docformatter: >=1.7.8 -> ==1.7.8
  - requirements.lock:coverage: 7.15.0 -> ==7.15.2
  - requirements.lock:mypy: 2.1.0 -> ==2.3.0
  - requirements.lock:ruff: 0.15.20 -> ==0.15.22

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`