### PR TITLE
docs: clarify volatility regime annualisation

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -135,15 +135,15 @@ regime:
   method: "rolling_return"
   lookback: 126
   smoothing: 3
-  threshold: 0.0               # per-period volatility boundary; scaled with the signal
-  neutral_band: 0.001          # per-period buffer; scaled with the signal
+  threshold: 0.0               # rolling-return boundary in compounded-signal units
+  neutral_band: 0.001          # rolling-return neutral buffer in compounded-signal units
   min_observations: 4
   risk_on_label: "Risk-On"
   risk_off_label: "Risk-Off"
   risk_off_target_vol_multiplier: 0.5
   risk_off_fund_count_multiplier: 0.5
   cache: true
-  annualise_volatility: true   # scales signal, threshold, and band together for volatility
+  annualise_volatility: true   # only for method: volatility; rescales signal and boundaries together
 
 # ----------------------------------------------------------------------
 # 7. PERFORMANCE METRICS

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -135,15 +135,15 @@ regime:
   method: "rolling_return"
   lookback: 126
   smoothing: 3
-  threshold: 0.0
-  neutral_band: 0.001
+  threshold: 0.0               # per-period volatility boundary; scaled with the signal
+  neutral_band: 0.001          # per-period buffer; scaled with the signal
   min_observations: 4
   risk_on_label: "Risk-On"
   risk_off_label: "Risk-Off"
   risk_off_target_vol_multiplier: 0.5
   risk_off_fund_count_multiplier: 0.5
   cache: true
-  annualise_volatility: true   # applies when method: volatility
+  annualise_volatility: true   # scales signal, threshold, and band together for volatility
 
 # ----------------------------------------------------------------------
 # 7. PERFORMANCE METRICS

--- a/config/demo.yml
+++ b/config/demo.yml
@@ -59,10 +59,10 @@ regime:
   method: rolling_return
   lookback: 24            # two-year lookback keeps demo responsive
   smoothing: 3
-  threshold: 0.0          # per-period volatility boundary; scaled with the signal
-  neutral_band: 0.0015    # per-period buffer; scaled with the signal
+  threshold: 0.0          # rolling-return boundary in compounded-signal units
+  neutral_band: 0.0015    # rolling-return neutral buffer in compounded-signal units
   min_observations: 3
-  annualise_volatility: true  # do not pre-annualise threshold or band
+  annualise_volatility: true  # only for method: volatility; do not pre-annualise its boundaries
 
 metrics:
   registry:

--- a/config/demo.yml
+++ b/config/demo.yml
@@ -59,10 +59,10 @@ regime:
   method: rolling_return
   lookback: 24            # two-year lookback keeps demo responsive
   smoothing: 3
-  threshold: 0.0
-  neutral_band: 0.0015    # small buffer around zero to avoid flapping
+  threshold: 0.0          # per-period volatility boundary; scaled with the signal
+  neutral_band: 0.0015    # per-period buffer; scaled with the signal
   min_observations: 3
-  annualise_volatility: true
+  annualise_volatility: true  # do not pre-annualise threshold or band
 
 metrics:
   registry:

--- a/config/trend.toml
+++ b/config/trend.toml
@@ -77,10 +77,10 @@ proxy = "SPX"
 method = "rolling_return"
 lookback = 24
 smoothing = 3
-threshold = 0.0 # per-period volatility boundary; scaled with the signal
-neutral_band = 0.0015 # per-period buffer; scaled with the signal
+threshold = 0.0 # rolling-return boundary in compounded-signal units
+neutral_band = 0.0015 # rolling-return neutral buffer in compounded-signal units
 min_observations = 3
-annualise_volatility = true # do not pre-annualise threshold or band
+annualise_volatility = true # only for method: volatility; do not pre-annualise its boundaries
 
 # ---------------------------------------------------------------------------
 # Metrics calculated for both score frames and report tables.

--- a/config/trend.toml
+++ b/config/trend.toml
@@ -77,10 +77,10 @@ proxy = "SPX"
 method = "rolling_return"
 lookback = 24
 smoothing = 3
-threshold = 0.0
-neutral_band = 0.0015
+threshold = 0.0 # per-period volatility boundary; scaled with the signal
+neutral_band = 0.0015 # per-period buffer; scaled with the signal
 min_observations = 3
-annualise_volatility = true
+annualise_volatility = true # do not pre-annualise threshold or band
 
 # ---------------------------------------------------------------------------
 # Metrics calculated for both score frames and report tables.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -280,8 +280,8 @@ regime:
   method: "rolling_return"
   lookback: 126          # number of observations to compound
   smoothing: 3           # optional moving average over the rolling return
-  threshold: 0.0         # per-period cut-over; scaled with volatility if annualised
-  neutral_band: 0.001    # per-period neutral buffer; scaled with volatility too
+  threshold: 0.0         # rolling-return boundary in compounded-signal units
+  neutral_band: 0.001    # rolling-return neutral buffer in compounded-signal units
   min_observations: 4    # minimum rows required to compute metrics
   annualise_volatility: true  # only used when method: volatility
 ```

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -280,8 +280,8 @@ regime:
   method: "rolling_return"
   lookback: 126          # number of observations to compound
   smoothing: 3           # optional moving average over the rolling return
-  threshold: 0.0         # shift the cut-over between regimes
-  neutral_band: 0.001    # treat small deviations as neutral noise
+  threshold: 0.0         # per-period cut-over; scaled with volatility if annualised
+  neutral_band: 0.001    # per-period neutral buffer; scaled with volatility too
   min_observations: 4    # minimum rows required to compute metrics
   annualise_volatility: true  # only used when method: volatility
 ```
