### PR TITLE
fix: persist demo profile across page navigation

### DIFF
--- a/streamlit_app/demo_profile.py
+++ b/streamlit_app/demo_profile.py
@@ -116,23 +116,11 @@ def get_active_profile() -> str:
     only the environment variable and default are consulted.
     """
 
-    session_value: Optional[str] = None
-    query_value: Optional[str] = None
     try:
         import streamlit as st  # noqa: PLC0415 -- lazy, optional dependency
     except ModuleNotFoundError:
-        st = None
-    if st is not None:
-        try:
-            session_value = st.session_state.get(PROFILE_SESSION_KEY)
-        except (AttributeError, TypeError):
-            session_value = None
-        query_value = _query_param_value(st)
-    return resolve_profile(
-        session=session_value,
-        query_param=query_value,
-        env=os.environ.get(PROFILE_ENV_VAR),
-    )
+        return resolve_profile(env=os.environ.get(PROFILE_ENV_VAR))
+    return _active_profile_from_module(st)
 
 
 def _active_profile_from_module(st_module) -> str:
@@ -143,11 +131,21 @@ def _active_profile_from_module(st_module) -> str:
         session_value = st_module.session_state.get(PROFILE_SESSION_KEY)
     except (AttributeError, TypeError):
         session_value = None
-    return resolve_profile(
+    query_value = _query_param_value(st_module)
+    active = resolve_profile(
         session=session_value,
-        query_param=_query_param_value(st_module),
+        query_param=query_value,
         env=os.environ.get(PROFILE_ENV_VAR),
     )
+    # Streamlit drops query parameters when a user changes pages. Persist only
+    # valid deep-link values, leaving malformed input as a safe fallback.
+    if (
+        session_value is None
+        and isinstance(query_value, str)
+        and query_value.strip().lower() in VALID_PROFILES
+    ):
+        _store_profile_on_module(st_module, active)
+    return active
 
 
 def _store_profile_on_module(st_module, profile: str) -> str:

--- a/streamlit_app/demo_profile.py
+++ b/streamlit_app/demo_profile.py
@@ -123,6 +123,23 @@ def get_active_profile() -> str:
     return _active_profile_from_module(st)
 
 
+def initialize_profile(st_module=None) -> str:
+    """Resolve and persist a valid deep-link profile without rendering controls.
+
+    Every Streamlit page must call this at entry so a valid ``?profile=`` is
+    retained even when a visitor lands on a page that does not show the demo
+    mode switcher.  Keeping this separate from :func:`render_profile_controls`
+    lets informational pages preserve the profile without adding duplicate UI.
+    """
+
+    if st_module is None:
+        try:
+            import streamlit as st_module  # noqa: PLC0415
+        except ModuleNotFoundError:
+            return get_active_profile()
+    return _active_profile_from_module(st_module)
+
+
 def _active_profile_from_module(st_module) -> str:
     """Resolve the active profile from an injected Streamlit-like module."""
 
@@ -221,6 +238,10 @@ def render_profile_controls(st_module=None) -> str:
 
     active = _active_profile_from_module(st_module)
     sidebar = getattr(st_module, "sidebar", st_module)
+    # Lightweight test adapters and embedded hosts may expose ``sidebar`` as a
+    # layout context but keep widgets on the root module.
+    if not hasattr(sidebar, "selectbox"):
+        sidebar = st_module
     try:
         index = VALID_PROFILES.index(active)
     except ValueError:

--- a/streamlit_app/pages/1_Data.py
+++ b/streamlit_app/pages/1_Data.py
@@ -37,6 +37,7 @@ from trend_analysis.io.market_data import MarketDataValidationError
 
 apply_ds_theme()
 apply_density_compact()
+demo_profile.render_profile_controls(st)
 
 DATE_COLUMN = "Date"
 REQUIRED_UPLOAD_COLUMNS = (DATE_COLUMN,)

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -2762,6 +2762,7 @@ for the covariance matrix.
 
 
 def render_model_page() -> None:
+    demo_profile.render_profile_controls(st)
     app_state.initialize_session_state()
     if _should_auto_render() and not demo_profile.custom_analysis_enabled():
         st.title("Model Configuration")

--- a/streamlit_app/pages/3_Results.py
+++ b/streamlit_app/pages/3_Results.py
@@ -26,6 +26,7 @@ from trend_analysis.util.weights import normalize_weights
 
 apply_ds_theme()
 apply_density_compact()
+demo_profile.initialize_profile(st)
 
 # =============================================================================
 # Formatting Helpers

--- a/streamlit_app/pages/4_Help.py
+++ b/streamlit_app/pages/4_Help.py
@@ -6,9 +6,11 @@ import streamlit as st
 
 st.set_page_config(page_title="Help - Portfolio Simulator", page_icon="📖", layout="wide")
 
+from streamlit_app import demo_profile  # noqa: E402
 from streamlit_app.theme import apply_ds_theme  # noqa: E402
 
 apply_ds_theme()
+demo_profile.initialize_profile(st)
 
 
 def render_help_page() -> None:

--- a/streamlit_app/pages/5_Monte_Carlo.py
+++ b/streamlit_app/pages/5_Monte_Carlo.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import streamlit as st
+
+from streamlit_app import demo_profile
 from streamlit_app.monte_carlo_page import render
 from streamlit_app.theme import apply_density_compact, apply_ds_theme
 
 apply_ds_theme()
 apply_density_compact()
+demo_profile.initialize_profile(st)
 render()

--- a/streamlit_app/pages/8_Validation.py
+++ b/streamlit_app/pages/8_Validation.py
@@ -30,12 +30,14 @@ st.set_page_config(
     layout="wide",
 )
 
+from streamlit_app import demo_profile  # noqa: E402
 from streamlit_app import state as app_state  # noqa: E402
 from streamlit_app.components import analysis_runner  # noqa: E402
 from streamlit_app.theme import apply_density_compact, apply_ds_theme  # noqa: E402
 
 apply_ds_theme()
 apply_density_compact()
+demo_profile.initialize_profile(st)
 
 # =============================================================================
 # Setting Definitions

--- a/tests/test_demo_profile.py
+++ b/tests/test_demo_profile.py
@@ -97,8 +97,10 @@ class _FakeSidebar:
     def __init__(self, selected: str) -> None:
         self._selected = selected
         self.captions: list[str] = []
+        self.selectbox_calls: list[str] = []
 
     def selectbox(self, _label: str, options, index: int, **_kw):  # noqa: ANN001
+        self.selectbox_calls.append(_label)
         return self._selected
 
     def caption(self, text: str) -> None:
@@ -146,11 +148,29 @@ def test_invalid_query_param_is_not_persisted() -> None:
     assert dp.PROFILE_SESSION_KEY not in fake.session_state
 
 
+def test_initialize_profile_persists_deep_link_without_rendering_controls() -> None:
+    fake = _FakeStreamlit(dp.PRESENTATION_SAFE)
+    fake.query_params[dp.PROFILE_QUERY_PARAM] = dp.PUBLIC_LLM_DEMO
+
+    assert dp.initialize_profile(fake) == dp.PUBLIC_LLM_DEMO
+    assert fake.session_state[dp.PROFILE_SESSION_KEY] == dp.PUBLIC_LLM_DEMO
+    assert fake.sidebar.selectbox_calls == []
+
+
 @pytest.mark.parametrize("page", ["1_Data.py", "2_Model.py"])
 def test_gated_pages_render_profile_controls(page: str) -> None:
     source = (REPO_ROOT / "streamlit_app" / "pages" / page).read_text(encoding="utf-8")
 
     assert "demo_profile.render_profile_controls(st)" in source
+
+
+@pytest.mark.parametrize(
+    "page", ["3_Results.py", "4_Help.py", "5_Monte_Carlo.py", "8_Validation.py"]
+)
+def test_other_page_entrypoints_initialize_demo_profile(page: str) -> None:
+    source = (REPO_ROOT / "streamlit_app" / "pages" / page).read_text(encoding="utf-8")
+
+    assert "demo_profile.initialize_profile(st)" in source
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_demo_profile.py
+++ b/tests/test_demo_profile.py
@@ -127,6 +127,32 @@ def test_render_profile_controls_presentation_safe_caption() -> None:
     assert any("Presentation-safe" in c for c in fake.sidebar.captions)
 
 
+def test_query_param_profile_persists_across_navigation() -> None:
+    fake = _FakeStreamlit(dp.PRESENTATION_SAFE)
+    fake.query_params[dp.PROFILE_QUERY_PARAM] = dp.PUBLIC_LLM_DEMO
+
+    assert dp._active_profile_from_module(fake) == dp.PUBLIC_LLM_DEMO
+    assert fake.session_state[dp.PROFILE_SESSION_KEY] == dp.PUBLIC_LLM_DEMO
+
+    fake.query_params.clear()
+    assert dp._active_profile_from_module(fake) == dp.PUBLIC_LLM_DEMO
+
+
+def test_invalid_query_param_is_not_persisted() -> None:
+    fake = _FakeStreamlit(dp.PRESENTATION_SAFE)
+    fake.query_params[dp.PROFILE_QUERY_PARAM] = "bogus"
+
+    assert dp._active_profile_from_module(fake) == dp.PRESENTATION_SAFE
+    assert dp.PROFILE_SESSION_KEY not in fake.session_state
+
+
+@pytest.mark.parametrize("page", ["1_Data.py", "2_Model.py"])
+def test_gated_pages_render_profile_controls(page: str) -> None:
+    source = (REPO_ROOT / "streamlit_app" / "pages" / page).read_text(encoding="utf-8")
+
+    assert "demo_profile.render_profile_controls(st)" in source
+
+
 # ---------------------------------------------------------------------------
 # Browser-demo artifact + build manifest
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #5812

## Summary
- Persist a valid `?profile=` selection into Streamlit session state before page navigation removes the query string.
- Render the existing Demo mode switcher on the Data and Model pages before their gated-state guidance.
- Cover valid deep-link persistence, malformed-input safety, and gated-page control placement.

## Validation
- `uv run --extra dev pytest -q tests/test_demo_profile.py tests/streamlit/test_data_fund_counter.py` (22 passed)
- `uv run --extra dev ruff check streamlit_app/demo_profile.py streamlit_app/pages/1_Data.py streamlit_app/pages/2_Model.py tests/test_demo_profile.py`
- `git diff --check`

## Deliberate-break evidence
Temporarily disabled the valid-query persistence condition; `tests/test_demo_profile.py::test_query_param_profile_persists_across_navigation` failed with a missing `demo_profile_active` session value. Restoring the condition made the focused suite pass.