### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/issue_format.py
+++ b/.github/scripts/issue_format.py
@@ -1,0 +1,152 @@
+"""Validate a GitHub issue body against the fleet AGENT_ISSUE_FORMAT contract."""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass, field
+
+REQUIRED: dict[str, tuple[str, ...]] = {
+    "Tasks": ("tasks", "task list", "implementation"),
+    "Acceptance Criteria": ("acceptance criteria", "acceptance", "definition of done"),
+}
+RECOMMENDED: dict[str, tuple[str, ...]] = {
+    "Why": ("why", "goals", "summary", "motivation", "finding"),
+    "Scope": ("scope", "background", "context", "overview"),
+    "Implementation Notes": ("implementation notes",),
+    "Non-Goals": ("non-goals", "out of scope", "constraints"),
+}
+GATE = re.compile(
+    r"(tests?/[\w./-]+\.py(::[\w:\[\]-]+)?"
+    r"|\btest_[\w]+"
+    r"|\bpytest\b|\bnpm test\b|\bmake test\b"
+    r"|\bgh workflow run\b|\bgh run\b"
+    r"|\bcurl\b|\bHTTP [1-5]\d\d\b"
+    r"|\b(?:API|endpoint|request|response)\s+(?:returns?|responds with)\s+[1-5]\d\d(?:\s+status)?\b"
+    r"|\bsmoke\b|\bverif)",
+    re.I,
+)
+BANNED_ADJECTIVES = ("clean", "nice", "good", "fast", "better", "intuitive", "polished")
+
+
+def _headings(body: str) -> list[tuple[str, int]]:
+    """Return markdown headings outside fenced code blocks with line indexes."""
+    out: list[tuple[str, int]] = []
+    fence: tuple[str, int] | None = None
+    for i, line in enumerate(body.splitlines()):
+        fence_match = re.match(r"\s{0,3}(`{3,}|~{3,})", line)
+        if fence_match:
+            marker = fence_match.group(1)
+            if fence is None:
+                fence = (marker[0], len(marker))
+            elif marker[0] == fence[0] and len(marker) >= fence[1]:
+                fence = None
+            continue
+        if fence is not None:
+            continue
+        heading = re.match(r"\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$", line)
+        if heading:
+            out.append((heading.group(2).strip().strip(":").lower(), i))
+    return out
+
+
+def _find(body: str, aliases: tuple[str, ...]) -> int | None:
+    for text, idx in _headings(body):
+        if any(text == alias or text.startswith(alias) for alias in aliases):
+            return idx
+    return None
+
+
+def _section_text(body: str, start: int) -> str:
+    lines = body.splitlines()
+    following = [idx for _, idx in _headings(body) if idx > start]
+    end = following[0] if following else len(lines)
+    return "\n".join(lines[start + 1 : end])
+
+
+@dataclass
+class Report:
+    ok: bool = True
+    missing_required: list[str] = field(default_factory=list)
+    missing_recommended: list[str] = field(default_factory=list)
+    problems: list[str] = field(default_factory=list)
+
+    def as_markdown(self) -> str:
+        if self.ok and not self.missing_recommended:
+            return "Issue body conforms to `docs/AGENT_ISSUE_FORMAT.md`."
+        if self.ok:
+            out = ["Issue body is agent-processable with advisories.", ""]
+        else:
+            out = [
+                "This issue is **not yet agent-processable**. See `docs/AGENT_ISSUE_FORMAT.md`.",
+                "",
+            ]
+        if self.missing_required:
+            out.append(
+                "**Missing required sections:** "
+                + ", ".join(f"`{section}`" for section in self.missing_required)
+            )
+        out.extend(f"- {problem}" for problem in self.problems)
+        if self.missing_recommended:
+            out.extend(
+                [
+                    "",
+                    "_Recommended but absent:_ "
+                    + ", ".join(f"`{section}`" for section in self.missing_recommended),
+                ]
+            )
+        return "\n".join(out)
+
+
+def validate(body: str) -> Report:
+    """Check an issue body; every structural format problem is non-conforming."""
+    report = Report()
+    body = body or ""
+    for name, aliases in REQUIRED.items():
+        if _find(body, aliases) is None:
+            report.missing_required.append(name)
+    for name, aliases in RECOMMENDED.items():
+        if _find(body, aliases) is None:
+            report.missing_recommended.append(name)
+
+    tasks_at = _find(body, REQUIRED["Tasks"])
+    if tasks_at is not None and not re.search(
+        r"^\s*[-*]\s*\[[ xX]\]", _section_text(body, tasks_at), re.M
+    ):
+        report.problems.append(
+            "`Tasks` has no checkbox items (`- [ ] …`); agents track progress by them."
+        )
+
+    acceptance_at = _find(body, REQUIRED["Acceptance Criteria"])
+    if acceptance_at is not None:
+        acceptance = _section_text(body, acceptance_at)
+        if not GATE.search(acceptance):
+            report.problems.append(
+                "`Acceptance Criteria` names no test, runnable command or observable "
+                "verification gate — Definition of Ready / Quality Bar §2 requires one."
+            )
+        hits = [word for word in BANNED_ADJECTIVES if re.search(rf"\b{word}\b", acceptance, re.I)]
+        if hits:
+            report.problems.append(
+                "`Acceptance Criteria` uses subjective wording ("
+                + ", ".join(sorted(hits))
+                + "); replace with a measurable check."
+            )
+    report.ok = not report.missing_required and not report.problems
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if argv:
+        with open(argv[0], encoding="utf-8") as issue_file:
+            body = issue_file.read()
+    else:
+        body = sys.stdin.read()
+    report = validate(body)
+    print(report.as_markdown())
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/agents-auto-label.yml
+++ b/.github/workflows/agents-auto-label.yml
@@ -50,11 +50,12 @@ jobs:
             github.event.workflow_run.repository.default_branch }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
