### PR TITLE
fix(deps): promote Ruff 0.16.2 with pre-commit alignment

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.16.1
+RUFF_VERSION=0.16.2
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.0
+    rev: v0.16.2
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ notebooks = [
 dev = [
     "pre-commit==4.6.0",
     "black==26.5.1",
-    "ruff==0.16.1",
+    "ruff==0.16.2",
     "isort==8.0.1",
     "docformatter==1.7.8",
     "mypy==2.3.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -448,7 +448,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.16.1
+ruff==0.16.2
     # via trend-model (pyproject.toml)
 scipy==1.18.0
     # via trend-model (pyproject.toml)


### PR DESCRIPTION
Promotes the generated Ruff 0.16.2 synchronization from #5795 and aligns the repo-local Ruff pre-commit hook in a separate repair commit.

Validation: the first commit reproduces exactly the selected generated dependency delta; the second changes only `.pre-commit-config.yaml` from `v0.16.0` to `v0.16.2`.

<!-- dependency-repair-promotion:v1 {"source_pr":5795,"source_base_sha":"ae15dea089bad4d61ca82d5f034f5e7e1bc1b967","source_head_sha":"d6d90b3f1e53c533ed09189308eac5036cb3fd8b","promotion_base_sha":"ae15dea089bad4d61ca82d5f034f5e7e1bc1b967"} -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Ruff development tooling to version 0.16.2.
  * Improved consistency across automated checks and local pre-commit validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->