### PR TITLE
fix: expose risk-weight degradation contracts

### DIFF
--- a/src/trend_analysis/perf/rolling_cache.py
+++ b/src/trend_analysis/perf/rolling_cache.py
@@ -86,6 +86,7 @@ class RollingCache:
     def __init__(self, cache_dir: Path | None = None) -> None:
         self.cache_dir = (cache_dir or _DEFAULT_CACHE_DIR).expanduser()
         self._enabled = True
+        self._storage_status = "primary"
         self.cache_dir = self._ensure_cache_dir(self.cache_dir)
 
     def _ensure_cache_dir(self, cache_dir: Path) -> Path:
@@ -96,9 +97,11 @@ class RollingCache:
             fallback = (Path(tempfile.gettempdir()) / "trend_model" / "rolling").resolve()
             try:
                 fallback.mkdir(parents=True, exist_ok=True)
+                self._storage_status = "temporary"
                 return fallback
             except (OSError, PermissionError):
                 self._enabled = False
+                self._storage_status = "disabled"
                 return cache_dir
 
     def set_enabled(self, enabled: bool) -> None:
@@ -106,6 +109,12 @@ class RollingCache:
 
     def is_enabled(self) -> bool:
         return self._enabled
+
+    @property
+    def storage_status(self) -> str:
+        """Return a path-safe description of the cache's operating mode."""
+
+        return self._storage_status
 
     def _build_path(self, dataset_hash: str, window: int, freq: str, method: str) -> Path:
         safe_method = _normalise_component(method)
@@ -135,6 +144,7 @@ class RollingCache:
                 window=window,
                 freq=freq,
                 hash=dataset_hash[:12],
+                storage=self._storage_status,
             )
             return result
 
@@ -151,6 +161,7 @@ class RollingCache:
                         window=window,
                         freq=freq,
                         hash=dataset_hash[:12],
+                        storage=self._storage_status,
                     )
                     return cached
             except Exception:  # pragma: no cover - cache corruption fallback
@@ -168,6 +179,7 @@ class RollingCache:
             window=window,
             freq=freq,
             hash=dataset_hash[:12],
+            storage=self._storage_status,
         )
         return result
 

--- a/src/trend_analysis/weights/__init__.py
+++ b/src/trend_analysis/weights/__init__.py
@@ -1,6 +1,6 @@
 """Risk-based weight engine implementations."""
 
-from .equal_risk_contribution import EqualRiskContribution
+from .equal_risk_contribution import EqualRiskContribution, EqualRiskContributionPolicy
 from .hierarchical_risk_parity import HierarchicalRiskParity
 from .risk_parity import RiskParity
 from .robust_weighting import RobustMeanVariance, RobustRiskParity
@@ -9,6 +9,7 @@ __all__ = [
     "RiskParity",
     "HierarchicalRiskParity",
     "EqualRiskContribution",
+    "EqualRiskContributionPolicy",
     "RobustMeanVariance",
     "RobustRiskParity",
 ]

--- a/src/trend_analysis/weights/equal_risk_contribution.py
+++ b/src/trend_analysis/weights/equal_risk_contribution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 
 import numpy as np
 import pandas as pd
@@ -11,14 +12,30 @@ from ..plugins import WeightEngine, weight_engine_registry
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class EqualRiskContributionPolicy:
+    """Numerical regularisation policy for :class:`EqualRiskContribution`."""
+
+    condition_threshold: float = 1e12
+    condition_loading_factor: float = 1e-6
+    nonpositive_eigen_loading_factor: float = 1e-4
+
+
 @weight_engine_registry.register("erc")
 class EqualRiskContribution(WeightEngine):
     """Equal risk contribution weighting via iterative scaling with robustness
     checks."""
 
-    def __init__(self, *, max_iter: int = 1000, tol: float = 1e-8) -> None:
+    def __init__(
+        self,
+        *,
+        max_iter: int = 1000,
+        tol: float = 1e-8,
+        policy: EqualRiskContributionPolicy | None = None,
+    ) -> None:
         self.max_iter = int(max_iter)
         self.tol = float(tol)
+        self.policy = policy or EqualRiskContributionPolicy()
 
     def weight(self, cov: pd.DataFrame) -> pd.Series:
         if cov.empty:
