### PR TITLE
fix: reject unknown configuration sections

### DIFF
--- a/src/trend_analysis/config/lint_keys.py
+++ b/src/trend_analysis/config/lint_keys.py
@@ -145,10 +145,20 @@ _DECLARED_RUN_KEYS = {
     "output_dir",
     "seed",
 }
+_DECLARED_PREPROCESSING_KEYS = {
+    "de_duplicate",
+    "holiday_calendar",
+    "log_prices",
+    "missing_data",
+    "resample",
+    "steps",
+    "winsorise",
+}
 
 _CLOSED_SECTIONS: dict[str, set[str]] = {
     "metrics": _DECLARED_METRICS_KEYS,
     "export": _DECLARED_EXPORT_KEYS,
+    "preprocessing": _DECLARED_PREPROCESSING_KEYS,
     "run": _DECLARED_RUN_KEYS,
 }
 

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -205,7 +205,19 @@ if _HAS_PYDANTIC:
         """Typed access to the YAML configuration (Pydantic mode)."""
 
         # Field lists generated dynamically from model fields to prevent maintenance burden
-        OPTIONAL_DICT_FIELDS: ClassVar[set[str]] = {"performance", "signals", "regime"}
+        # These sections are accepted by the closed top-level schema but are
+        # optional in the shipped and legacy configurations.  Keep this list in
+        # sync with the fallback model: ``_dict_field_names`` drives
+        # ``REQUIRED_DICT_FIELDS`` for the runtime validation layer.
+        OPTIONAL_DICT_FIELDS: ClassVar[set[str]] = {
+            "extra",
+            "identity",
+            "performance",
+            "regime",
+            "signals",
+            "strategy",
+            "walk_forward",
+        }
 
         @classmethod
         def _dict_field_names(cls) -> List[str]:
@@ -454,14 +466,27 @@ else:  # Fallback mode for tests without pydantic
             "signals",
             "export",
             "performance",
+            "identity",
+            "extra",
             "output",
             "run",
+            "multi_period",
+            "strategy",
+            "walk_forward",
             "jobs",
             "checkpoint_dir",
             "seed",
         ]
 
-        OPTIONAL_DICT_FIELDS: ClassVar[set[str]] = {"performance", "signals", "regime"}
+        OPTIONAL_DICT_FIELDS: ClassVar[set[str]] = {
+            "extra",
+            "identity",
+            "performance",
+            "regime",
+            "signals",
+            "strategy",
+            "walk_forward",
+        }
 
         # Attribute declarations for linters/type-checkers
         version: str
@@ -476,9 +501,13 @@ else:  # Fallback mode for tests without pydantic
         signals: Dict[str, Any]
         export: Dict[str, Any]
         performance: Dict[str, Any]
+        identity: Dict[str, Any]
+        extra: Dict[str, Any]
         output: Dict[str, Any] | None
         run: Dict[str, Any]
         multi_period: Dict[str, Any] | None
+        strategy: Dict[str, Any]
+        walk_forward: Dict[str, Any]
         jobs: int | None
         checkpoint_dir: str | None
         seed: int
@@ -496,8 +525,13 @@ else:  # Fallback mode for tests without pydantic
                 "signals": {},
                 "export": {},
                 "performance": {},
+                "identity": {},
+                "extra": {},
                 "output": None,
                 "run": {},
+                "multi_period": None,
+                "strategy": {},
+                "walk_forward": {},
                 "jobs": None,
                 "checkpoint_dir": None,
                 "seed": 42,

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -270,7 +270,10 @@ if _HAS_PYDANTIC:
 
         # Use a plain dict for model_config to avoid type-checker issues when
         # Pydantic is not installed (tests toggle availability).
-        model_config = {"extra": "ignore"}
+        # Keep the production model closed at the top level.  Every supported
+        # top-level section is declared below, so a misspelled section cannot be
+        # silently discarded before the pipeline sees it.
+        model_config = {"extra": "forbid"}
         # ``version`` must be a non-empty string. ``min_length`` handles the empty
         # string case and produces the standard pydantic error message
         # "String should have at least 1 character". A separate validator below
