### PR TITLE
fix: clarify export and JSON contracts

### DIFF
--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -91,6 +91,7 @@ from trend_analysis.signal_presets import (
 )
 from trend_analysis.universe_catalog import load_universe
 from trend_analysis.util.hash import working_run_id
+from trend_analysis.util.json_compat import JSON_UNSUPPORTED, json_compatible, json_primitive
 from trend_analysis.viz.artifacts import extract_bundle_zip
 from trend_model.spec import ensure_run_spec
 from utils.paths import proj_path
@@ -1017,15 +1018,13 @@ def _json_default(obj: Any) -> Any:  # pragma: no cover - helper
                 coerced_key = key
             else:
                 coerced_key = str(key)
-            if isinstance(value, (np.floating, np.integer)):
-                data[coerced_key] = float(value)
-            else:
-                data[coerced_key] = value
+            data[coerced_key] = json_compatible(value)
         return data
     if isinstance(obj, pd.DataFrame):
-        return obj.to_dict()
-    if isinstance(obj, Path):
-        return str(obj)
+        return json_compatible(obj.to_dict())
+    primitive = json_primitive(obj)
+    if primitive is not JSON_UNSUPPORTED:
+        return primitive
     raise TypeError(f"Object of type {type(obj).__name__} is not JSON serialisable")
 
 

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -1021,7 +1021,15 @@ def _json_default(obj: Any) -> Any:  # pragma: no cover - helper
             data[coerced_key] = json_compatible(value)
         return data
     if isinstance(obj, pd.DataFrame):
-        return json_compatible(obj.to_dict())
+        result: dict[str | int | float, Any] = {}
+        for col in obj.columns:
+            coerced_col: str | int | float
+            if isinstance(col, (str, int, float)):
+                coerced_col = col
+            else:
+                coerced_col = str(col)
+            result[coerced_col] = _json_default(obj[col])
+        return result
     primitive = json_primitive(obj)
     if primitive is not JSON_UNSUPPORTED:
         return primitive

--- a/src/trend_analysis/backtesting/harness.py
+++ b/src/trend_analysis/backtesting/harness.py
@@ -19,6 +19,7 @@ from ..schedules import normalize_frequency
 from ..schedules import rebalance_calendar as _rebalance_calendar
 from ..universe import MembershipTable, build_membership_mask
 from ..util.frequency import infer_periods_per_year as _infer_periods_per_year
+from ..util.json_compat import JSON_UNSUPPORTED, json_primitive
 
 logger = logging.getLogger(__name__)
 
@@ -635,10 +636,11 @@ def _weights_to_dict(weights: pd.DataFrame) -> Dict[str, Dict[str, float]]:
 
 
 def _json_default(obj: object) -> object:
-    if isinstance(obj, (pd.Timestamp, pd.Timedelta)):
-        return obj.isoformat()
-    if isinstance(obj, (np.floating, np.integer)):
-        return float(obj)
+    primitive = json_primitive(obj)
+    if primitive is not JSON_UNSUPPORTED:
+        if isinstance(obj, np.integer):
+            return float(primitive)
+        return primitive
     raise TypeError(f"Object of type {type(obj)!r} is not JSON serializable")
 
 

--- a/src/trend_analysis/backtesting/harness.py
+++ b/src/trend_analysis/backtesting/harness.py
@@ -19,7 +19,7 @@ from ..schedules import normalize_frequency
 from ..schedules import rebalance_calendar as _rebalance_calendar
 from ..universe import MembershipTable, build_membership_mask
 from ..util.frequency import infer_periods_per_year as _infer_periods_per_year
-from ..util.json_compat import JSON_UNSUPPORTED, json_primitive
+from ..util.json_compat import JSON_UNSUPPORTED, json_compatible, json_primitive
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +139,7 @@ class BacktestResult:
     def to_json(self, **dumps_kwargs: Any) -> str:
         """Serialise :meth:`summary` to JSON for downstream consumers."""
 
