### PR TITLE
docs: define supported trend command surface

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -32,7 +32,7 @@ See [docs/DemoMaintenance.md](docs/DemoMaintenance.md) for the full checklist.
 
 | Purpose | Command |
 |---------|---------|
-| CLI analysis | `PYTHONPATH="./src" python -m trend_analysis.run_analysis -c config/demo.yml` |
+| CLI analysis | `PYTHONPATH="./src" python -m trend.cli run -c config/demo.yml` |
 | Streamlit app | `./scripts/run_streamlit.sh` |
 | Tests | `./scripts/run_tests.sh` |
 | Fast validation | `./scripts/dev_check.sh --fix` |

--- a/DOCKER_QUICKSTART.md
+++ b/DOCKER_QUICKSTART.md
@@ -39,7 +39,7 @@ docker run --rm trend-model:local python scripts/generate_demo.py
 
 # Run trend analysis with demo config
 docker run --rm -v $(pwd):/workspace trend-model:local \
-  trend-analysis -c config/demo.yml
+  trend run -c config/demo.yml
 ```
 
 When using the published image, replace `trend-model:local` with
@@ -87,7 +87,7 @@ whenever you modify `pyproject.toml`.
 
 ### Included Components
 - **Streamlit Web App**: Full-featured interactive interface at port 8501
-- **CLI Tools**: `trend-analysis`, `trend-multi-analysis`, and `trend-model` commands
+- **CLI Tools**: the supported `trend` command and its `run`, `report`, `quick-report`, `app`, `check`, and `mc` subcommands
 - **Demo Data**: Built-in demo datasets for testing
 - **All Dependencies**: Pandas, NumPy, PyYAML, and all required packages
 
@@ -104,17 +104,15 @@ whenever you modify `pyproject.toml`.
 Inside the container, you can use:
 
 ```bash
-# Main analysis command
-trend-analysis -c config/demo.yml
+# Supported analysis command
+trend run -c config/demo.yml
 
-# Multi-period analysis
-trend-multi-analysis -c config/demo.yml
+# Inspect the supported command surface
+trend --help
+trend mc --help
 
-# General trend model CLI
-trend-model --help
-
-# Direct Python execution
-python -m trend_analysis.run_analysis -c config/demo.yml
+# Direct Python execution from an uninstalled checkout
+PYTHONPATH=./src python -m trend.cli run -c config/demo.yml
 ```
 
 ## Development Workflow
@@ -148,7 +146,7 @@ curl -f http://localhost:8501/_stcore/health
 docker stop trend-test && docker rm trend-test
 
 # Test CLI functionality
-docker run --rm trend-model:local trend-analysis --help
+docker run --rm trend-model:local trend --help
 
 # Comprehensive test suite
 ./scripts/test_docker.sh
@@ -225,7 +223,7 @@ Override the default command for specific use cases:
 ```bash
 # Run only the analysis without web interface
 docker run --rm -v $(pwd):/workspace trend-model:local \
-  python -m trend_analysis.run_analysis -c /workspace/my-config.yml
+  trend run -c /workspace/my-config.yml
 
 # Start Jupyter notebook server instead
 docker run -p 8888:8888 trend-model:local \

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -33,11 +33,15 @@ aliases remain removal-bound and must not be used in new documentation or automa
 | `trend quick-report` | Build a compact report from existing run artefacts. | Supported |
 | `trend app` | Launch the Streamlit application. | Supported |
 | `trend check` | Print environment and dependency diagnostics. | Supported |
-| `trend mc` | List, validate, run, and visualize registered Monte Carlo scenarios. | Supported; scenario work is documented in `docs/phase-3/MonteCarlo.md`. |
+| `trend mc viz` | Render charts from an existing Monte Carlo bundle. | Supported. |
+| `python -m trend_analysis.cli mc` | List, validate, and run registered Monte Carlo scenarios. | Transitional compatibility surface until those commands move into `trend`. |
 
 Compatibility commands such as `trend-analysis`, `trend-multi-analysis`,
 `trend-model`, `trend-app`, and `trend-run` are transitional aliases only and
-will be removed. Use the `trend` forms above in scripts, examples, and releases.
+will be removed. The scenario examples below intentionally invoke
+`python -m trend_analysis.cli` because its `mc list`, `mc validate`, and `mc run`
+subcommands have not yet moved to `trend`; `trend mc` currently supports only
+`viz`.
 
 ## Launching the Streamlit UI (`trend app`)
 