@@ -287,9 +290,13 @@ if _HAS_PYDANTIC:
         signals: dict[str, Any] = Field(default_factory=dict)
         export: dict[str, Any] = Field(default_factory=dict)
         performance: dict[str, Any] = Field(default_factory=dict)
+        identity: dict[str, Any] = Field(default_factory=dict)
+        extra: dict[str, Any] = Field(default_factory=dict)
         output: dict[str, Any] | None = None
         run: dict[str, Any] = Field(default_factory=dict)
         multi_period: dict[str, Any] | None = None
+        strategy: dict[str, Any] = Field(default_factory=dict)
+        walk_forward: dict[str, Any] = Field(default_factory=dict)
         jobs: int | None = None
         checkpoint_dir: str | None = None
         seed: int = 42

--- a/src/trend_analysis/config/models.py
+++ b/src/trend_analysis/config/models.py
@@ -58,6 +58,8 @@ class ConfigProtocol(Protocol):
     ALL_FIELDS: ClassVar[List[str]]
 
     version: str
+    identity: dict[str, Any]
+    extra: dict[str, Any]
     data: dict[str, Any]
     preprocessing: dict[str, Any]
     vol_adjust: dict[str, Any]
@@ -69,6 +71,8 @@ class ConfigProtocol(Protocol):
     export: dict[str, Any]
     output: dict[str, Any] | None
     run: dict[str, Any]
+    strategy: dict[str, Any]
+    walk_forward: dict[str, Any]
     multi_period: dict[str, Any] | None
     jobs: int | None
     checkpoint_dir: str | None
@@ -564,6 +568,12 @@ else:  # Fallback mode for tests without pydantic
                     raise ValueError(f"{field} section is required")
                 if not isinstance(value, dict):
                     raise ValueError(f"{field} must be a dictionary")
+            for optional_field in self.OPTIONAL_DICT_FIELDS:
+                value = getattr(self, optional_field, None)
+                if value is None:
+                    continue
+                if not isinstance(value, dict):
+                    raise ValueError(f"{optional_field} must be a dictionary")
             # Light-weight validation for turnover / cost controls
             port = getattr(self, "portfolio", {})
             if isinstance(port, dict):

--- a/src/trend_analysis/gui/app.py
+++ b/src/trend_analysis/gui/app.py
@@ -13,7 +13,7 @@ import pandas as pd
 import yaml
 
 from ..config import Config
-from ..config.models import DEFAULTS
+from ..config.models import DEFAULTS, Config as ConfigModel
 from ..diagnostics import coerce_pipeline_result
 from .plugins import discover_plugins, iter_plugins
 from .store import ParamStore
@@ -394,7 +394,9 @@ def _normalize_gui_store_cfg(cfg: Dict[str, Any]) -> Dict[str, Any]:
     if portfolio:
         normalized["portfolio"] = portfolio
 
-    allowed = set(Config.ALL_FIELDS)
+    # ``Config`` remains an injectable factory for GUI tests and callers; use
+    # the concrete schema class to identify the strict top-level fields.
+    allowed = set(ConfigModel.ALL_FIELDS)
     return {key: value for key, value in normalized.items() if key in allowed}
 
 

--- a/src/trend_analysis/gui/app.py
+++ b/src/trend_analysis/gui/app.py
@@ -358,18 +358,27 @@ def _as_dict(v: Any) -> Dict[str, Any]:
     return dict(v) if isinstance(v, dict) else {}
 
 
+_REQUIRED_MAPPING_SECTIONS = (
+    "data",
+    "preprocessing",
+    "vol_adjust",
+    "sample_split",
+    "portfolio",
+    "benchmarks",
+    "metrics",
+    "export",
+    "run",
+)
+
+
 def _ensure_mapping_sections(cfg: Dict[str, Any]) -> None:
     """Best-effort ensure mapping types for top-level config sections."""
