### PR TITLE
Align risk-free behavior across pipeline entry points

### DIFF
--- a/src/trend_analysis/pipeline_entrypoints.py
+++ b/src/trend_analysis/pipeline_entrypoints.py
@@ -56,9 +56,14 @@ def _resolve_single_period_monthly_cost(portfolio_cfg: Any, run_cfg: Any) -> flo
     return resolve_pipeline_monthly_cost(run_cfg, portfolio_cfg)
 
 
-def _prepare_risk_free_settings(data_settings: Any) -> tuple[str | None, bool]:
+def _prepare_risk_free_settings(data_settings: Any, section_get: Any) -> tuple[str | None, bool]:
     """Resolve the risk-free contract shared by both public config entry points."""
-    return resolve_risk_free_settings(data_settings if isinstance(data_settings, Mapping) else None)
+    return resolve_risk_free_settings(
+        {
+            "risk_free_column": section_get(data_settings, "risk_free_column"),
+            "allow_risk_free_fallback": section_get(data_settings, "allow_risk_free_fallback"),
+        }
+    )
 
 
 def run_from_config(cfg: Any, *, bindings: ConfigBindings) -> pd.DataFrame:
@@ -134,7 +139,9 @@ def run_from_config(cfg: Any, *, bindings: ConfigBindings) -> pd.DataFrame:
     )
     trend_spec = bindings.build_trend_spec(cfg, vol_adjust)
     lambda_tc_val = bindings.section_get(portfolio_cfg, "lambda_tc", 0.0)
-    risk_free_column, allow_risk_free_fallback = _prepare_risk_free_settings(data_settings)
+    risk_free_column, allow_risk_free_fallback = _prepare_risk_free_settings(
+        data_settings, bindings.section_get
+    )
 
     diag_res = bindings.invoke_analysis_with_diag(
         df,
@@ -269,7 +276,9 @@ def run_full_from_config(cfg: Any, *, bindings: ConfigBindings) -> PipelineResul
     )
     trend_spec = bindings.build_trend_spec(cfg, vol_adjust)
     lambda_tc_val = bindings.section_get(portfolio_cfg, "lambda_tc", 0.0)