@@ -57,10 +61,9 @@ trend app --server.headless true --server.port 8502
 
 ## Running analyses headlessly (`trend run`)
 
-The `trend run` command executes the full volatility-adjusted trend
-pipeline using a YAML or TOML configuration file and produces an HTML report by
-default. The repository now ships with a TOML example at `config/trend.toml`
-that mirrors the demonstration YAML configuration.
+The `trend run` command executes the full volatility-adjusted trend pipeline
+using a YAML configuration file. The repository now ships with a TOML example
+at `config/trend.toml` for configuration reference.
 
 If you pass a Streamlit JSON export instead of YAML/TOML, the `run` command will
 auto-detect it and replay the UI settings using the same mapping logic as the
@@ -70,39 +73,25 @@ Generate the demo dataset first (see the prerequisites above), then invoke the
 command:
 
 ```bash
-trend run -c config/trend.toml -o reports/cli_demo.html
+trend run -c config/trend.toml
 ```
 
-The example configuration writes the report to the location provided via
-`-o/--output`. You can also direct the command to export CSV, JSON, XLSX, or TXT
-artefacts by pointing `--artefacts` at a directory and optionally specifying the
-formats to emit.
+Use `trend report` when you need an HTML report or summary artefacts. It accepts
+`--output` for the HTML path, `--out` for the artefact directory, and
+`--formats` for the emitted artefact formats.
 
 Example:
 
 ```bash
-trend run -c config/trend.toml \
-  -o reports/cli_demo.html \
-  --artefacts reports/artefacts \
+trend report -c config/trend.toml \
+  --output reports/cli_demo.html \
+  --out reports/artefacts \
   --formats csv json xlsx
 ```
 
-If your CSV contains fixable date issues (e.g., 11/31/2024), you can opt into
-the Streamlit-style correction pass:
-
-```bash
-trend run \
-  -c config/trend.toml \
-  -i demo/demo_returns.csv \
-  --auto-fix-dates
-```
-
-You will be prompted to confirm the corrections. Use `--yes` to skip the
-interactive prompt in automation.
-
 ### PDF export
 
-Pass `--pdf` to render a PDF alongside the HTML report. This requires the
+Pass `--pdf` to `trend report` to render a PDF alongside the HTML report. This requires the
 `fpdf2` dependency (install with `pip install "fpdf2>=2.7"`). When enabled, the
 command writes `<output>.pdf` next to the HTML file.
 
@@ -136,17 +125,17 @@ new replay instructions.
 
 ## Monte Carlo Commands
 
-Use `trend mc` for the scenario workflow: discover registered scenarios,
-validate scenario files, execute simulations, and export charts from completed
-bundles. Scenario authoring and output interpretation stay in
+Use `python -m trend_analysis.cli mc` for scenario discovery, validation, and
+simulation until those commands move to the unified CLI. Use `trend mc viz` to
+export charts from completed bundles. Scenario authoring and output interpretation stay in
 `docs/phase-3/MonteCarlo.md`.
 
-### List Scenarios (`trend mc list`)
+### List Scenarios (`python -m trend_analysis.cli mc list`)
 
 List registered scenarios from the default registry.
 
 ```bash
-trend mc list
+python -m trend_analysis.cli mc list
 ```
 
 Filter by tags with `--tags`. The option accepts comma-separated values and can
@@ -155,17 +144,17 @@ listing; the default format is `table`. Use `--registry PATH` to point at a
 custom scenario registry.
 
 ```bash
-trend mc list --tags hedge_fund --format json
-trend mc list --tags hedge_fund,example \
+python -m trend_analysis.cli mc list --tags hedge_fund --format json
+python -m trend_analysis.cli mc list --tags hedge_fund,example \
   --registry config/scenarios/monte_carlo/index.yml
 ```
 
-### Validate Scenarios (`trend mc validate`)
+### Validate Scenarios (`python -m trend_analysis.cli mc validate`)
 
 Validate all registered scenarios:
 
 ```bash
-trend mc validate
+python -m trend_analysis.cli mc validate
 ```
 
 Pass a scenario name or a config path to validate a single scenario. Use
