### PR TITLE
fix: harden UI, API, and Streamlit runtime contracts

### DIFF
--- a/src/trend_analysis/api_server/__init__.py
+++ b/src/trend_analysis/api_server/__init__.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Tupl
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
+from starlette.types import Message
 
 if TYPE_CHECKING:
     from trend_analysis.tool_layer import ToolLayer
@@ -73,6 +74,15 @@ def _bad_request(detail: str) -> JSONResponse:
     return JSONResponse(status_code=400, content={"detail": detail})
 
 
+def _request_with_replayed_body(request: Request, body: bytes) -> Request:
+    """Create a supported request wrapper that replays an already-read body."""
+
+    async def receive() -> Message:
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(request.scope, receive=receive)
+
+
 async def _risky_change_guard(
     request: Request,
     call_next: Callable[[Request], Awaitable[Response]],
@@ -89,9 +99,6 @@ async def _risky_change_guard(
     body = await request.body()
     if not body:
         return _bad_request("Request body is required.")
-
-    # Preserve the body for downstream request parsing.
-    request._body = body
 
     try:
         payload = json.loads(body)
@@ -124,7 +131,7 @@ async def _risky_change_guard(
             detail = _build_risky_detail(flags)
             return JSONResponse(status_code=400, content={"detail": detail})
 
-    return await call_next(request)
+    return await call_next(_request_with_replayed_body(request, body))
 
 
 app.middleware("http")(_risky_change_guard)

--- a/src/trend_analysis/gui/app.py
+++ b/src/trend_analysis/gui/app.py
@@ -461,6 +461,19 @@ def build_config_from_store(store: ParamStore) -> ConfigType:
     return Config(**cfg)
 
 
+def _clear_grid_error_border(grid: Any) -> None:
+    """Clear a transient edit error without assuming a notebook event loop exists."""
+
+    def clear_border() -> None:
+        grid.layout.border = ""
+
+    try:
+        asyncio.get_running_loop().call_later(1.0, clear_border)
+    except RuntimeError:
+        # Widget construction and tests can run outside an active asyncio loop.
+        clear_border()
+
+
 def _build_step0(store: ParamStore) -> widgets.Widget:
     """Return widgets for Step 0 (config loader/editor)."""
 
@@ -491,7 +504,7 @@ def _build_step0(store: ParamStore) -> widgets.Widget:
             except Exception:
                 grid_df.iloc[event["row"], 1] = old
                 grid.layout.border = "2px solid red"
-                asyncio.get_event_loop().call_later(1.0, lambda: setattr(grid.layout, "border", ""))
+                _clear_grid_error_border(grid)
 
         try:
             grid.on("cell_edited", on_cell_change)

--- a/streamlit_app/components/csv_validation.py
+++ b/streamlit_app/components/csv_validation.py
@@ -281,5 +281,5 @@ def validate_uploaded_csv(
 
         logger.debug("CSV upload validated: %s rows × %s columns", len(df.index), len(df.columns))
     except CSVValidationError as err:
-        logger.exception("CSV upload failed validation: %s", err)
+        logger.warning("CSV upload failed validation: %s", err)
         raise

--- a/streamlit_app/components/data_cache.py
+++ b/streamlit_app/components/data_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import hashlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -52,8 +53,19 @@ def list_sample_datasets() -> list[SampleDataset]:
 def _hash_dataframe(df: pd.DataFrame) -> str:
     """Return a stable hash for a dataframe used as a cache key."""
 
-    payload = df.to_json(date_format="iso", date_unit="ns", orient="split")
-    return json.dumps({"data": payload})
+    payload = json.dumps(
+        {
+            "columns": [repr(column) for column in df.columns],
+            "dtypes": [str(dtype) for dtype in df.dtypes],
+            "index_dtype": str(df.index.dtype),
+            "index_type": type(df.index).__qualname__,
+            "data": df.to_json(date_format="iso", date_unit="ns", orient="split"),
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 @st.cache_data(show_spinner="Loading dataset…")

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1,6 +1,7 @@
 """Tests for the FastAPI server."""
 
 import asyncio
+import inspect
 import runpy
 import sys
 from types import SimpleNamespace
@@ -105,6 +106,24 @@ async def test_api_allows_risky_patch_with_confirmation(client):
     body = response.json()
     assert body["status"] == "success"
     assert "portfolio" in body["config"]
+
+
+@pytest.mark.anyio
+async def test_risky_guard_replays_body_without_private_mutation(client):
+    payload = {
+        "config": {"portfolio": {"max_turnover": 1.0}},
+        "patch": {
+            "operations": [{"op": "remove", "path": "portfolio.max_turnover"}],
+            "risk_flags": [],
+            "summary": "Remove turnover cap.",
+        },
+        "confirm_risky": True,
+    }
+
+    response = await client.post("/config/patch", json=payload)
+
+    assert response.status_code == 200
+    assert "request._body" not in inspect.getsource(api_server._risky_change_guard)
 
 
 @pytest.mark.anyio

--- a/tests/test_gui_app_extended.py
+++ b/tests/test_gui_app_extended.py
@@ -156,6 +156,17 @@ def test_build_step0_upload_refresh(monkeypatch, tmp_path):
     assert grid.data == [store.cfg]
 
 
+def test_grid_error_border_clears_without_running_loop(monkeypatch):
+    grid = SimpleNamespace(layout=SimpleNamespace(border="2px solid red"))
+    monkeypatch.setattr(
+        app.asyncio, "get_running_loop", lambda: (_ for _ in ()).throw(RuntimeError())
+    )
+
+    app._clear_grid_error_border(grid)
+
+    assert grid.layout.border == ""
+
+
 def test_manual_override_grid_updates_state(monkeypatch):
     created_instances.clear()
     store = ParamStore(

--- a/tests/test_streamlit_csv_validation.py
+++ b/tests/test_streamlit_csv_validation.py
@@ -35,11 +35,14 @@ def test_validate_uploaded_csv_flags_missing_required_column() -> None:
     assert "Missing columns" in excinfo.value.issues[0]
 
 
-def test_validate_uploaded_csv_detects_invalid_dates() -> None:
+def test_validate_uploaded_csv_detects_invalid_dates(caplog: pytest.LogCaptureFixture) -> None:
     content = _csv(["not-a-date,0.01,0.02"])
-    with pytest.raises(CSVValidationError) as excinfo:
-        validate_uploaded_csv(content, ("Date",), max_rows=10)
+    with caplog.at_level("WARNING"):
+        with pytest.raises(CSVValidationError) as excinfo:
+            validate_uploaded_csv(content, ("Date",), max_rows=10)
     assert "cannot be parsed" in " ".join(excinfo.value.issues)
+    assert "CSV upload failed validation" in caplog.text
+    assert not any(record.exc_info for record in caplog.records)
 
 
 def test_validate_uploaded_csv_detects_duplicate_dates() -> None:

--- a/tests/unit/test_streamlit_model_cache_keys.py
+++ b/tests/unit/test_streamlit_model_cache_keys.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pandas as pd
+
+from streamlit_app.components.data_cache import cache_key_for_frame
+
 
 def _load_model_page():
     module_path = Path(__file__).resolve().parents[2] / "streamlit_app" / "pages" / "2_Model.py"
@@ -73,3 +77,15 @@ def test_invalidation_fields_include_connection_overrides():
     module = _load_model_page()
     assert "base_url" in module._CONFIG_CHAIN_INVALIDATION_FIELDS
     assert "organization" in module._CONFIG_CHAIN_INVALIDATION_FIELDS
+
+
+def test_dataframe_cache_key_is_digest_and_tracks_schema_index_and_data():
+    frame = pd.DataFrame({"returns": [0.1, 0.2]}, index=pd.Index(["a", "b"], name="asset"))
+
+    key = cache_key_for_frame(frame)
+
+    assert len(key) == 64
+    assert key == cache_key_for_frame(frame.copy())
+    assert key != cache_key_for_frame(frame.rename(columns={"returns": "risk"}))
+    assert key != cache_key_for_frame(frame.set_axis(["x", "y"], axis="index"))
+    assert key != cache_key_for_frame(frame.assign(returns=[0.1, 0.3]))


### PR DESCRIPTION
Closes #5845

## Summary
- replay guarded API request bodies through a supported receive wrapper instead of mutating private request state
- use a bounded SHA-256 dataframe cache digest and safe no-loop UI error reset
- log expected CSV validation failures without tracebacks

## Validation
- python -m pytest tests/test_gui_app_extended.py tests/test_api_server.py tests/unit/test_streamlit_model_cache_keys.py tests/test_streamlit_csv_validation.py -q (74 passed)
- ruff check and Black check on changed files
- git diff --check
- deliberate break: restoring request._body = body makes tests/test_api_server.py::test_risky_guard_replays_body_without_private_mutation fail, then restoration passes