### PR TITLE
fix: keep Results banner Sharpe portfolio-level

### DIFF
--- a/streamlit_app/pages/3_Results.py
+++ b/streamlit_app/pages/3_Results.py
@@ -115,19 +115,7 @@ def _completed_state_sharpe(result: Any) -> float | None:
     """Return portfolio-level Sharpe for the completed-state banner."""
     raw_details = getattr(result, "details", None)
     details = raw_details if isinstance(raw_details, dict) else {}
-    portfolio_sharpe = _stats_value(details.get("out_user_stats"), "sharpe")
-    if portfolio_sharpe is not None:
-        return portfolio_sharpe
-
-    metrics = getattr(result, "metrics", None)
-    if isinstance(metrics, pd.DataFrame) and not metrics.empty:
-        for column in ("Sharpe", "sharpe"):
-            if column in metrics.columns:
-                sharpe = pd.to_numeric(metrics[column], errors="coerce")
-                sharpe = sharpe[np.isfinite(sharpe)].dropna()
-                if not sharpe.empty:
-                    return float(sharpe.iloc[0])
-    return None
+    return _stats_value(details.get("out_user_stats"), "sharpe")
 
 
 def _stats_value(stats: Any, name: str) -> float | None:

--- a/tests/app/test_results_page.py
+++ b/tests/app/test_results_page.py
@@ -707,10 +707,8 @@ def test_results_completed_state_skips_non_finite_fallback_sharpe(
 
     page.render_results_page()
 
-    assert any(
-        "Demo results loaded — 2 funds — Sharpe 1.23." in msg for msg in stub.success_messages
-    )
-    assert not any("Sharpe —" in msg for msg in stub.success_messages)
+    assert any("Demo results loaded — 2 funds." in msg for msg in stub.success_messages)
+    assert not any("Sharpe" in msg for msg in stub.success_messages)
 
 
 def test_demo_run_renders_results_end_to_end(monkeypatch: pytest.MonkeyPatch, results_page) -> None:

--- a/tests/streamlit/test_results_banner_sharpe.py
+++ b/tests/streamlit/test_results_banner_sharpe.py
@@ -12,9 +12,7 @@ def test_banner_sharpe_is_portfolio_level_or_absent(monkeypatch) -> None:
     monkeypatch.setattr(page.st, "session_state", {})
     result = SimpleNamespace(
         details={
-            "out_sample_scaled": pd.DataFrame(
-                {"Fund A": [0.02, 0.01], "Fund B": [0.01, 0.02]}
-            ),
+            "out_sample_scaled": pd.DataFrame({"Fund A": [0.02, 0.01], "Fund B": [0.01, 0.02]}),
             "fund_weights": {"Fund A": 0.5, "Fund B": 0.5},
         },
         metrics=pd.DataFrame({"Sharpe": [-2.04, 1.14]}, index=["Fund A", "Fund B"]),

--- a/tests/streamlit/test_results_banner_sharpe.py
+++ b/tests/streamlit/test_results_banner_sharpe.py
@@ -14,9 +14,15 @@ def test_banner_sharpe_is_portfolio_level_or_absent(monkeypatch) -> None:
         details={
             "out_sample_scaled": pd.DataFrame({"Fund A": [0.02, 0.01], "Fund B": [0.01, 0.02]}),
             "fund_weights": {"Fund A": 0.5, "Fund B": 0.5},
+            "out_user_stats": {"Sharpe": 1.14},
         },
         metrics=pd.DataFrame({"Sharpe": [-2.04, 1.14]}, index=["Fund A", "Fund B"]),
     )
 
-    assert page._completed_state_sharpe(result) is None
+    assert page._completed_state_sharpe(result) == 1.14
+    assert "Sharpe 1.14" in page._completed_state_line(result, fund_count=2)
     assert "-2.04" not in page._completed_state_line(result, fund_count=2)
+
+    result.details.pop("out_user_stats")
+    assert page._completed_state_sharpe(result) is None
+    assert "Sharpe" not in page._completed_state_line(result, fund_count=2)

--- a/tests/streamlit/test_results_banner_sharpe.py
+++ b/tests/streamlit/test_results_banner_sharpe.py
@@ -1,0 +1,24 @@
+"""Regression coverage for the Results-page completion banner."""
+
+import importlib
+from types import SimpleNamespace
+
+import pandas as pd
+
+
+def test_banner_sharpe_is_portfolio_level_or_absent(monkeypatch) -> None:
+    """A fund-level metrics table must never supply the banner's Sharpe value."""
+    page = importlib.import_module("streamlit_app.pages.3_Results")
+    monkeypatch.setattr(page.st, "session_state", {})
+    result = SimpleNamespace(
+        details={
+            "out_sample_scaled": pd.DataFrame(
+                {"Fund A": [0.02, 0.01], "Fund B": [0.01, 0.02]}
+            ),
+            "fund_weights": {"Fund A": 0.5, "Fund B": 0.5},
+        },
+        metrics=pd.DataFrame({"Sharpe": [-2.04, 1.14]}, index=["Fund A", "Fund B"]),
+    )
+
+    assert page._completed_state_sharpe(result) is None
+    assert "-2.04" not in page._completed_state_line(result, fund_count=2)


### PR DESCRIPTION
Closes #5810

## Summary

- Remove the unsafe per-fund metrics fallback from the completed Results banner.
- Show a Sharpe value only when the result provides an explicit portfolio-level statistic.
- Add a regression test proving a first-row fund Sharpe cannot appear in the banner.

## Validation

- uv run --extra dev python -m pytest -q tests/streamlit/test_results_banner_sharpe.py (1 passed)
- uv run --extra dev ruff check streamlit_app/pages/3_Results.py tests/streamlit/test_results_banner_sharpe.py (passed)

## Deliberate-break evidence

Reinstating the former first-row metrics fallback made the named regression test fail with -2.04 returned; restoring the fix made it pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Results-page completion banner to display only the portfolio Sharpe value.
  * Prevented fund-level Sharpe metrics from appearing in the completion-state message.

* **Tests**
  * Added regression coverage to verify the banner excludes fund-level Sharpe values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->