### PR TITLE
fix: align Data selection counter on first render

### DIFF
--- a/streamlit_app/pages/1_Data.py
+++ b/streamlit_app/pages/1_Data.py
@@ -731,15 +731,6 @@ def render_data_page() -> None:
                             st.session_state[f"{include_prefix}{fund}"] = False
                         st.rerun()
 
-            # Stats (live)
-            n_selected = sum(
-                1
-                for fund in available_funds
-                if bool(st.session_state.get(f"{include_prefix}{fund}", False))
-            )
-            n_total = len(available_funds)
-            st.markdown(f"**{n_selected} of {n_total}** funds selected")
-
             # Seed checkbox widget values from canonical selection (vectorized).
             _t_seed_start = time.perf_counter()
             defaults = {
@@ -751,6 +742,16 @@ def render_data_page() -> None:
                 st.session_state.update(defaults)
 
             _t_seed_done = time.perf_counter()
+
+            # Stats (live).  Seed before counting so a newly loaded dataset
+            # reports the same selection that its checkboxes will render.
+            n_selected = sum(
+                1
+                for fund in available_funds
+                if bool(st.session_state.get(f"{include_prefix}{fund}", False))
+            )
+            n_total = len(available_funds)
+            st.markdown(f"**{n_selected} of {n_total}** funds selected")
 
             # Faster rendering: one widget per row (avoid per-row columns/write).
             _t_render_start = time.perf_counter()

--- a/tests/app/test_data_page.py
+++ b/tests/app/test_data_page.py
@@ -63,6 +63,7 @@ class DummyStreamlit:
         self.error_messages: list[str] = []
         self.warning_messages: list[str] = []
         self.captions: list[str] = []
+        self.markdowns: list[str] = []
         self.code_blocks: list[tuple[str, str | None]] = []
         self.dataframes: list[pd.DataFrame] = []
         self.selectbox_map: dict[str, Any] = {}
@@ -123,8 +124,8 @@ class DummyStreamlit:
     def dataframe(self, df: pd.DataFrame) -> None:
         self.dataframes.append(df)
 
-    def markdown(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - trivial
-        return None
+    def markdown(self, text: str, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - trivial
+        self.markdowns.append(str(text))
 
     def expander(self, *_args: Any, **_kwargs: Any) -> "DummyStreamlit._Column":
         return DummyStreamlit._Column(self)

--- a/tests/streamlit/test_data_fund_counter.py
+++ b/tests/streamlit/test_data_fund_counter.py
@@ -1,0 +1,43 @@
+"""Regression coverage for the Data-page fund-selection headline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+import pandas as pd
+import pytest
+
+from tests.app.test_data_page import DummyStreamlit, data_page  # noqa: F401
+
+
+def _load_sample(monkeypatch: pytest.MonkeyPatch, page: ModuleType, stub: DummyStreamlit) -> None:
+    stub.session_state.clear()
+    df = pd.DataFrame(
+        {"FundA": [0.01, 0.02, -0.01], "SPX Index": [0.03, -0.02, 0.01]},
+        index=pd.date_range("2024-01-31", periods=3, freq="ME"),
+    )
+    meta = {"validation": {"issues": [], "warnings": []}, "frequency_label": "monthly"}
+    sample = page.data_cache.SampleDataset("demo.csv", Path("demo/demo_returns.csv"))
+    monkeypatch.setattr(page.data_cache, "default_sample_dataset", lambda: sample)
+    monkeypatch.setattr(page.data_cache, "dataset_choices", lambda: {sample.label: sample})
+    monkeypatch.setattr(page.data_cache, "load_dataset_from_path", lambda _path: (df, meta))
+    monkeypatch.setattr(page, "infer_benchmarks", lambda _columns: ["SPX Index"])
+    stub.selectbox_map["Choose a sample"] = sample.label
+    stub.selectbox_map["Benchmark column (optional)"] = "SPX Index"
+
+
+def test_selection_counter_matches_applied_count_on_first_render(
+    monkeypatch: pytest.MonkeyPatch, data_page  # noqa: F811 - reused pytest fixture
+) -> None:
+    page, stub = data_page
+    _load_sample(monkeypatch, page, stub)
+
+    page.render_data_page()
+
+    checked_count = sum(
+        value for key, value in stub.session_state.items() if key.startswith("fund_include::")
+    )
+    assert f"**{checked_count} of {checked_count}** funds selected" in stub.markdowns
+    noun = "fund" if checked_count == 1 else "funds"
+    assert f"Applied automatically for analysis: {checked_count} {noun}" in stub.captions


### PR DESCRIPTION
Closes #5811

## Summary

- Seed per-fund checkbox state before calculating the Data-page selection headline.
- Capture rendered Markdown in the Data-page test harness.
- Add first-render regression coverage that compares the headline, checked state, and applied-analysis caption.

## Validation

- `uv run --extra dev pytest -q tests/streamlit/test_data_fund_counter.py tests/app/test_data_page.py tests/app/test_data_page_no_perf_caption.py` → 7 passed
- `uv run --extra dev ruff check streamlit_app/pages/1_Data.py tests/app/test_data_page.py tests/streamlit/test_data_fund_counter.py` → passed
- `git diff --check` → passed
- Deliberate break: moving checkbox-state seeding below the headline makes `tests/streamlit/test_data_fund_counter.py::test_selection_counter_matches_applied_count_on_first_render` fail with `**0 of 20** funds selected`; restoring the order passes.