### PR TITLE
fix: honor configured date columns in load_parquet

### DIFF
--- a/src/trend_analysis/data.py
+++ b/src/trend_analysis/data.py
@@ -478,11 +478,12 @@ def load_parquet(
     *,
     errors: ValidationErrorMode = "log",
     include_date_column: bool = True,
+    date_column: str = "Date",
     missing_policy: str | Mapping[str, str] | None = None,
     missing_limit: MissingLimitArg = None,
     **_legacy_kwargs: object,
 ) -> Optional[pd.DataFrame]:
-    """Load and validate a Parquet file containing market data."""
+    """Load and validate a Parquet file using ``date_column`` as the date field."""
 
     if missing_policy is None and "nan_policy" in _legacy_kwargs:
         missing_policy = _coerce_policy_kwarg(_legacy_kwargs.pop("nan_policy"))
@@ -503,7 +504,7 @@ def load_parquet(
         if not _is_readable(mode):
             raise PermissionError(f"Permission denied accessing file: {path}")
 
-        raw = pd.read_parquet(str(p))
+        raw = _canonicalise_date_column(pd.read_parquet(str(p)), date_column)
         result = _validate_payload(
             raw,
             origin=str(p),

--- a/tests/test_date_column_parquet_path.py
+++ b/tests/test_date_column_parquet_path.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import pytest
+
+from trend_analysis.data import load_parquet
+from trend_analysis.io.market_data import MarketDataValidationError
+
+
+def _write_parquet(tmp_path, column: str) -> str:
+    path = tmp_path / "returns.parquet"
+    pd.DataFrame(
+        {
+            column: pd.to_datetime(["2024-01-31", "2024-02-29"]),
+            "ManagerA": [0.01, 0.03],
+        }
+    ).to_parquet(path)
+    return str(path)
+
+
+def test_load_parquet_honors_configured_date_column(tmp_path) -> None:
+    frame = load_parquet(
+        _write_parquet(tmp_path, "Timestamp"),
+        errors="raise",
+        date_column="Timestamp",
+    )
+
+    assert frame is not None
+    assert list(frame.columns) == ["Date", "ManagerA"]
+    assert pd.api.types.is_datetime64_any_dtype(frame["Date"])
+
+
+def test_load_parquet_default_date_column_unchanged(tmp_path) -> None:
+    frame = load_parquet(_write_parquet(tmp_path, "Date"), errors="raise")
+
+    assert frame is not None
+    assert list(frame.columns) == ["Date", "ManagerA"]
+
+
+def test_load_parquet_rejects_missing_configured_date_column(tmp_path) -> None:
+    with pytest.raises(MarketDataValidationError, match="Timestamp"):
+        load_parquet(
+            _write_parquet(tmp_path, "Date"),
+            errors="raise",
+            date_column="Timestamp",
+        )


### PR DESCRIPTION
Closes #5823

## Summary
- Add the `date_column` contract to `load_parquet` and canonicalize it before shared validation.
- Cover custom, default, and missing configured Parquet date columns.

## Validation
- `PYTHONPATH=src python -m pytest -q tests/test_date_column_parquet_path.py tests/test_date_column_main_path.py tests/test_data.py` (72 passed)
- Deliberate break: bypassing `_canonicalise_date_column` made `test_load_parquet_honors_configured_date_column` fail with `Missing required column 'Date'`; restored before push.