@@ -173,18 +162,18 @@ Pass a scenario name or a config path to validate a single scenario. Use
 override the registry location.
 
 ```bash
-trend mc validate config/scenarios/monte_carlo/cost_regime_example.yml
-trend mc validate cost_regime_example \
+python -m trend_analysis.cli mc validate config/scenarios/monte_carlo/cost_regime_example.yml
+python -m trend_analysis.cli mc validate cost_regime_example \
   --registry config/scenarios/monte_carlo/index.yml
 ```
 
-### Run Scenarios (`trend mc run`)
+### Run Scenarios (`python -m trend_analysis.cli mc run`)
 
 Run a scenario by name or config path with `--scenario`, and optionally choose
 the output bundle directory with `--out`.
 
 ```bash
-trend mc run --scenario cost_regime_example --out outputs/mc_run_1
+python -m trend_analysis.cli mc run --scenario cost_regime_example --out outputs/mc_run_1
 ```
 
 Runtime overrides include `--data` for an alternate CSV/Parquet input,
@@ -201,9 +190,9 @@ summaries, aggregation files such as `path_summary.<fmt>` and
 `nav_paths_fold_<id>.parquet`. No separate frozen scenario YAML file is produced.
 
 ```bash
-trend mc run --scenario cost_regime_example \
+python -m trend_analysis.cli mc run --scenario cost_regime_example \
   --n-paths 500 --jobs 4 --seed 123
-trend mc run --scenario cost_regime_example \
+python -m trend_analysis.cli mc run --scenario cost_regime_example \
   --dry-run --n-paths 10
 ```
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,7 +1,8 @@
 # Trend Model CLI Quickstart
 
-This guide walks through the two console entry points exposed by the Trend Model
-package after it has been installed (for example via `pip install -e .`).
+This guide defines the supported command surface after installation (for example
+via `pip install -e .`). The supported entry point is `trend`; compatibility
+aliases remain removal-bound and must not be used in new documentation or automation.
 
 ## Prerequisites
 
@@ -12,8 +13,7 @@ package after it has been installed (for example via `pip install -e .`).
    pip install -e .[app]
    ```
 
-   The optional `app` extra pulls in Streamlit so that the `trend-app` command
-   can launch the interactive UI.
+   The optional `app` extra pulls in Streamlit for `trend app`.
 
 3. Generate the demo dataset that the sample configuration relies on:
 
@@ -24,13 +24,27 @@ package after it has been installed (for example via `pip install -e .`).
    This writes `demo/demo_returns.csv`, which the sample configuration file
    references.
 
-## Launching the Streamlit UI (`trend-app`)
+## Supported surface
 
-Run the `trend-app` console script to launch the Streamlit interface bundled in
-`streamlit_app/app.py`:
+| Command | Supported purpose | Current state |
+| --- | --- | --- |
+| `trend run` | Execute an analysis from YAML, TOML, or a Streamlit JSON export. | Supported |
+| `trend report` | Generate report artefacts from a configuration. | Supported |
+| `trend quick-report` | Build a compact report from existing run artefacts. | Supported |
+| `trend app` | Launch the Streamlit application. | Supported |
+| `trend check` | Print environment and dependency diagnostics. | Supported |
+| `trend mc` | List, validate, run, and visualize registered Monte Carlo scenarios. | Supported; scenario work is documented in `docs/phase-3/MonteCarlo.md`. |
+
+Compatibility commands such as `trend-analysis`, `trend-multi-analysis`,
+`trend-model`, `trend-app`, and `trend-run` are transitional aliases only and
+will be removed. Use the `trend` forms above in scripts, examples, and releases.
+
+## Launching the Streamlit UI (`trend app`)
+
+Run the supported command to launch the Streamlit interface:
 
 ```bash
-trend-app
+trend app
 ```
 
 The command proxies directly to `streamlit run streamlit_app/app.py`, so any
@@ -38,12 +52,12 @@ arguments you provide are forwarded to Streamlit itself. For example, to launch
 headless on a specific port:
 
 ```bash
-trend-app --server.headless true --server.port 8502
+trend app --server.headless true --server.port 8502
 ```
 
-## Running analyses headlessly (`trend-run`)
+## Running analyses headlessly (`trend run`)
 
-The `trend-run` console script executes the full volatility-adjusted trend
+The `trend run` command executes the full volatility-adjusted trend
 pipeline using a YAML or TOML configuration file and produces an HTML report by
 default. The repository now ships with a TOML example at `config/trend.toml`
 that mirrors the demonstration YAML configuration.
@@ -56,7 +70,7 @@ Generate the demo dataset first (see the prerequisites above), then invoke the
 command:
 
 ```bash
