### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.22
+RUFF_VERSION=0.16.0
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.0
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ force-exclude = '''
 '''
 
 [tool.ruff]
+lint.select = ["E4", "E7", "E9", "F"]
 extend-exclude = [
     "archives",
     "archives/**",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ notebooks = [
 dev = [
     "pre-commit==4.6.0",
     "black==26.5.1",
-    "ruff==0.15.22",
+    "ruff==0.16.0",
     "isort==8.0.1",
     "docformatter==1.7.8",
     "mypy==2.3.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -448,7 +448,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.22
+ruff==0.16.0
     # via trend-model (pyproject.toml)
 scipy==1.18.0
     # via trend-model (pyproject.toml)

--- a/tests/workflows/test_autofix_full_pipeline.py
+++ b/tests/workflows/test_autofix_full_pipeline.py
@@ -38,6 +38,10 @@ def test_autofix_pipeline_resolves_lint_and_typing(
     tests_dir = tmp_path / "tests"
     src_dir.mkdir()
     tests_dir.mkdir()
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.ruff.lint]\nselect = ["E4", "E7", "E9", "F"]\n',
+        encoding="utf-8",
+    )
 
     sample = src_dir / "autofix_target.py"
     sample.write_text(
@@ -131,6 +135,9 @@ def test_autofix_pipeline_resolves_lint_and_typing(
     )
     exit_code = mypy_autofix.main(["--paths", str(sample)])
     assert exit_code == 0
+
+    # The type-hygiene pass can add imports after the initial formatter pass.
+    _run([sys.executable, "-m", "black", str(sample)], cwd=tmp_path)
 
     for cmd in (
         [sys.executable, "-m", "isort", str(sample)],

--- a/tests/workflows/test_autofix_pipeline_diverse.py
+++ b/tests/workflows/test_autofix_pipeline_diverse.py
@@ -54,6 +54,9 @@ def test_autofix_pipeline_handles_diverse_errors(
         dedent("""
             [tool.black]
             line-length = 88
+
+            [tool.ruff.lint]
+            select = ["E4", "E7", "E9", "F"]
             """).lstrip(),
         encoding="utf-8",
     )


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 2 version updates:
  - ruff: ==0.15.22 -> ==0.16.0
  - requirements.lock:ruff: 0.15.22 -> ==0.16.0

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`