### PR TITLE
fix: disclose Monte Carlo scenario provenance

### DIFF
--- a/src/trend_analysis/gui/app.py
+++ b/src/trend_analysis/gui/app.py
@@ -13,7 +13,8 @@ import pandas as pd
 import yaml
 
 from ..config import Config
-from ..config.models import DEFAULTS, Config as ConfigModel
+from ..config.models import DEFAULTS
+from ..config.models import Config as ConfigModel
 from ..diagnostics import coerce_pipeline_result
 from .plugins import discover_plugins, iter_plugins
 from .store import ParamStore

--- a/streamlit_app/monte_carlo_page.py
+++ b/streamlit_app/monte_carlo_page.py
@@ -77,7 +77,7 @@ def _link_to_page(path: str, *, label: str) -> None:
         st.page_link(path, label=label)
     except KeyError:
         # AppTest smoke runs a single page file without multipage registration.
-        st.markdown(f"**{label}**")
+        st.markdown(f"[{label}]({path})")
 
 
 def _session_frequency(returns: pd.DataFrame) -> str:

--- a/streamlit_app/monte_carlo_page.py
+++ b/streamlit_app/monte_carlo_page.py
@@ -44,6 +44,7 @@ def _should_auto_render() -> bool:
 
 
 MC_RESULTS_KEY = "mc_results"
+MC_RESULTS_PROVENANCE_KEY = "mc_results_provenance"
 MC_RUNNING_KEY = "mc_running"
 MC_CANCEL_KEY = "mc_cancel_requested"
 MC_LAST_ERROR_KEY = "mc_last_error"
@@ -828,10 +829,14 @@ def render() -> None:
             results = runner.run(progress_callback=progress_callback, jobs=jobs)
             progress_bar.progress(1.0, text="Simulation complete.")
             st.session_state[MC_RESULTS_KEY] = results
+            # The Data/Model session can change after a completed run.  Keep the
+            # exports tied to the inputs that actually produced these results.
+            st.session_state[MC_RESULTS_PROVENANCE_KEY] = provenance
             st.success("Simulation completed.")
         except _RunCancelled:
             st.warning("Simulation cancelled.")
             st.session_state[MC_RESULTS_KEY] = None
+            st.session_state[MC_RESULTS_PROVENANCE_KEY] = None
         except Exception as exc:
             st.error("Simulation failed.")
             st.session_state[MC_LAST_ERROR_KEY] = str(exc)
@@ -843,4 +848,7 @@ def render() -> None:
     results = st.session_state.get(MC_RESULTS_KEY)
     if results is not None:
         st.divider()
-        _render_results(results, fold_selection=fold_selection, provenance=provenance)
+        result_provenance = st.session_state.get(MC_RESULTS_PROVENANCE_KEY)
+        if not isinstance(result_provenance, str):
+            result_provenance = provenance
+        _render_results(results, fold_selection=fold_selection, provenance=result_provenance)

--- a/streamlit_app/monte_carlo_page.py
+++ b/streamlit_app/monte_carlo_page.py
@@ -69,6 +69,16 @@ def _scenario_provenance_message(*, uses_session_state: bool) -> str:
     )
 
 
+def _link_to_page(path: str, *, label: str) -> None:
+    """Link to another multipage entry when the runtime exposes page metadata."""
+
+    try:
+        st.page_link(path, label=label)
+    except KeyError:
+        # AppTest smoke runs a single page file without multipage registration.
+        st.markdown(f"**{label}**")
+
+
 def _session_frequency(returns: pd.DataFrame) -> str:
     meta = st.session_state.get("schema_meta")
     if isinstance(meta, Mapping):
@@ -691,7 +701,7 @@ def render() -> None:
     provenance = _scenario_provenance_message(uses_session_state=bool(runner_kwargs))
     st.info(provenance)
     if not runner_kwargs:
-        st.page_link("pages/1_Data.py", label="Open the Data page")
+        _link_to_page("pages/1_Data.py", label="Open the Data page")
     if session_error:
         st.warning("Current Data/Model state could not be applied to Monte Carlo.")
         with st.expander("Details"):

--- a/streamlit_app/monte_carlo_page.py
+++ b/streamlit_app/monte_carlo_page.py
@@ -49,6 +49,25 @@ MC_CANCEL_KEY = "mc_cancel_requested"
 MC_LAST_ERROR_KEY = "mc_last_error"
 MC_LAST_VALIDATION_KEY = "mc_last_validation"
 
