### PR TITLE
fix: align entrypoint configuration contract

### DIFF
--- a/src/trend_analysis/config_contract.py
+++ b/src/trend_analysis/config_contract.py
@@ -45,8 +45,8 @@ def resolve_portfolio_weighting_name(
     """Resolve legacy and nested weighting keys with one documented precedence."""
 
     weighting_cfg = section_get(portfolio_cfg, "weighting", {})
-    nested_name = section_get(weighting_cfg, "name")
-    legacy_name = section_get(portfolio_cfg, "weighting_scheme")
+    nested_name = section_get(weighting_cfg, "name", None)
+    legacy_name = section_get(portfolio_cfg, "weighting_scheme", None)
     if legacy_name not in (None, ""):
         resolved_legacy = normalise_weighting_name(legacy_name)
         if resolved_legacy not in _WEIGHTING_SCHEME_PLACEHOLDERS or not nested_name:
@@ -61,9 +61,26 @@ def optional_cost_bps(value: Any, *, field: str) -> float | None:
         parsed = float(value)
     except (TypeError, ValueError) as exc:
         raise CoreConfigError(f"portfolio.{field} must be numeric") from exc
-    if not math.isfinite(parsed) or parsed < 0:
-        raise CoreConfigError(f"portfolio.{field} must be finite and non-negative")
+    if not math.isfinite(parsed):
+        raise CoreConfigError(f"portfolio.{field} must be finite")
+    if parsed < 0:
+        raise CoreConfigError(f"portfolio.{field} cannot be negative")
     return parsed
+
+
+def first_configured_cost(
+    section: Any,
+    primary_key: str,
+    legacy_key: str,
+    *,
+    section_get: SectionGet,
+) -> tuple[Any, str]:
+    """Return the preferred configured cost alias and its diagnostic field name."""
+
+    primary_value = section_get(section, primary_key, None)
+    if primary_value is not None:
+        return primary_value, primary_key
+    return section_get(section, legacy_key, None), legacy_key
 
 
 def resolve_portfolio_cost_bps(
@@ -73,14 +90,26 @@ def resolve_portfolio_cost_bps(
 ) -> tuple[float, float]:
     """Return canonical transaction-cost and slippage inputs in basis points."""
 
-    cost_model = section_get(portfolio_cfg, "cost_model")
+    cost_model = section_get(portfolio_cfg, "cost_model", None)
+    bps_per_trade_value, bps_per_trade_key = first_configured_cost(
+        cost_model,
+        "per_trade_bps",
+        "bps_per_trade",
+        section_get=section_get,
+    )
     bps_per_trade = optional_cost_bps(
-        section_get(cost_model, "per_trade_bps", section_get(cost_model, "bps_per_trade")),
-        field="cost_model.per_trade_bps",
+        bps_per_trade_value,
+        field=f"cost_model.{bps_per_trade_key}",
+    )
+    slippage_bps_value, slippage_bps_key = first_configured_cost(
+        cost_model,
+        "half_spread_bps",
+        "slippage_bps",
+        section_get=section_get,
     )
     slippage_bps = optional_cost_bps(
-        section_get(cost_model, "half_spread_bps", section_get(cost_model, "slippage_bps")),
-        field="cost_model.half_spread_bps",
+        slippage_bps_value,
+        field=f"cost_model.{slippage_bps_key}",
     )
     if bps_per_trade is None:
         bps_per_trade = optional_cost_bps(
@@ -102,11 +131,24 @@ def resolve_pipeline_monthly_cost(
 ) -> float:
     """Resolve the decimal per-period cost sent to the shared analysis pipeline."""
 
-    tc_bps, slippage_bps = resolve_portfolio_cost_bps(portfolio_cfg, section_get=section_get)
-    if any(
-        section_get(portfolio_cfg, key) is not None
-        for key in ("cost_model", "transaction_cost_bps", "slippage_bps")
-    ):
+    tc_bps, slippage_bps = resolve_portfolio_cost_bps(
+        portfolio_cfg, section_get=section_get
+    )
+    cost_model = section_get(portfolio_cfg, "cost_model", None)
+    cost_values = (
+        *(
+            section_get(cost_model, key, None)
+            for key in (
+                "per_trade_bps",
+                "bps_per_trade",
+                "half_spread_bps",
+                "slippage_bps",
+            )
+        ),
+        section_get(portfolio_cfg, "transaction_cost_bps", None),
+        section_get(portfolio_cfg, "slippage_bps", None),
+    )
+    if any(value is not None for value in cost_values):
         return (tc_bps + slippage_bps) / 10000.0
     try:
         monthly_cost = float(section_get(run_cfg, "monthly_cost", 0.0) or 0.0)

--- a/src/trend_analysis/config_contract.py
+++ b/src/trend_analysis/config_contract.py
@@ -131,9 +131,7 @@ def resolve_pipeline_monthly_cost(
 ) -> float:
     """Resolve the decimal per-period cost sent to the shared analysis pipeline."""
 
-    tc_bps, slippage_bps = resolve_portfolio_cost_bps(
-        portfolio_cfg, section_get=section_get
-    )
+    tc_bps, slippage_bps = resolve_portfolio_cost_bps(portfolio_cfg, section_get=section_get)
     cost_model = section_get(portfolio_cfg, "cost_model", None)
     cost_values = (
         *(

--- a/src/trend_analysis/config_contract.py
+++ b/src/trend_analysis/config_contract.py
@@ -102,9 +102,7 @@ def resolve_pipeline_monthly_cost(
 ) -> float:
     """Resolve the decimal per-period cost sent to the shared analysis pipeline."""
 
-    tc_bps, slippage_bps = resolve_portfolio_cost_bps(
-        portfolio_cfg, section_get=section_get
-    )
+    tc_bps, slippage_bps = resolve_portfolio_cost_bps(portfolio_cfg, section_get=section_get)
     if any(
         section_get(portfolio_cfg, key) is not None
         for key in ("cost_model", "transaction_cost_bps", "slippage_bps")

--- a/src/trend_analysis/config_contract.py
+++ b/src/trend_analysis/config_contract.py
@@ -1,0 +1,119 @@
+"""Shared configuration-resolution contract for analysis entry points."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Callable, Mapping
+
+from trend.config_schema import CoreConfigError
+
+SectionGet = Callable[[Any, str, Any], Any]
+
+_WEIGHTING_NAME_ALIASES = {"ew": "equal", "robust": "robust_mv"}
+_WEIGHTING_SCHEME_PLACEHOLDERS = {"equal", "custom"}
+
+
+def mapping_get(section: Any, key: str, default: Any = None) -> Any:
+    """Read either a mapping or a config-model section."""
+
+    if isinstance(section, Mapping):
+        return section.get(key, default)
+    getter = getattr(section, "get", None)
+    if callable(getter):
+        try:
+            return getter(key, default)
+        except TypeError:
+            try:
+                return getter(key)
+            except KeyError:
+                return default
+        except KeyError:
+            return default
+    return getattr(section, key, default)
+
+
+def normalise_weighting_name(value: Any) -> str:
+    name = str(value or "equal").strip().lower()
+    return _WEIGHTING_NAME_ALIASES.get(name, name)
+
+
+def resolve_portfolio_weighting_name(
+    portfolio_cfg: Any,
+    *,
+    section_get: SectionGet = mapping_get,
+) -> str:
+    """Resolve legacy and nested weighting keys with one documented precedence."""
+
+    weighting_cfg = section_get(portfolio_cfg, "weighting", {})
+    nested_name = section_get(weighting_cfg, "name")
+    legacy_name = section_get(portfolio_cfg, "weighting_scheme")
+    if legacy_name not in (None, ""):
+        resolved_legacy = normalise_weighting_name(legacy_name)
+        if resolved_legacy not in _WEIGHTING_SCHEME_PLACEHOLDERS or not nested_name:
+            return resolved_legacy
+    return normalise_weighting_name(nested_name)
+
+
+def optional_cost_bps(value: Any, *, field: str) -> float | None:
+    if value in (None, "", "null"):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise CoreConfigError(f"portfolio.{field} must be numeric") from exc
+    if not math.isfinite(parsed) or parsed < 0:
+        raise CoreConfigError(f"portfolio.{field} must be finite and non-negative")
+    return parsed
+
+
+def resolve_portfolio_cost_bps(
+    portfolio_cfg: Any,
+    *,
+    section_get: SectionGet = mapping_get,
+) -> tuple[float, float]:
+    """Return canonical transaction-cost and slippage inputs in basis points."""
+
+    cost_model = section_get(portfolio_cfg, "cost_model")
+    bps_per_trade = optional_cost_bps(
+        section_get(cost_model, "per_trade_bps", section_get(cost_model, "bps_per_trade")),
+        field="cost_model.per_trade_bps",
+    )
+    slippage_bps = optional_cost_bps(
+        section_get(cost_model, "half_spread_bps", section_get(cost_model, "slippage_bps")),
+        field="cost_model.half_spread_bps",
+    )
+    if bps_per_trade is None:
+        bps_per_trade = optional_cost_bps(
+            section_get(portfolio_cfg, "transaction_cost_bps", 0.0),
+            field="transaction_cost_bps",
+        )
+    if slippage_bps is None:
+        slippage_bps = optional_cost_bps(
+            section_get(portfolio_cfg, "slippage_bps", 0.0), field="slippage_bps"
+        )
+    return float(bps_per_trade or 0.0), float(slippage_bps or 0.0)
+
+
+def resolve_pipeline_monthly_cost(
+    run_cfg: Any,
+    portfolio_cfg: Any,
+    *,
+    section_get: SectionGet = mapping_get,
+) -> float:
+    """Resolve the decimal per-period cost sent to the shared analysis pipeline."""
+
+    tc_bps, slippage_bps = resolve_portfolio_cost_bps(
+        portfolio_cfg, section_get=section_get
+    )
+    if any(
+        section_get(portfolio_cfg, key) is not None
+        for key in ("cost_model", "transaction_cost_bps", "slippage_bps")
+    ):
+        return (tc_bps + slippage_bps) / 10000.0
+    try:
+        monthly_cost = float(section_get(run_cfg, "monthly_cost", 0.0) or 0.0)
+    except (TypeError, ValueError) as exc:
+        raise CoreConfigError("run.monthly_cost must be numeric") from exc
+    if not math.isfinite(monthly_cost) or monthly_cost < 0:
+        raise CoreConfigError("run.monthly_cost must be finite and non-negative")
+    return monthly_cost

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -33,7 +33,11 @@ from trend.diagnostics import DiagnosticResult
 from .._typing import FloatArray
 from ..config_contract import (
     resolve_pipeline_monthly_cost as _shared_resolve_pipeline_monthly_cost,
+)
+from ..config_contract import (
     resolve_portfolio_cost_bps as _shared_resolve_portfolio_cost_bps,
+)
+from ..config_contract import (
     resolve_portfolio_weighting_name,
 )
 from ..constants import NUMERICAL_TOLERANCE_HIGH

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -31,6 +31,11 @@ from trend.config_schema import CoreConfigError
 from trend.diagnostics import DiagnosticResult
 
 from .._typing import FloatArray
+from ..config_contract import (
+    resolve_pipeline_monthly_cost as _shared_resolve_pipeline_monthly_cost,
+    resolve_portfolio_cost_bps as _shared_resolve_portfolio_cost_bps,
+    resolve_portfolio_weighting_name,
+)
 from ..constants import NUMERICAL_TOLERANCE_HIGH
 from ..core.rank_selection import ASCENDING_METRICS
 from ..data import load_csv
@@ -192,18 +197,7 @@ def _resolve_portfolio_weighting(
     if not isinstance(raw_params, Mapping):
         raise ValueError("portfolio.weighting.params must be a mapping")
     w_params = cast(Mapping[str, Any], raw_params)
-    weighting_scheme = portfolio_cfg.get("weighting_scheme")
-    if "weighting_scheme" in portfolio_cfg and weighting_scheme not in (
-        None,
-        "",
-    ):
-        scheme_name = _normalise_weighting_name(weighting_scheme)
-        if scheme_name in _WEIGHTING_SCHEME_PLACEHOLDERS and w_cfg.get("name"):
-            weighting_name = _normalise_weighting_name(w_cfg.get("name"))
-        else:
-            weighting_name = scheme_name
-    else:
-        weighting_name = _normalise_weighting_name(w_cfg.get("name", "equal"))
+    weighting_name = resolve_portfolio_weighting_name(portfolio_cfg)
 
     if weighting_name not in _SUPPORTED_NORMALISED_WEIGHTING_NAMES:
         allowed = ", ".join(sorted(_SUPPORTED_WEIGHTING_NAMES))
@@ -311,31 +305,7 @@ def _resolve_portfolio_cost_bps(
     portfolio_cfg: Mapping[str, Any],
 ) -> tuple[float, float]:
     """Resolve canonical turnover-cost inputs for the multi-period engine."""
-
-    cost_model = portfolio_cfg.get("cost_model")
-    bps_per_trade = None
-    slippage_bps = None
-    if cost_model is not None:
-        bps_per_trade = _optional_cost_bps(
-            _mapping_or_attr_get(cost_model, "bps_per_trade"),
-            field="cost_model.bps_per_trade",
-        )
-        slippage_bps = _optional_cost_bps(
-            _mapping_or_attr_get(cost_model, "slippage_bps"),
-            field="cost_model.slippage_bps",
-        )
-
-    if bps_per_trade is None:
-        bps_per_trade = _optional_cost_bps(
-            portfolio_cfg.get("transaction_cost_bps", 0.0),
-            field="transaction_cost_bps",
-        )
-    if slippage_bps is None:
-        slippage_bps = _optional_cost_bps(
-            portfolio_cfg.get("slippage_bps", 0.0),
-            field="slippage_bps",
-        )
-    return float(bps_per_trade or 0.0), float(slippage_bps or 0.0)
+    return _shared_resolve_portfolio_cost_bps(portfolio_cfg)
 
 
 def _resolve_pipeline_monthly_cost(
@@ -347,12 +317,8 @@ def _resolve_pipeline_monthly_cost(
 ) -> float:
     """Return decimal per-period cost for delegated non-threshold analysis."""
 
-    if any(key in portfolio_cfg for key in ("cost_model", "transaction_cost_bps", "slippage_bps")):
-        return (tc_bps + slippage_bps) / 10000.0
-    try:
-        return float(run_cfg.get("monthly_cost", 0.0) or 0.0)
-    except (TypeError, ValueError) as exc:
-        raise CoreConfigError("run.monthly_cost must be numeric") from exc
+    del tc_bps, slippage_bps
+    return _shared_resolve_pipeline_monthly_cost(run_cfg, portfolio_cfg)
 
 
 def _period_turnover_cost(

--- a/src/trend_analysis/pipeline_entrypoints.py
+++ b/src/trend_analysis/pipeline_entrypoints.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import inspect
 import logging
-import math
 from dataclasses import dataclass
 from typing import Any, Mapping, cast
 
@@ -10,6 +9,10 @@ import pandas as pd
 
 from trend.diagnostics import DiagnosticResult
 
+from .config_contract import (
+    resolve_pipeline_monthly_cost,
+    resolve_portfolio_weighting_name,
+)
 from .diagnostics import PipelineResult, coerce_pipeline_result
 from .util.risk_free import resolve_risk_free_settings
 
@@ -45,65 +48,12 @@ def _accepts_keyword(func: Any, keyword: str) -> bool:
 
 def _resolve_single_period_weighting_scheme(portfolio_cfg: Any, section_get: Any) -> str:
     """Use the same public weighting-key precedence as the multi-period engine."""
-
-    weighting_cfg = section_get(portfolio_cfg, "weighting", {})
-    nested_name = section_get(weighting_cfg, "name") if isinstance(weighting_cfg, Mapping) else None
-    legacy_name = section_get(portfolio_cfg, "weighting_scheme")
-    if legacy_name not in (None, "", "equal", "custom"):
-        return _normalise_single_period_weighting_name(legacy_name)
-    if nested_name not in (None, ""):
-        return _normalise_single_period_weighting_name(nested_name)
-    return _normalise_single_period_weighting_name(legacy_name)
-
-
-def _normalise_single_period_weighting_name(value: Any) -> str:
-    return {"ew": "equal", "robust": "robust_mv"}.get(
-        str(value or "equal").strip().lower(), str(value or "equal").strip().lower()
-    )
-
-
-def _optional_cost_bps(value: Any, *, field: str) -> float | None:
-    if value in (None, "", "null"):
-        return None
-    try:
-        parsed = float(value)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"portfolio.{field} must be numeric") from exc
-    if not math.isfinite(parsed) or parsed < 0:
-        raise ValueError(f"portfolio.{field} must be finite and non-negative")
-    return parsed
+    return resolve_portfolio_weighting_name(portfolio_cfg, section_get=section_get)
 
 
 def _resolve_single_period_monthly_cost(portfolio_cfg: Any, run_cfg: Any) -> float:
     """Translate the canonical portfolio cost model for the single-period path."""
-
-    portfolio = dict(portfolio_cfg) if isinstance(portfolio_cfg, Mapping) else {}
-    run = dict(run_cfg) if isinstance(run_cfg, Mapping) else {}
-    cost_model = portfolio.get("cost_model")
-    cost_model = cost_model if isinstance(cost_model, Mapping) else {}
-    tc_bps = _optional_cost_bps(
-        cost_model.get("per_trade_bps", cost_model.get("bps_per_trade")),
-        field="cost_model.per_trade_bps",
-    )
-    if tc_bps is None:
-        tc_bps = _optional_cost_bps(
-            portfolio.get("transaction_cost_bps", 0.0), field="transaction_cost_bps"
-        )
-    slippage_bps = _optional_cost_bps(
-        cost_model.get("half_spread_bps", cost_model.get("slippage_bps")),
-        field="cost_model.half_spread_bps",
-    )
-    if slippage_bps is None:
-        slippage_bps = _optional_cost_bps(portfolio.get("slippage_bps", 0.0), field="slippage_bps")
-    if any(key in portfolio for key in ("cost_model", "transaction_cost_bps", "slippage_bps")):
-        return (float(tc_bps or 0.0) + float(slippage_bps or 0.0)) / 10000.0
-    try:
-        monthly_cost = float(run.get("monthly_cost", 0.0) or 0.0)
-    except (TypeError, ValueError) as exc:
-        raise ValueError("run.monthly_cost must be numeric") from exc
-    if not math.isfinite(monthly_cost) or monthly_cost < 0:
-        raise ValueError("run.monthly_cost must be finite and non-negative")
-    return monthly_cost
+    return resolve_pipeline_monthly_cost(run_cfg, portfolio_cfg)
 
 
 def run_from_config(cfg: Any, *, bindings: ConfigBindings) -> pd.DataFrame:

--- a/tests/test_entrypoint_contract_parity.py
+++ b/tests/test_entrypoint_contract_parity.py
@@ -1,0 +1,46 @@
+"""Regression coverage for configuration values shared by both analysis paths."""
+
+from __future__ import annotations
+
+import pytest
+
+from trend_analysis.multi_period.engine import (
+    _resolve_pipeline_monthly_cost,
+    _resolve_portfolio_cost_bps,
+    _resolve_portfolio_weighting,
+)
+from trend_analysis.pipeline_entrypoints import (
+    _resolve_single_period_monthly_cost,
+    _resolve_single_period_weighting_scheme,
+)
+
+
+def test_same_config_same_numbers_across_entrypoints() -> None:
+    """Cost and weighting inputs agree before either entry point executes them."""
+
+    portfolio = {
+        "transaction_cost_bps": 12,
+        "cost_model": {"slippage_bps": 3},
+        "weighting": {"name": "score_prop_bayes"},
+    }
+    run = {"monthly_cost": 0.0}
+
+    single_cost = _resolve_single_period_monthly_cost(portfolio, run)
+    multi_tc_bps, multi_slippage_bps = _resolve_portfolio_cost_bps(portfolio)
+    multi_cost = _resolve_pipeline_monthly_cost(
+        run,
+        portfolio,
+        tc_bps=multi_tc_bps,
+        slippage_bps=multi_slippage_bps,
+    )
+    _, _, _, _, multi_weighting = _resolve_portfolio_weighting(portfolio)
+
+    assert single_cost == multi_cost == pytest.approx(0.0015)
+    assert _resolve_single_period_weighting_scheme(portfolio, dict.get) == multi_weighting
+
+    gross_return = 0.01
+    zero_cost = _resolve_single_period_monthly_cost(
+        {"transaction_cost_bps": 0}, run
+    )
+    assert gross_return - single_cost < gross_return - zero_cost
+    assert gross_return - multi_cost < gross_return - zero_cost

--- a/tests/test_entrypoint_contract_parity.py
+++ b/tests/test_entrypoint_contract_parity.py
@@ -39,8 +39,6 @@ def test_same_config_same_numbers_across_entrypoints() -> None:
     assert _resolve_single_period_weighting_scheme(portfolio, dict.get) == multi_weighting
 
     gross_return = 0.01
-    zero_cost = _resolve_single_period_monthly_cost(
-        {"transaction_cost_bps": 0}, run
-    )
+    zero_cost = _resolve_single_period_monthly_cost({"transaction_cost_bps": 0}, run)
     assert gross_return - single_cost < gross_return - zero_cost
     assert gross_return - multi_cost < gross_return - zero_cost

--- a/tests/test_entrypoint_contract_parity.py
+++ b/tests/test_entrypoint_contract_parity.py
@@ -77,7 +77,10 @@ def test_empty_cost_model_keeps_run_monthly_cost() -> None:
     [
         ({"weighting": {"name": "ew"}}, "equal"),
         ({"weighting": {"name": "score_prop_bayes"}, "weighting_scheme": "robust"}, "robust_mv"),
-        ({"weighting": {"name": "score_prop_bayes"}, "weighting_scheme": "equal"}, "score_prop_bayes"),
+        (
+            {"weighting": {"name": "score_prop_bayes"}, "weighting_scheme": "equal"},
+            "score_prop_bayes",
+        ),
     ],
 )
 def test_weighting_aliases_and_precedence_match_both_entrypoints(

--- a/tests/test_entrypoint_contract_parity.py
+++ b/tests/test_entrypoint_contract_parity.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 import pytest
 
+from trend_analysis.config.model import CostModelSettings
+from trend_analysis.config_contract import (
+    resolve_pipeline_monthly_cost,
+    resolve_portfolio_cost_bps,
+    resolve_portfolio_weighting_name,
+)
 from trend_analysis.multi_period.engine import (
     _resolve_pipeline_monthly_cost,
     _resolve_portfolio_cost_bps,
@@ -42,3 +48,53 @@ def test_same_config_same_numbers_across_entrypoints() -> None:
     zero_cost = _resolve_single_period_monthly_cost({"transaction_cost_bps": 0}, run)
     assert gross_return - single_cost < gross_return - zero_cost
     assert gross_return - multi_cost < gross_return - zero_cost
+
+
+def test_cost_model_dump_preserves_legacy_values_when_optional_aliases_are_null() -> None:
+    """Pydantic's null optional aliases must not mask configured legacy costs."""
+
+    cost_model = CostModelSettings(bps_per_trade=12, slippage_bps=3).model_dump()
+    portfolio = {"cost_model": cost_model}
+
+    assert resolve_portfolio_cost_bps(portfolio) == (12.0, 3.0)
+    assert _resolve_single_period_monthly_cost(portfolio, {"monthly_cost": 0.0}) == pytest.approx(
+        0.0015
+    )
+
+
+def test_empty_cost_model_keeps_run_monthly_cost() -> None:
+    """An empty mapping is not a configured portfolio cost override."""
+
+    portfolio = {"cost_model": {}}
+    run = {"monthly_cost": 0.0025}
+
+    assert resolve_pipeline_monthly_cost(run, portfolio) == pytest.approx(0.0025)
+    assert _resolve_single_period_monthly_cost(portfolio, run) == pytest.approx(0.0025)
+
+
+@pytest.mark.parametrize(
+    ("portfolio", "expected"),
+    [
+        ({"weighting": {"name": "ew"}}, "equal"),
+        ({"weighting": {"name": "score_prop_bayes"}, "weighting_scheme": "robust"}, "robust_mv"),
+        ({"weighting": {"name": "score_prop_bayes"}, "weighting_scheme": "equal"}, "score_prop_bayes"),
+    ],
+)
+def test_weighting_aliases_and_precedence_match_both_entrypoints(
+    portfolio: dict[str, object], expected: str
+) -> None:
+    """Nested aliases and explicit legacy weighting settings share one precedence rule."""
+
+    _, _, _, _, multi_weighting = _resolve_portfolio_weighting(portfolio)
+    assert resolve_portfolio_weighting_name(portfolio) == expected
+    assert _resolve_single_period_weighting_scheme(portfolio, dict.get) == expected
+    assert multi_weighting == expected
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -1])
+def test_invalid_costs_are_rejected_by_shared_contract(value: float) -> None:
+    """Both entry points reject non-finite and negative cost inputs consistently."""
+
+    portfolio = {"cost_model": {"bps_per_trade": value}}
+    with pytest.raises(Exception, match="cost_model.bps_per_trade"):
+        _resolve_single_period_monthly_cost(portfolio, {"monthly_cost": 0.0})

--- a/tests/test_pipeline_entrypoints.py
+++ b/tests/test_pipeline_entrypoints.py
@@ -61,6 +61,8 @@ def test_single_period_cost_model_honours_effective_override_fields() -> None:
     }
 
     assert _resolve_single_period_monthly_cost(portfolio, {}) == pytest.approx(0.0015)
+
+
 def test_single_period_legacy_weighting_scheme_overrides_nested_name() -> None:
     portfolio = {
         "weighting_scheme": "risk_parity",

--- a/tests/test_pipeline_entrypoints.py
+++ b/tests/test_pipeline_entrypoints.py
@@ -61,8 +61,6 @@ def test_single_period_cost_model_honours_effective_override_fields() -> None:
     }
 
     assert _resolve_single_period_monthly_cost(portfolio, {}) == pytest.approx(0.0015)
-
-
 def test_single_period_legacy_weighting_scheme_overrides_nested_name() -> None:
     portfolio = {
         "weighting_scheme": "risk_parity",

--- a/tests/test_pipeline_entrypoints.py
+++ b/tests/test_pipeline_entrypoints.py
@@ -42,11 +42,16 @@ def test_same_config_same_numbers_across_entrypoints() -> None:
     assert _resolve_single_period_monthly_cost(portfolio, {}) == pytest.approx(0.0015)
 
 
-@pytest.mark.parametrize("invalid", [float("nan"), float("inf"), -1])
-def test_single_period_costs_reject_non_finite_and_negative_values(invalid: float) -> None:
-    with pytest.raises(ValueError, match="finite and non-negative"):
+@pytest.mark.parametrize(
+    ("invalid", "error_fragment"),
+    [(float("nan"), "finite"), (float("inf"), "finite"), (-1, "negative")],
+)
+def test_single_period_costs_reject_non_finite_and_negative_values(
+    invalid: float, error_fragment: str
+) -> None:
+    with pytest.raises(ValueError, match=error_fragment):
         _resolve_single_period_monthly_cost({"transaction_cost_bps": invalid}, {})
-    with pytest.raises(ValueError, match="finite and non-negative"):
+    with pytest.raises(ValueError, match=error_fragment):
         _resolve_single_period_monthly_cost({}, {"monthly_cost": invalid})
 
 

--- a/tests/test_trend_config_model_additional.py
+++ b/tests/test_trend_config_model_additional.py
@@ -267,8 +267,6 @@ def test_risk_settings_enabled_defaults_to_true() -> None:
     settings = RiskSettings.model_validate({"target_vol": 0.1})
 
     assert settings.enabled is True
-
-
 def test_resolve_config_path_variants(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     default_path = _resolve_config_path("demo")
     assert default_path.name == "demo.yml"

--- a/tests/test_trend_config_model_additional.py
+++ b/tests/test_trend_config_model_additional.py
@@ -267,6 +267,8 @@ def test_risk_settings_enabled_defaults_to_true() -> None:
     settings = RiskSettings.model_validate({"target_vol": 0.1})
 
     assert settings.enabled is True
+
+
 def test_resolve_config_path_variants(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     default_path = _resolve_config_path("demo")
     assert default_path.name == "demo.yml"


### PR DESCRIPTION
Closes #5813

## Summary
- centralize cost and weighting resolution used by both single-period and multi-period entry points
- preserve finite/non-negative cost validation and align harness Sharpe/volatility with the canonical metrics
- add a named cross-entry-point contract test

## Validation
- `PYTHONPATH=src python -m pytest -q tests/test_entrypoint_contract_parity.py tests/test_pipeline_entrypoints.py tests/test_trend_config_model_additional.py tests/test_weighting_resolution.py tests/backtesting/test_harness.py` (66 passed)
- `python -m ruff check src/trend_analysis/config_contract.py src/trend_analysis/pipeline_entrypoints.py src/trend_analysis/multi_period/engine.py tests/test_entrypoint_contract_parity.py`
- `git diff --check`

## Deliberate-break evidence
Temporarily changed the single-period monthly-cost resolver to return `0.0`; `tests/test_entrypoint_contract_parity.py::test_same_config_same_numbers_across_entrypoints` failed with `0.0 == 0.0015`. Restored the shared resolver and the focused suite passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized portfolio weighting and transaction-cost configuration across single-period and multi-period analysis.
  * Added consistent handling for configuration formats, precedence rules, validation, and legacy fallbacks.
  * Ensured monthly pipeline costs are converted consistently.

* **Bug Fixes**
  * Resolved inconsistencies where equivalent portfolio settings could produce different costs or weighting schemes.
  * Confirmed that nonzero transaction costs appropriately reduce returns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->