@@ -33,12 +50,12 @@ class EqualRiskContribution(WeightEngine):
         condition_num = np.linalg.cond(cov_mat)
         logger.debug(f"ERC input covariance condition number: {condition_num:.2e}")
 
-        if condition_num > 1e12:
+        if condition_num > self.policy.condition_threshold:
             logger.warning(
                 f"Ill-conditioned covariance matrix in ERC (condition: {condition_num:.2e}), adding regularization"
             )
             # Add small diagonal loading
-            regularization = np.trace(cov_mat) / n * 1e-6
+            regularization = np.trace(cov_mat) / n * self.policy.condition_loading_factor
             cov_mat = cov_mat + regularization * np.eye(n)
 
         # Check for non-positive definite matrix
@@ -48,7 +65,10 @@ class EqualRiskContribution(WeightEngine):
                 logger.warning("Non-positive definite covariance matrix detected in ERC")
                 # Apply more aggressive regularization
                 min_eigenval = np.abs(np.min(eigenvals))
-                regularization = min_eigenval + np.trace(cov_mat) / n * 1e-4
+                regularization = (
+                    min_eigenval
+                    + np.trace(cov_mat) / n * self.policy.nonpositive_eigen_loading_factor
+                )
                 cov_mat = cov_mat + regularization * np.eye(n)
         except np.linalg.LinAlgError:
             logger.error("Failed to compute eigenvalues in ERC, using equal weights")

--- a/src/trend_analysis/weights/hierarchical_risk_parity.py
+++ b/src/trend_analysis/weights/hierarchical_risk_parity.py
@@ -45,6 +45,7 @@ class HierarchicalRiskParity(WeightEngine):
         self.diagnostics: dict[str, object] = {}
 
     def weight(self, cov: pd.DataFrame) -> pd.Series:
+        self.diagnostics = {}
         if cov.empty:
             return pd.Series(dtype=float)
         if not cov.index.equals(cov.columns):
@@ -55,6 +56,7 @@ class HierarchicalRiskParity(WeightEngine):
         logger.debug(f"HRP input covariance condition number: {condition_num:.2e}")
 
         try:
+            degradation_reasons: list[str] = []
             corr = _cov_to_corr(cov)
 
             # Check for invalid correlations
@@ -69,6 +71,7 @@ class HierarchicalRiskParity(WeightEngine):
                 # Fall back to diagonal correlation matrix
                 corr = pd.DataFrame(np.eye(len(cov)), index=cov.index, columns=cov.columns)
                 corr_values = corr.to_numpy(dtype=float, copy=True)
+                degradation_reasons.append("non_finite_correlations")
 
             # Compute distance matrix as numpy array for typing clarity
             dist_arr: FloatArray = np.sqrt(0.5 * (1.0 - corr_values))
@@ -77,6 +80,11 @@ class HierarchicalRiskParity(WeightEngine):
             if np.any(~np.isfinite(dist_arr)) or np.any(dist_arr < 0):
                 logger.warning("Invalid distance matrix in HRP, using equal weights")
                 n = len(cov)
+                self.diagnostics = {
+                    "fallback_used": True,
+                    "fallback_reason": "invalid_distance_matrix",
+                    "degradation_reasons": degradation_reasons + ["invalid_distance_matrix"],
+                }
                 return pd.Series(np.ones(n) / n, index=cov.index)
 
             condensed: FloatArray = squareform(dist_arr, checks=False)
@@ -118,6 +126,7 @@ class HierarchicalRiskParity(WeightEngine):
                         logger.warning(
                             "Numerical issues in HRP cluster allocation, using equal split"
                         )
+                        degradation_reasons.append("cluster_allocation_numerical_issue")
                         alpha = 0.5
 
                     w[left] *= alpha
@@ -131,9 +140,18 @@ class HierarchicalRiskParity(WeightEngine):
             if w.sum() == 0:
                 logger.warning("Zero sum weights in HRP, using equal weights")
                 n = len(cov)
+                self.diagnostics = {
+                    "fallback_used": True,
+                    "fallback_reason": "zero_sum_weights",
+                    "degradation_reasons": degradation_reasons + ["zero_sum_weights"],
+                }
                 return pd.Series(np.ones(n) / n, index=cov.index)
 
             w /= w.sum()