@@ -302,9 +302,12 @@ The `regime_notes` entry in the result dictionary carries the collected
 footnotes; they are exported as a one-column table for easy auditing alongside
 the numeric breakdown. Supplying your own proxy is as simple as adding the
 column to the input data or pointing `regime.proxy` at a custom series in the
-indices bundle. When using the volatility method the threshold is interpreted as
-annualised volatility when `annualise_volatility: true` (set to `false` to work
-with per-period figures).
+indices bundle. For the volatility method, provide `regime.threshold` and
+`regime.neutral_band` on the same per-period basis as the input returns. When
+`annualise_volatility: true`, the code scales the calculated volatility,
+threshold, and neutral band together by the same factor. This keeps regime
+classification invariant when annualisation is toggled; callers must not
+pre-annualise either boundary.
 
 In multi-period portfolio runs, regime detection currently changes allocation
 behavior through regime-conditional turnover-cap lookup. A regime-conditional

--- a/scripts/fetch_offline_runtime.py
+++ b/scripts/fetch_offline_runtime.py
@@ -9,9 +9,9 @@ are fetched separately from PyPI using pinned filenames.
 
 from __future__ import annotations
 
-import hashlib
 import base64
 import csv
+import hashlib
 import io
 import json
 import re

--- a/tests/test_llm_settings.py
+++ b/tests/test_llm_settings.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import pytest
 
+from streamlit_app.components import llm_settings
 from streamlit_app.components.llm_settings import (
     anthropic_api_key_status,
     llm_provider_options,
     resolve_anthropic_api_key,
     resolve_llm_provider_config,
 )
-from streamlit_app.components import llm_settings
 
 _ENV_KEYS = (
     "CLAUDE_API_STRANSKE",

--- a/tests/test_regime_documentation_contract.py
+++ b/tests/test_regime_documentation_contract.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_regime_documentation_contract.py
+++ b/tests/test_regime_documentation_contract.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_user_guide_matches_regime_annualisation_contract() -> None:
+    guide = (ROOT / "docs" / "UserGuide.md").read_text(encoding="utf-8")
+    defaults = (ROOT / "config" / "defaults.yml").read_text(encoding="utf-8")
+
+    assert "classification invariant when annualisation is toggled" in guide
+    assert "pre-annualise either boundary" in guide
+    assert "threshold, and neutral band together" in guide
+    assert "per-period volatility boundary; scaled with the signal" in defaults
+    assert "threshold is interpreted as\nannualised volatility" not in guide

--- a/tests/test_regime_documentation_contract.py
+++ b/tests/test_regime_documentation_contract.py
@@ -16,4 +16,10 @@ def test_user_guide_matches_regime_annualisation_contract() -> None:
         assert "rolling-return boundary in compounded-signal units" in config
         assert "rolling-return neutral buffer in compounded-signal units" in config
         assert "only for method: volatility" in config
+
+    rolling_return_block = guide.split('method: "rolling_return"', 1)[1].split("```", 1)[0]
+    assert "rolling-return boundary in compounded-signal units" in rolling_return_block
+    assert "rolling-return neutral buffer in compounded-signal units" in rolling_return_block
+    assert "per-period cut-over" not in rolling_return_block
+    assert "per-period neutral buffer" not in rolling_return_block
     assert "threshold is interpreted as\nannualised volatility" not in guide

--- a/tests/test_regime_documentation_contract.py
+++ b/tests/test_regime_documentation_contract.py
@@ -6,9 +6,14 @@ ROOT = Path(__file__).resolve().parents[1]
 def test_user_guide_matches_regime_annualisation_contract() -> None:
     guide = (ROOT / "docs" / "UserGuide.md").read_text(encoding="utf-8")
     defaults = (ROOT / "config" / "defaults.yml").read_text(encoding="utf-8")
+    demo = (ROOT / "config" / "demo.yml").read_text(encoding="utf-8")
+    trend_toml = (ROOT / "config" / "trend.toml").read_text(encoding="utf-8")
 
     assert "classification invariant when annualisation is toggled" in guide
     assert "pre-annualise either boundary" in guide
     assert "threshold, and neutral band together" in guide
-    assert "per-period volatility boundary; scaled with the signal" in defaults
+    for config in (defaults, demo, trend_toml):
+        assert "rolling-return boundary in compounded-signal units" in config
+        assert "rolling-return neutral buffer in compounded-signal units" in config
+        assert "only for method: volatility" in config
     assert "threshold is interpreted as\nannualised volatility" not in guide


### PR DESCRIPTION
Closes #5822

## Summary

- Document per-period volatility regime thresholds and neutral bands.
- Keep annualisation classification-invariant in examples and config comments.
- Add a documentation contract regression test.

## Validation

- `PYTHONPATH=src python -m pytest -q tests/test_regime_annualise.py tests/test_regime_documentation_contract.py`
- Deliberately restored the pre-annualised-threshold wording; the documentation contract test failed, then passed after restoration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified regime-analysis configuration units for thresholds and neutral bands.
  - Documented how volatility annualisation scales calculated values and boundaries.
  - Updated configuration comments and user guidance while keeping settings unchanged.

- **Tests**
  - Added checks to ensure regime annualisation guidance remains accurate and consistent.

- **Style**
  - Standardized import ordering without changing runtime or test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->