### PR TITLE
fix: hide developer surfaces by default

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -56,8 +56,11 @@ if custom_analysis_available:
             "For full control over all parameters, use the Custom Analysis flow.",
         ]
     )
-quick_start.append(
-    "The demo uses a specialized policy-based engine optimized for the sample dataset."
+quick_start.extend(
+    [
+        "",
+        "The demo uses a specialized policy-based engine optimized for the sample dataset.",
+    ]
 )
 st.markdown("\n".join(quick_start))
 

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -39,18 +39,25 @@ apply_ds_theme()
 # are hidden; ``public_llm_demo`` exposes the LangChain UI. See
 # ``streamlit_app/demo_profile.py`` and ``demo/wasm/``.
 _active_profile = demo_profile.render_profile_controls(st)
+custom_analysis_available = demo_profile.custom_analysis_enabled(_active_profile)
 
 st.title("Portfolio Simulator")
-st.markdown("""
-Welcome! This app analyzes trend-following fund portfolios with volatility adjustment.
-
-**Quick Start:**
-- Use the **Demo** section below to run analysis on sample data with preset configurations
-- Use the **Custom Analysis** section to load your own data and configure every parameter
-
-The demo uses a specialized policy-based engine optimized for the sample dataset.
-For full control over all parameters, use the Custom Analysis flow.
-    """)
+quick_start = [
+    "Welcome! This app analyzes trend-following fund portfolios with volatility adjustment.",
+    "",
+    "**Quick Start:**",
+    "- Use the **Demo** section below to run analysis on sample data with preset configurations",
+]
+if custom_analysis_available:
+    quick_start.extend(
+        [
+            "- Use the **Custom Analysis** section to load your own data and configure every parameter",
+            "",
+            "For full control over all parameters, use the Custom Analysis flow.",
+        ]
+    )
+quick_start.append("The demo uses a specialized policy-based engine optimized for the sample dataset.")
+st.markdown("\n".join(quick_start))
 
 st.markdown("---")
 
@@ -243,7 +250,7 @@ st.markdown("---")
 # The custom-analysis flow loads user-supplied data and exposes the full
 # parameter/LLM surface. It is hidden in ``presentation_safe`` so a presentation
 # or locked-down PC only ever sees the deterministic synthetic-data demo above.
-if demo_profile.custom_analysis_enabled(_active_profile):
+if custom_analysis_available:
     st.subheader("🔧 Custom Analysis")
     st.markdown("""
         For full control over all parameters, use the manual workflow:

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -56,7 +56,9 @@ if custom_analysis_available:
             "For full control over all parameters, use the Custom Analysis flow.",
         ]
     )
-quick_start.append("The demo uses a specialized policy-based engine optimized for the sample dataset.")
+quick_start.append(
+    "The demo uses a specialized policy-based engine optimized for the sample dataset."
+)
 st.markdown("\n".join(quick_start))
 
 st.markdown("---")

--- a/streamlit_app/demo_profile.py
+++ b/streamlit_app/demo_profile.py
@@ -263,4 +263,11 @@ def render_profile_controls(st_module=None) -> str:
         sidebar.caption("🔓 LLM/LangChain UI enabled. Provider keys are runtime-only.")
     else:
         sidebar.caption("🔒 Presentation-safe: no LLM, custom analysis, or uploads.")
+    if custom_analysis_enabled(active) or st_module.session_state.get("show_perf_diagnostics"):
+        if hasattr(sidebar, "page_link"):
+            sidebar.page_link(
+                "developer_settings_validation.py",
+                label="Developer: Settings Validation",
+                icon="🔧",
+            )
     return active

--- a/streamlit_app/developer_settings_validation.py
+++ b/streamlit_app/developer_settings_validation.py
@@ -547,6 +547,18 @@ def format_value(value: Any) -> str:
 def render_validation_page() -> None:
     """Render the developer Settings Validation page."""
 
+    active_profile = demo_profile.get_active_profile()
+    if (
+        not demo_profile.custom_analysis_enabled(active_profile)
+        and not st.session_state.get("show_perf_diagnostics")
+    ):
+        st.warning(
+            "Developer settings validation is disabled in **presentation_safe** mode. "
+            "Switch to **public_llm_demo** in the sidebar, or enable "
+            "`show_perf_diagnostics` for QA access."
+        )
+        st.stop()
+
     app_state.initialize_session_state()
     st.title("🔧 Developer: Settings Validation")
     st.markdown("""

--- a/streamlit_app/developer_settings_validation.py
+++ b/streamlit_app/developer_settings_validation.py
@@ -548,9 +548,8 @@ def render_validation_page() -> None:
     """Render the developer Settings Validation page."""
 
     active_profile = demo_profile.get_active_profile()
-    if (
-        not demo_profile.custom_analysis_enabled(active_profile)
-        and not st.session_state.get("show_perf_diagnostics")
+    if not demo_profile.custom_analysis_enabled(active_profile) and not st.session_state.get(
+        "show_perf_diagnostics"
     ):
         st.warning(
             "Developer settings validation is disabled in **presentation_safe** mode. "

--- a/streamlit_app/pages/1_Data.py
+++ b/streamlit_app/pages/1_Data.py
@@ -843,7 +843,9 @@ def render_data_page() -> None:
                         "perf_ms": {
                             "derive_funds": round((_t_funds_derived - _t_fund_start) * 1000, 2),
                             "seed_defaults": round((_t_seed_done - _t_seed_start) * 1000, 2),
-                            "render_checkboxes": round((_t_render_done - _t_render_start) * 1000, 2),
+                            "render_checkboxes": round(
+                                (_t_render_done - _t_render_start) * 1000, 2
+                            ),
                             "fund_total": round((_t_render_done - _t_fund_start) * 1000, 2),
                         },
                         "selected_fund_columns_count": len(

--- a/streamlit_app/pages/1_Data.py
+++ b/streamlit_app/pages/1_Data.py
@@ -823,49 +823,51 @@ def render_data_page() -> None:
             with summary_cols[2]:
                 st.metric("Fund Columns", final_count)
 
-            # Debug panel to inspect selection state when diagnosing persistence
-            with st.expander("Debug: Fund selection state", expanded=False):
-                st.session_state["_debug_fund_run"] = (
-                    int(st.session_state.get("_debug_fund_run", 0)) + 1
-                )
+            # This persistence diagnostic is useful during investigation, but must
+            # never expose selection counters or timing data in the end-user UI.
+            if st.session_state.get("show_perf_diagnostics"):
+                with st.expander("Debug: Fund selection state", expanded=False):
+                    st.session_state["_debug_fund_run"] = (
+                        int(st.session_state.get("_debug_fund_run", 0)) + 1
+                    )
 
-                snapshot = {
-                    "run": st.session_state.get("_debug_fund_run"),
-                    "data_loaded_key": st.session_state.get("data_loaded_key"),
-                    "available_funds_count": len(available_funds),
-                    "index_candidates_count": len(index_candidates),
-                    "default_selected_funds_count": len(default_selected_funds),
-                    "checkbox_selected_count": len(new_selection_list),
-                    "range_funds_count": len(range_funds),
-                    "defaults_seeded_count": len(defaults),
-                    "perf_ms": {
-                        "derive_funds": round((_t_funds_derived - _t_fund_start) * 1000, 2),
-                        "seed_defaults": round((_t_seed_done - _t_seed_start) * 1000, 2),
-                        "render_checkboxes": round((_t_render_done - _t_render_start) * 1000, 2),
-                        "fund_total": round((_t_render_done - _t_fund_start) * 1000, 2),
-                    },
-                    "selected_fund_columns_count": len(
-                        st.session_state.get("selected_fund_columns") or []
-                    ),
-                    "fund_columns_count": len(st.session_state.get("fund_columns") or []),
-                }
-
-                history = st.session_state.get("_debug_fund_history", [])
-                if not isinstance(history, list):
-                    history = []
-                history.append(snapshot)
-                st.session_state["_debug_fund_history"] = history[-8:]
-
-                st.json(
-                    {
-                        "latest": snapshot,
-                        "history": st.session_state.get("_debug_fund_history", []),
-                        "available_funds": available_funds,
-                        "selected_fund_columns": st.session_state.get("selected_fund_columns"),
-                        "fund_columns": st.session_state.get("fund_columns"),
-                        "checkbox_prefix": include_prefix,
+                    snapshot = {
+                        "run": st.session_state.get("_debug_fund_run"),
+                        "data_loaded_key": st.session_state.get("data_loaded_key"),
+                        "available_funds_count": len(available_funds),
+                        "index_candidates_count": len(index_candidates),
+                        "default_selected_funds_count": len(default_selected_funds),
+                        "checkbox_selected_count": len(new_selection_list),
+                        "range_funds_count": len(range_funds),
+                        "defaults_seeded_count": len(defaults),
+                        "perf_ms": {
+                            "derive_funds": round((_t_funds_derived - _t_fund_start) * 1000, 2),
+                            "seed_defaults": round((_t_seed_done - _t_seed_start) * 1000, 2),
+                            "render_checkboxes": round((_t_render_done - _t_render_start) * 1000, 2),
+                            "fund_total": round((_t_render_done - _t_fund_start) * 1000, 2),
+                        },
+                        "selected_fund_columns_count": len(
+                            st.session_state.get("selected_fund_columns") or []
+                        ),
+                        "fund_columns_count": len(st.session_state.get("fund_columns") or []),
                     }
-                )
+
+                    history = st.session_state.get("_debug_fund_history", [])
+                    if not isinstance(history, list):
+                        history = []
+                    history.append(snapshot)
+                    st.session_state["_debug_fund_history"] = history[-8:]
+
+                    st.json(
+                        {
+                            "latest": snapshot,
+                            "history": st.session_state.get("_debug_fund_history", []),
+                            "available_funds": available_funds,
+                            "selected_fund_columns": st.session_state.get("selected_fund_columns"),
+                            "fund_columns": st.session_state.get("fund_columns"),
+                            "checkbox_prefix": include_prefix,
+                        }
+                    )
 
 
 render_data_page()

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -1056,7 +1056,8 @@ def _render_llm_status_panel() -> None:
         if missing_vars:
             missing_list = ", ".join(missing_vars)
             st.warning(
-                f"Missing required environment variables for {provider_label}. " f"Set: {missing_list}."
+                f"Missing required environment variables for {provider_label}. "
+                f"Set: {missing_list}."
             )
 
 

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -1026,6 +1026,7 @@ def _llm_env_var_status(provider: str) -> dict[str, bool]:
 
 
 def _render_llm_status_panel() -> None:
+    """Show optional LLM diagnostics only when a user expands them."""
     provider_labels = {
         "openai": "OpenAI",
         "anthropic": "Anthropic",
@@ -1037,25 +1038,26 @@ def _render_llm_status_panel() -> None:
         _normalize_cache_str(st.session_state.get("selected_model")) or _DEFAULT_CONFIG_CHAT_MODEL
     )
     provider_label = provider_labels.get(selected_provider, selected_provider)
-    st.info(f"Active provider: {provider_label}")
-    st.info(f"Active model: {selected_model}")
-    required_vars = _llm_required_env_vars(selected_provider)
-    if required_vars is None:
-        st.warning(f"Unknown provider: {selected_provider}. Update your LLM settings.")
-        return
-    if not required_vars:
-        st.caption("Expected environment variables: None required.")
-        return
-    missing_vars = [name for name in required_vars if not _llm_env_var_present(name)]
-    st.caption("Expected environment variables (values hidden):")
-    for name in required_vars:
-        icon = "✓" if name not in missing_vars else "✗"
-        st.write(f"{icon} `{name}`")
-    if missing_vars:
-        missing_list = ", ".join(missing_vars)
-        st.warning(
-            f"Missing required environment variables for {provider_label}. " f"Set: {missing_list}."
-        )
+    with st.expander("Optional LLM connection status", expanded=False):
+        st.info(f"Active provider: {provider_label}")
+        st.info(f"Active model: {selected_model}")
+        required_vars = _llm_required_env_vars(selected_provider)
+        if required_vars is None:
+            st.warning(f"Unknown provider: {selected_provider}. Update your LLM settings.")
+            return
+        if not required_vars:
+            st.caption("Expected environment variables: None required.")
+            return
+        missing_vars = [name for name in required_vars if not _llm_env_var_present(name)]
+        st.caption("Expected environment variables (values hidden):")
+        for name in required_vars:
+            icon = "✓" if name not in missing_vars else "✗"
+            st.write(f"{icon} `{name}`")
+        if missing_vars:
+            missing_list = ", ".join(missing_vars)
+            st.warning(
+                f"Missing required environment variables for {provider_label}. " f"Set: {missing_list}."
+            )
 
 
 def _sync_llm_selection_from_overrides() -> None:

--- a/streamlit_app/pages/4_Help.py
+++ b/streamlit_app/pages/4_Help.py
@@ -49,6 +49,10 @@ These settings control how funds are evaluated and filtered for inclusion in the
 | **Conservative** | Longer lookback periods, more data required. Reduces noise but may lag market turns. |
 | **Aggressive** | Shorter lookbacks, faster response. More responsive but potentially noisier. |
 | **Custom** | Manually configure all parameters below. |
+
+The **Demo Settings Preset** selector on the home page is a separate, synthetic-data
+profile. Its `Balanced` option is not a Model configuration preset; use the table
+above when choosing settings on the Model page.
         """)
 
     st.subheader("Lookback Window (months)")

--- a/streamlit_app/pages/8_Validation.py
+++ b/streamlit_app/pages/8_Validation.py
@@ -1,4 +1,4 @@
-"""Settings Validation page for systematically testing UI settings.
+"""Developer settings-validation page for systematically testing UI settings.
 
 This page allows interactive testing of individual settings to verify
 they are properly wired into the analysis pipeline. Each test:
@@ -25,7 +25,7 @@ import streamlit as st
 # evaluates an ``@st.cache_data`` decorator at import time, so configure the
 # page before importing them.
 st.set_page_config(
-    page_title="Settings Validation",
+    page_title="Developer: Settings Validation",
     page_icon="🔧",
     layout="wide",
 )
@@ -545,10 +545,10 @@ def format_value(value: Any) -> str:
 
 
 def render_validation_page() -> None:
-    """Render the Settings Validation page."""
+    """Render the developer Settings Validation page."""
 
     app_state.initialize_session_state()
-    st.title("🔧 Settings Validation")
+    st.title("🔧 Developer: Settings Validation")
     st.markdown("""
     This page systematically tests each UI setting to verify it's properly
     connected to the analysis pipeline. Select a setting, choose test values,

--- a/tests/app/test_data_page.py
+++ b/tests/app/test_data_page.py
@@ -280,9 +280,9 @@ def test_data_page_autoloads_sample(monkeypatch: pytest.MonkeyPatch, data_page) 
 
 def test_debug_surfaces_hidden_without_flag(monkeypatch: pytest.MonkeyPatch, data_page) -> None:
     page, stub = data_page
-    source = (Path(__file__).resolve().parents[2] / "streamlit_app" / "pages" / "1_Data.py").read_text(
-        encoding="utf-8"
-    )
+    source = (
+        Path(__file__).resolve().parents[2] / "streamlit_app" / "pages" / "1_Data.py"
+    ).read_text(encoding="utf-8")
     assert (
         "never expose selection counters or timing data in the end-user UI.\n"
         '            if st.session_state.get("show_perf_diagnostics"):\n'

--- a/tests/app/test_data_page.py
+++ b/tests/app/test_data_page.py
@@ -261,7 +261,7 @@ def test_data_page_autoloads_sample(monkeypatch: pytest.MonkeyPatch, data_page) 
     monkeypatch.setattr(page.data_cache, "load_dataset_from_path", lambda path: (df, meta))
 
     stub.selectbox_map["Choose a sample"] = sample.label
-    stub.selectbox_map["Benchmark column (optional)"] = "SPX Index"
+    stub.selectbox_map["Benchmark Column (optional)"] = "SPX Index"
     monkeypatch.setattr(page, "infer_benchmarks", lambda columns: ["SPX Index"])
 
     initial_clears = stub.clear_calls
@@ -303,7 +303,7 @@ def test_debug_surfaces_hidden_without_flag(monkeypatch: pytest.MonkeyPatch, dat
     )
     monkeypatch.setattr(page, "infer_benchmarks", lambda _columns: ["SPX Index"])
     stub.selectbox_map["Choose a sample"] = sample.label
-    stub.selectbox_map["Benchmark column (optional)"] = "SPX Index"
+    stub.selectbox_map["Benchmark Column (optional)"] = "SPX Index"
 
     page.render_data_page()
 

--- a/tests/app/test_data_page.py
+++ b/tests/app/test_data_page.py
@@ -71,6 +71,7 @@ class DummyStreamlit:
         self.column_config = DummyStreamlit._ColumnConfig()
         self.rerun_called = False
         self.metrics: list[tuple[str, Any]] = []
+        self.expander_labels: list[str] = []
 
     def title(self, text: str) -> None:
         self.title_calls.append(text)
@@ -127,7 +128,8 @@ class DummyStreamlit:
     def markdown(self, text: str, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - trivial
         self.markdowns.append(str(text))
 
-    def expander(self, *_args: Any, **_kwargs: Any) -> "DummyStreamlit._Column":
+    def expander(self, label: str, **_kwargs: Any) -> "DummyStreamlit._Column":
+        self.expander_labels.append(label)
         return DummyStreamlit._Column(self)
 
     def container(self, *_args: Any, **_kwargs: Any) -> "DummyStreamlit._Column":
@@ -274,6 +276,38 @@ def test_data_page_autoloads_sample(monkeypatch: pytest.MonkeyPatch, data_page) 
     assert stub.clear_calls == initial_clears + 1
     for key in ["analysis_result", "analysis_result_key", "analysis_error"]:
         assert key not in page.st.session_state
+
+
+def test_debug_surfaces_hidden_without_flag(monkeypatch: pytest.MonkeyPatch, data_page) -> None:
+    page, stub = data_page
+    source = (Path(__file__).resolve().parents[2] / "streamlit_app" / "pages" / "1_Data.py").read_text(
+        encoding="utf-8"
+    )
+    assert (
+        "never expose selection counters or timing data in the end-user UI.\n"
+        '            if st.session_state.get("show_perf_diagnostics"):\n'
+        '                with st.expander("Debug: Fund selection state"'
+    ) in source
+    stub.session_state.clear()
+    df = pd.DataFrame(
+        {"FundA": [0.01, 0.02, -0.01], "SPX Index": [0.03, -0.02, 0.01]},
+        index=pd.date_range("2024-01-31", periods=3, freq="ME"),
+    )
+    sample = page.data_cache.SampleDataset("demo.csv", Path("demo/demo_returns.csv"))
+    monkeypatch.setattr(page.data_cache, "default_sample_dataset", lambda: sample)
+    monkeypatch.setattr(page.data_cache, "dataset_choices", lambda: {sample.label: sample})
+    monkeypatch.setattr(
+        page.data_cache,
+        "load_dataset_from_path",
+        lambda _path: (df, {"validation": {"issues": [], "warnings": []}}),
+    )
+    monkeypatch.setattr(page, "infer_benchmarks", lambda _columns: ["SPX Index"])
+    stub.selectbox_map["Choose a sample"] = sample.label
+    stub.selectbox_map["Benchmark column (optional)"] = "SPX Index"
+
+    page.render_data_page()
+
+    assert not any(label.startswith("Debug:") for label in stub.expander_labels)
 
 
 def test_data_page_upload_failure(monkeypatch: pytest.MonkeyPatch, data_page) -> None:

--- a/tests/app/test_validation_page_renders.py
+++ b/tests/app/test_validation_page_renders.py
@@ -131,9 +131,9 @@ def _reload_validation_page(monkeypatch: pytest.MonkeyPatch, streamlit_module: M
     from streamlit_app import state as app_state
 
     monkeypatch.setattr(app_state, "st", streamlit_module)
-    sys.modules.pop("streamlit_app.pages.8_Validation", None)
+    sys.modules.pop("streamlit_app.developer_settings_validation", None)
     importlib.invalidate_caches()
-    return importlib.import_module("streamlit_app.pages.8_Validation")
+    return importlib.import_module("streamlit_app.developer_settings_validation")
 
 
 def test_validation_page_auto_renders_with_uploaded_returns(
@@ -142,6 +142,7 @@ def test_validation_page_auto_renders_with_uploaded_returns(
     stub = DummyStreamlit()
     stub.session_state.update(
         {
+            "show_perf_diagnostics": True,
             "returns_df": pd.DataFrame(
                 {"FundA": [0.01, -0.02], "FundB": [0.03, 0.01]},
                 index=pd.date_range("2024-01-31", periods=2, freq="ME"),
@@ -159,7 +160,7 @@ def test_validation_page_auto_renders_with_uploaded_returns(
     _reload_validation_page(monkeypatch, streamlit_module)
 
     assert stub.page_config_calls
-    assert any("Settings Validation" in call for call in stub.title_calls)
+    assert any("Developer: Settings Validation" in call for call in stub.title_calls)
     assert "returns_df" in stub.session_state.get_keys
     assert "app_data" not in stub.session_state.get_keys
     assert not any("Please load data" in message for message in stub.warning_messages)

--- a/tests/baseline/test_streamlit_smoke.py
+++ b/tests/baseline/test_streamlit_smoke.py
@@ -28,7 +28,7 @@ _CLEAN_PAGES = [
     "streamlit_app/pages/1_Data.py",
     "streamlit_app/pages/3_Results.py",
     "streamlit_app/pages/4_Help.py",
-    "streamlit_app/pages/8_Validation.py",
+    "streamlit_app/developer_settings_validation.py",
     "streamlit_app/pages/5_Monte_Carlo.py",
 ]
 

--- a/tests/streamlit/test_no_dev_surfaces_by_default.py
+++ b/tests/streamlit/test_no_dev_surfaces_by_default.py
@@ -19,9 +19,9 @@ def test_quick_start_matches_active_profile() -> None:
 
 def test_developer_surfaces_are_explicitly_marked_or_gated() -> None:
     data_source = (REPO_ROOT / "streamlit_app" / "pages" / "1_Data.py").read_text(encoding="utf-8")
-    validation_source = (REPO_ROOT / "streamlit_app" / "pages" / "8_Validation.py").read_text(
-        encoding="utf-8"
-    )
+    validation_source = (
+        REPO_ROOT / "streamlit_app" / "developer_settings_validation.py"
+    ).read_text(encoding="utf-8")
 
     assert (
         'if st.session_state.get("show_perf_diagnostics"):\n                with st.expander("Debug: Fund selection state"'
@@ -29,3 +29,4 @@ def test_developer_surfaces_are_explicitly_marked_or_gated() -> None:
     )
     assert 'page_title="Developer: Settings Validation"' in validation_source
     assert 'st.title("🔧 Developer: Settings Validation")' in validation_source
+    assert "not demo_profile.custom_analysis_enabled(active_profile)" in validation_source

--- a/tests/streamlit/test_no_dev_surfaces_by_default.py
+++ b/tests/streamlit/test_no_dev_surfaces_by_default.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_quick_start_matches_active_profile() -> None:
+    source = (REPO_ROOT / "streamlit_app" / "app.py").read_text(encoding="utf-8")
+
+    assert "custom_analysis_available = demo_profile.custom_analysis_enabled(_active_profile)" in source
+    assert "if custom_analysis_available:" in source
+    assert '"- Use the **Custom Analysis** section' in source
+    assert 'st.markdown("\\n".join(quick_start))' in source
+
+
+def test_developer_surfaces_are_explicitly_marked_or_gated() -> None:
+    data_source = (REPO_ROOT / "streamlit_app" / "pages" / "1_Data.py").read_text(encoding="utf-8")
+    validation_source = (
+        REPO_ROOT / "streamlit_app" / "pages" / "8_Validation.py"
+    ).read_text(encoding="utf-8")
+
+    assert 'if st.session_state.get("show_perf_diagnostics"):\n                with st.expander("Debug: Fund selection state"' in data_source
+    assert 'page_title="Developer: Settings Validation"' in validation_source
+    assert 'st.title("🔧 Developer: Settings Validation")' in validation_source

--- a/tests/streamlit/test_no_dev_surfaces_by_default.py
+++ b/tests/streamlit/test_no_dev_surfaces_by_default.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_quick_start_matches_active_profile() -> None:
     source = (REPO_ROOT / "streamlit_app" / "app.py").read_text(encoding="utf-8")
 
-    assert "custom_analysis_available = demo_profile.custom_analysis_enabled(_active_profile)" in source
+    assert (
+        "custom_analysis_available = demo_profile.custom_analysis_enabled(_active_profile)"
+        in source
+    )
     assert "if custom_analysis_available:" in source
     assert '"- Use the **Custom Analysis** section' in source
     assert 'st.markdown("\\n".join(quick_start))' in source
@@ -17,10 +19,13 @@ def test_quick_start_matches_active_profile() -> None:
 
 def test_developer_surfaces_are_explicitly_marked_or_gated() -> None:
     data_source = (REPO_ROOT / "streamlit_app" / "pages" / "1_Data.py").read_text(encoding="utf-8")
-    validation_source = (
-        REPO_ROOT / "streamlit_app" / "pages" / "8_Validation.py"
-    ).read_text(encoding="utf-8")
+    validation_source = (REPO_ROOT / "streamlit_app" / "pages" / "8_Validation.py").read_text(
+        encoding="utf-8"
+    )
 
-    assert 'if st.session_state.get("show_perf_diagnostics"):\n                with st.expander("Debug: Fund selection state"' in data_source
+    assert (
+        'if st.session_state.get("show_perf_diagnostics"):\n                with st.expander("Debug: Fund selection state"'
+        in data_source
+    )
     assert 'page_title="Developer: Settings Validation"' in validation_source
     assert 'st.title("🔧 Developer: Settings Validation")' in validation_source

--- a/tests/test_demo_profile.py
+++ b/tests/test_demo_profile.py
@@ -164,11 +164,17 @@ def test_gated_pages_render_profile_controls(page: str) -> None:
     assert "demo_profile.render_profile_controls(st)" in source
 
 
-@pytest.mark.parametrize(
-    "page", ["3_Results.py", "4_Help.py", "5_Monte_Carlo.py", "8_Validation.py"]
-)
+@pytest.mark.parametrize("page", ["3_Results.py", "4_Help.py", "5_Monte_Carlo.py"])
 def test_other_page_entrypoints_initialize_demo_profile(page: str) -> None:
     source = (REPO_ROOT / "streamlit_app" / "pages" / page).read_text(encoding="utf-8")
+
+    assert "demo_profile.initialize_profile(st)" in source
+
+
+def test_developer_validation_entrypoint_initializes_demo_profile() -> None:
+    source = (
+        REPO_ROOT / "streamlit_app" / "developer_settings_validation.py"
+    ).read_text(encoding="utf-8")
 
     assert "demo_profile.initialize_profile(st)" in source
 

--- a/tests/test_demo_profile.py
+++ b/tests/test_demo_profile.py
@@ -172,9 +172,9 @@ def test_other_page_entrypoints_initialize_demo_profile(page: str) -> None:
 
 
 def test_developer_validation_entrypoint_initializes_demo_profile() -> None:
-    source = (
-        REPO_ROOT / "streamlit_app" / "developer_settings_validation.py"
-    ).read_text(encoding="utf-8")
+    source = (REPO_ROOT / "streamlit_app" / "developer_settings_validation.py").read_text(
+        encoding="utf-8"
+    )
 
     assert "demo_profile.initialize_profile(st)" in source
 

--- a/tests/test_design_system_theme.py
+++ b/tests/test_design_system_theme.py
@@ -9,7 +9,7 @@ DATA_DENSE_ENTRYPOINTS = (
     "streamlit_app/pages/2_Model.py",
     "streamlit_app/pages/3_Results.py",
     "streamlit_app/pages/5_Monte_Carlo.py",
-    "streamlit_app/pages/8_Validation.py",
+    "streamlit_app/developer_settings_validation.py",
 )
 
 
@@ -36,7 +36,7 @@ def test_theme_adopted() -> None:
 def test_streamlit_entrypoint_discovery_covers_every_page() -> None:
     discovered = {str(path.relative_to(REPO_ROOT)) for path in _streamlit_entrypoints()}
     assert "streamlit_app/app.py" in discovered
-    assert "streamlit_app/pages/8_Validation.py" in discovered
+    assert "streamlit_app/developer_settings_validation.py" not in discovered
     assert not any("pages/6_" in path or "pages/7_" in path for path in discovered)
 
 


### PR DESCRIPTION
Closes #5816

## Summary
- hide Data-page debug state behind the existing diagnostics flag
- keep Quick Start, preset help, validation tooling, and optional LLM diagnostics aligned with the active user experience

## Validation
- `uv run --all-extras pytest tests/app/test_data_page.py::test_debug_surfaces_hidden_without_flag tests/streamlit/test_no_dev_surfaces_by_default.py tests/app/test_preset_vocabulary.py tests/app/test_validation_page_renders.py -q` (6 passed)
- `uv run --all-extras ruff check streamlit_app/app.py streamlit_app/pages/1_Data.py streamlit_app/pages/2_Model.py streamlit_app/pages/4_Help.py streamlit_app/pages/8_Validation.py tests/app/test_data_page.py tests/streamlit/test_no_dev_surfaces_by_default.py`
- `git diff --check`

## Deliberate break
- Replaced the Debug-expander gate with `if True`; the named regression test failed. Restored the gate and reran the passing suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **User Experience**
  - Quick Start content adapts to the selected demo profile and shows Custom Analysis guidance only when available.
  - Debug and performance diagnostics remain hidden unless explicitly enabled.
  - LLM connection details are available in an optional collapsed panel.

- **Documentation**
  - Clarified the difference between Demo Settings Presets and Model configuration presets.
  - Identified the Validation page as developer-oriented.

- **Tests**
  - Added coverage confirming developer-facing diagnostics and debug surfaces stay hidden by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->