+REGISTRY_SCENARIO_PROVENANCE = (
+    "Monte Carlo provenance: this is a standalone registry scenario, not a forecast "
+    "derived from the Data → Model → Results portfolio."
+)
+
+
+def _scenario_provenance_message(*, uses_session_state: bool) -> str:
+    """Explain whether the active run uses the current Data/Model session state."""
+
+    if uses_session_state:
+        return (
+            f"{REGISTRY_SCENARIO_PROVENANCE} The loaded Data and Model state is "
+            "supplied as runtime input, while the scenario assumptions remain registry-defined."
+        )
+    return (
+        f"{REGISTRY_SCENARIO_PROVENANCE} Load data and configure a model on the "
+        "Data page to supply current session state as runtime input."
+    )
+
 
 def _session_frequency(returns: pd.DataFrame) -> str:
     meta = st.session_state.get("schema_meta")
@@ -390,6 +409,7 @@ def _render_results(
     results: object,
     *,
     fold_selection: str | None,
+    provenance: str = REGISTRY_SCENARIO_PROVENANCE,
 ) -> None:
     results_frame = None
     if hasattr(results, "results_frame"):
@@ -443,8 +463,15 @@ def _render_results(
         chart_bundle_inputs.update(_render_diagnostic_charts(summary, canonical_paths))
 
     st.subheader("Downloads")
-    payloads = _build_download_payloads(summary_table, filtered_results)
-    chart_bundle_payload, chart_bundle_warnings = _build_chart_bundle_payload(chart_bundle_inputs)
+    payloads = _build_download_payloads(
+        summary_table,
+        filtered_results,
+        provenance=provenance,
+    )
+    chart_bundle_payload, chart_bundle_warnings = _build_chart_bundle_payload(
+        chart_bundle_inputs,
+        provenance=provenance,
+    )
     if chart_bundle_payload is not None:
         payloads.append(chart_bundle_payload)
     warning_text = _png_export_warning_message(chart_bundle_warnings)
@@ -487,6 +514,8 @@ def _export_parquet_bytes(frame: pd.DataFrame) -> bytes | None:
 def _build_download_payloads(
     summary_table: pd.DataFrame,
     filtered_results: pd.DataFrame,
+    *,
+    provenance: str = REGISTRY_SCENARIO_PROVENANCE,
 ) -> list[dict[str, Any]]:
     """Return download button payloads for CSV, Parquet, and ZIP bundles.
 
@@ -495,8 +524,11 @@ def _build_download_payloads(
     are omitted but the CSV downloads still render, so the page never crashes.
     """
 
-    summary_csv = summary_table.to_csv(index=False)
-    path_frame = aggregate_monte_carlo_results(filtered_results).path_frame
+    summary_for_export = summary_table.copy()
+    summary_for_export["Scenario provenance"] = provenance
+    summary_csv = summary_for_export.to_csv(index=False)
+    path_frame = aggregate_monte_carlo_results(filtered_results).path_frame.copy()
+    path_frame["Scenario provenance"] = provenance
     parquet_bytes = _export_parquet_bytes(path_frame)
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -523,6 +555,7 @@ def _build_download_payloads(
     zip_buffer = BytesIO()
     with zipfile.ZipFile(zip_buffer, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
         bundle.writestr("summary.csv", summary_csv)
+        bundle.writestr("README.txt", provenance)
         if parquet_bytes is not None:
             bundle.writestr("representative_paths.parquet", parquet_bytes)
     zip_buffer.seek(0)
@@ -541,6 +574,8 @@ def _build_download_payloads(
 
 def _build_chart_bundle_payload(
     charts: Mapping[str, go.Figure],
+    *,
+    provenance: str = REGISTRY_SCENARIO_PROVENANCE,
 ) -> tuple[dict[str, Any] | None, list[str]]:
     if not charts:
         return None, []
@@ -553,7 +588,9 @@ def _build_chart_bundle_payload(
         payload.seek(0)
     else:
         payload = bundle_buffer
-        payload.seek(0)
+    with zipfile.ZipFile(payload, "a", compression=zipfile.ZIP_DEFLATED) as bundle:
+        bundle.writestr("README.txt", provenance)
+    payload.seek(0)
     return (
         {
             "label": "Download charts bundle",
@@ -651,6 +688,10 @@ def render() -> None:
         st.error("Scenario settings are not resolved.")
         return
     runner_kwargs, session_error = _session_runner_kwargs()
+    provenance = _scenario_provenance_message(uses_session_state=bool(runner_kwargs))
+    st.info(provenance)
+    if not runner_kwargs:
+        st.page_link("pages/1_Data.py", label="Open the Data page")
     if session_error:
         st.warning("Current Data/Model state could not be applied to Monte Carlo.")
         with st.expander("Details"):
@@ -792,4 +833,4 @@ def render() -> None:
     results = st.session_state.get(MC_RESULTS_KEY)
     if results is not None:
         st.divider()
-        _render_results(results, fold_selection=fold_selection)
+        _render_results(results, fold_selection=fold_selection, provenance=provenance)

--- a/tests/streamlit/test_mc_page.py
+++ b/tests/streamlit/test_mc_page.py
@@ -65,6 +65,7 @@ class DummyStreamlit:
         self.error_messages: list[str] = []
         self.warning_messages: list[str] = []
         self.info_messages: list[str] = []
+        self.page_links: list[tuple[str, str]] = []
         self.caption_messages: list[str] = []
         self.write_messages: list[str] = []
         self.progress_calls: list[tuple[float, str | None]] = []
@@ -94,6 +95,9 @@ class DummyStreamlit:
 
     def info(self, message: str) -> None:
         self.info_messages.append(message)
+
+    def page_link(self, path: str, *, label: str, **_kwargs: Any) -> None:
+        self.page_links.append((path, label))
 
     def success(self, _message: str) -> None:
         return None
@@ -316,6 +320,32 @@ def test_scenario_picker_and_tag_filtering(monkeypatch: pytest.MonkeyPatch) -> N
     assert calls[0]["tags"] is None
     assert calls[1]["tags"] == ["macro"]
     assert stub.selectbox_calls[0][1] == ["macro"]
+
+
+def test_mc_page_declares_scenario_provenance(monkeypatch: pytest.MonkeyPatch) -> None:
+    page, stub = _load_page(monkeypatch)
+    scenario_entry = ScenarioRegistryEntry(
+        name="macro",
+        path=Path("config/scenarios/monte_carlo/example.yml"),
+        description="Macro scenario",
+        tags=("production",),
+    )
+    monkeypatch.setattr(page, "list_scenarios", lambda **_kwargs: [scenario_entry])
+    monkeypatch.setattr(page, "load_scenario", lambda _name: _make_scenario("macro"))
+    monkeypatch.setattr(page, "_session_runner_kwargs", lambda: ({}, None))
+
+    page.render()
+
+    assert any("standalone registry scenario" in message for message in stub.info_messages)
+    assert stub.page_links == [("pages/1_Data.py", "Open the Data page")]
+
+    monkeypatch.setattr(page, "_session_runner_kwargs", lambda: ({"base_config": object()}, None))
+    page.render()
+
+    assert any(
+        "loaded Data and Model state is supplied as runtime input" in message
+        for message in stub.info_messages
+    )
 
 
 def test_runtime_override_validation(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -620,7 +650,12 @@ def test_download_link_generation(monkeypatch: pytest.MonkeyPatch) -> None:
     if hasattr(zip_data, "seek"):
         zip_data.seek(0)
     with zipfile.ZipFile(zip_data) as bundle:
-        assert set(bundle.namelist()) == {"summary.csv", "representative_paths.parquet"}
+        assert set(bundle.namelist()) == {
+            "README.txt",
+            "summary.csv",
+            "representative_paths.parquet",
+        }
+        assert "standalone registry scenario" in bundle.read("README.txt").decode()
         summary_text = bundle.read("summary.csv").decode("utf-8")
         assert "Strategy" in summary_text
 
@@ -639,7 +674,7 @@ def test_render_results_surfaces_png_export_warning(
     monkeypatch.setattr(
         page,
         "_build_chart_bundle_payload",
-        lambda _charts: (
+        lambda _charts, **_kwargs: (
             {
                 "label": "Download charts bundle",
                 "data": buffer,
@@ -750,7 +785,12 @@ def test_build_download_payloads_zip_bundle_content(
     assert zip_payload["label"] == "Download ZIP bundle"
     assert hasattr(zip_buffer, "getvalue")
     with zipfile.ZipFile(BytesIO(zip_buffer.getvalue())) as bundle:
-        assert set(bundle.namelist()) == {"summary.csv", "representative_paths.parquet"}
+        assert set(bundle.namelist()) == {
+            "README.txt",
+            "summary.csv",
+            "representative_paths.parquet",
+        }
+        assert "standalone registry scenario" in bundle.read("README.txt").decode()
         summary_text = bundle.read("summary.csv").decode("utf-8")
         assert "Strategy,Sharpe (median)" in summary_text
         assert bundle.read("representative_paths.parquet")[:4] == b"PAR1"
@@ -820,7 +860,11 @@ def test_build_download_payloads_tolerates_buffer_closing_engine(
 
     zip_payload = next(payload for payload in payloads if payload["mime"] == "application/zip")
     with zipfile.ZipFile(BytesIO(zip_payload["data"].getvalue())) as bundle:
-        assert set(bundle.namelist()) == {"summary.csv", "representative_paths.parquet"}
+        assert set(bundle.namelist()) == {
+            "README.txt",
+            "summary.csv",
+            "representative_paths.parquet",
+        }
 
 
 def test_build_download_payloads_degrades_when_parquet_unavailable(
@@ -842,7 +886,8 @@ def test_build_download_payloads_degrades_when_parquet_unavailable(
 
     zip_payload = next(payload for payload in payloads if payload["mime"] == "application/zip")
     with zipfile.ZipFile(BytesIO(zip_payload["data"].getvalue())) as bundle:
-        assert bundle.namelist() == ["summary.csv"]
+        assert bundle.namelist() == ["summary.csv", "README.txt"]
+        assert "standalone registry scenario" in bundle.read("README.txt").decode()
 
 
 def test_export_parquet_bytes_returns_none_on_engine_failure(

--- a/tests/streamlit/test_mc_page.py
+++ b/tests/streamlit/test_mc_page.py
@@ -459,6 +459,9 @@ def test_run_button_flow_with_progress(monkeypatch: pytest.MonkeyPatch) -> None:
     assert ["Core", "Diagnostics"] in stub.tabs_calls
     assert all(call.get("use_container_width") is True for call in stub.plotly_calls)
     assert stub.dataframes
+    assert stub.session_state[page.MC_RESULTS_PROVENANCE_KEY].startswith(
+        "Monte Carlo provenance: this is a standalone registry scenario"
+    )
 
     columns = list(stub.dataframes[0].columns)
     assert columns == [
@@ -469,6 +472,43 @@ def test_run_button_flow_with_progress(monkeypatch: pytest.MonkeyPatch) -> None:
         "Max DD (5th)",
         "Terminal Wealth",
     ]
+
+
+def test_completed_run_exports_keep_their_original_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Changing Data/Model state later must not relabel cached run exports."""
+    page, stub = _load_page(monkeypatch)
+    scenario_entry = ScenarioRegistryEntry(
+        name="macro",
+        path=Path("config/scenarios/monte_carlo/example.yml"),
+        description="Macro scenario",
+        tags=("macro",),
+    )
+    monkeypatch.setattr(page, "list_scenarios", lambda **_kwargs: [scenario_entry])
+    monkeypatch.setattr(page, "load_scenario", lambda _name: _make_scenario("macro"))
+    session_inputs: dict[str, object] = {}
+    monkeypatch.setattr(page, "_session_runner_kwargs", lambda: (session_inputs, None))
+
+    class FakeRunner:
+        def __init__(self, _scenario: MonteCarloScenario, **_kwargs: object) -> None:
+            return None
+
+        def run(self, **_kwargs: object) -> DummyResults:
+            return _sample_results()
+
+    monkeypatch.setattr(page, "MonteCarloRunner", FakeRunner)
+    stub.button_responses = [True, False]
+    page.render()
+
+    session_inputs["base_config"] = object()
+    stub.downloads.clear()
+    stub.button_responses = [False, False]
+    page.render()
+
+    summary_csv = next(download for download in stub.downloads if download["mime"] == "text/csv")["data"]
+    assert "Load data and configure a model" in summary_csv
+    assert "supplied as runtime input" not in summary_csv
 
 
 def test_validate_button_flow(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/streamlit/test_mc_page.py
+++ b/tests/streamlit/test_mc_page.py
@@ -506,7 +506,9 @@ def test_completed_run_exports_keep_their_original_provenance(
     stub.button_responses = [False, False]
     page.render()
 
-    summary_csv = next(download for download in stub.downloads if download["mime"] == "text/csv")["data"]
+    summary_csv = next(download for download in stub.downloads if download["mime"] == "text/csv")[
+        "data"
+    ]
     assert "Load data and configure a model" in summary_csv
     assert "supplied as runtime input" not in summary_csv
 

--- a/tests/streamlit/test_mc_page.py
+++ b/tests/streamlit/test_mc_page.py
@@ -66,6 +66,7 @@ class DummyStreamlit:
         self.warning_messages: list[str] = []
         self.info_messages: list[str] = []
         self.page_links: list[tuple[str, str]] = []
+        self.markdown_messages: list[str] = []
         self.caption_messages: list[str] = []
         self.write_messages: list[str] = []
         self.progress_calls: list[tuple[float, str | None]] = []
@@ -98,6 +99,9 @@ class DummyStreamlit:
 
     def page_link(self, path: str, *, label: str, **_kwargs: Any) -> None:
         self.page_links.append((path, label))
+
+    def markdown(self, message: str, **_kwargs: Any) -> None:
+        self.markdown_messages.append(message)
 
     def success(self, _message: str) -> None:
         return None
@@ -346,6 +350,21 @@ def test_mc_page_declares_scenario_provenance(monkeypatch: pytest.MonkeyPatch) -
         "loaded Data and Model state is supplied as runtime input" in message
         for message in stub.info_messages
     )
+
+
+def test_link_to_page_falls_back_to_markdown_when_page_link_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page, stub = _load_page(monkeypatch)
+
+    def raise_key_error(_path: str, *, label: str, **_kwargs: Any) -> None:
+        raise KeyError("url_pathname")
+
+    monkeypatch.setattr(page.st, "page_link", raise_key_error)
+
+    page._link_to_page("pages/1_Data.py", label="Open the Data page")
+
+    assert stub.markdown_messages == ["[Open the Data page](pages/1_Data.py)"]
 
 
 def test_runtime_override_validation(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -700,6 +719,20 @@ def test_download_link_generation(monkeypatch: pytest.MonkeyPatch) -> None:
         assert "standalone registry scenario" in bundle.read("README.txt").decode()
         summary_text = bundle.read("summary.csv").decode("utf-8")
         assert "Strategy" in summary_text
+
+    charts_zip_entry = next(
+        entry
+        for entry in stub.downloads
+        if entry.get("mime") == "application/zip"
+        and str(entry.get("label")) == "Download charts bundle"
+    )
+    charts_zip_data = charts_zip_entry.get("data")
+    assert hasattr(charts_zip_data, "getvalue")
+    if hasattr(charts_zip_data, "seek"):
+        charts_zip_data.seek(0)
+    with zipfile.ZipFile(charts_zip_data) as charts_bundle:
+        assert "README.txt" in charts_bundle.namelist()
+        assert "standalone registry scenario" in charts_bundle.read("README.txt").decode()
 
 
 def test_render_results_surfaces_png_export_warning(


### PR DESCRIPTION
Closes #5815

## Summary
- Make the standalone registry-scenario provenance explicit on the Monte Carlo page.
- Link empty sessions to the Data page and distinguish loaded runtime inputs from registry-defined assumptions.
- Include the provenance statement in CSV, Parquet, ZIP, and chart-bundle downloads.

## Validation
- `PYTHONPATH=src python -m pytest -q tests/streamlit/test_mc_page.py` (22 passed)
- `PYTHONPATH=src python -m ruff check streamlit_app/monte_carlo_page.py tests/streamlit/test_mc_page.py`
- `git diff --check`

## Deliberate-break evidence
Removed the standalone disclosure phrase; `test_mc_page_declares_scenario_provenance` failed. Restored it and the test passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scenario provenance details to Monte Carlo results and the page interface.
  * Included provenance metadata in CSV, Parquet, ZIP, and chart bundle exports, including README information.
  * Added a convenient link to the Data page when required session inputs are unavailable.

* **Bug Fixes**
  * Preserved original scenario provenance for previously completed results and exports.
  * Cleared outdated provenance information when runs are cancelled.
  * Included provenance metadata in fallback exports when Parquet generation is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->