-trend-run -c config/trend.toml -o reports/cli_demo.html
+trend run -c config/trend.toml -o reports/cli_demo.html
 ```
 
 The example configuration writes the report to the location provided via
@@ -67,7 +81,7 @@ formats to emit.
 Example:
 
 ```bash
-trend-run -c config/trend.toml \
+trend run -c config/trend.toml \
   -o reports/cli_demo.html \
   --artefacts reports/artefacts \
   --formats csv json xlsx
@@ -77,7 +91,7 @@ If your CSV contains fixable date issues (e.g., 11/31/2024), you can opt into
 the Streamlit-style correction pass:
 
 ```bash
-trend-model run \
+trend run \
   -c config/trend.toml \
   -i demo/demo_returns.csv \
   --auto-fix-dates
@@ -113,27 +127,26 @@ configuration schema in `config/defaults.yml`.
 
 ## Replaying Streamlit JSON runs
 
-Use `trend-model run` with the JSON file exported from the Streamlit Model page.
+Use `trend run` with the JSON file exported from the Streamlit Model page.
 The CLI auto-detects the JSON format and applies the same UI mapping and data
 contract checks.
 
-The deprecated `trend-model run-ui` command continues to work but will be
-removed in a future release.
+Historical compatibility aliases are removal-bound; use `trend run` for all
+new replay instructions.
 
 ## Monte Carlo Commands
 
-Use the Monte Carlo module CLI for the scenario workflow: discover registered
-scenarios, validate scenario files, execute simulations, and export charts from
-completed bundles. These commands are exposed by `trend_analysis.cli`; run them
-with `python -m trend_analysis.cli mc ...` from an installed checkout. Scenario
-authoring and output interpretation stay in `docs/phase-3/MonteCarlo.md`.
+Use `trend mc` for the scenario workflow: discover registered scenarios,
+validate scenario files, execute simulations, and export charts from completed
+bundles. Scenario authoring and output interpretation stay in
+`docs/phase-3/MonteCarlo.md`.
 
-### List Scenarios (`python -m trend_analysis.cli mc list`)
+### List Scenarios (`trend mc list`)
 
 List registered scenarios from the default registry.
 
 ```bash
-python -m trend_analysis.cli mc list
+trend mc list
 ```
 
 Filter by tags with `--tags`. The option accepts comma-separated values and can
@@ -142,17 +155,17 @@ listing; the default format is `table`. Use `--registry PATH` to point at a
 custom scenario registry.
 
 ```bash
-python -m trend_analysis.cli mc list --tags hedge_fund --format json
-python -m trend_analysis.cli mc list --tags hedge_fund,example \
+trend mc list --tags hedge_fund --format json
+trend mc list --tags hedge_fund,example \
   --registry config/scenarios/monte_carlo/index.yml
 ```
 
-### Validate Scenarios (`python -m trend_analysis.cli mc validate`)
+### Validate Scenarios (`trend mc validate`)
 
 Validate all registered scenarios:
 
 ```bash
-python -m trend_analysis.cli mc validate
+trend mc validate
 ```
 
 Pass a scenario name or a config path to validate a single scenario. Use
@@ -160,18 +173,18 @@ Pass a scenario name or a config path to validate a single scenario. Use
 override the registry location.
 
 ```bash
-python -m trend_analysis.cli mc validate config/scenarios/monte_carlo/cost_regime_example.yml
-python -m trend_analysis.cli mc validate cost_regime_example \
+trend mc validate config/scenarios/monte_carlo/cost_regime_example.yml
+trend mc validate cost_regime_example \
   --registry config/scenarios/monte_carlo/index.yml
 ```
 
-### Run Scenarios (`python -m trend_analysis.cli mc run`)
+### Run Scenarios (`trend mc run`)
 
 Run a scenario by name or config path with `--scenario`, and optionally choose
 the output bundle directory with `--out`.
 
 ```bash