+          path: eligibility-source
 
       # Escape hatch: set mode: warning if false-negative skips appear post-merge.
       - name: Check event eligibility
         id: eligibility
-        uses: ./.github/actions/agent-event-eligibility
+        uses: ./eligibility-source/.github/actions/agent-event-eligibility
         with:
           expected-actions: opened,reopened,edited
           custom-predicate: >-

--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -1,0 +1,143 @@
+name: Agents Issue Format Guard
+
+on:
+  issues:
+    types: [opened, edited, reopened, labeled, unlabeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue to (re)check"
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+
+concurrency:
+  group: issue-format-guard-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Resolve issue
+        id: issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+        run: |
+          set -euo pipefail
+          gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json number,body,labels,state,author > issue.json
+          jq -r '.body // ""' issue.json > body.md
+          exempt=false
+          held=false
+          if jq -e '[.labels[].name] | any(. == "tracker:durable" or . == "wontfix")' issue.json >/dev/null; then exempt=true; fi
+          if jq -e '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' issue.json >/dev/null; then held=true; fi
+          if jq -er '.author.login // ""' issue.json | grep -qiE '(\[bot\]|^renovate$|^dependabot$)'; then exempt=true; fi
+          if grep -qiE 'do not dispatch|not a (repo|cloud) coding task' body.md; then exempt=true; fi
+          {
+            echo "number=$NUMBER"
+            echo "exempt=$exempt"
+            echo "held=$held"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate against AGENT_ISSUE_FORMAT
+        id: validate
+        if: steps.issue.outputs.exempt != 'true'
+        run: |
+          set +e
+          if [[ ! -f .github/scripts/issue_format.py ]]; then
+            echo "validator absent — skipping while this repo is mid-sync"
+            echo "rc=skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python3 .github/scripts/issue_format.py body.md > report.md
+          rc=$?
+          set -e
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          cat report.md || true
+          if [[ "$rc" -ne 0 && "$rc" -ne 1 ]]; then
+            exit "$rc"
+          fi
+
+      - name: Invalidate stale format completion while held
+        if: github.event.action == 'edited' && steps.issue.outputs.held == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ steps.issue.outputs.number }}
+        run: |
+          set -euo pipefail
+          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+              --jq '.labels[].name' | grep -qx 'agents:formatted'; then
+            gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:formatted"
+            echo "Held issue was edited — cleared agents:formatted so resume revalidates it."
+          fi
+
+      - name: Route non-conforming issue to the optimizer
+        if: steps.issue.outputs.exempt != 'true' && steps.issue.outputs.held != 'true' && steps.validate.outputs.rc == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ steps.issue.outputs.number }}
+        run: |
+          set -euo pipefail
+          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+              --jq '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' | grep -qx true; then
+            echo "Issue is now held — skipping optimizer dispatch."
+            exit 0
+          fi
+          fingerprint="$(sha256sum body.md | cut -c1-12)"
+          if ! gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json comments \
+              --jq '.comments[].body' | grep -qF "format-guard:$fingerprint"; then
+            {
+              cat report.md
+              echo
+              echo "Dispatching the Agents Issue Optimizer format phase."
+              echo
+              echo "<!-- format-guard:$fingerprint -->"
+            } | gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file -
+          fi
+          gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "agents:format" \
+            || echo "::warning::could not apply agents:format (label missing in this repo?)"
+          # GITHUB_TOKEN label edits do not start issues:labeled workflows; dispatch is explicit.
+          gh workflow run agents-issue-optimizer.yml --repo "$GITHUB_REPOSITORY" \
+            -f issue_number="$NUMBER" -f phase=format
+
+      - name: Restore format completion after an unheld revalidation
+        if: >-
+          steps.issue.outputs.exempt != 'true' && steps.validate.outputs.rc == '0' &&
+          (steps.issue.outputs.held == 'true' ||
+          (github.event.action == 'unlabeled' &&
+          (github.event.label.name == 'agents:auto-pilot-pause' || github.event.label.name == 'needs-human')))
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ steps.issue.outputs.number }}
+        run: |
+          set -euo pipefail
+          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+              --jq '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' | grep -qx true; then
+            echo "Issue remains held — leaving agents:formatted cleared."
+            exit 0
+          fi
+          gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "agents:formatted"
+          echo "Held edit revalidated after resume — restored agents:formatted."
+
+      - name: Clear the stale format trigger
+        if: steps.issue.outputs.exempt != 'true' && steps.issue.outputs.held != 'true' && steps.validate.outputs.rc == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ steps.issue.outputs.number }}
+        run: |
+          set -euo pipefail
+          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+              --jq '.labels[].name' | grep -qx 'agents:format'; then
+            gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:format"
+            echo "Conforms now — cleared agents:format."
+          fi


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-issue-format-guard.yml: Issue format guard - validates issues on open/edit/reopen and hold-label changes against AGENT_ISSUE_FORMAT, while durable/wontfix and bot issues remain exempt. Pause and needs-human labels hold dispatch, clear stale agents:formatted state on held edits, and revalidate on resume. Non-conforming unheld work gets agents:format so the optimizer repairs it. Requires .github/scripts/issue_format.py.
- agents-auto-label.yml: Auto-label - suggests/applies labels based on semantic matching (Phase 5A)
- issue_format.py: Pure-stdlib validator for AGENT_ISSUE_FORMAT compliance. Single fleet definition of agent-processable; used by agents-issue-format-guard.yml and callable directly by local filers to pre-flight before gh issue create (non-zero exit = unfit). Do not fork per repo.

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- AGENTS.md: Repo keeps historical Agents.md casing to avoid case-only path conflicts
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `ebc3f8ca75ed715a7e38e56b5a6ec77c982eb46f`
**Template hash:** `afd28ed6e2a3`
**Consumer-sync plan ID:** `sha256:afd28ed6e2a326d35bfbd03b12313b096930d41c11571bd07e6cf83048fd42d2`
**Sync phase:** `canary`
**Sync branch:** `sync/workflows-afd28ed6e2a3`
**Consumer repo:** `stranske/Trend_Model_Project`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Trend_Model_Project","source_repository":"stranske/Workflows","source_sha":"ebc3f8ca75ed715a7e38e56b5a6ec77c982eb46f","template_hash":"afd28ed6e2a3","plan_id":"sha256:afd28ed6e2a326d35bfbd03b12313b096930d41c11571bd07e6cf83048fd42d2","sync_phase":"canary","sync_branch":"sync/workflows-afd28ed6e2a3","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"31096612826","run_attempt":"1","changes_count":3} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:afd28ed6e2a326d35bfbd03b12313b096930d41c11571bd07e6cf83048fd42d2","generation":"afd28ed6e2a3","repository":"stranske/Trend_Model_Project","desired_tree_hash":"071da044c7232fa223f5cec99fbaa34b2a7b93c8","source_commit":"ebc3f8ca75ed715a7e38e56b5a6ec77c982eb46f","lease_expires_at":"2026-08-09T11:17:47Z","predecessor_prs":[],"successor_prs":[]} -->