### PR TITLE
fix(ci): pin black line-length to 100 and enforce format_check on the PR gate

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -71,7 +71,12 @@ jobs:
     with:
       python-versions: '["3.12", "3.13"]'
       coverage-min: "80"
-      format_check: false  # Using ruff for formatting
+      # Must stay true: ci.yml enforces `black --check --line-length 100` on push to phase-3,
+      # so a PR gate that skips the format check lets unformatted code merge green and redden
+      # the default branch on the very next push. The old comment here ("Using ruff for
+      # formatting") was inaccurate - this repo does not run `ruff format`, and its ruff config
+      # is lint.select = ["E4","E7","E9","F"], which performs no formatting at all.
+      format_check: true
       working-directory: "."
       artifact-prefix: "gate-"
       # Keep PR Gate fast: the MC-viz CLI integration suite runs in a dedicated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,10 @@ dev = [
 ]
 
 [tool.black]
+# Must equal the CI gate in ci.yml (black --check --line-length 100). Because the pre-commit
+# hook and scripts/style_gate_local.sh both invoke black with no --line-length flag, they read
+# this value - so setting it here is what keeps local formatting and CI in agreement.
+line-length = 100
 extend-exclude = '''
 /(
         Old

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -3963,8 +3963,7 @@ def _run_threshold_hold_multi_periods(
                 candidates = [
                     str(c)
                     for c in sf.index
-                    if str(c) not in {str(h) for h in holdings}
-                    and _eligible_sticky_add(str(c))
+                    if str(c) not in {str(h) for h in holdings} and _eligible_sticky_add(str(c))
                 ]
                 if cooldown_periods > 0 and cooldown_book:
                     candidates = [c for c in candidates if str(c) not in cooldown_book]

--- a/streamlit_app/monte_carlo_page.py
+++ b/streamlit_app/monte_carlo_page.py
@@ -87,9 +87,7 @@ def _analysis_frame_from_session(
         regime_proxy = model_state.get("regime_proxy")
     prohibited = {selected_rf, benchmark, info_ratio_benchmark, regime_proxy} - {None}
 
-    sanitized_funds = [
-        c for c in applied_funds if c in returns.columns and c not in prohibited
-    ]
+    sanitized_funds = [c for c in applied_funds if c in returns.columns and c not in prohibited]
     if not sanitized_funds:
         # The one-click demo (and any flow that never visited the Data page)
         # leaves no explicit fund selection in session. Without this fallback
@@ -257,9 +255,7 @@ def _fold_options(scenario: MonteCarloScenario) -> list[str]:
     return options
 
 
-def _filter_results_by_fold(
-    results: pd.DataFrame, selection: str | None
-) -> pd.DataFrame:
+def _filter_results_by_fold(results: pd.DataFrame, selection: str | None) -> pd.DataFrame:
     if not selection or selection == "All folds":
         return results
     if results.empty:
@@ -313,9 +309,7 @@ def _fold_selection_for_adapters(selection: str | None) -> int | str | None:
     return selection
 
 
-def _render_diagnostic_charts(
-    summary: pd.DataFrame, paths: pd.DataFrame
-) -> dict[str, go.Figure]:
+def _render_diagnostic_charts(summary: pd.DataFrame, paths: pd.DataFrame) -> dict[str, go.Figure]:
     charts: dict[str, go.Figure] = {}
     if summary.empty:
         st.warning("Diagnostics unavailable: summary frame is empty.")
@@ -334,9 +328,7 @@ def _render_diagnostic_charts(
     try:
         sharpe_fig = sharpe_ladder_chart.make(summary, metric="sharpe")
     except Exception:
-        st.warning(
-            "Sharpe ladder unavailable: summary does not include a usable 'sharpe' metric."
-        )
+        st.warning("Sharpe ladder unavailable: summary does not include a usable 'sharpe' metric.")
         sharpe_fig = go.Figure()
     corr_fig = corr_heatmap_chart.build_figure(paths, window=60)
     rolling_fig = rolling_panel_chart.build_figure(
@@ -431,9 +423,7 @@ def _render_results(
         if tokens and tokens[-1].isdigit():
             fold_id = int(tokens[-1])
     nav_paths = _extract_nav_paths(results, fold_id=fold_id)
-    canonical_paths = (
-        _cached_make_paths(nav_paths) if not nav_paths.empty else pd.DataFrame()
-    )
+    canonical_paths = _cached_make_paths(nav_paths) if not nav_paths.empty else pd.DataFrame()
 
     st.subheader("Charts")
     chart_bundle_inputs: dict[str, go.Figure] = {}
@@ -441,28 +431,20 @@ def _render_results(
     with tabs[0]:
         if nav_paths.empty:
             st.warning("No NAV paths available for the selected fold.")
-        chart_bundle_inputs["Sharpe Histogram"] = mc_plots.render_sharpe_histogram(
-            filtered_results
-        )
+        chart_bundle_inputs["Sharpe Histogram"] = mc_plots.render_sharpe_histogram(filtered_results)
         chart_bundle_inputs["Fan Chart"] = mc_plots.render_fan_chart(nav_paths)
-        chart_bundle_inputs["Path Distribution"] = (
-            mc_plots.render_path_distribution_chart(filtered_results)
-        )
-        chart_bundle_inputs["Risk Return"] = mc_plots.render_risk_return_chart(
+        chart_bundle_inputs["Path Distribution"] = mc_plots.render_path_distribution_chart(
             filtered_results
         )
-        chart_bundle_inputs["Strategy Box Plot"] = mc_plots.render_box_plot(
-            filtered_results
-        )
+        chart_bundle_inputs["Risk Return"] = mc_plots.render_risk_return_chart(filtered_results)
+        chart_bundle_inputs["Strategy Box Plot"] = mc_plots.render_box_plot(filtered_results)
         chart_bundle_inputs["Outcome CDF"] = mc_plots.render_cdf_plot(filtered_results)
     with tabs[1]:
         chart_bundle_inputs.update(_render_diagnostic_charts(summary, canonical_paths))
 
     st.subheader("Downloads")
     payloads = _build_download_payloads(summary_table, filtered_results)
-    chart_bundle_payload, chart_bundle_warnings = _build_chart_bundle_payload(
-        chart_bundle_inputs
-    )
+    chart_bundle_payload, chart_bundle_warnings = _build_chart_bundle_payload(chart_bundle_inputs)
     if chart_bundle_payload is not None:
         payloads.append(chart_bundle_payload)
     warning_text = _png_export_warning_message(chart_bundle_warnings)

--- a/tests/monte_carlo/test_runner_path_window_alignment.py
+++ b/tests/monte_carlo/test_runner_path_window_alignment.py
@@ -274,9 +274,7 @@ def test_extract_portfolio_metrics_accepts_series_stats() -> None:
     run_result = RunResult(
         metrics=per_fund,
         details={
-            "out_user_stats": pd.Series(
-                {"sharpe": 1.5, "bad_inf": np.inf, "is_avg_corr": True}
-            )
+            "out_user_stats": pd.Series({"sharpe": 1.5, "bad_inf": np.inf, "is_avg_corr": True})
         },
         seed=0,
         environment={},

--- a/tests/streamlit/test_mc_page.py
+++ b/tests/streamlit/test_mc_page.py
@@ -113,9 +113,7 @@ class DummyStreamlit:
             return self.multiselect_returns.pop(0)
         return []
 
-    def selectbox(
-        self, label: str, options: list[str], index: int = 0, **_kwargs: Any
-    ) -> str:
+    def selectbox(self, label: str, options: list[str], index: int = 0, **_kwargs: Any) -> str:
         self.selectbox_calls.append((label, list(options)))
         if self.selectbox_returns:
             return self.selectbox_returns.pop(0)
@@ -300,9 +298,7 @@ def test_scenario_picker_and_tag_filtering(monkeypatch: pytest.MonkeyPatch) -> N
 
     calls: list[dict[str, Any]] = []
 
-    def fake_list_scenarios(
-        *, tags: list[str] | None = None
-    ) -> list[ScenarioRegistryEntry]:
+    def fake_list_scenarios(*, tags: list[str] | None = None) -> list[ScenarioRegistryEntry]:
         calls.append({"tags": tags})
         if tags:
             return [entry for entry in scenarios if set(tags) & set(entry.tags)]
@@ -601,16 +597,12 @@ def test_download_link_generation(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "application/x-parquet" in mimes
     assert "application/zip" in mimes
 
-    csv_entry = next(
-        entry for entry in stub.downloads if entry.get("mime") == "text/csv"
-    )
+    csv_entry = next(entry for entry in stub.downloads if entry.get("mime") == "text/csv")
     assert isinstance(csv_entry.get("data"), str)
     assert "Strategy" in csv_entry.get("data")
 
     parquet_entry = next(
-        entry
-        for entry in stub.downloads
-        if entry.get("mime") == "application/x-parquet"
+        entry for entry in stub.downloads if entry.get("mime") == "application/x-parquet"
     )
     parquet_data = parquet_entry.get("data")
     assert hasattr(parquet_data, "getvalue")
@@ -661,9 +653,7 @@ def test_render_results_surfaces_png_export_warning(
     page._render_results(_sample_results(), fold_selection=None)
 
     assert any("PNG export warnings" in message for message in stub.warning_messages)
-    assert any(
-        entry.get("label") == "Download charts bundle" for entry in stub.downloads
-    )
+    assert any(entry.get("label") == "Download charts bundle" for entry in stub.downloads)
 
 
 def test_download_payload_file_names_use_timestamp(
@@ -754,9 +744,7 @@ def test_build_download_payloads_zip_bundle_content(
     filtered_results = _sample_results().results_frame
 
     payloads = page._build_download_payloads(summary_table, filtered_results)
-    zip_payload = next(
-        payload for payload in payloads if payload["mime"] == "application/zip"
-    )
+    zip_payload = next(payload for payload in payloads if payload["mime"] == "application/zip")
     zip_buffer = zip_payload["data"]
 
     assert zip_payload["label"] == "Download ZIP bundle"
@@ -780,9 +768,7 @@ def test_build_download_payloads_binary_buffers_are_rewound(
     parquet_payload = next(
         payload for payload in payloads if payload["mime"] == "application/x-parquet"
     )
-    zip_payload = next(
-        payload for payload in payloads if payload["mime"] == "application/zip"
-    )
+    zip_payload = next(payload for payload in payloads if payload["mime"] == "application/zip")
 
     parquet_buffer = parquet_payload["data"]
     zip_buffer = zip_payload["data"]
@@ -811,9 +797,7 @@ def test_build_download_payloads_tolerates_buffer_closing_engine(
 
     real_to_parquet = pd.DataFrame.to_parquet
 
-    def closing_to_parquet(
-        self: pd.DataFrame, path: Any = None, *args: Any, **kwargs: Any
-    ) -> Any:
+    def closing_to_parquet(self: pd.DataFrame, path: Any = None, *args: Any, **kwargs: Any) -> Any:
         result = real_to_parquet(self, path, *args, **kwargs)
         # fastparquet closes any open file object it is handed (a path does not).
         if hasattr(path, "close"):
@@ -834,9 +818,7 @@ def test_build_download_payloads_tolerates_buffer_closing_engine(
     parquet_bytes = parquet_payload["data"].getvalue()
     assert parquet_bytes[:4] == b"PAR1"
 
-    zip_payload = next(
-        payload for payload in payloads if payload["mime"] == "application/zip"
-    )
+    zip_payload = next(payload for payload in payloads if payload["mime"] == "application/zip")
     with zipfile.ZipFile(BytesIO(zip_payload["data"].getvalue())) as bundle:
         assert set(bundle.namelist()) == {"summary.csv", "representative_paths.parquet"}
 
@@ -858,9 +840,7 @@ def test_build_download_payloads_degrades_when_parquet_unavailable(
     assert "text/csv" in mimes
     assert "application/x-parquet" not in mimes  # parquet omitted, not crashing
 
-    zip_payload = next(
-        payload for payload in payloads if payload["mime"] == "application/zip"
-    )
+    zip_payload = next(payload for payload in payloads if payload["mime"] == "application/zip")
     with zipfile.ZipFile(BytesIO(zip_payload["data"].getvalue())) as bundle:
         assert bundle.namelist() == ["summary.csv"]
 


### PR DESCRIPTION
Fixes the red default branch, **and** the reason it keeps coming back. `phase-3` has failed `Python CI / lint-format` on every push since 2026-08-04.

## Two distinct defects

**1. What produced the unformatted code.** `line-length` was set **nowhere** in the repo, so black used its built-in default of **88** everywhere except CI, which passes an explicit `--line-length 100`. Both the pre-commit black hook and `scripts/style_gate_local.sh` invoke black with **no** `--line-length` flag, so they read `pyproject.toml` — setting it there fixes every local surface at once, so no `.pre-commit-config.yaml` or `style_gate_local.sh` change is needed.

Scale: with black's 88 default, a bare `black .` reformats **648 of 1053 files** relative to the CI-formatted tree.

**2. What let it merge.** `pr-00-gate.yml` passed `format_check: false`, so **PRs never ran the format check at all** — while push-to-`phase-3` does. Unformatted code merged green through the gate and reddened the branch on the next push. The stated reason (`# Using ruff for formatting`) was inaccurate: this repo does not run `ruff format`, and its ruff config is `lint.select = ["E4","E7","E9","F"]`, which performs no formatting. The reusable workflow already defaults `format_check: true`; TMP was overriding it off.

Fixing only (1) clears today's red. Fixing (2) is what stops the recurrence.

## Changes

- `pyproject.toml` `[tool.black]`: add `line-length = 100`
- `.github/workflows/pr-00-gate.yml`: `format_check: false` → `true`, with the rationale in a comment
- Reformat the 4 files CI rejects, using black **26.5.1** (the pin in `.github/workflows/autofix-versions.env`)

## Verification (CI-pinned tools)

```
black --check --line-length 100 --exclude '(\.venv|\.workflows-lib|node_modules)' .  -> 1053 files unchanged
black --check .                              (bare; reads pyproject)                 -> 1053 files unchanged
ruff check --select E4,E7,E9,F --extend-exclude .workflows-lib .                     -> All checks passed!
```

**Deliberate break → revert:** setting `line-length = 88` makes the bare check fail (648 files); reverting to `100` passes.

Note that `Python CI / lint-format` shows as *skipped* on this PR — `ci.yml` is push-only by design (`branches: [main, phase-3]`). With change (2) the **gate's** format check now runs on PRs, so this PR is the first one whose formatting is actually verified before merge.

## Deliberately not changed

- **`[tool.ruff]` line-length** — `lint.select` excludes `E501`, so it would be inert config.
- **`.pre-commit-config.yaml`** — already correct at tip (black `26.5.1`, ruff `v0.16.2`, mypy `v2.3.0`), matching `autofix-versions.env`. An earlier draft of #5809 claimed a version skew here; that was read from a stale local checkout and is **not** true at tip (correction posted on the issue).

Refs #5809