-python -m trend_analysis.cli mc run --scenario cost_regime_example --out outputs/mc_run_1
+trend mc run --scenario cost_regime_example --out outputs/mc_run_1
 ```
 
 Runtime overrides include `--data` for an alternate CSV/Parquet input,
@@ -188,19 +201,19 @@ summaries, aggregation files such as `path_summary.<fmt>` and
 `nav_paths_fold_<id>.parquet`. No separate frozen scenario YAML file is produced.
 
 ```bash
-python -m trend_analysis.cli mc run --scenario cost_regime_example \
+trend mc run --scenario cost_regime_example \
   --n-paths 500 --jobs 4 --seed 123
-python -m trend_analysis.cli mc run --scenario cost_regime_example \
+trend mc run --scenario cost_regime_example \
   --dry-run --n-paths 10
 ```
 
-### Export Charts (`python -m trend_analysis.cli mc viz`)
+### Export Charts (`trend mc viz`)
 
 Render chart artifacts from an existing Monte Carlo bundle. `--bundle` points
 to the bundle directory and `--out` points to the export directory.
 
 ```bash
-python -m trend_analysis.cli mc viz \
+trend mc viz \
   --bundle outputs/mc_run_1 \
   --out outputs/mc_run_1_exports \
   --charts fan,path_dist,risk_return \

--- a/docs/PresetStrategies.md
+++ b/docs/PresetStrategies.md
@@ -28,7 +28,7 @@ Use when seeking higher returns and willing to accept larger drawdowns. Shorter 
 To run the pipeline with a preset on demo data:
 
 ```bash
-python -m trend_analysis.run_analysis -c config/presets/balanced.yml
+PYTHONPATH=./src python -m trend.cli run -c config/presets/balanced.yml
 ```
 
 Replace `balanced` with `conservative` or `aggressive` as needed.

--- a/docs/ReproducibilityGuide.md
+++ b/docs/ReproducibilityGuide.md
@@ -64,7 +64,7 @@ To ensure reproducible hash behavior across runs:
 1. **Set `PYTHONHASHSEED` before starting Python:**
    ```bash
    export PYTHONHASHSEED=0
-   python -m trend_analysis.run_analysis -c config/demo.yml
+   PYTHONPATH=./src python -m trend.cli run -c config/demo.yml
    ```
 
 2. **Use in test environments:**
@@ -77,7 +77,7 @@ To ensure reproducible hash behavior across runs:
    ```bash
    #!/bin/bash
    export PYTHONHASHSEED=0
-   exec python -m trend_analysis.run_analysis "$@"
+   exec env PYTHONPATH=./src python -m trend.cli run "$@"
    ```
 
 ### CI/CD Considerations
@@ -112,11 +112,11 @@ To verify that your setup produces reproducible results:
 ```bash
 # Run 1
 export PYTHONHASHSEED=0
-python -m trend_analysis.run_analysis -c config/demo.yml > results1.txt
+PYTHONPATH=./src python -m trend.cli run -c config/demo.yml > results1.txt
 
 # Run 2  
 export PYTHONHASHSEED=0
-python -m trend_analysis.run_analysis -c config/demo.yml > results2.txt
+PYTHONPATH=./src python -m trend.cli run -c config/demo.yml > results2.txt
 
 # Compare
 diff results1.txt results2.txt

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -18,7 +18,7 @@ This document introduces the main features of the Trend Model Project and explai
 
 Invoke the pipeline with an optional YAML configuration file:
 ```bash
-python -m trend_analysis.run_analysis -c path/to/config.yml
+PYTHONPATH=./src python -m trend.cli run -c path/to/config.yml
 ```
 If `-c` is omitted, the tool loads `config/defaults.yml` or the file specified by the `TREND_CFG` environment variable.
 
@@ -50,7 +50,7 @@ Ready-made presets live in `config/presets/` and provide sensible defaults for c
 Select a preset on the Streamlit **Configure** page or load it from the command line:
 
 ```bash
-python -m trend_analysis.run_analysis -c config/presets/balanced.yml
+PYTHONPATH=./src python -m trend.cli run -c config/presets/balanced.yml
 ```
 
 Replace `balanced` with `conservative` or `aggressive` as needed. See
@@ -231,14 +231,14 @@ Command examples:
 
 ```bash
 # Default (creates outputs/logs/run_<id>.jsonl)
-python -m trend_analysis.run_analysis -c config/demo.yml -i demo/demo_returns.csv
+PYTHONPATH=./src python -m trend.cli run -c config/demo.yml -i demo/demo_returns.csv
 
 # Custom path
