### PR TITLE
fix(dev): align ruff pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.2
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.1
+    rev: v0.16.2
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.0
+    rev: v0.16.2
     hooks:
       - id: ruff
         args: ["--fix"]


### PR DESCRIPTION
Companion repair for generated dev-tool sync PR #5798.

Updates only the repo-local `ruff-pre-commit` hook from `v0.16.0` to `v0.16.2`, aligning it with the canonical Ruff pin. After this lands, Maint 52 should generate a clean replacement for #5798; the generated PR itself remains unmodified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Ruff code-quality tooling to a newer revision, providing the latest available checks and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->