### PR TITLE
Deploy the stlite demo with GitHub Pages

### DIFF
--- a/.github/workflows/pages-wasm-demo.yml
+++ b/.github/workflows/pages-wasm-demo.yml
@@ -1,0 +1,72 @@
+name: Deploy stlite browser demo
+
+on:
+  push:
+    branches: [phase-3]
+    paths:
+      - ".github/workflows/pages-wasm-demo.yml"
+      - "analysis/**"
+      - "config/defaults.yml"
+      - "config/scenarios/**"
+      - "demo/demo_returns.csv"
+      - "demo/wasm/**"
+      - "design-system/**"
+      - "scripts/build_wasm_demo.py"
+      - "scripts/build_wasm_site.py"
+      - "src/backtest/**"
+      - "src/data/**"
+      - "src/trend/**"
+      - "src/trend_analysis/**"
+      - "src/utils/**"
+      - "streamlit_app/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.12"
+
+      - name: Build Pages artifact
+        run: python scripts/build_wasm_site.py --output dist/wasm-demo
+
+      - name: Install focused test tools
+        run: python -m pip install "pytest==9.1.1" "pytest-xdist==3.8.0"
+
+      - name: Verify artifact contract
+        run: pytest -q tests/wasm/test_build_wasm_site.py tests/wasm/test_demo_no_external_cdn.py
+
+      - name: Configure Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        with:
+          path: dist/wasm-demo
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/pages-wasm-demo.yml
+++ b/.github/workflows/pages-wasm-demo.yml
@@ -7,6 +7,7 @@ on:
       - ".github/workflows/pages-wasm-demo.yml"
       - "analysis/**"
       - "config/defaults.yml"
+      - "config.schema.compact.json"
       - "config/scenarios/**"
       - "demo/demo_returns.csv"
       - "demo/wasm/**"

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ ci/autofix/diagnostics.json
 !tools/requirements-llm.txt
 
 # Python package build artifacts