-python -m trend_analysis.run_analysis -c config/demo.yml -i demo/demo_returns.csv \
+PYTHONPATH=./src python -m trend.cli run -c config/demo.yml -i demo/demo_returns.csv \
    --log-file logs/my_run.jsonl
 
 # Disable structured logging
-python -m trend_analysis.run_analysis -c config/demo.yml -i demo/demo_returns.csv \
+PYTHONPATH=./src python -m trend.cli run -c config/demo.yml -i demo/demo_returns.csv \
    --no-structured-log
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -79,8 +79,8 @@ uvicorn trend_analysis.api_server:app --host 0.0.0.0 --port 8000
 | `/docs` | GET | OpenAPI documentation |
 
 The REST surface is scoped to config-patch preview and apply. Running an
-analysis is not exposed over HTTP — use the [`trend-run`](CLI.md) CLI
-(`trend-run -c <config>`) or the Python API at the top of this document
+analysis is not exposed over HTTP — use the [`trend run`](CLI.md) CLI
+(`trend run -c <config>`) or the Python API at the top of this document
 instead.
 
 ### Example Request

--- a/docs/config.md
+++ b/docs/config.md
@@ -156,7 +156,7 @@ Pre-built risk profiles in `config/presets/`:
 ### Using Presets
 
 ```bash
-PYTHONPATH="./src" python -m trend_analysis.run_analysis -c config/presets/balanced.yml
+PYTHONPATH="./src" python -m trend.cli run -c config/presets/balanced.yml
 ```
 
 ## Environment Variables

--- a/docs/directory-index/config.md
+++ b/docs/directory-index/config.md
@@ -37,10 +37,10 @@ Pre-configured analysis presets for common use cases.
 
 ```bash
 # Run with specific config
-python -m trend_analysis.run_analysis -c config/demo.yml
+PYTHONPATH=./src python -m trend.cli run -c config/demo.yml
 
 # Use environment variable
-TREND_CFG=config/defaults.yml python -m trend_analysis.run_analysis
+TREND_CFG=config/defaults.yml PYTHONPATH=./src python -m trend.cli run
 ```
 
 ---

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,7 +18,7 @@ cd Trend_Model_Project
 python scripts/generate_demo.py
 
 # Run the analysis
-PYTHONPATH="./src" python -m trend_analysis.run_analysis -c config/demo.yml
+PYTHONPATH="./src" python -m trend.cli run -c config/demo.yml
 ```
 
 ## Prerequisites
@@ -69,7 +69,7 @@ After installation, verify everything works:
 ./scripts/run_tests.sh
 
 # Check CLI
-PYTHONPATH="./src" python -m trend_analysis.run_analysis --help
+PYTHONPATH="./src" python -m trend.cli --help
 
 # Launch Streamlit app
 ./scripts/run_streamlit.sh

--- a/docs/planning/nl-config-audit.md
+++ b/docs/planning/nl-config-audit.md
@@ -20,7 +20,7 @@ Purpose: map the current YAML configuration flow, validation, and runtime entryp
 - Use: `_run_pipeline` in `src/trend/cli.py`, which calls `run_simulation(cfg, returns)` in `src/trend_analysis/api.py`.
 
 ### CLI (trend-analysis-multi)
-- Entry: `src/trend_analysis/run_multi_analysis.py` (`trend-analysis-multi`).
+- Historical compatibility note: the removed multi-analysis runner is no longer an entry point; use `trend mc` for the supported Monte Carlo workflow.
 - Load: `load(args.config)` from `src/trend_analysis/config/models.py`.
   - Reads YAML via `yaml.safe_load`, validates required sections, merges legacy `output` into `export`, then runs `validate_trend_config` when available.
 - Use: `trend_analysis.multi_period.run_from_config(cfg)` to run the multi-period engine.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -150,14 +150,16 @@ python -c "import trend_analysis; print(trend_analysis.__version__)"
 
 ## CLI Commands
 
-The package provides CLI commands after installation:
+The supported release surface is the `trend` command. Compatibility aliases
+remain removal-bound and are not release examples:
 
 ```bash
-# Single-period analysis
-trend-analysis -c config.yml
+# Analysis and reports
+trend run -c config.yml
+trend report -c config.yml --out reports
 
