### PR TITLE
Establish one frequency and annualisation contract

### DIFF
--- a/src/trend_analysis/stages/portfolio.py
+++ b/src/trend_analysis/stages/portfolio.py
@@ -643,9 +643,15 @@ def _compute_weights_and_stats(
     out_ew = calc_portfolio_returns(ew_weights, out_scaled)
     out_ew_raw = calc_portfolio_returns(ew_weights, window.out_df[fund_cols])
 
-    in_ew_stats = _compute_stats(pd.DataFrame({"ew": in_ew}), rf_in, periods_per_year=window.periods_per_year)["ew"]
-    out_ew_stats = _compute_stats(pd.DataFrame({"ew": out_ew}), rf_out, periods_per_year=window.periods_per_year)["ew"]
-    out_ew_stats_raw = _compute_stats(pd.DataFrame({"ew": out_ew_raw}), rf_out, periods_per_year=window.periods_per_year)["ew"]
+    in_ew_stats = _compute_stats(
+        pd.DataFrame({"ew": in_ew}), rf_in, periods_per_year=window.periods_per_year
+    )["ew"]
+    out_ew_stats = _compute_stats(
+        pd.DataFrame({"ew": out_ew}), rf_out, periods_per_year=window.periods_per_year
+    )["ew"]
+    out_ew_stats_raw = _compute_stats(
+        pd.DataFrame({"ew": out_ew_raw}), rf_out, periods_per_year=window.periods_per_year
+    )["ew"]
 
     user_w = weights_series.to_numpy(dtype=float, copy=False)
     user_w_dict = {c: float(weights_series[c]) for c in fund_cols}
@@ -677,9 +683,15 @@ def _compute_weights_and_stats(
         periods_per_year=window.periods_per_year,
     )["portfolio"]
 
-    in_user_stats = _compute_stats(pd.DataFrame({"user": in_user}), rf_in, periods_per_year=window.periods_per_year)["user"]
-    out_user_stats = _compute_stats(pd.DataFrame({"user": out_user}), rf_out, periods_per_year=window.periods_per_year)["user"]
-    out_user_stats_raw = _compute_stats(pd.DataFrame({"user": out_user_raw}), rf_out, periods_per_year=window.periods_per_year)["user"]
+    in_user_stats = _compute_stats(
+        pd.DataFrame({"user": in_user}), rf_in, periods_per_year=window.periods_per_year
+    )["user"]
+    out_user_stats = _compute_stats(
+        pd.DataFrame({"user": out_user}), rf_out, periods_per_year=window.periods_per_year
+    )["user"]
+    out_user_stats_raw = _compute_stats(
+        pd.DataFrame({"user": out_user_raw}), rf_out, periods_per_year=window.periods_per_year
+    )["user"]
 
     return _ComputationStage(
         weights_series=weights_series,
@@ -760,14 +772,20 @@ def _assemble_analysis_output(
         if col not in in_df.columns or col not in out_df.columns:
             continue
         benchmark_stats[label] = {
-            "in_sample": _compute_stats(pd.DataFrame({label: in_df[col]}), computation.rf_in, periods_per_year=window.periods_per_year)[
-                label
-            ],
-            "out_sample": _compute_stats(pd.DataFrame({label: out_df[col]}), computation.rf_out, periods_per_year=window.periods_per_year)[
-                label
-            ],
+            "in_sample": _compute_stats(
+                pd.DataFrame({label: in_df[col]}),
+                computation.rf_in,
+                periods_per_year=window.periods_per_year,
+            )[label],
+            "out_sample": _compute_stats(
+                pd.DataFrame({label: out_df[col]}),
+                computation.rf_out,
+                periods_per_year=window.periods_per_year,
+            )[label],
         }
-        ir_series = information_ratio(computation.out_scaled[fund_cols], out_df[col], window.periods_per_year)
+        ir_series = information_ratio(
+            computation.out_scaled[fund_cols], out_df[col], window.periods_per_year
+        )
         ir_dict = (
             ir_series.to_dict()
             if isinstance(ir_series, pd.Series)

--- a/src/trend_analysis/stages/portfolio.py
+++ b/src/trend_analysis/stages/portfolio.py
@@ -160,6 +160,7 @@ def _compute_stats(
     df: pd.DataFrame,
     rf: pd.Series,
     *,
+    periods_per_year: int = 12,
     in_sample_avg_corr: dict[str, float] | None = None,
     out_sample_avg_corr: dict[str, float] | None = None,
 ) -> dict[str, _Stats]:
@@ -169,12 +170,12 @@ def _compute_stats(
     for col in df:
         key = str(col)
         stats[key] = _Stats(
-            cagr=float(annual_return(df[col])),
-            vol=float(volatility(df[col])),
-            sharpe=float(sharpe_ratio(df[col], rf)),
-            sortino=float(sortino_ratio(df[col], rf)),
+            cagr=float(annual_return(df[col], periods_per_year)),
+            vol=float(volatility(df[col], periods_per_year)),
+            sharpe=float(sharpe_ratio(df[col], rf, periods_per_year)),
+            sortino=float(sortino_ratio(df[col], rf, periods_per_year)),
             max_drawdown=float(max_drawdown(df[col])),
-            information_ratio=float(information_ratio(df[col], rf)),
+            information_ratio=float(information_ratio(df[col], rf, periods_per_year)),
             is_avg_corr=(in_sample_avg_corr or {}).get(col),
             os_avg_corr=(out_sample_avg_corr or {}).get(col),
         )
@@ -617,18 +618,21 @@ def _compute_weights_and_stats(
     in_stats = _compute_stats(
         in_scaled,
         rf_in,
+        periods_per_year=window.periods_per_year,
         in_sample_avg_corr=is_avg_corr,
         out_sample_avg_corr=None,
     )
     out_stats = _compute_stats(
         out_scaled,
         rf_out,
+        periods_per_year=window.periods_per_year,
         in_sample_avg_corr=None,
         out_sample_avg_corr=os_avg_corr,
     )
     out_stats_raw = _compute_stats(
         window.out_df[fund_cols],
         rf_out,
+        periods_per_year=window.periods_per_year,
         in_sample_avg_corr=None,
         out_sample_avg_corr=os_avg_corr,
     )
@@ -639,9 +643,9 @@ def _compute_weights_and_stats(
     out_ew = calc_portfolio_returns(ew_weights, out_scaled)
     out_ew_raw = calc_portfolio_returns(ew_weights, window.out_df[fund_cols])
 
-    in_ew_stats = _compute_stats(pd.DataFrame({"ew": in_ew}), rf_in)["ew"]
-    out_ew_stats = _compute_stats(pd.DataFrame({"ew": out_ew}), rf_out)["ew"]
-    out_ew_stats_raw = _compute_stats(pd.DataFrame({"ew": out_ew_raw}), rf_out)["ew"]
+    in_ew_stats = _compute_stats(pd.DataFrame({"ew": in_ew}), rf_in, periods_per_year=window.periods_per_year)["ew"]
+    out_ew_stats = _compute_stats(pd.DataFrame({"ew": out_ew}), rf_out, periods_per_year=window.periods_per_year)["ew"]
+    out_ew_stats_raw = _compute_stats(pd.DataFrame({"ew": out_ew_raw}), rf_out, periods_per_year=window.periods_per_year)["ew"]
 
     user_w = weights_series.to_numpy(dtype=float, copy=False)
     user_w_dict = {c: float(weights_series[c]) for c in fund_cols}
@@ -673,9 +677,9 @@ def _compute_weights_and_stats(
         periods_per_year=window.periods_per_year,
     )["portfolio"]
 
-    in_user_stats = _compute_stats(pd.DataFrame({"user": in_user}), rf_in)["user"]
-    out_user_stats = _compute_stats(pd.DataFrame({"user": out_user}), rf_out)["user"]
-    out_user_stats_raw = _compute_stats(pd.DataFrame({"user": out_user_raw}), rf_out)["user"]
+    in_user_stats = _compute_stats(pd.DataFrame({"user": in_user}), rf_in, periods_per_year=window.periods_per_year)["user"]
+    out_user_stats = _compute_stats(pd.DataFrame({"user": out_user}), rf_out, periods_per_year=window.periods_per_year)["user"]
+    out_user_stats_raw = _compute_stats(pd.DataFrame({"user": out_user_raw}), rf_out, periods_per_year=window.periods_per_year)["user"]
 
     return _ComputationStage(
         weights_series=weights_series,
@@ -756,22 +760,22 @@ def _assemble_analysis_output(
         if col not in in_df.columns or col not in out_df.columns:
             continue
         benchmark_stats[label] = {
-            "in_sample": _compute_stats(pd.DataFrame({label: in_df[col]}), computation.rf_in)[
+            "in_sample": _compute_stats(pd.DataFrame({label: in_df[col]}), computation.rf_in, periods_per_year=window.periods_per_year)[
                 label
             ],
-            "out_sample": _compute_stats(pd.DataFrame({label: out_df[col]}), computation.rf_out)[
+            "out_sample": _compute_stats(pd.DataFrame({label: out_df[col]}), computation.rf_out, periods_per_year=window.periods_per_year)[
                 label
             ],
         }
-        ir_series = information_ratio(computation.out_scaled[fund_cols], out_df[col])
+        ir_series = information_ratio(computation.out_scaled[fund_cols], out_df[col], window.periods_per_year)
         ir_dict = (
             ir_series.to_dict()
             if isinstance(ir_series, pd.Series)
             else {fund_cols[0]: float(ir_series)}
         )
         try:
-            ir_eq = information_ratio(out_ew_raw, out_df[col])
-            ir_usr = information_ratio(out_user_raw, out_df[col])
+            ir_eq = information_ratio(out_ew_raw, out_df[col], window.periods_per_year)
+            ir_usr = information_ratio(out_user_raw, out_df[col], window.periods_per_year)
             ir_dict["equal_weight"] = (
                 float(ir_eq) if isinstance(ir_eq, (float, int, np.floating)) else float("nan")
             )

--- a/src/trend_analysis/stages/portfolio.py
+++ b/src/trend_analysis/stages/portfolio.py
@@ -160,22 +160,23 @@ def _compute_stats(
     df: pd.DataFrame,
     rf: pd.Series,
     *,
-    periods_per_year: int = 12,
+    periods_per_year: float = 12,
     in_sample_avg_corr: dict[str, float] | None = None,
     out_sample_avg_corr: dict[str, float] | None = None,
 ) -> dict[str, _Stats]:
     # Metrics expect 1D Series; iterating keeps the logic simple for a handful
     # of columns and avoids reshaping into higher-dimensional arrays.
+    annualisation_periods = int(periods_per_year)
     stats: dict[str, _Stats] = {}
     for col in df:
         key = str(col)
         stats[key] = _Stats(
-            cagr=float(annual_return(df[col], periods_per_year)),
-            vol=float(volatility(df[col], periods_per_year)),
-            sharpe=float(sharpe_ratio(df[col], rf, periods_per_year)),
-            sortino=float(sortino_ratio(df[col], rf, periods_per_year)),
+            cagr=float(annual_return(df[col], annualisation_periods)),
+            vol=float(volatility(df[col], annualisation_periods)),
+            sharpe=float(sharpe_ratio(df[col], rf, annualisation_periods)),
+            sortino=float(sortino_ratio(df[col], rf, annualisation_periods)),
             max_drawdown=float(max_drawdown(df[col])),
-            information_ratio=float(information_ratio(df[col], rf, periods_per_year)),
+            information_ratio=float(information_ratio(df[col], rf, annualisation_periods)),
             is_avg_corr=(in_sample_avg_corr or {}).get(col),
             os_avg_corr=(out_sample_avg_corr or {}).get(col),
         )

--- a/src/trend_analysis/stages/selection.py
+++ b/src/trend_analysis/stages/selection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Mapping
 
 import numpy as np
@@ -442,6 +442,10 @@ def _select_universe(
 
     if stats_cfg is None:
         stats_cfg = RiskStatsConfig(risk_free=0.0)
+    # The selection metrics must use the same cadence as the portfolio output.
+    # Keep a caller-supplied configuration immutable so it can be reused across
+    # separate analyses without leaking a prior window's annualisation.
+    stats_cfg = replace(stats_cfg, periods_per_year=int(window.periods_per_year))
 
     if risk_free_override is None:
         risk_free_override = window.in_df[rf_col]

--- a/src/trend_analysis/stages/selection.py
+++ b/src/trend_analysis/stages/selection.py
@@ -445,7 +445,10 @@ def _select_universe(
     # The selection metrics must use the same cadence as the portfolio output.
     # Keep a caller-supplied configuration immutable so it can be reused across
     # separate analyses without leaking a prior window's annualisation.
+    extra_metrics = getattr(stats_cfg, "extra_metrics", None)
     stats_cfg = replace(stats_cfg, periods_per_year=int(window.periods_per_year))
+    if extra_metrics is not None:
+        setattr(stats_cfg, "extra_metrics", extra_metrics)
 
     if risk_free_override is None:
         risk_free_override = window.in_df[rf_col]

--- a/src/trend_analysis/walk_forward.py
+++ b/src/trend_analysis/walk_forward.py
@@ -14,6 +14,7 @@ import pandas as pd
 import yaml
 
 from trend_analysis.metrics import annual_return, max_drawdown, sharpe_ratio
+from trend_analysis.util.frequency import infer_periods_per_year
 
 
 @dataclass(slots=True)
@@ -138,27 +139,6 @@ def load_returns(data_cfg: DataConfig) -> pd.DataFrame:
             raise ValueError(f"Missing columns in CSV: {', '.join(missing)}")
         numeric = numeric.loc[:, list(data_cfg.columns)]
     return numeric
-
-
-def infer_periods_per_year(index: pd.DatetimeIndex) -> int:
-    if len(index) < 2:
-        return 1
-    diffs_days = np.diff(index.to_numpy()) / np.timedelta64(1, "D")
-    if len(diffs_days) == 0:
-        return 1
-    median_days = float(np.median(diffs_days))
-    if median_days <= 0:
-        return 1
-    approx = int(round(365 / median_days))
-    if approx >= 300:
-        return 252
-    if 45 <= approx <= 60:
-        return 52
-    if 10 <= approx <= 14:
-        return 12
-    if 3 <= approx <= 5:
-        return 4
-    return approx
 
 
 def _window_splits(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -567,12 +567,12 @@ def test_run_analysis_benchmark_ir_fallback(monkeypatch):
     original_ir = pipeline.information_ratio
     raised = {"flag": False}
 
-    def selective_boom(series_a, series_b):
+    def selective_boom(series_a, series_b, *args, **kwargs):
         target_name = getattr(series_b, "name", "")
         if target_name == "SPX" and getattr(series_a, "ndim", 1) == 1:
             raised["flag"] = True
             raise ZeroDivisionError("bad benchmark")
-        return original_ir(series_a, series_b)
+        return original_ir(series_a, series_b, *args, **kwargs)
 
     # Patch the module-level binding in pipeline.py so run_analysis sees our stub
     monkeypatch.setattr(pipeline, "information_ratio", selective_boom)

--- a/tests/test_pipeline_entrypoints.py
+++ b/tests/test_pipeline_entrypoints.py
@@ -307,6 +307,18 @@ def test_compute_stats_includes_optional_avg_corr() -> None:
     assert stats["FundB"].os_avg_corr == 0.25
 
 
+def test_portfolio_stats_use_window_periods_per_year() -> None:
+    returns = pd.DataFrame({"FundA": [0.01] * 12})
+    risk_free = pd.Series(0.0, index=returns.index)
+
+    monthly = pipeline._compute_stats(returns, risk_free, periods_per_year=12)["FundA"]
+    weekly = pipeline._compute_stats(returns, risk_free, periods_per_year=52)["FundA"]
+
+    assert weekly.cagr > monthly.cagr
+    assert weekly.vol > monthly.vol
+    assert weekly.sharpe > monthly.sharpe
+
+
 def test_calc_portfolio_returns_scales_weights(sample_frame: pd.DataFrame) -> None:
     weights = np.array([0.6, 0.4])
     portfolio = pipeline.calc_portfolio_returns(weights, sample_frame[["FundA", "FundB"]])

--- a/tests/test_pipeline_entrypoints.py
+++ b/tests/test_pipeline_entrypoints.py
@@ -308,7 +308,7 @@ def test_compute_stats_includes_optional_avg_corr() -> None:
 
 
 def test_portfolio_stats_use_window_periods_per_year() -> None:
-    returns = pd.DataFrame({"FundA": [0.01] * 12})
+    returns = pd.DataFrame({"FundA": [0.015, -0.004, 0.005, -0.008] * 3})
     risk_free = pd.Series(0.0, index=returns.index)
 
     monthly = pipeline._compute_stats(returns, risk_free, periods_per_year=12)["FundA"]

--- a/tests/test_pipeline_optional_features.py
+++ b/tests/test_pipeline_optional_features.py
@@ -734,10 +734,10 @@ def test_run_analysis_benchmark_ir_best_effort(monkeypatch: pytest.MonkeyPatch) 
 
     original_ir = pipeline.information_ratio
 
-    def flaky_information_ratio(a, b):
+    def flaky_information_ratio(a, b, *args, **kwargs):
         if isinstance(a, pd.Series) and a.attrs.get("portfolio_role") == "equal_weight":
             raise RuntimeError("portfolio IR failure")
-        return original_ir(a, b)
+        return original_ir(a, b, *args, **kwargs)
 
     monkeypatch.setattr(pipeline, "calc_portfolio_returns", tagging_calc)
     monkeypatch.setattr(pipeline, "information_ratio", flaky_information_ratio)
@@ -833,11 +833,11 @@ def test_run_analysis_benchmark_ir_handles_scalar_response(
 
     original_ir = pipeline.information_ratio
 
-    def scalar_information_ratio(a, b):
+    def scalar_information_ratio(a, b, *args, **kwargs):
         calls.append(type(a).__name__)
         if isinstance(a, pd.DataFrame):
             return 0.42
-        return original_ir(a, b)
+        return original_ir(a, b, *args, **kwargs)
 
     monkeypatch.setattr(pipeline, "information_ratio", scalar_information_ratio)
 
@@ -911,12 +911,12 @@ def test_run_analysis_benchmark_ir_non_numeric_enrichment(
         series.attrs["portfolio_role"] = role
         return series
 
-    def fake_information_ratio(a, b):
+    def fake_information_ratio(a, b, *args, **kwargs):
         if isinstance(a, pd.DataFrame):
             return pd.Series({"FundA": 0.4, "FundB": 0.2})
         if isinstance(a, pd.Series) and a.attrs.get("portfolio_role"):
             return {"role": a.attrs["portfolio_role"]}
-        return original_ir(a, b)
+        return original_ir(a, b, *args, **kwargs)
 
     monkeypatch.setattr(pipeline, "calc_portfolio_returns", tagging_calc)
     monkeypatch.setattr(pipeline, "information_ratio", fake_information_ratio)

--- a/tests/test_pipeline_stage_isolation.py
+++ b/tests/test_pipeline_stage_isolation.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from trend_analysis import pipeline
 from trend_analysis.pipeline import PipelineResult, RiskStatsConfig
@@ -118,3 +119,64 @@ def test_stage_isolation_matches_pipeline_output() -> None:
     assert expected["fund_weights"] == actual["fund_weights"]
     assert expected["out_sample_stats"] == actual["out_sample_stats"]
     pd.testing.assert_frame_equal(expected["out_sample_scaled"], actual["out_sample_scaled"])
+
+
+def test_rank_selection_uses_window_cadence_without_mutating_caller_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    df = _sample_frame()
+    caller_cfg = RiskStatsConfig(periods_per_year=12, risk_free=0.0)
+    preprocess = preprocessing_stage._prepare_preprocess_stage(
+        df,
+        floor_vol=None,
+        warmup_periods=0,
+        missing_policy=None,
+        missing_limit=None,
+        stats_cfg=caller_cfg,
+        periods_per_year_override=52,
+        allow_risk_free_fallback=True,
+    )
+    assert not isinstance(preprocess, PipelineResult)
+    window = preprocessing_stage._build_sample_windows(
+        preprocess,
+        in_start="2020-01",
+        in_end="2020-03",
+        out_start="2020-04",
+        out_end="2020-06",
+    )
+    assert not isinstance(window, PipelineResult)
+
+    observed_periods: list[int] = []
+
+    def _rank_stub(_: pd.DataFrame, stats_cfg: RiskStatsConfig, **__: object) -> list[str]:
+        observed_periods.append(stats_cfg.periods_per_year)
+        return ["A"]
+
+    def _score_stub(_: pd.DataFrame, *args: object, **kwargs: object) -> pd.DataFrame:
+        stats_cfg = kwargs["stats_cfg"]
+        assert isinstance(stats_cfg, RiskStatsConfig)
+        observed_periods.append(stats_cfg.periods_per_year)
+        return pd.DataFrame({"Sharpe": [1.0]}, index=["A"])
+
+    monkeypatch.setattr(selection_stage, "rank_select_funds", _rank_stub)
+    monkeypatch.setattr(selection_stage, "single_period_run", _score_stub)
+    selection = selection_stage._select_universe(
+        preprocess,
+        window,
+        in_label="2020-01",
+        in_end_label="2020-03",
+        selection_mode="rank",
+        random_n=1,
+        custom_weights=None,
+        rank_kwargs=None,
+        manual_funds=None,
+        indices_list=None,
+        seed=1,
+        stats_cfg=caller_cfg,
+        risk_free_column="rf",
+        allow_risk_free_fallback=True,
+    )
+
+    assert not isinstance(selection, PipelineResult)
+    assert observed_periods == [52, 52]
+    assert caller_cfg.periods_per_year == 12

--- a/tests/test_pipeline_stage_isolation.py
+++ b/tests/test_pipeline_stage_isolation.py
@@ -180,3 +180,41 @@ def test_rank_selection_uses_window_cadence_without_mutating_caller_config(
     assert not isinstance(selection, PipelineResult)
     assert observed_periods == [52, 52]
     assert caller_cfg.periods_per_year == 12
+
+
+def test_run_analysis_propagates_window_cadence_to_portfolios_and_benchmark() -> None:
+    """The public entrypoint keeps every published metric on the window cadence."""
+    frame = pd.DataFrame(
+        {
+            "Date": pd.date_range("2020-01-31", periods=8, freq="ME", tz="UTC"),
+            "A": [0.01, -0.02, 0.03, -0.01, 0.02, -0.03, 0.04, -0.015],
+            "B": [-0.01, 0.015, -0.005, 0.025, -0.02, 0.01, -0.01, 0.02],
+            "Bench": [0.005, -0.01, 0.02, -0.005, 0.01, -0.02, 0.025, -0.01],
+            "rf": [0.0] * 8,
+        }
+    )
+    frame.attrs["calendar_settings"] = {"timezone": None}
+    common = dict(
+        stats_cfg=RiskStatsConfig(risk_free=0.0),
+        risk_free_column="rf",
+        allow_risk_free_fallback=True,
+        benchmarks={"bench": "Bench"},
+    )
+
+    monthly = pipeline.run_analysis(
+        frame, "2020-01", "2020-04", "2020-05", "2020-08", None, 0.0,
+        periods_per_year=12, **common,
+    ).unwrap()
+    weekly = pipeline.run_analysis(
+        frame, "2020-01", "2020-04", "2020-05", "2020-08", None, 0.0,
+        periods_per_year=52, **common,
+    ).unwrap()
+
+    assert weekly["out_sample_stats"]["A"].vol > monthly["out_sample_stats"]["A"].vol
+    assert weekly["out_sample_stats"]["A"].sortino > monthly["out_sample_stats"]["A"].sortino
+    assert weekly["out_sample_stats"]["A"].information_ratio > monthly["out_sample_stats"]["A"].information_ratio
+    assert weekly["out_sample_stats"]["A"].sharpe > monthly["out_sample_stats"]["A"].sharpe
+    assert weekly["out_ew_stats"].vol > monthly["out_ew_stats"].vol
+    assert weekly["out_user_stats"].vol > monthly["out_user_stats"].vol
+    assert weekly["benchmark_stats"]["bench"]["out_sample"].vol > monthly["benchmark_stats"]["bench"]["out_sample"].vol
+    assert weekly["benchmark_ir"]["bench"]["A"] > monthly["benchmark_ir"]["bench"]["A"]

--- a/tests/test_pipeline_stage_isolation.py
+++ b/tests/test_pipeline_stage_isolation.py
@@ -202,19 +202,39 @@ def test_run_analysis_propagates_window_cadence_to_portfolios_and_benchmark() ->
     )
 
     monthly = pipeline.run_analysis(
-        frame, "2020-01", "2020-04", "2020-05", "2020-08", None, 0.0,
-        periods_per_year=12, **common,
+        frame,
+        "2020-01",
+        "2020-04",
+        "2020-05",
+        "2020-08",
+        None,
+        0.0,
+        periods_per_year=12,
+        **common,
     ).unwrap()
     weekly = pipeline.run_analysis(
-        frame, "2020-01", "2020-04", "2020-05", "2020-08", None, 0.0,
-        periods_per_year=52, **common,
+        frame,
+        "2020-01",
+        "2020-04",
+        "2020-05",
+        "2020-08",
+        None,
+        0.0,
+        periods_per_year=52,
+        **common,
     ).unwrap()
 
     assert weekly["out_sample_stats"]["A"].vol > monthly["out_sample_stats"]["A"].vol
     assert weekly["out_sample_stats"]["A"].sortino > monthly["out_sample_stats"]["A"].sortino
-    assert weekly["out_sample_stats"]["A"].information_ratio > monthly["out_sample_stats"]["A"].information_ratio
+    assert (
+        weekly["out_sample_stats"]["A"].information_ratio
+        > monthly["out_sample_stats"]["A"].information_ratio
+    )
     assert weekly["out_sample_stats"]["A"].sharpe > monthly["out_sample_stats"]["A"].sharpe
     assert weekly["out_ew_stats"].vol > monthly["out_ew_stats"].vol
     assert weekly["out_user_stats"].vol > monthly["out_user_stats"].vol
-    assert weekly["benchmark_stats"]["bench"]["out_sample"].vol > monthly["benchmark_stats"]["bench"]["out_sample"].vol
+    assert (
+        weekly["benchmark_stats"]["bench"]["out_sample"].vol
+        > monthly["benchmark_stats"]["bench"]["out_sample"].vol
+    )
     assert weekly["benchmark_ir"]["bench"]["A"] > monthly["benchmark_ir"]["bench"]["A"]


### PR DESCRIPTION
## Summary

- replace the duplicate walk-forward cadence resolver with the canonical frequency helper
- propagate each analysis window's `periods_per_year` through annual return, volatility, Sharpe, Sortino, and information-ratio statistics
- cover the non-monthly annualisation invariant directly

Closes #5841

## Validation

- `python -m pytest tests/test_util_frequency_targeted.py tests/test_frequency_honored.py tests/test_pipeline_entrypoints.py tests/test_rebalance_frequency_wiring.py -q` — 43 passed
- `ruff check src/trend_analysis/walk_forward.py src/trend_analysis/stages/portfolio.py tests/test_pipeline_entrypoints.py`
- `git diff --check`

## Deliberate break

- Removed `periods_per_year` from the `_compute_stats` Sharpe call; `tests/test_pipeline_entrypoints.py::test_portfolio_stats_use_window_periods_per_year` failed because weekly and monthly Sharpe values became identical. Restored the argument and reran the focused suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected annualized performance calculations to use each analysis window’s configured frequency.
  - Improved accuracy of CAGR, volatility, and Sharpe ratio results across fund, portfolio, and benchmark statistics.
  - Updated benchmark information-ratio calculations to reflect the selected reporting frequency.
  - Ensured portfolio selection uses the window’s cadence without altering the original settings.
  - Resolved inconsistencies between weekly, monthly, and other analysis periods.

- **Tests**
  - Added regression coverage for frequency-specific metrics and portfolio selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->