+dist/
 *.egg-info/
 trend_model.egg-info/
 coverage.xml

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ A zero-install browser build runs the real app and the deterministic engine in
 the browser via [stlite](https://github.com/whitphx/stlite) / Pyodide.
 
 - **Live demo:** <https://stranske.github.io/Trend_Model_Project/> (presentation-safe by default)
-- **Build:** `python scripts/build_wasm_demo.py`
+- **Pages artifact build:** `python scripts/build_wasm_site.py --output dist/wasm-demo`
+- **Manifest refresh:** `python scripts/build_wasm_demo.py`
 - **Modes** (via the sidebar switcher or `?profile=`):
   - `presentation_safe` (default): bundled synthetic data only; LLM,
     custom-analysis, and upload surfaces hidden; no LLM dependency footprint.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Then open http://localhost:8501 in your browser.
 A zero-install browser build runs the real app and the deterministic engine in
 the browser via [stlite](https://github.com/whitphx/stlite) / Pyodide.
 
-- **Live demo:** _published URL — see `demo/wasm/README.md` (TODO: fill in after deploy)_
+- **Live demo:** <https://stranske.github.io/Trend_Model_Project/> (presentation-safe by default)
 - **Build:** `python scripts/build_wasm_demo.py`
 - **Modes** (via the sidebar switcher or `?profile=`):
   - `presentation_safe` (default): bundled synthetic data only; LLM,

--- a/README_APP.md
+++ b/README_APP.md
@@ -51,6 +51,8 @@ Runtime modes are selected with the sidebar **Demo mode** switcher or the
 - `public_llm_demo`: exposes the LangChain LLM UI; provider keys/endpoints are
   runtime-only and never bundled.
 
+Public demo: <https://stranske.github.io/Trend_Model_Project/>
+
 See [`demo/wasm/README.md`](demo/wasm/README.md) for build/deploy steps and the
 live-URL/screenshot/network-evidence verification checklist.
 

--- a/demo/wasm/README.md
+++ b/demo/wasm/README.md
@@ -69,6 +69,22 @@ so it does not need separate vendoring. Re-fetch all of the above with
 
 ## Deploy
 
+The public GitHub Pages target is
+<https://stranske.github.io/Trend_Model_Project/>. The default profile is
+presentation-safe; the explicit LLM profile is available at
+<https://stranske.github.io/Trend_Model_Project/?profile=public_llm_demo>.
+
+Pushes to `phase-3` that change the browser-demo inputs run
+`.github/workflows/pages-wasm-demo.yml`. The workflow builds a self-contained
+artifact with:
+
+```bash
+python scripts/build_wasm_site.py --output dist/wasm-demo
+```
+
+and publishes it with GitHub Pages. The manual layout below remains valid for
+another static host.
+
 The demo is a static bundle plus the published application source subset:
 
 1. `python scripts/build_wasm_demo.py`

--- a/scripts/build_wasm_demo.py
+++ b/scripts/build_wasm_demo.py
@@ -130,7 +130,13 @@ SOURCE_DIRS = (
 )
 
 #: Bundled synthetic data shipped with the demo (presentation-safe default).
-DATA_FILES = ("demo/demo_returns.csv",)
+DATA_FILES = (
+    "demo/demo_returns.csv",
+    # The public-LLM profile loads this at runtime when constructing the
+    # configuration-assistant chain. Keep it in the browser filesystem next to
+    # the repository sources rather than relying on an undeployed root file.
+    "config.schema.compact.json",
+)
 
 #: Non-Python config globbed into the browser FS so the Monte Carlo page can load
 #: its scenario registry (``config/scenarios/monte_carlo/index.yml``) and run a

--- a/scripts/build_wasm_site.py
+++ b/scripts/build_wasm_site.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Assemble the static stlite bundle consumed by GitHub Pages.
+
+The runtime assets live under ``demo/wasm`` while the application sources named
+by ``build_wasm_demo.py`` remain in their canonical repository locations. A
+Pages artifact needs both in one tree, so this command writes the generated
+manifest at the site root and copies each declared source beneath ``app/``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path, PurePosixPath
+
+if __package__:
+    from scripts.build_wasm_demo import REPO_ROOT, build_manifest
+else:  # Direct invocation: python scripts/build_wasm_site.py
+    from build_wasm_demo import REPO_ROOT, build_manifest
+
+
+DEFAULT_OUTPUT = REPO_ROOT / "dist" / "wasm-demo"
+
+
+def _validated_relative_path(value: str) -> Path:
+    """Return a safe relative path from a generated manifest entry."""
+
+    raw_parts = value.split("/")
+    posix = PurePosixPath(value)
+    if posix.is_absolute() or not posix.parts or any(part in {"", ".", ".."} for part in raw_parts):
+        raise ValueError(f"unsafe manifest path: {value!r}")
+    return Path(*posix.parts)
+
+
+def _prepare_output(repo_root: Path, output_dir: Path) -> None:
+    repo = repo_root.resolve()
+    output = output_dir.resolve()
+    if output == repo or output in repo.parents:
+        raise ValueError(f"refusing broad output path: {output}")
+    if output.exists():
+        shutil.rmtree(output)
+    output.mkdir(parents=True)
+
+
+def assemble_site(repo_root: Path = REPO_ROOT, output_dir: Path = DEFAULT_OUTPUT) -> dict:
+    """Build a self-contained Pages artifact and return its manifest."""
+
+    repo_root = repo_root.resolve()
+    output_dir = output_dir.resolve()
+    _prepare_output(repo_root, output_dir)
+
+    demo_root = repo_root / "demo" / "wasm"
+    index_path = demo_root / "index.html"
+    vendor_path = demo_root / "vendor"
+    if not index_path.is_file() or not vendor_path.is_dir():
+        raise FileNotFoundError("demo/wasm must contain index.html and vendor/")
+
+    shutil.copy2(index_path, output_dir / "index.html")
+    shutil.copytree(vendor_path, output_dir / "vendor")
+
+    manifest = build_manifest(repo_root)
+    (output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+
+    app_root = output_dir / "app"
+    for value in manifest["files"]:
+        relative = _validated_relative_path(value)
+        source = repo_root / relative
+        if not source.is_file():
+            raise FileNotFoundError(f"manifest source is missing: {relative.as_posix()}")
+        destination = app_root / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+    return manifest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Pages artifact directory (default: dist/wasm-demo)",
+    )
+    args = parser.parse_args(argv)
+
+    manifest = assemble_site(output_dir=args.output)
+    print(f"wrote {args.output.resolve()} ({len(manifest['files'])} application files)")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/build_wasm_site.py
+++ b/scripts/build_wasm_site.py
@@ -15,9 +15,9 @@ import shutil
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 if __package__:
-    from scripts.build_wasm_demo import REPO_ROOT, build_manifest
+    from scripts.build_wasm_demo import REPO_ROOT, SOURCE_DIRS, build_manifest
 else:  # Direct invocation: python scripts/build_wasm_site.py
-    from build_wasm_demo import REPO_ROOT, build_manifest
+    from build_wasm_demo import REPO_ROOT, SOURCE_DIRS, build_manifest
 
 
 DEFAULT_OUTPUT = REPO_ROOT / "dist" / "wasm-demo"
@@ -40,11 +40,23 @@ def _validated_relative_path(value: str) -> Path:
     return Path(*posix.parts)
 
 
-def _prepare_output(repo_root: Path, output_dir: Path) -> None:
+def _paths_overlap(first: Path, second: Path) -> bool:
+    """Return whether either resolved path contains the other."""
+
+    return first == second or first in second.parents or second in first.parents
+
+
+def _prepare_output(
+    repo_root: Path, output_dir: Path, *, protected_paths: tuple[Path, ...]
+) -> None:
     repo = repo_root.resolve()
     output = output_dir.resolve()
     if output == repo or output in repo.parents:
         raise ValueError(f"refusing broad output path: {output}")
+    for protected in protected_paths:
+        protected = protected.resolve()
+        if _paths_overlap(output, protected):
+            raise ValueError(f"refusing output path that overlaps source input: {output}")
     if output.exists():
         shutil.rmtree(output)
     output.mkdir(parents=True)
@@ -55,18 +67,25 @@ def assemble_site(repo_root: Path = REPO_ROOT, output_dir: Path = DEFAULT_OUTPUT
 
     repo_root = repo_root.resolve()
     output_dir = output_dir.resolve()
-    _prepare_output(repo_root, output_dir)
-
+    if output_dir == repo_root or output_dir in repo_root.parents:
+        raise ValueError(f"refusing broad output path: {output_dir}")
     demo_root = repo_root / "demo" / "wasm"
     index_path = demo_root / "index.html"
     vendor_path = demo_root / "vendor"
     if not index_path.is_file() or not vendor_path.is_dir():
         raise FileNotFoundError("demo/wasm must contain index.html and vendor/")
 
+    manifest = build_manifest(repo_root)
+    protected_paths = (
+        demo_root,
+        *(repo_root / relative for relative in SOURCE_DIRS),
+        *(repo_root / _validated_relative_path(value) for value in manifest["files"]),
+    )
+    _prepare_output(repo_root, output_dir, protected_paths=protected_paths)
+
     shutil.copy2(index_path, output_dir / "index.html")
     shutil.copytree(vendor_path, output_dir / "vendor")
 
-    manifest = build_manifest(repo_root)
     (output_dir / "manifest.json").write_text(
         json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
     )

--- a/scripts/build_wasm_site.py
+++ b/scripts/build_wasm_site.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import shutil
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 if __package__:
     from scripts.build_wasm_demo import REPO_ROOT, build_manifest
@@ -26,9 +26,16 @@ DEFAULT_OUTPUT = REPO_ROOT / "dist" / "wasm-demo"
 def _validated_relative_path(value: str) -> Path:
     """Return a safe relative path from a generated manifest entry."""
 
-    raw_parts = value.split("/")
+    raw_parts = value.replace("\\", "/").split("/")
     posix = PurePosixPath(value)
-    if posix.is_absolute() or not posix.parts or any(part in {"", ".", ".."} for part in raw_parts):
+    windows = PureWindowsPath(value)
+    if (
+        posix.is_absolute()
+        or windows.is_absolute()
+        or bool(windows.drive)
+        or not posix.parts
+        or any(part in {"", ".", ".."} for part in raw_parts)
+    ):
         raise ValueError(f"unsafe manifest path: {value!r}")
     return Path(*posix.parts)
 

--- a/tests/wasm/test_build_wasm_site.py
+++ b/tests/wasm/test_build_wasm_site.py
@@ -1,0 +1,46 @@
+"""Tests for the GitHub Pages stlite artifact assembler."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.build_wasm_site import _validated_relative_path, assemble_site
+
+
+def _write(path: Path, content: str = "fixture") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_assemble_site_copies_runtime_manifest_and_declared_sources(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    output = tmp_path / "site"
+    _write(repo / "demo/wasm/index.html", "<main>demo</main>")
+    _write(repo / "demo/wasm/vendor/stlite.js")
+    _write(repo / "streamlit_app/app.py", "print('demo')")
+    _write(repo / "demo/demo_returns.csv", "date,value\n2026-01-01,1\n")
+
+    manifest = assemble_site(repo_root=repo, output_dir=output)
+
+    assert (output / "index.html").read_text(encoding="utf-8") == "<main>demo</main>"
+    assert (output / "vendor/stlite.js").is_file()
+    assert (output / "app/streamlit_app/app.py").is_file()
+    assert (output / "app/demo/demo_returns.csv").is_file()
+    assert json.loads((output / "manifest.json").read_text(encoding="utf-8")) == manifest
+
+
+@pytest.mark.parametrize("value", ["../secret", "/absolute", "a/../../secret", "./relative"])
+def test_manifest_paths_cannot_escape_the_pages_artifact(value: str) -> None:
+    with pytest.raises(ValueError, match="unsafe manifest path"):
+        _validated_relative_path(value)
+
+
+def test_assemble_site_refuses_repository_root_as_output(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    with pytest.raises(ValueError, match="refusing broad output path"):
+        assemble_site(repo_root=repo, output_dir=repo)

--- a/tests/wasm/test_build_wasm_site.py
+++ b/tests/wasm/test_build_wasm_site.py
@@ -22,6 +22,7 @@ def test_assemble_site_copies_runtime_manifest_and_declared_sources(tmp_path: Pa
     _write(repo / "demo/wasm/vendor/stlite.js")
     _write(repo / "streamlit_app/app.py", "print('demo')")
     _write(repo / "demo/demo_returns.csv", "date,value\n2026-01-01,1\n")
+    _write(repo / "config.schema.compact.json", '{"type": "object"}\n')
 
     manifest = assemble_site(repo_root=repo, output_dir=output)
 
@@ -29,6 +30,7 @@ def test_assemble_site_copies_runtime_manifest_and_declared_sources(tmp_path: Pa
     assert (output / "vendor/stlite.js").is_file()
     assert (output / "app/streamlit_app/app.py").is_file()
     assert (output / "app/demo/demo_returns.csv").is_file()
+    assert (output / "app/config.schema.compact.json").is_file()
     assert json.loads((output / "manifest.json").read_text(encoding="utf-8")) == manifest
 
 
@@ -56,3 +58,23 @@ def test_assemble_site_refuses_repository_root_as_output(tmp_path: Path) -> None
 
     with pytest.raises(ValueError, match="refusing broad output path"):
         assemble_site(repo_root=repo, output_dir=repo)
+
+
+@pytest.mark.parametrize("relative_output", ["demo", "demo/wasm", "streamlit_app"])
+def test_assemble_site_refuses_output_that_overlaps_sources(
+    tmp_path: Path, relative_output: str
+) -> None:
+    repo = tmp_path / "repo"
+    _write(repo / "demo/wasm/index.html", "<main>do not delete</main>")
+    _write(repo / "demo/wasm/vendor/stlite.js")
+    _write(repo / "streamlit_app/app.py", "print('do not delete')")
+    _write(repo / "demo/demo_returns.csv")
+    _write(repo / "config.schema.compact.json", "{}\n")
+
+    with pytest.raises(ValueError, match="overlaps source input"):
+        assemble_site(repo_root=repo, output_dir=repo / relative_output)
+
+    assert (repo / "demo/wasm/index.html").read_text(encoding="utf-8") == (
+        "<main>do not delete</main>"
+    )
+    assert (repo / "streamlit_app/app.py").read_text(encoding="utf-8") == ("print('do not delete')")

--- a/tests/wasm/test_build_wasm_site.py
+++ b/tests/wasm/test_build_wasm_site.py
@@ -32,7 +32,19 @@ def test_assemble_site_copies_runtime_manifest_and_declared_sources(tmp_path: Pa
     assert json.loads((output / "manifest.json").read_text(encoding="utf-8")) == manifest
 
 
-@pytest.mark.parametrize("value", ["../secret", "/absolute", "a/../../secret", "./relative"])
+@pytest.mark.parametrize(
+    "value",
+    [
+        "../secret",
+        "/absolute",
+        "a/../../secret",
+        "./relative",
+        r"..\secret",
+        r"C:\secret",
+        r"C:relative",
+        r"\\server\share\secret",
+    ],
+)
 def test_manifest_paths_cannot_escape_the_pages_artifact(value: str) -> None:
     with pytest.raises(ValueError, match="unsafe manifest path"):
         _validated_relative_path(value)


### PR DESCRIPTION
Closes #5343

## What changed

- add a deterministic Pages artifact assembler that publishes the generated stlite manifest, vendored runtime, and exactly the application sources declared by the manifest
- add a pinned GitHub Pages workflow for `phase-3`
- document the public presentation-safe and explicit `public_llm_demo` URLs
- reject absolute or traversal paths before copying manifest sources into the Pages artifact

## Validation

- `uv run --with pytest-xdist pytest -q tests/wasm/test_build_wasm_site.py tests/wasm/test_demo_no_external_cdn.py` -> 16 passed
- `uv run ruff check scripts/build_wasm_site.py tests/wasm/test_build_wasm_site.py` -> passed
- `uv run black --check --line-length 100 scripts/build_wasm_site.py tests/wasm/test_build_wasm_site.py` -> passed
- `actionlint .github/workflows/pages-wasm-demo.yml` -> passed
- `python scripts/build_wasm_site.py --output dist/wasm-demo` -> 246 application files, 190 MB artifact

## Deployment

After merge, the workflow publishes <https://stranske.github.io/Trend_Model_Project/> from the default `presentation_safe` profile. The LLM UI is explicit at `?profile=public_llm_demo`; no secrets are bundled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an automated deployment pipeline for the browser-based WASM demo.
  - Published the demo to GitHub Pages for easy online access.
  - Added a reliable site package process that includes the demo runtime and application files.

- **Documentation**
  - Updated project documentation with the live demo link.
  - Documented available runtime profiles, build steps, deployment triggers, and manual hosting options.

- **Tests**
  - Added coverage to validate site packaging, generated metadata, file handling, and safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->