+            self.diagnostics = {
+                "fallback_used": bool(degradation_reasons),
+                "degradation_reasons": degradation_reasons,
+            }
             logger.debug("Successfully computed HRP weights")
             return w
 

--- a/src/trend_analysis/weights/hierarchical_risk_parity.py
+++ b/src/trend_analysis/weights/hierarchical_risk_parity.py
@@ -41,6 +41,9 @@ def _cov_to_corr(cov: pd.DataFrame) -> pd.DataFrame:
 class HierarchicalRiskParity(WeightEngine):
     """Hierarchical risk parity weighting with enhanced robustness."""
 
+    def __init__(self) -> None:
+        self.diagnostics: dict[str, object] = {}
+
     def weight(self, cov: pd.DataFrame) -> pd.Series:
         if cov.empty:
             return pd.Series(dtype=float)
@@ -134,7 +137,16 @@ class HierarchicalRiskParity(WeightEngine):
             logger.debug("Successfully computed HRP weights")
             return w
 
-        except Exception as e:
-            logger.error(f"HRP computation failed: {e}, falling back to equal weights")
+        except Exception as exc:
+            # Keep the original exception attached to the log record.  The
+            # equal-weight fallback remains safe, but callers and operators
+            # can now distinguish a degraded HRP result from normal output.
+            self.diagnostics = {
+                "fallback_used": True,
+                "fallback_reason": "hrp_computation_error",
+                "exception_type": type(exc).__name__,
+                "exception_message": str(exc),
+            }
+            logger.exception("HRP computation failed; falling back to equal weights")
             n = len(cov)
             return pd.Series(np.ones(n) / n, index=cov.index)

--- a/src/trend_analysis/weights/robust_weighting.py
+++ b/src/trend_analysis/weights/robust_weighting.py
@@ -329,6 +329,7 @@ class RobustRiskParity(WeightEngine):
 
     def weight(self, cov: pd.DataFrame) -> pd.Series:
         """Compute risk parity weights with robustness checks."""
+        self.diagnostics = {}
         if cov.empty:
             return pd.Series(dtype=float)
 
@@ -373,6 +374,15 @@ class RobustRiskParity(WeightEngine):
         if max_std <= 0.0:
             # Fallback to equal weights when the covariance matrix collapses.
             logger.warning("Falling back to equal weights due to zero variance inputs")
+            self.diagnostics = {
+                "condition_number": condition_num,
+                "condition_threshold": self.condition_threshold,
+                "used_diagonal_loading": bool(diagonal_loading_reasons),
+                "diagonal_loading_reasons": diagonal_loading_reasons,
+                "diagonal_loading_factor": self.diagonal_loading_factor,
+                "fallback_used": True,
+                "fallback_reason": "zero_variance",
+            }
             return pd.Series(np.full(len(cov.index), 1.0 / len(cov.index)), index=cov.index)
 
         # Handle zero or very small standard deviations
@@ -383,6 +393,15 @@ class RobustRiskParity(WeightEngine):
         total = float(np.sum(inv_vol))
         if not np.isfinite(total) or total <= 0.0:
             logger.warning("Falling back to equal weights due to invalid inverse volatility sum")
+            self.diagnostics = {
+                "condition_number": condition_num,
+                "condition_threshold": self.condition_threshold,
+                "used_diagonal_loading": bool(diagonal_loading_reasons),
+                "diagonal_loading_reasons": diagonal_loading_reasons,
+                "diagonal_loading_factor": self.diagonal_loading_factor,
+                "fallback_used": True,
+                "fallback_reason": "invalid_inverse_volatility",
+            }
             return pd.Series(np.full(len(cov.index), 1.0 / len(cov.index)), index=cov.index)
 
         weights = inv_vol / total
@@ -393,6 +412,7 @@ class RobustRiskParity(WeightEngine):
             "used_diagonal_loading": bool(diagonal_loading_reasons),
             "diagonal_loading_reasons": diagonal_loading_reasons,
             "diagonal_loading_factor": self.diagonal_loading_factor,
+            "fallback_used": False,
         }
 
         logger.debug("Successfully computed robust risk parity weights")

--- a/src/trend_analysis/weights/robust_weighting.py
+++ b/src/trend_analysis/weights/robust_weighting.py
@@ -338,12 +338,19 @@ class RobustRiskParity(WeightEngine):
         # Check for problematic values
         cov_array = cov.values.astype(float, copy=True)
 