-    risk_free_column, allow_risk_free_fallback = _prepare_risk_free_settings(data_settings)
+    risk_free_column, allow_risk_free_fallback = _prepare_risk_free_settings(
+        data_settings, bindings.section_get
+    )
 
     diag_res = bindings.invoke_analysis_with_diag(
         df,

--- a/src/trend_analysis/pipeline_entrypoints.py
+++ b/src/trend_analysis/pipeline_entrypoints.py
@@ -56,6 +56,11 @@ def _resolve_single_period_monthly_cost(portfolio_cfg: Any, run_cfg: Any) -> flo
     return resolve_pipeline_monthly_cost(run_cfg, portfolio_cfg)
 
 
+def _prepare_risk_free_settings(data_settings: Any) -> tuple[str | None, bool]:
+    """Resolve the risk-free contract shared by both public config entry points."""
+    return resolve_risk_free_settings(data_settings if isinstance(data_settings, Mapping) else None)
+
+
 def run_from_config(cfg: Any, *, bindings: ConfigBindings) -> pd.DataFrame:
     """Run the analysis pipeline using a config-like object.
 
@@ -129,9 +134,7 @@ def run_from_config(cfg: Any, *, bindings: ConfigBindings) -> pd.DataFrame:
     )
     trend_spec = bindings.build_trend_spec(cfg, vol_adjust)
     lambda_tc_val = bindings.section_get(portfolio_cfg, "lambda_tc", 0.0)
-    risk_free_column, allow_risk_free_fallback = resolve_risk_free_settings(
-        data_settings if isinstance(data_settings, Mapping) else None
-    )
+    risk_free_column, allow_risk_free_fallback = _prepare_risk_free_settings(data_settings)
 
     diag_res = bindings.invoke_analysis_with_diag(
         df,
@@ -264,11 +267,9 @@ def run_full_from_config(cfg: Any, *, bindings: ConfigBindings) -> PipelineResul
     weight_engine_params = bindings.weight_engine_params_from_robustness(
         weighting_scheme, robustness_cfg
     )
-    risk_free_column = bindings.section_get(data_settings, "risk_free_column")
     trend_spec = bindings.build_trend_spec(cfg, vol_adjust)
     lambda_tc_val = bindings.section_get(portfolio_cfg, "lambda_tc", 0.0)
-    risk_free_column = bindings.section_get(data_settings, "risk_free_column")
-    allow_risk_free_fallback = bindings.section_get(data_settings, "allow_risk_free_fallback")
+    risk_free_column, allow_risk_free_fallback = _prepare_risk_free_settings(data_settings)
 
     diag_res = bindings.invoke_analysis_with_diag(
         df,

--- a/tests/test_pipeline_entrypoints.py
+++ b/tests/test_pipeline_entrypoints.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -270,6 +272,40 @@ def test_both_entrypoints_share_risk_free_resolution(
         (kwargs["risk_free_column"], kwargs["allow_risk_free_fallback"]) for kwargs in captured
     ]
     assert observed == [expected, expected]
+
+
+def test_both_entrypoints_preserve_object_backed_risk_free_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    sample_frame: pd.DataFrame,
+    sample_split: dict[str, str],
+) -> None:
+    config = SimpleNamespace(
+        data=SimpleNamespace(
+            csv_path="dummy.csv", risk_free_column="RF", allow_risk_free_fallback=True
+        ),
+        sample_split={},
+        preprocessing={},
+        run={},
+        portfolio={},
+        vol_adjust={},
+    )
+    captured: list[dict[str, object]] = []
+
+    monkeypatch.setattr(pipeline, "load_csv", lambda *_, **__: sample_frame)
+    monkeypatch.setattr(pipeline, "_resolve_sample_split", lambda *_args, **_kwargs: sample_split)
+    monkeypatch.setattr(pipeline, "_build_trend_spec", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(
+        pipeline,
+        "_run_analysis",
+        lambda *_, **kwargs: captured.append(kwargs) or pipeline._empty_run_full_result(),
+    )
+
+    pipeline.run(config)
+    pipeline.run_full(config)
+
+    assert [
+        (kwargs["risk_free_column"], kwargs["allow_risk_free_fallback"]) for kwargs in captured
+    ] == [("RF", False), ("RF", False)]
 
 
 def test_run_full_propagates_analysis_payload(

--- a/tests/test_pipeline_entrypoints.py
+++ b/tests/test_pipeline_entrypoints.py
@@ -226,6 +226,52 @@ def test_run_resolves_risk_free_defaults(
     assert captured_kwargs["allow_risk_free_fallback"] is expected_allow
 
 
+@pytest.mark.parametrize(
+    ("data_overrides", "expected"),
+    [
+        ({"risk_free_column": "RF", "allow_risk_free_fallback": True}, ("RF", False)),
+        ({"allow_risk_free_fallback": True}, (None, True)),
+        ({"allow_risk_free_fallback": False}, (None, False)),
+        ({}, (None, False)),
+    ],
+    ids=["explicit-column", "fallback-enabled", "fallback-disabled", "missing-column"],
+)
+def test_both_entrypoints_share_risk_free_resolution(
+    data_overrides: dict[str, object],
+    expected: tuple[str | None, bool],
+    monkeypatch: pytest.MonkeyPatch,
+    sample_frame: pd.DataFrame,
+    sample_split: dict[str, str],
+) -> None:
+    config: dict[str, object] = {
+        "data": {"csv_path": "dummy.csv", **data_overrides},
+        "sample_split": {},
+        "preprocessing": {},
+        "run": {},
+        "portfolio": {},
+        "vol_adjust": {},
+    }
+    captured: list[dict[str, object]] = []
+
+    monkeypatch.setattr(pipeline, "load_csv", lambda *_, **__: sample_frame)
+    monkeypatch.setattr(pipeline, "_resolve_sample_split", lambda *_args, **_kwargs: sample_split)
+    monkeypatch.setattr(pipeline, "_build_trend_spec", lambda *_args, **_kwargs: object())
+
+    def fake_run_analysis(*_args: object, **kwargs: object) -> dict[str, object]:
+        captured.append(kwargs)
+        return pipeline._empty_run_full_result()
+
+    monkeypatch.setattr(pipeline, "_run_analysis", fake_run_analysis)
+
+    pipeline.run(config)
+    pipeline.run_full(config)
+
+    observed = [
+        (kwargs["risk_free_column"], kwargs["allow_risk_free_fallback"]) for kwargs in captured
+    ]
+    assert observed == [expected, expected]
+
+
 def test_run_full_propagates_analysis_payload(
     monkeypatch: pytest.MonkeyPatch,
     sample_frame: pd.DataFrame,


### PR DESCRIPTION
## Summary

- route both public config entry points through one canonical risk-free settings preparer
- preserve explicit-column precedence and explicit fallback opt-in behavior
- add parity coverage for explicit, enabled, disabled, and missing configurations

Closes #5842

## Validation

- python -m pytest tests/test_risk_free_default_alignment.py tests/test_pipeline_entrypoints.py -q (37 passed)
- ruff check src/trend_analysis/pipeline_entrypoints.py tests/test_pipeline_entrypoints.py
- git diff --check

## Deliberate break

- Restored the direct risk-free field reads for one entry point; test_both_entrypoints_share_risk_free_resolution failed for explicit-column and missing-column configurations. Restored the shared preparer and reran validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when resolving risk-free settings across standard and full pipeline runs.
  * Mapping-based configurations now apply risk-free column and fallback settings consistently.
  * Explicit risk-free settings in object-based configurations are preserved as expected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->