### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.16.1
+RUFF_VERSION=0.16.2
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ notebooks = [
 dev = [
     "pre-commit==4.6.0",
     "black==26.5.1",
-    "ruff==0.16.1",
+    "ruff==0.16.2",
     "isort==8.0.1",
     "docformatter==1.7.8",
     "mypy==2.3.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -448,7 +448,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.16.1
+ruff==0.16.2
     # via trend-model (pyproject.toml)
 scipy==1.18.0
     # via trend-model (pyproject.toml)


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 2 version updates:
  - ruff: ==0.16.1 -> ==0.16.2
  - requirements.lock:ruff: 0.16.1 -> ==0.16.2

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`
**Settled source commit:** `d49a90808881026ad7daf2ab841bb138c6a3f419`

<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"dev-tool-69b135912235","generation":"69b135912235","repository":"stranske/Trend_Model_Project","desired_tree_hash":"f8f94e7051d4951708436563a774c87c5bac6c6c","source_commit":"d49a90808881026ad7daf2ab841bb138c6a3f419","lease_expires_at":"2026-08-12T05:20:45Z","predecessor_prs":[],"successor_prs":[]} -->