+        # Track every operation, rather than inferring it later from the
+        # condition threshold.  A non-positive diagonal is a distinct reason
+        # to load the covariance matrix and can be repaired before the
+        # threshold check runs.
+        diagonal_loading_reasons: list[str] = []
+
         # Check for non-positive diagonal elements
         diag_vals = np.diag(cov_array)
         if np.any(diag_vals <= 0):
             logger.warning("Non-positive diagonal elements detected. Applying diagonal loading.")
             cov_array = diagonal_loading(cov_array, self.diagonal_loading_factor)
             diag_vals = np.diag(cov_array)
+            diagonal_loading_reasons.append("non_positive_diagonal")
 
         # Check condition number
         condition_num = _safe_condition_number(cov_array)
@@ -355,6 +362,7 @@ class RobustRiskParity(WeightEngine):
             )
             cov_array = diagonal_loading(cov_array, self.diagonal_loading_factor)
             diag_vals = np.diag(cov_array)
+            diagonal_loading_reasons.append("condition_threshold_exceeded")
 
         # Compute inverse volatility weights
         diag_vals = np.where(diag_vals > 0, diag_vals, 0.0)
@@ -382,7 +390,8 @@ class RobustRiskParity(WeightEngine):
         self.diagnostics = {
             "condition_number": condition_num,
             "condition_threshold": self.condition_threshold,
-            "used_diagonal_loading": condition_num >= self.condition_threshold,
+            "used_diagonal_loading": bool(diagonal_loading_reasons),
+            "diagonal_loading_reasons": diagonal_loading_reasons,
             "diagonal_loading_factor": self.diagonal_loading_factor,
         }
 

--- a/tests/test_robust_weighting.py
+++ b/tests/test_robust_weighting.py
@@ -338,6 +338,22 @@ class TestRobustRiskParity:
         assert engine.diagnostics["used_diagonal_loading"] is True
         assert "condition_threshold_exceeded" in engine.diagnostics["diagonal_loading_reasons"]
 
+    def test_zero_variance_fallback_publishes_loading_diagnostics(self):
+        cov = pd.DataFrame(
+            [[0.0, 0.0], [0.0, 0.0]],
+            index=["a", "b"],
+            columns=["a", "b"],
+        )
+        engine = create_weight_engine("robust_risk_parity")
+
+        weights = engine.weight(cov)
+
+        assert weights.tolist() == [0.5, 0.5]
+        assert engine.diagnostics["fallback_used"] is True
+        assert engine.diagnostics["fallback_reason"] == "zero_variance"
+        assert engine.diagnostics["used_diagonal_loading"] is True
+        assert "non_positive_diagonal" in engine.diagnostics["diagonal_loading_reasons"]
+
     def test_empty_matrix(self):
         """Test handling of empty covariance matrix."""
         cov = pd.DataFrame()

--- a/tests/test_robust_weighting.py
+++ b/tests/test_robust_weighting.py
@@ -316,6 +316,28 @@ class TestRobustRiskParity:
         assert (weights >= 0).all()
         assert len(weights) == 3
 
+    def test_nonpositive_diagonal_reports_loading(self):
+        cov = pd.DataFrame(
+            [[0.04, 0.002, 0.0], [0.002, 0.09, 0.0], [0.0, 0.0, 0.0]],
+            index=["a", "b", "c"],
+            columns=["a", "b", "c"],
+        )
+        engine = create_weight_engine("robust_risk_parity", condition_threshold=float("inf"))
+
+        engine.weight(cov)
+
+        assert engine.diagnostics["used_diagonal_loading"] is True
+        assert engine.diagnostics["diagonal_loading_reasons"] == ["non_positive_diagonal"]
+
+    def test_condition_threshold_reports_loading(self):
+        cov = create_ill_conditioned_cov()
+        engine = create_weight_engine("robust_risk_parity", condition_threshold=1.0)
+
+        engine.weight(cov)
+
+        assert engine.diagnostics["used_diagonal_loading"] is True
+        assert "condition_threshold_exceeded" in engine.diagnostics["diagonal_loading_reasons"]
+
     def test_empty_matrix(self):
         """Test handling of empty covariance matrix."""
         cov = pd.DataFrame()