-        return json.dumps(self.summary(), default=_json_default, **dumps_kwargs)
+        return json.dumps(json_compatible(self.summary()), **dumps_kwargs)
 
 
 def run_backtest(

--- a/src/trend_analysis/core/rank_selection.py
+++ b/src/trend_analysis/core/rank_selection.py
@@ -29,6 +29,7 @@ import numpy as np
 import pandas as pd
 
 from .. import metrics as _metrics
+from ..util.json_compat import JSON_UNSUPPORTED, json_primitive
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from ..perf.cache import CovCache, CovPayload
@@ -69,12 +70,13 @@ class RankSelectionDiagnostics:
 def _json_default(value: Any) -> Any:
     """Helper for JSON serialisation of stats configuration objects."""
 
-    if isinstance(value, (set, tuple)):
-        return list(value)
-    if isinstance(value, np.ndarray):
-        return value.tolist()
-    if isinstance(value, (np.floating, np.integer)):
-        return float(value)
+    primitive = json_primitive(value)
+    if primitive is not JSON_UNSUPPORTED:
+        return (
+            float(primitive)
+            if isinstance(value, np.generic) and primitive is not None
+            else primitive
+        )
     raise TypeError(f"Object of type {type(value)!r} is not JSON serialisable")
 
 

--- a/src/trend_analysis/export/__init__.py
+++ b/src/trend_analysis/export/__init__.py
@@ -41,6 +41,45 @@ _OPENPYXL_COLOR_MAP = {
 logger = logging.getLogger(__name__)
 
 
+class SummaryResultContractError(ValueError):
+    """Raised when a partial result cannot be rendered consistently."""
+
+
+def _summary_result_contract(
+    res: Mapping[str, Any],
+) -> tuple[list[tuple[str, Any, Any]], Mapping[str, Any], Mapping[str, Any]]:
+    """Validate summary inputs before a formatter can mutate a workbook.
+
+    Aggregate rows are optional, but each in/out pair is atomic.  Per-fund
+    mappings are optional and default to empty mappings so partial runs still
+    produce a labelled workbook/text report rather than an incidental KeyError.
+    """
+
+    aggregate_rows: list[tuple[str, Any, Any]] = []
+    for label, in_key, out_key in (
+        ("Equal Weight", "in_ew_stats", "out_ew_stats"),
+        ("User Weight", "in_user_stats", "out_user_stats"),
+    ):
+        in_stats = res.get(in_key)
+        out_stats = res.get(out_key)
+        if (in_stats is None) != (out_stats is None):
+            raise SummaryResultContractError(
+                f"{in_key} and {out_key} must be supplied together for {label} summary output"
+            )
+        if in_stats is not None:
+            aggregate_rows.append((label, in_stats, out_stats))
+
+    def optional_mapping(key: str) -> Mapping[str, Any]:
+        value = res.get(key)
+        if value is None:
+            return {}
+        if not isinstance(value, Mapping):
+            raise SummaryResultContractError(f"{key} must be a mapping when supplied")
+        return value
+
+    return aggregate_rows, optional_mapping("in_sample_stats"), optional_mapping("out_sample_stats")
+
+
 def _normalise_color(value: Any) -> str | None:
     """Return an ARGB hex colour string understood by openpyxl."""
 
@@ -443,6 +482,8 @@ def _build_summary_formatter(
 ) -> Callable[[Any, Any], None]:
     """Return a formatter function for a summary sheet."""
 
+    aggregate_rows, in_sample_stats, out_sample_stats = _summary_result_contract(res)
+
     def fmt_summary(ws: Any, wb: Any) -> None:
         bold = wb.add_format({"bold": True})
         num2 = wb.add_format({"num_format": "0.00"})
@@ -545,10 +586,7 @@ def _build_summary_formatter(
             return (total, int(s.shape[0]))
 
         row = header_row + 1
-        for label, ins, outs in [
-            ("Equal Weight", res["in_ew_stats"], res["out_ew_stats"]),
-            ("User Weight", res["in_user_stats"], res["out_user_stats"]),
-        ]:
+        for label, ins, outs in aggregate_rows:
             ws.write(row, 0, label, bold)
             ws.write(row, 1, safe(""))
             weights = None
@@ -577,8 +615,8 @@ def _build_summary_formatter(
         # Start fund rows immediately after the aggregate rows (no spacer),
         # so the first fund appears on row 8 (1-based indexing).
         fund_weights = cast(Mapping[str, float], res.get("fund_weights", {}))
-        for fund, stat_in in res["in_sample_stats"].items():
-            stat_out = res.get("out_sample_stats", {}).get(fund)
+        for fund, stat_in in in_sample_stats.items():
+            stat_out = out_sample_stats.get(fund)
             if stat_out is None:
                 continue
             ws.write(row, 0, fund, bold)
@@ -736,6 +774,8 @@ def format_summary_text(
 ) -> str:
     """Return a plain-text summary table similar to the Excel output."""
 
+    aggregate_rows, in_sample_stats, out_sample_stats = _summary_result_contract(res)
+
     def safe(val: float | int | str | None) -> str:
         if val is None:
             return ""
@@ -810,17 +850,7 @@ def format_summary_text(
 
     rows: list[list[str | float | None]] = []
 
-    base_rows: list[tuple[str, Any, Any]] = []
-    in_ew = res.get("in_ew_stats")
-    out_ew = res.get("out_ew_stats")
-    if in_ew is not None and out_ew is not None:
-        base_rows.append(("Equal Weight", in_ew, out_ew))
-    in_user = res.get("in_user_stats")
-    out_user = res.get("out_user_stats")
-    if in_user is not None and out_user is not None:
-        base_rows.append(("User Weight", in_user, out_user))
-
-    for label, ins, outs in base_rows:
+    for label, ins, outs in aggregate_rows:
         weights = None
         if label == "User Weight":
             weights = cast(Mapping[str, float], res.get("fund_weights", {}))
@@ -842,8 +872,6 @@ def format_summary_text(
 
     rows.append([None] * len(columns))
 
-    in_sample_stats = res.get("in_sample_stats", {})
-    out_sample_stats = res.get("out_sample_stats", {})
     fund_weights = res.get("fund_weights", {})
     for fund, stat_in in in_sample_stats.items():
         stat_out = out_sample_stats.get(fund)
@@ -1951,6 +1979,7 @@ __all__ = [
     "make_summary_formatter",
     "make_period_formatter",
     "format_summary_text",
+    "SummaryResultContractError",
     "narrative_frame_from_result",
     "append_narrative_section",
     "export_to_excel",

--- a/src/trend_analysis/util/json_compat.py
+++ b/src/trend_analysis/util/json_compat.py
@@ -1,0 +1,62 @@
+"""Small, explicit JSON-compatible primitives shared by runtime adapters."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+JSON_UNSUPPORTED = object()
+
+
+def json_primitive(value: Any) -> Any:
+    """Return a safe JSON primitive or a private unsupported sentinel.
+
+    Callers retain ownership of their container shape (for example, a Series
+    can be a list in a JSONL record but a keyed mapping in a CLI response).
+    This helper only centralises scalar and universally safe conversions.
+    """
+
+    if value is pd.NA:
+        return None
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, (pd.Timestamp, pd.Timedelta)):
+        return value.isoformat()
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        scalar = value.item()
+        return None if isinstance(scalar, float) and not math.isfinite(scalar) else scalar
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, (set, tuple)):
+        return list(value)
+    return JSON_UNSUPPORTED
+
+
+def json_compatible(value: Any) -> Any:
+    """Recursively normalise values before serialising a known payload shape."""
+
+    primitive = json_primitive(value)
+    if primitive is not JSON_UNSUPPORTED:
+        return json_compatible(primitive) if primitive is not value else primitive
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, Mapping):
+        return {str(key): json_compatible(item) for key, item in value.items()}
+    if isinstance(value, pd.Series):
+        return [json_compatible(item) for item in value.tolist()]
+    if isinstance(value, pd.Index):
+        return [json_compatible(item) for item in value.tolist()]
+    if isinstance(value, pd.DataFrame):
+        return json_compatible(value.to_dict())
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [json_compatible(item) for item in value]
+    raise TypeError(f"Object of type {type(value)!r} is not JSON serialisable")

--- a/src/trend_analysis/walk_forward.py
+++ b/src/trend_analysis/walk_forward.py
@@ -15,7 +15,7 @@ import yaml
 
 from trend_analysis.metrics import annual_return, max_drawdown, sharpe_ratio
 from trend_analysis.util.frequency import infer_periods_per_year
-from trend_analysis.util.json_compat import JSON_UNSUPPORTED, json_primitive
+from trend_analysis.util.json_compat import JSON_UNSUPPORTED, json_compatible, json_primitive
 
 
 @dataclass(slots=True)
@@ -310,7 +310,7 @@ def _json_default(value: Any) -> Any:
 def _write_jsonl(path: Path, records: Iterable[Mapping[str, Any]]) -> None:
     with path.open("w", encoding="utf-8") as handle:
         for record in records:
-            handle.write(json.dumps(record, default=_json_default))
+            handle.write(json.dumps(json_compatible(dict(record))))
             handle.write("\n")
 
 

--- a/src/trend_analysis/walk_forward.py
+++ b/src/trend_analysis/walk_forward.py
@@ -15,6 +15,7 @@ import yaml
 
 from trend_analysis.metrics import annual_return, max_drawdown, sharpe_ratio
 from trend_analysis.util.frequency import infer_periods_per_year
+from trend_analysis.util.json_compat import JSON_UNSUPPORTED, json_primitive
 
 
 @dataclass(slots=True)
@@ -298,10 +299,9 @@ def evaluate_parameter_grid(
 
 
 def _json_default(value: Any) -> Any:
-    if isinstance(value, (np.floating, np.integer)):
-        return value.item()
-    if isinstance(value, (pd.Timestamp, pd.Timedelta)):
-        return value.isoformat()
+    primitive = json_primitive(value)
+    if primitive is not JSON_UNSUPPORTED:
+        return primitive
     if isinstance(value, (pd.Series, pd.Index)):
         return value.to_list()
     raise TypeError(f"Object of type {type(value)!r} is not JSON serialisable")

--- a/tests/test_export_formatter.py
+++ b/tests/test_export_formatter.py
@@ -5,6 +5,7 @@ import pytest
 
 from trend_analysis.export import (
     FORMATTERS_EXCEL,
+    SummaryResultContractError,
     _maybe_remove_openpyxl_default_sheet,
     _normalise_color,
     export_to_excel,
@@ -240,6 +241,22 @@ def test_format_summary_text_basic():
     assert "Vol-Adj Trend Analysis" in text
     assert "fund" in text
     assert "Fingerprint: feed1234beef" in text
+
+
+def test_partial_result_contract_is_explicit():
+    """Partial results render blanks, while half-pairs fail before sheet writes."""
+
+    partial = {"in_sample_stats": {}, "out_sample_stats": {}}
+    formatter = make_summary_formatter(partial, "a", "b", "c", "d")
+    ws = DummyWS()
+    formatter(ws, DummyWB())
+
+    assert any(row[2][0] == "Vol-Adj Trend Analysis" for row in ws.rows)
+    assert not any(cell[2] == "Equal Weight" for cell in ws.cells)
+    assert "Equal Weight" not in format_summary_text(partial, "a", "b", "c", "d")
+
+    with pytest.raises(SummaryResultContractError, match="in_ew_stats and out_ew_stats"):
+        make_summary_formatter({"in_ew_stats": (1, 1, 1, 1, 1, 1)}, "a", "b", "c", "d")
 
 
 def test_format_summary_text_includes_regime_breakdown():

--- a/tests/test_json_compat.py
+++ b/tests/test_json_compat.py
@@ -51,3 +51,32 @@ def test_callers_preserve_their_documented_container_shapes() -> None:
 
     with pytest.raises(TypeError, match="not JSON serialisable"):
         rank_selection._json_default(object())
+
+
+def test_backtest_to_json_normalizes_builtin_nan_metrics() -> None:
+    idx = pd.date_range("2024-01-01", periods=2, freq="D")
+    empty = pd.Series(dtype=float)
+    empty_frame = pd.DataFrame()
+    result = harness.BacktestResult(
+        returns=empty,
+        equity_curve=pd.Series([1.0], index=idx[:1]),
+        weights=empty_frame,
+        turnover=empty,
+        per_period_turnover=empty,
+        transaction_costs=empty,
+        cost_drag=empty,
+        rolling_sharpe=empty,
+        drawdown=empty,
+        metrics={"cagr": float("nan"), "sharpe": float("nan")},
+        cost_model=harness.CostModel(),
+        calendar=idx[:1],
+        window_mode="rolling",
+        window_size=1,
+        training_windows={},
+    )
+
+    encoded = result.to_json()
+    assert "NaN" not in encoded
+    parsed = json.loads(encoded)
+    assert parsed["metrics"]["cagr"] is None
+    assert parsed["metrics"]["sharpe"] is None

--- a/tests/test_json_compat.py
+++ b/tests/test_json_compat.py
@@ -1,0 +1,53 @@
+"""Contract coverage for JSON adapters with intentionally different shapes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from trend import cli
+from trend_analysis.backtesting import harness
+from trend_analysis.core import rank_selection
+from trend_analysis.util.json_compat import json_compatible, json_primitive
+from trend_analysis import walk_forward
+
+
+def test_shared_primitives_normalise_nan_and_reject_unknown_values() -> None:
+    assert json_primitive(pd.Timestamp("2024-01-01")) == "2024-01-01T00:00:00"
+    assert json_primitive(np.array([np.int64(2), np.float64(3.5)])) == [2, 3.5]
+    assert json_compatible({"nan": np.float64("nan"), "path": Path("report.json")}) == {
+        "nan": None,
+        "path": "report.json",
+    }
+    with pytest.raises(TypeError, match="not JSON serialisable"):
+        json_compatible(object())
+
+
+def test_callers_preserve_their_documented_container_shapes() -> None:
+    timestamp = pd.Timestamp("2024-01-01")
+    assert harness._json_default(timestamp) == timestamp.isoformat()
+    assert harness._json_default(np.int64(2)) == 2.0
+    assert harness._json_default(np.float32("nan")) is None
+
+    assert walk_forward._json_default(pd.Index(["a", "b"])) == ["a", "b"]
+    assert walk_forward._json_default(np.float32("nan")) is None
+
+    assert rank_selection._json_default(np.array([1, 2])) == [1, 2]
+    assert rank_selection._json_default(("a", "b")) == ["a", "b"]
+    assert rank_selection._json_default(np.float32("nan")) is None
+
+    series = pd.Series([np.float32(1.5), np.float32("nan")], index=[timestamp, "b"])
+    encoded = json.dumps(
+        {"series": series, "frame": pd.DataFrame({"x": series})}, default=cli._json_default
+    )
+    decoded = json.loads(encoded)
+    expected = {str(timestamp): 1.5, "b": None}
+    assert decoded["series"] == expected
+    assert decoded["frame"]["x"] == expected
+
+    with pytest.raises(TypeError, match="not JSON serialisable"):
+        rank_selection._json_default(object())


### PR DESCRIPTION
Closes #5843

## Summary
- make partial summary results explicit before workbook writes
- share safe JSON primitives while preserving caller-specific container shapes
- add serializer and partial-result contract coverage

## Validation
- python -m pytest tests/test_export_formatter.py tests/test_export_errors.py tests/test_export_manifest_schema.py tests/test_cli_utils.py tests/test_selector_cache.py tests/test_json_compat.py -q (34 passed)
- ruff check on changed files
- python -m black --check --target-version py312 --line-length 100 on changed files
- git diff --check
- deliberate break: restoring raw in_ew_stats indexing makes test_partial_result_contract_is_explicit fail, then restoration passes