### PR TITLE
test: pin the debug-surface gate, not its removal

### DIFF
--- a/tests/app/test_data_page.py
+++ b/tests/app/test_data_page.py
@@ -278,17 +278,13 @@ def test_data_page_autoloads_sample(monkeypatch: pytest.MonkeyPatch, data_page) 
         assert key not in page.st.session_state
 
 
-def test_debug_surfaces_hidden_without_flag(monkeypatch: pytest.MonkeyPatch, data_page) -> None:
-    page, stub = data_page
-    source = (
-        Path(__file__).resolve().parents[2] / "streamlit_app" / "pages" / "1_Data.py"
-    ).read_text(encoding="utf-8")
-    assert (
-        "never expose selection counters or timing data in the end-user UI.\n"
-        '            if st.session_state.get("show_perf_diagnostics"):\n'
-        '                with st.expander("Debug: Fund selection state"'
-    ) in source
+def _load_sample_for_debug_gate(
+    monkeypatch: pytest.MonkeyPatch, page: ModuleType, stub: DummyStreamlit
+) -> None:
+    """Drive the Data page into the loaded-dataset state that renders the
+    fund-selection section, where the debug expander lives."""
     stub.session_state.clear()
+    stub.expander_labels.clear()
     df = pd.DataFrame(
         {"FundA": [0.01, 0.02, -0.01], "SPX Index": [0.03, -0.02, 0.01]},
         index=pd.date_range("2024-01-31", periods=3, freq="ME"),
@@ -305,9 +301,39 @@ def test_debug_surfaces_hidden_without_flag(monkeypatch: pytest.MonkeyPatch, dat
     stub.selectbox_map["Choose a sample"] = sample.label
     stub.selectbox_map["Benchmark Column (optional)"] = "SPX Index"
 
+
+def test_debug_surfaces_hidden_without_flag(monkeypatch: pytest.MonkeyPatch, data_page) -> None:
+    """Issue #5816: internal selection counters/timings must not reach end users.
+
+    The source-level assertion this test used to carry pinned exact indentation
+    (``'            if st.session_state.get(...)'``), so any re-indent broke it without a
+    behaviour change. The behavioural assertion below covers the same intent, so the
+    brittle string match was dropped.
+    """
+    page, stub = data_page
+    _load_sample_for_debug_gate(monkeypatch, page, stub)
+
     page.render_data_page()
 
     assert not any(label.startswith("Debug:") for label in stub.expander_labels)
+
+
+def test_debug_surfaces_visible_with_flag(monkeypatch: pytest.MonkeyPatch, data_page) -> None:
+    """The developer diagnostic must remain REACHABLE behind ``show_perf_diagnostics``.
+
+    Without this counterpart, ``test_debug_surfaces_hidden_without_flag`` also passes if
+    the expander is deleted outright, so the pair cannot distinguish "correctly gated"
+    from "removed". This pins the gate rather than the removal.
+    """
+    page, stub = data_page
+    _load_sample_for_debug_gate(monkeypatch, page, stub)
+    stub.session_state["show_perf_diagnostics"] = True
+
+    page.render_data_page()
+
+    assert any(
+        label.startswith("Debug:") for label in stub.expander_labels
+    ), "show_perf_diagnostics was set but no Debug expander rendered"
 
 
 def test_data_page_upload_failure(monkeypatch: pytest.MonkeyPatch, data_page) -> None:

--- a/tests/streamlit/test_no_dev_surfaces_by_default.py
+++ b/tests/streamlit/test_no_dev_surfaces_by_default.py
@@ -23,10 +23,17 @@ def test_developer_surfaces_are_explicitly_marked_or_gated() -> None:
         REPO_ROOT / "streamlit_app" / "developer_settings_validation.py"
     ).read_text(encoding="utf-8")
 
-    assert (
-        'if st.session_state.get("show_perf_diagnostics"):\n                with st.expander("Debug: Fund selection state"'
-        in data_source
-    )
+    # Indentation-insensitive: the exact-whitespace form of this assertion broke on any
+    # re-indent without a behaviour change. The behavioural pair in
+    # tests/app/test_data_page.py (test_debug_surfaces_hidden_without_flag /
+    # test_debug_surfaces_visible_with_flag) is what actually pins the gate.
+    assert 'if st.session_state.get("show_perf_diagnostics"):' in data_source
+    assert 'with st.expander("Debug: Fund selection state"' in data_source
+    assert data_source.index(
+        'if st.session_state.get("show_perf_diagnostics"):'
+    ) < data_source.index(
+        'with st.expander("Debug: Fund selection state"'
+    ), "the Debug expander must sit inside the show_perf_diagnostics gate"
     assert 'page_title="Developer: Settings Validation"' in validation_source
     assert 'st.title("🔧 Developer: Settings Validation")' in validation_source
     assert "not demo_profile.custom_analysis_enabled(active_profile)" in validation_source


### PR DESCRIPTION
Tests-only follow-up to #5834 (which closed #5816). No production change.

## 1. The existing gate cannot tell "correctly gated" from "removed"

`test_debug_surfaces_hidden_without_flag` asserts no `Debug:` expander renders without `show_perf_diagnostics`. That assertion **also passes if the expander is deleted outright** — so an over-correction that removes the developer diagnostic entirely looks identical to a correct fix.

Added `test_debug_surfaces_visible_with_flag`: set the flag, assert the expander *is* present. The pair now pins the gate rather than the absence.

**Demonstrated** — delete the expander block entirely:

| Test | Result |
|---|---|
| `test_debug_surfaces_hidden_without_flag` | **passes** (nothing to find) |
| `test_debug_surfaces_visible_with_flag` | **FAILS** |

Reverted; 319 pass.

## 2. Two assertions pinned exact indentation

```python
"never expose selection counters or timing data in the end-user UI.\n"
'            if st.session_state.get("show_perf_diagnostics"):\n'
'                with st.expander("Debug: Fund selection state"'
```

Any re-indent or reformat breaks this with no behaviour change — and this repo reformats with `black --line-length 100`, so that is a live hazard rather than a hypothetical one.

- In `tests/app/test_data_page.py` the behavioural assertion already covers the intent, so the string match is dropped.
- In `tests/streamlit/test_no_dev_surfaces_by_default.py` it becomes two indentation-insensitive substring checks **plus an ordering check** (the gate must appear before the expander), which is what the original was actually trying to express.

## 3. Shared setup extracted

`_load_sample_for_debug_gate` so both behavioural tests drive the page identically.

## Verification

```
319 passed   (tests/app, tests/streamlit, tests/test_demo_profile)
black --check .                                                  -> 1061 files clean
ruff check --select E4,E7,E9,F --extend-exclude .workflows-lib .  -> All checks passed!
```

## Context

I had independently implemented #5816 in #5835 while #5834 was in flight, and closed mine as superseded — #5834 is complete and in one respect better (it renamed the QA page out of `pages/` entirely, removing it from the nav, rather than merely retitling it). I also posted a correction there: my first read wrongly claimed #5834's tests were purely source-string assertions, having missed the genuine behavioural test it added to `tests/app/test_data_page.py`. This PR keeps only the two things that were actually still missing.

Refs #5816