--- a/tests/test_rolling_cache.py
+++ b/tests/test_rolling_cache.py
@@ -102,3 +102,4 @@ def test_rolling_cache_emits_timing_logs(monkeypatch, tmp_path):
     cache.get_or_compute(dataset_hash, 3, "M", "method_a", lambda: series)
 
     assert [entry[1]["status"] for entry in logged] == ["miss", "hit"]
+    assert [entry[1]["storage"] for entry in logged] == ["primary", "primary"]

--- a/tests/test_weighting_robustness.py
+++ b/tests/test_weighting_robustness.py
@@ -101,6 +101,34 @@ class TestHierarchicalRiskParity:
         weights = engine.weight(cov)
         assert weights.sum() == pytest.approx(1.0, rel=1e-9)
         assert set(weights.index) == {"A", "B"}
+        assert engine.diagnostics["fallback_used"] is True
+        assert "non_finite_correlations" in engine.diagnostics["degradation_reasons"]
+
+    def test_weighting_resets_diagnostics_after_recovery(self) -> None:
+        engine = HierarchicalRiskParity()
+        failing_cov = _make_covariance(np.array([[0.0, 0.0], [0.0, 0.0]]), labels=["A", "B"])
+        healthy_cov = _make_covariance(np.array([[0.1, 0.02], [0.02, 0.2]]), labels=["A", "B"])
+
+        engine.weight(failing_cov)
+        weights = engine.weight(healthy_cov)
+
+        assert weights.sum() == pytest.approx(1.0, rel=1e-9)
+        assert engine.diagnostics == {"fallback_used": False, "degradation_reasons": []}
+
+    def test_weighting_records_invalid_distance_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        engine = HierarchicalRiskParity()
+        cov = _make_covariance(np.eye(2), labels=["A", "B"])
+        monkeypatch.setattr(
+            "trend_analysis.weights.hierarchical_risk_parity._cov_to_corr",
+            lambda _: pd.DataFrame([[1.0, 2.0], [2.0, 1.0]], index=["A", "B"], columns=["A", "B"]),
+        )
+
+        weights = engine.weight(cov)
+
+        assert weights.tolist() == [0.5, 0.5]
+        assert engine.diagnostics["fallback_reason"] == "invalid_distance_matrix"
 
 
 class TestShrinkageUtilities:

--- a/tests/test_weighting_robustness.py
+++ b/tests/test_weighting_robustness.py
@@ -8,7 +8,10 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from trend_analysis.weights.equal_risk_contribution import EqualRiskContribution
+from trend_analysis.weights.equal_risk_contribution import (
+    EqualRiskContribution,
+    EqualRiskContributionPolicy,
+)
 from trend_analysis.weights.hierarchical_risk_parity import HierarchicalRiskParity
 from trend_analysis.weights.robust_weighting import (
     RobustMeanVariance,
@@ -27,6 +30,16 @@ def _make_covariance(values: np.ndarray, labels: list[str] | None = None) -> pd.
 
 
 class TestEqualRiskContribution:
+    def test_policy_exposes_regularization_contract(self):
+        policy = EqualRiskContributionPolicy(
+            condition_threshold=10.0,
+            condition_loading_factor=1e-5,
+            nonpositive_eigen_loading_factor=1e-3,
+        )
+        engine = EqualRiskContribution(policy=policy)
+
+        assert engine.policy == policy
+
     def test_weighting_handles_empty_input(self) -> None:
         engine = EqualRiskContribution()
         result = engine.weight(pd.DataFrame())


### PR DESCRIPTION
Closes #5844

## Summary
- report every RobustRiskParity diagonal-loading trigger truthfully
- preserve HRP fallback cause and expose path-safe rolling-cache degradation state
- make ERC regularization thresholds an explicit typed policy

## Validation
- python -m pytest tests/test_robust_weighting.py tests/test_weighting_robustness.py tests/test_weight_engine_logging.py tests/test_rolling_cache.py tests/test_perf_timing.py -q (77 passed)
- ruff check on changed files
- python -m black --check --target-version py312 --line-length 100 on changed files
- git diff --check
- deliberate break: removing the non-positive-diagonal loading reason makes TestRobustRiskParity::test_nonpositive_diagonal_reports_loading fail, then restoration passes