-    cfg.setdefault("data", _as_dict(cfg.get("data")))
-    cfg.setdefault("preprocessing", _as_dict(cfg.get("preprocessing")))
-    cfg.setdefault("vol_adjust", _as_dict(cfg.get("vol_adjust")))
-    cfg.setdefault("sample_split", _as_dict(cfg.get("sample_split")))
-    cfg.setdefault("portfolio", _as_dict(cfg.get("portfolio")))
-    cfg.setdefault("benchmarks", _as_dict(cfg.get("benchmarks")))
-    cfg.setdefault("metrics", _as_dict(cfg.get("metrics")))
-    cfg.setdefault("export", _as_dict(cfg.get("export")))
-    cfg.setdefault("run", _as_dict(cfg.get("run")))
-    cfg.setdefault("multi_period", _as_dict(cfg.get("multi_period")))
+    for section in _REQUIRED_MAPPING_SECTIONS:
+        cfg[section] = _as_dict(cfg.get(section))
+    if "multi_period" not in cfg:
+        cfg["multi_period"] = {}
+    elif cfg["multi_period"] is not None:
+        cfg["multi_period"] = _as_dict(cfg.get("multi_period"))
 
 
 def _normalize_gui_store_cfg(cfg: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/trend_analysis/gui/app.py
+++ b/src/trend_analysis/gui/app.py
@@ -351,6 +351,53 @@ def reset_weight_state(store: ParamStore) -> None:
         WEIGHT_STATE_FILE.unlink()
 
 
+_GUI_STORE_KEYS = frozenset({"mode", "rank", "use_ranking", "use_vol_adjust"})
+
+
+def _as_dict(v: Any) -> Dict[str, Any]:
+    return dict(v) if isinstance(v, dict) else {}
+
+
+def _ensure_mapping_sections(cfg: Dict[str, Any]) -> None:
+    """Best-effort ensure mapping types for top-level config sections."""
+    cfg.setdefault("data", _as_dict(cfg.get("data")))
+    cfg.setdefault("preprocessing", _as_dict(cfg.get("preprocessing")))
+    cfg.setdefault("vol_adjust", _as_dict(cfg.get("vol_adjust")))
+    cfg.setdefault("sample_split", _as_dict(cfg.get("sample_split")))
+    cfg.setdefault("portfolio", _as_dict(cfg.get("portfolio")))
+    cfg.setdefault("benchmarks", _as_dict(cfg.get("benchmarks")))
+    cfg.setdefault("metrics", _as_dict(cfg.get("metrics")))
+    cfg.setdefault("export", _as_dict(cfg.get("export")))
+    cfg.setdefault("run", _as_dict(cfg.get("run")))
+    cfg.setdefault("multi_period", _as_dict(cfg.get("multi_period")))
+
+
+def _normalize_gui_store_cfg(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Translate legacy GUI store keys into the strict top-level Config schema."""
+    normalized = dict(cfg)
+    portfolio = _as_dict(normalized.get("portfolio"))
+
+    mode = normalized.pop("mode", None)
+    if mode is not None and "selection_mode" not in portfolio:
+        portfolio["selection_mode"] = mode
+
+    rank = normalized.pop("rank", None)
+    if isinstance(rank, dict):
+        existing_rank = portfolio.get("rank")
+        portfolio["rank"] = (
+            {**_as_dict(existing_rank), **rank} if isinstance(existing_rank, dict) else dict(rank)
+        )
+
+    for gui_key in _GUI_STORE_KEYS:
+        normalized.pop(gui_key, None)
+
+    if portfolio:
+        normalized["portfolio"] = portfolio
+
+    allowed = set(Config.ALL_FIELDS)
+    return {key: value for key, value in normalized.items() if key in allowed}
+
+
 def build_config_dict(store: ParamStore) -> Dict[str, Any]:
     """Return the config dictionary kept in ``store`` as a plain dict."""
     cfg = dict(store.cfg)
@@ -360,20 +407,7 @@ def build_config_dict(store: ParamStore) -> Dict[str, Any]:
     if set(cfg.keys()) <= {"mode", "output"}:
         return cfg
 
-    # Best-effort ensure mapping types for top-level sections
-    def as_dict(v: Any) -> Dict[str, Any]:
-        return dict(v) if isinstance(v, dict) else {}
-
-    cfg.setdefault("data", as_dict(cfg.get("data")))
-    cfg.setdefault("preprocessing", as_dict(cfg.get("preprocessing")))
-    cfg.setdefault("vol_adjust", as_dict(cfg.get("vol_adjust")))
-    cfg.setdefault("sample_split", as_dict(cfg.get("sample_split")))
-    cfg.setdefault("portfolio", as_dict(cfg.get("portfolio")))
-    cfg.setdefault("benchmarks", as_dict(cfg.get("benchmarks")))
-    cfg.setdefault("metrics", as_dict(cfg.get("metrics")))
-    cfg.setdefault("export", as_dict(cfg.get("export")))
-    cfg.setdefault("run", as_dict(cfg.get("run")))
-    cfg.setdefault("multi_period", as_dict(cfg.get("multi_period")))
+    _ensure_mapping_sections(cfg)
     return cfg
 
 
@@ -409,6 +443,8 @@ def _ensure_version(cfg: Dict[str, Any]) -> None:
 def build_config_from_store(store: ParamStore) -> ConfigType:
     """Convert ``store`` into a :class:`Config` object."""
     cfg: Dict[str, Any] = build_config_dict(store)
+    cfg = _normalize_gui_store_cfg(cfg)
+    _ensure_mapping_sections(cfg)
     _ensure_version(cfg)
     return Config(**cfg)
 

--- a/tests/test_app_coverage.py
+++ b/tests/test_app_coverage.py
@@ -991,7 +991,7 @@ def test_build_config_from_store_uses_config_factory(monkeypatch):
     monkeypatch.setattr(app_module, "Config", fake_config)
     cfg_obj = app_module.build_config_from_store(store)
 
-    assert created and cfg_obj.mode == "rank"
+    assert created and cfg_obj.portfolio["selection_mode"] == "rank"
 
 
 def test_build_step0_datagrid_callbacks(monkeypatch, tmp_path):

--- a/tests/test_config_forbids_unknown_keys.py
+++ b/tests/test_config_forbids_unknown_keys.py
@@ -1,0 +1,63 @@
+"""Regression coverage for strict top-level and portfolio config keys."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from trend_analysis.config import models
+from trend_analysis.config.model import validate_trend_config
+
+
+def _valid_payload(tmp_path: Path) -> dict[str, object]:
+    csv_path = tmp_path / "returns.csv"
+    csv_path.write_text("Date,FundA\\n2024-01-31,0.01\\n", encoding="utf-8")
+    return {
+        "data": {"csv_path": str(csv_path), "date_column": "Date", "frequency": "M"},
+        "portfolio": {
+            "selection_mode": "all",
+            "rebalance_calendar": "NYSE",
+            "max_turnover": 1.0,
+            "transaction_cost_bps": 0,
+        },
+        "vol_adjust": {"target_vol": 0.1},
+    }
+
+
+def test_unknown_top_level_and_nested_keys_are_rejected(tmp_path: Path) -> None:
+    production_payload = {
+        "version": "1",
+        "data": {},
+        "preprocessing": {},
+        "vol_adjust": {},
+        "sample_split": {},
+        "portfolio": {},
+        "metrics": {},
+        "export": {},
+        "run": {},
+        "bogus_section": {},
+    }
+    with pytest.raises(ValidationError, match="bogus_section"):
+        models.Config.model_validate(production_payload)
+
+    top_level = _valid_payload(tmp_path)
+    top_level["bogus_section"] = {}
+    with pytest.raises(ValueError, match="bogus_section"):
+        validate_trend_config(top_level, base_path=tmp_path)
+
+    nested = _valid_payload(tmp_path)
+    nested["portfolio"] = {**nested["portfolio"], "bogus_key": 1}  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match=r"portfolio\.bogus_key"):
+        validate_trend_config(nested, base_path=tmp_path)
+
+    preprocessing = _valid_payload(tmp_path)
+    preprocessing["preprocessing"] = {"misspelled_step": True}
+    with pytest.raises(ValueError, match=r"preprocessing\.misspelled_step"):
+        validate_trend_config(preprocessing, base_path=tmp_path)
+
+    # The closed production model still accepts every declared section shipped
+    # by the two canonical configurations.
+    for config_path in ("config/defaults.yml", "config/demo.yml"):
+        assert models.load(config_path).version

--- a/tests/test_config_forbids_unknown_keys.py
+++ b/tests/test_config_forbids_unknown_keys.py
@@ -69,4 +69,6 @@ def test_declared_legacy_sections_remain_optional(tmp_path: Path) -> None:
     validated = validate_trend_config(payload, base_path=tmp_path)
 
     assert validated.data.csv_path.name == "returns.csv"
-    assert not ({"identity", "extra", "strategy", "walk_forward"} & set(models.Config.REQUIRED_DICT_FIELDS))
+    assert not (
+        {"identity", "extra", "strategy", "walk_forward"} & set(models.Config.REQUIRED_DICT_FIELDS)
+    )

--- a/tests/test_config_forbids_unknown_keys.py
+++ b/tests/test_config_forbids_unknown_keys.py
@@ -61,3 +61,12 @@ def test_unknown_top_level_and_nested_keys_are_rejected(tmp_path: Path) -> None:
     # by the two canonical configurations.
     for config_path in ("config/defaults.yml", "config/demo.yml"):
         assert models.load(config_path).version
+
+
+def test_declared_legacy_sections_remain_optional(tmp_path: Path) -> None:
+    payload = _valid_payload(tmp_path)
+
+    validated = validate_trend_config(payload, base_path=tmp_path)
+
+    assert validated.data.csv_path.name == "returns.csv"
+    assert not ({"identity", "extra", "strategy", "walk_forward"} & set(models.Config.REQUIRED_DICT_FIELDS))

--- a/tests/test_config_forbids_unknown_keys.py
+++ b/tests/test_config_forbids_unknown_keys.py
@@ -65,10 +65,24 @@ def test_unknown_top_level_and_nested_keys_are_rejected(tmp_path: Path) -> None:
 
 def test_declared_legacy_sections_remain_optional(tmp_path: Path) -> None:
     payload = _valid_payload(tmp_path)
+    payload.update(
+        {
+            "version": "1",
+            "identity": {"name": "legacy-identity"},
+            "extra": {"note": "legacy-extra"},
+            "strategy": {"name": "legacy-strategy"},
+            "walk_forward": {"enabled": False},
+        }
+    )
 
     validated = validate_trend_config(payload, base_path=tmp_path)
+    model = models.Config.model_validate(payload)
 
     assert validated.data.csv_path.name == "returns.csv"
     assert not (
         {"identity", "extra", "strategy", "walk_forward"} & set(models.Config.REQUIRED_DICT_FIELDS)
     )
+    assert model.identity == {"name": "legacy-identity"}
+    assert model.extra == {"note": "legacy-extra"}
+    assert model.strategy == {"name": "legacy-strategy"}
+    assert model.walk_forward == {"enabled": False}


### PR DESCRIPTION
Closes #5814

## Summary

- Make the production configuration model reject unknown top-level sections while retaining every declared legacy section.
- Add preprocessing to strict key linting.
- Add regression coverage for unknown top-level, portfolio, and preprocessing keys.

## Validation

- `PYTHONPATH=src python -m pytest -q tests/test_config_forbids_unknown_keys.py tests/config/test_strict_config_keys.py tests/test_config_models.py tests/test_config_pydantic_fallback.py` (25 passed)
- `PYTHONPATH=src python -m ruff check src/trend_analysis/config/models.py src/trend_analysis/config/lint_keys.py tests/test_config_forbids_unknown_keys.py`
- `git diff --check`

## Deliberate-break evidence

Changed the production model back to `extra="ignore"`; `tests/test_config_forbids_unknown_keys.py` failed because the named unknown-section assertion did not raise. Restored `extra="forbid"` and the focused suite passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for identity, extra, strategy, and walk-forward configuration sections.
  * Added preprocessing configuration validation with recognized keys.
  * Improved configuration handling in the application, including legacy setting compatibility.

* **Bug Fixes**
  * Configuration files now reject unknown top-level, portfolio, and preprocessing settings.
  * Existing canonical configurations and optional legacy sections continue to load successfully.

* **Tests**
  * Added regression coverage for valid and invalid configuration keys.
  * Updated application configuration tests for portfolio selection settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->