-# Multi-period analysis  
-trend-multi-analysis -c config.yml
+# Scenario work
+trend mc list
 ```
 
 ## Troubleshooting

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,13 +8,13 @@ Quick reference for common Trend Model Project operations.
 
 ```bash
 # Basic analysis with config file
-PYTHONPATH="./src" python -m trend_analysis.run_analysis -c config/demo.yml
+PYTHONPATH="./src" python -m trend.cli run -c config/demo.yml
 
 # Using environment variable
-TREND_CFG=config/demo.yml PYTHONPATH="./src" python -m trend_analysis.run_analysis
+TREND_CFG=config/demo.yml PYTHONPATH="./src" python -m trend.cli run
 
 # With default config
-PYTHONPATH="./src" python -m trend_analysis.run_analysis
+PYTHONPATH="./src" python -m trend.cli run
 ```
 
 ### Streamlit App

--- a/tests/test_active_docs_supported_commands.py
+++ b/tests/test_active_docs_supported_commands.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ACTIVE_DOCS = (
+    Path("Agents.md"),
+    Path("DOCKER_QUICKSTART.md"),
+    *Path("docs").rglob("*.md"),
+)
+EXCLUDED_DOC_ROOTS = (Path("docs/archive"), Path("docs/keepalive"))
+REMOVED_RUNNERS = ("trend_analysis.run_analysis", "trend_analysis.run_multi_analysis")
+
+
+def test_active_docs_do_not_reference_removed_runners() -> None:
+    offenders: list[str] = []
+    for path in ACTIVE_DOCS:
+        if not path.exists() or any(path.is_relative_to(root) for root in EXCLUDED_DOC_ROOTS):
+            continue
+        text = path.read_text(encoding="utf-8")
+        for runner in REMOVED_RUNNERS:
+            if runner in text:
+                offenders.append(f"{path}: {runner}")
+
+    assert not offenders, "Active documentation references removed runner modules:\n" + "\n".join(offenders)

--- a/tests/test_active_docs_supported_commands.py
+++ b/tests/test_active_docs_supported_commands.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 ACTIVE_DOCS = (
     Path("Agents.md"),
     Path("DOCKER_QUICKSTART.md"),
@@ -22,4 +21,6 @@ def test_active_docs_do_not_reference_removed_runners() -> None:
             if runner in text:
                 offenders.append(f"{path}: {runner}")
 
-    assert not offenders, "Active documentation references removed runner modules:\n" + "\n".join(offenders)
+    assert not offenders, "Active documentation references removed runner modules:\n" + "\n".join(
+        offenders
+    )

--- a/tests/test_trend_cli_help.py
+++ b/tests/test_trend_cli_help.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 import pytest
 
@@ -58,3 +59,12 @@ def test_trend_cli_core_help(
     assert exc.value.code == 0
     assert "usage:" in captured.out
     assert f"trend {command}" in captured.out
+
+
+def test_cli_quickstart_documents_each_command_on_its_implemented_surface() -> None:
+    quickstart = Path("docs/CLI.md").read_text(encoding="utf-8")
+
+    assert "trend report -c config/trend.toml" in quickstart
+    assert "trend run -c config/trend.toml -o" not in quickstart
+    assert "python -m trend_analysis.cli mc list" in quickstart
+    assert "trend mc list" not in quickstart


### PR DESCRIPTION
## Summary

- define `trend` as the supported CLI surface and demote legacy aliases to removal-bound compatibility paths
- replace active documentation references to deleted runner modules across user, Docker, config, preset, reproducibility, API, release, and CLI guides
- add a documentation command-reference regression gate while preserving archived and keepalive historical records

Closes #5839

## Validation

- `python -m pytest tests/test_active_docs_supported_commands.py tests/test_legacy_runners_removed.py -q` (4 passed)
- `PYTHONPATH=src python -m trend.cli --help`
- `PYTHONPATH=src python -m trend.cli run --help`
- `PYTHONPATH=src python -m trend.cli app --help`
- `ruff check tests/test_active_docs_supported_commands.py`
- `git diff --check`

## Deliberate break

Temporarily restoring `trend_analysis.run_analysis` in `docs/usage.md` makes `tests/test_active_docs_supported_commands.py::test_active_docs_do_not_reference_removed_runners` fail with that exact active-doc reference; the supported command was restored and the full focused suite passed.
