### PR TITLE
fix(ui): stop shipping developer surfaces and self-contradictory guidance

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -41,7 +41,13 @@ apply_ds_theme()
 _active_profile = demo_profile.render_profile_controls(st)
 
 st.title("Portfolio Simulator")
-st.markdown("""
+
+# Quick Start must describe only the sections this profile actually renders. The
+# Custom Analysis section below is conditional on ``custom_analysis_enabled``, so
+# advertising it unconditionally sent presentation_safe users looking for a section
+# that is not on the page (issue #5816).
+if demo_profile.custom_analysis_enabled(_active_profile):
+    st.markdown("""
 Welcome! This app analyzes trend-following fund portfolios with volatility adjustment.
 
 **Quick Start:**
@@ -50,6 +56,17 @@ Welcome! This app analyzes trend-following fund portfolios with volatility adjus
 
 The demo uses a specialized policy-based engine optimized for the sample dataset.
 For full control over all parameters, use the Custom Analysis flow.
+    """)
+else:
+    st.markdown("""
+Welcome! This app analyzes trend-following fund portfolios with volatility adjustment.
+
+**Quick Start:**
+- Use the **Demo** section below to run analysis on sample data with preset configurations
+
+This mode runs the bundled synthetic dataset through a deterministic policy-based engine.
+To load your own data and configure every parameter, switch **Demo mode** to
+**Public LLM demo** in the sidebar.
     """)
 
 st.markdown("---")

--- a/streamlit_app/pages/1_Data.py
+++ b/streamlit_app/pages/1_Data.py
@@ -823,49 +823,55 @@ def render_data_page() -> None:
             with summary_cols[2]:
                 st.metric("Fund Columns", final_count)
 
-            # Debug panel to inspect selection state when diagnosing persistence
-            with st.expander("Debug: Fund selection state", expanded=False):
-                st.session_state["_debug_fund_run"] = (
-                    int(st.session_state.get("_debug_fund_run", 0)) + 1
-                )
+            # Debug panel to inspect selection state when diagnosing persistence.
+            # Developer-only: gated behind the same ``show_perf_diagnostics`` flag as the
+            # perf caption above (issue #5411 gated that caption but missed this expander,
+            # so raw internal counters stayed visible to end users -- issue #5816).
+            if st.session_state.get("show_perf_diagnostics"):
+                with st.expander("Debug: Fund selection state", expanded=False):
+                    st.session_state["_debug_fund_run"] = (
+                        int(st.session_state.get("_debug_fund_run", 0)) + 1
+                    )
 
-                snapshot = {
-                    "run": st.session_state.get("_debug_fund_run"),
-                    "data_loaded_key": st.session_state.get("data_loaded_key"),
-                    "available_funds_count": len(available_funds),
-                    "index_candidates_count": len(index_candidates),
-                    "default_selected_funds_count": len(default_selected_funds),
-                    "checkbox_selected_count": len(new_selection_list),
-                    "range_funds_count": len(range_funds),
-                    "defaults_seeded_count": len(defaults),
-                    "perf_ms": {
-                        "derive_funds": round((_t_funds_derived - _t_fund_start) * 1000, 2),
-                        "seed_defaults": round((_t_seed_done - _t_seed_start) * 1000, 2),
-                        "render_checkboxes": round((_t_render_done - _t_render_start) * 1000, 2),
-                        "fund_total": round((_t_render_done - _t_fund_start) * 1000, 2),
-                    },
-                    "selected_fund_columns_count": len(
-                        st.session_state.get("selected_fund_columns") or []
-                    ),
-                    "fund_columns_count": len(st.session_state.get("fund_columns") or []),
-                }
-
-                history = st.session_state.get("_debug_fund_history", [])
-                if not isinstance(history, list):
-                    history = []
-                history.append(snapshot)
-                st.session_state["_debug_fund_history"] = history[-8:]
-
-                st.json(
-                    {
-                        "latest": snapshot,
-                        "history": st.session_state.get("_debug_fund_history", []),
-                        "available_funds": available_funds,
-                        "selected_fund_columns": st.session_state.get("selected_fund_columns"),
-                        "fund_columns": st.session_state.get("fund_columns"),
-                        "checkbox_prefix": include_prefix,
+                    snapshot = {
+                        "run": st.session_state.get("_debug_fund_run"),
+                        "data_loaded_key": st.session_state.get("data_loaded_key"),
+                        "available_funds_count": len(available_funds),
+                        "index_candidates_count": len(index_candidates),
+                        "default_selected_funds_count": len(default_selected_funds),
+                        "checkbox_selected_count": len(new_selection_list),
+                        "range_funds_count": len(range_funds),
+                        "defaults_seeded_count": len(defaults),
+                        "perf_ms": {
+                            "derive_funds": round((_t_funds_derived - _t_fund_start) * 1000, 2),
+                            "seed_defaults": round((_t_seed_done - _t_seed_start) * 1000, 2),
+                            "render_checkboxes": round(
+                                (_t_render_done - _t_render_start) * 1000, 2
+                            ),
+                            "fund_total": round((_t_render_done - _t_fund_start) * 1000, 2),
+                        },
+                        "selected_fund_columns_count": len(
+                            st.session_state.get("selected_fund_columns") or []
+                        ),
+                        "fund_columns_count": len(st.session_state.get("fund_columns") or []),
                     }
-                )
+
+                    history = st.session_state.get("_debug_fund_history", [])
+                    if not isinstance(history, list):
+                        history = []
+                    history.append(snapshot)
+                    st.session_state["_debug_fund_history"] = history[-8:]
+
+                    st.json(
+                        {
+                            "latest": snapshot,
+                            "history": st.session_state.get("_debug_fund_history", []),
+                            "available_funds": available_funds,
+                            "selected_fund_columns": st.session_state.get("selected_fund_columns"),
+                            "fund_columns": st.session_state.get("fund_columns"),
+                            "checkbox_prefix": include_prefix,
+                        }
+                    )
 
 
 render_data_page()

--- a/streamlit_app/pages/2_Model.py
+++ b/streamlit_app/pages/2_Model.py
@@ -1037,25 +1037,41 @@ def _render_llm_status_panel() -> None:
         _normalize_cache_str(st.session_state.get("selected_model")) or _DEFAULT_CONFIG_CHAT_MODEL
     )
     provider_label = provider_labels.get(selected_provider, selected_provider)
-    st.info(f"Active provider: {provider_label}")
-    st.info(f"Active model: {selected_model}")
     required_vars = _llm_required_env_vars(selected_provider)
-    if required_vars is None:
-        st.warning(f"Unknown provider: {selected_provider}. Update your LLM settings.")
-        return
-    if not required_vars:
-        st.caption("Expected environment variables: None required.")
-        return
-    missing_vars = [name for name in required_vars if not _llm_env_var_present(name)]
-    st.caption("Expected environment variables (values hidden):")
-    for name in required_vars:
-        icon = "✓" if name not in missing_vars else "✗"
-        st.write(f"{icon} `{name}`")
-    if missing_vars:
-        missing_list = ", ".join(missing_vars)
-        st.warning(
-            f"Missing required environment variables for {provider_label}. " f"Set: {missing_list}."
+    missing_vars = (
+        [name for name in required_vars if not _llm_env_var_present(name)] if required_vars else []
+    )
+
+    # The LLM assistant is OPTIONAL. Previously this panel led the Model page's sidebar
+    # with "Active provider", three ✗ rows and a "Missing required environment variables"
+    # st.warning -- so an allocator who only wanted to configure a run was met by what
+    # looked like a broken required dependency (issue #5816). Everything now lives inside
+    # a collapsed, plainly-labelled expander, and an unconfigured optional feature is
+    # reported as a caption rather than a warning.
+    status_suffix = " — not configured" if missing_vars else ""
+    with st.expander(f"LLM assistant status (optional){status_suffix}", expanded=False):
+        st.caption(
+            "The LLM assistant is optional. Every analysis feature works without it; "
+            "configure it only if you want the Config Chat / explain surfaces."
         )
+        st.caption(f"Active provider: {provider_label}")
+        st.caption(f"Active model: {selected_model}")
+        if required_vars is None:
+            st.caption(f"Unknown provider: {selected_provider}. Update your LLM settings.")
+            return
+        if not required_vars:
+            st.caption("Expected environment variables: None required.")
+            return
+        st.caption("Expected environment variables (values hidden):")
+        for name in required_vars:
+            icon = "✓" if name not in missing_vars else "✗"
+            st.write(f"{icon} `{name}`")
+        if missing_vars:
+            missing_list = ", ".join(missing_vars)
+            st.caption(
+                f"To enable the LLM assistant for {provider_label}, set: {missing_list}. "
+                "Until then the rest of the app is unaffected."
+            )
 
 
 def _sync_llm_selection_from_overrides() -> None:

--- a/streamlit_app/pages/4_Help.py
+++ b/streamlit_app/pages/4_Help.py
@@ -49,6 +49,11 @@ These settings control how funds are evaluated and filtered for inclusion in the
 | **Conservative** | Longer lookback periods, more data required. Reduces noise but may lag market turns. |
 | **Aggressive** | Shorter lookbacks, faster response. More responsive but potentially noisier. |
 | **Custom** | Manually configure all parameters below. |
+
+> **Note — two separate preset sets.** The presets above belong to the **Model** page
+> (custom analysis). The **Demo with Sample Data** section on the Home page has its own,
+> separate preset list (for example *Balanced*) which drives the bundled-dataset demo
+> engine. A name appearing in one list does not imply it exists in the other.
         """)
 
     st.subheader("Lookback Window (months)")

--- a/streamlit_app/pages/8_Validation.py
+++ b/streamlit_app/pages/8_Validation.py
@@ -548,8 +548,13 @@ def render_validation_page() -> None:
     """Render the Settings Validation page."""
 
     app_state.initialize_session_state()
-    st.title("🔧 Settings Validation")
+    # Marked as a developer tool: this is a QA harness for checking that UI settings
+    # reach the pipeline, not part of the allocator workflow. It sits in the same
+    # navigation as Data/Model/Results, so the title has to say what it is (issue #5816).
+    st.title("🔧 Settings Validation (developer tool)")
     st.markdown("""
+    **Developer/QA utility — not part of the Data → Model → Results workflow.**
+
     This page systematically tests each UI setting to verify it's properly
     connected to the analysis pipeline. Select a setting, choose test values,
     and compare the results.

--- a/tests/app/test_model_page_helpers.py
+++ b/tests/app/test_model_page_helpers.py
@@ -1923,9 +1923,21 @@ def test_llm_status_panel_allows_env_var_names_but_not_values(
         assert secret not in rendered_text
 
 
-def test_llm_status_panel_warns_once_with_all_missing_env_vars(
+def test_llm_status_panel_reports_missing_env_vars_without_warning(
     monkeypatch: pytest.MonkeyPatch, model_module: ModuleType
 ) -> None:
+    """A missing OPTIONAL dependency must not present as a warning/error.
+
+    Issue #5816: this panel used to lead the Model page's sidebar with
+    ``Active provider``, three ``✗`` rows and a ``st.warning`` reading "Missing required
+    environment variables ...". Driving the app showed an allocator who only wanted to
+    configure a run being met by what looked like a broken required dependency, above the
+    actual configuration controls. The LLM assistant is optional, so the panel now lives in
+    a collapsed expander and reports an unconfigured provider as a caption.
+
+    The information must still be there (the variable names), but ``st.warning`` must not
+    be used for it. Restoring the warning makes this test fail.
+    """
     stub = model_module.st
     stub.session_state.clear()
     stub.session_state["selected_provider"] = "openai"
@@ -1938,12 +1950,27 @@ def test_llm_status_panel_warns_once_with_all_missing_env_vars(
     warnings: list[str] = []
     stub.warning = lambda message, **_kwargs: warnings.append(message)
 
+    calls = _capture_streamlit_calls(stub, ("info", "caption", "write"))
     model_module._render_llm_status_panel()
 
-    assert len(warnings) == 1
-    warning_text = warnings[0]
+    assert warnings == [], (
+        "an unconfigured optional LLM provider must not raise st.warning; " f"got {warnings!r}"
+    )
+
+    rendered_texts: list[str] = []
+    for _name, args, kwargs in calls:
+        for arg in args:
+            rendered_texts.extend(_extract_strings(arg))
+        for value in kwargs.values():
+            rendered_texts.extend(_extract_strings(value))
+    rendered_text = " ".join(rendered_texts)
+
     for name in ("TREND_LLM_API_KEY", "OPENAI_API_KEY"):
-        assert name in warning_text
+        assert name in rendered_text, f"{name} should still be surfaced to the user"
+    assert "optional" in rendered_text.lower(), (
+        "the panel should say the LLM assistant is optional so a missing key does not "
+        "read as a broken required dependency"
+    )
 
 
 def test_llm_required_env_vars_warns_on_unknown_provider(

--- a/tests/app/test_no_dev_surfaces_by_default.py
+++ b/tests/app/test_no_dev_surfaces_by_default.py
@@ -1,0 +1,119 @@
+"""Guard that developer surfaces stay hidden and on-page guidance matches the profile.
+
+Issue #5816. Two defects observed by driving the live app:
+
+1. ``streamlit_app/pages/1_Data.py`` rendered a ``Debug: Fund selection state`` expander
+   unconditionally, dumping internal counters (run counter, ``data_loaded_key``,
+   ``available_funds_count``, raw perf timings, ...) to end users. Issue #5411 gated the
+   sibling perf *caption* behind ``show_perf_diagnostics`` but missed this expander, so the
+   same information stayed visible. The fix puts the expander behind the same flag.
+
+2. ``streamlit_app/app.py`` advertised "Use the **Custom Analysis** section to load your own
+   data" unconditionally in Quick Start, while that section only renders when
+   ``demo_profile.custom_analysis_enabled(...)`` is true. In the default ``presentation_safe``
+   profile the instruction pointed at a section that is not on the page.
+
+Deliberate-break gates: un-gating the Debug expander makes
+``test_debug_surfaces_hidden_without_flag`` fail; making the Quick Start copy unconditional
+again makes ``test_quick_start_matches_active_profile`` fail.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+import pandas as pd
+import pytest
+
+# Reuse the established DummyStreamlit harness + page fixture from the sibling
+# Data-page test module. ``data_page`` is a pytest fixture; importing it here
+# registers it for this module's tests.
+from tests.app.test_data_page import DummyStreamlit, data_page  # noqa: F401
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The Debug expander body increments this session key and is the only writer of it,
+# so its presence is a reliable signal that the expander rendered.
+_DEBUG_RUN_KEY = "_debug_fund_run"
+
+
+def _load_sample(monkeypatch: pytest.MonkeyPatch, page: ModuleType, stub: DummyStreamlit) -> None:
+    """Drive the Data page into the loaded-dataset state that renders the
+    fund-selection section (where the debug expander lives)."""
+    stub.session_state.clear()
+    stub.clear_calls = 0
+
+    df = pd.DataFrame(
+        {"FundA": [0.01, 0.02, -0.01], "SPX Index": [0.03, -0.02, 0.01]},
+        index=pd.date_range("2024-01-31", periods=3, freq="ME"),
+    )
+    meta = {"validation": {"issues": [], "warnings": []}, "frequency_label": "monthly"}
+    sample = page.data_cache.SampleDataset("demo.csv", Path("demo/demo_returns.csv"))
+
+    monkeypatch.setattr(page.data_cache, "default_sample_dataset", lambda: sample)
+    monkeypatch.setattr(page.data_cache, "dataset_choices", lambda: {sample.label: sample})
+    monkeypatch.setattr(page.data_cache, "load_dataset_from_path", lambda path: (df, meta))
+    stub.selectbox_map["Choose a sample"] = sample.label
+    stub.selectbox_map["Benchmark column (optional)"] = "SPX Index"
+    monkeypatch.setattr(page, "infer_benchmarks", lambda columns: ["SPX Index"])
+
+
+def test_debug_surfaces_hidden_without_flag(
+    monkeypatch: pytest.MonkeyPatch, data_page  # noqa: F811 - reused pytest fixture
+) -> None:
+    """With no debug flag set, the Data page renders no debug expander."""
+    page, stub = data_page
+    _load_sample(monkeypatch, page, stub)
+
+    page.render_data_page()
+
+    assert _DEBUG_RUN_KEY not in stub.session_state, (
+        "Debug: Fund selection state expander rendered without show_perf_diagnostics; "
+        "internal counters must not reach end users."
+    )
+
+
+def test_debug_surfaces_visible_with_flag(
+    monkeypatch: pytest.MonkeyPatch, data_page  # noqa: F811 - reused pytest fixture
+) -> None:
+    """The expander is still available to developers behind the flag."""
+    page, stub = data_page
+    _load_sample(monkeypatch, page, stub)
+    stub.session_state["show_perf_diagnostics"] = True
+
+    page.render_data_page()
+
+    assert stub.session_state.get(_DEBUG_RUN_KEY), (
+        "show_perf_diagnostics was set but the debug expander did not render; "
+        "the developer diagnostic must remain reachable."
+    )
+
+
+def test_quick_start_matches_active_profile() -> None:
+    """Home-page Quick Start must not advertise a section this profile hides.
+
+    ``app.py`` executes at import time, so this asserts on the page source in the same
+    style as ``tests/test_demo_profile.py::test_gated_pages_render_profile_controls``.
+    """
+    source = (REPO_ROOT / "streamlit_app" / "app.py").read_text(encoding="utf-8")
+
+    marker = "Use the **Custom Analysis** section"
+    assert marker in source, "expected the Custom Analysis Quick Start bullet to still exist"
+
+    gate = "demo_profile.custom_analysis_enabled(_active_profile)"
+    assert gate in source, "Quick Start copy must be gated on custom_analysis_enabled"
+
+    # The Custom Analysis bullet must appear *after* the profile gate, i.e. inside the
+    # branch that only runs when the section is actually rendered.
+    assert source.index(gate) < source.index(marker), (
+        "The 'Use the Custom Analysis section' bullet appears before the "
+        "custom_analysis_enabled gate, so presentation_safe users are told to use a "
+        "section that is not rendered."
+    )
+
+    # And the presentation-safe branch must point at the control that actually exists.
+    assert "switch **Demo mode**" in source or "Demo mode" in source, (
+        "presentation_safe Quick Start should tell the user how to enable custom "
+        "analysis (the Demo mode switcher), not reference a hidden section."
+    )


### PR DESCRIPTION
Closes #5816 — the five UI-honesty items from the 2026-08-11 observed UX review. Every one was found by **driving the live app**, not by reading code.

## What was wrong, and what changed

**1. `Debug: Fund selection state` expander was ungated** (`pages/1_Data.py`)
It dumped internal counters — run counter, `data_loaded_key`, `available_funds_count`, raw perf timings — to every user. #5411 gated the *sibling perf caption* behind `show_perf_diagnostics` but missed this expander, so the same data stayed visible. Now behind the same flag.

**2. `Settings Validation` was indistinguishable from a workflow page** (`pages/8_Validation.py`)
It is a QA harness that checks UI settings reach the pipeline, sitting in the nav beside Data/Model/Results. Legacy `pages/` routing means its file presence creates the nav entry, so the title and intro now state what it is: **"Settings Validation (developer tool)"** plus a developer/QA notice.

**3. Quick Start advertised a section the default profile hides** (`app.py`)
"Use the **Custom Analysis** section to load your own data" rendered unconditionally, while that section is gated on `custom_analysis_enabled()`. In the default `presentation_safe` profile the instruction pointed at a section that is not on the page. Quick Start is now per-profile, and the safe-mode variant points at the **Demo mode** switcher — a control that actually exists.

**4. Two preset vocabularies, unexplained** (`pages/4_Help.py`)
Help documents `Baseline/Conservative/Aggressive/Custom` (Model page) while the home demo selector offers `Balanced`. They are genuinely separate sets, so Help now says so explicitly instead of leaving the user to guess.

**5. An optional LLM integration presented as a broken required dependency** (`pages/2_Model.py`)
The panel led the Model sidebar with `Active provider`, three `✗` rows, and a `st.warning` reading "Missing required environment variables …" — above the actual configuration controls, for a feature the user may never want. It is now a collapsed **"LLM assistant status (optional)"** expander, and an unconfigured provider is a caption. The variable names are still surfaced.

## Test gates

`tests/app/test_no_dev_surfaces_by_default.py`:
- `test_debug_surfaces_hidden_without_flag` — no debug surface without the flag
- `test_debug_surfaces_visible_with_flag` — still reachable for developers
- `test_quick_start_matches_active_profile` — Quick Start copy is profile-gated

**Deliberate-break → revert, all three demonstrated:**

| Break | Result |
|---|---|
| un-gate the Debug expander | `test_debug_surfaces_hidden_without_flag` **FAILS** |
| make Quick Start unconditional | `test_quick_start_matches_active_profile` **FAILS** |
| restore the LLM `st.warning` | `test_llm_status_panel_reports_missing_env_vars_without_warning` **FAILS** |

Each was reverted and the suite returned to green.

## One existing test was retargeted, deliberately

`test_llm_status_panel_warns_once_with_all_missing_env_vars` asserted `st.warning` fires for a missing **optional** dependency — exactly the contract item 5 changes. Rather than delete or weaken it, it now asserts the new contract: the variable names are still shown, "optional" is stated, and `st.warning` is **not** used. Renamed to `test_llm_status_panel_reports_missing_env_vars_without_warning`.

Also note item 2 avoided `st.caption` on the Validation page: that page's existing test stub does not implement `caption`, so the notice went into the `markdown` call it already supports rather than weakening the harness.

## Verification

```
318 passed   (tests/app, tests/streamlit, tests/test_demo_profile)
black --check .                                                   -> 1061 files clean
ruff check --select E4,E7,E9,F --extend-exclude .workflows-lib .   -> All checks passed!
```

Closes #5816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick Start guidance now adapts to the selected demo profile.
  * LLM status details are available in an optional collapsed panel.
  * Help content clarifies that Model and Home presets are separate.

* **Improvements**
  * Developer diagnostics are hidden by default and available when enabled.
  * Validation is clearly identified as a Developer/QA tool.
  * Optional LLM configuration issues no longer appear as warnings.

* **Tests**
  * Added coverage for profile-specific guidance and diagnostic visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->