### PR TITLE
Clarify public APIs and consolidate preset ownership

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ include = [
 # into the package search path when additional roots are added.
 exclude = ["Old*", "retired*", "**/Old*", "**/retired*"]
 
+[tool.setuptools.package-data]
+trend_analysis = ["preset_data/*.yml"]
+
 [project.optional-dependencies]
 app = [
     "streamlit==1.58.0",

--- a/src/health_summarize/__init__.py
+++ b/src/health_summarize/__init__.py
@@ -392,19 +392,6 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 __all__ = [
     "Args",
-    "_branch_row",
-    "_doc_url",
-    "_escape_table",
-    "_extract_contexts",
-    "_format_delta",
-    "_format_require_up_to_date",
-    "_load_json",
-    "_read_bool",
-    "_select_previous_section",
-    "_signature_row",
-    "_snapshot_detail",
-    "_write_json",
-    "_write_summary",
     "build_signature_hash",
     "main",
 ]

--- a/src/trend_analysis/preset_data/aggressive.yml
+++ b/src/trend_analysis/preset_data/aggressive.yml
@@ -1,0 +1,31 @@
+version: "1"
+name: Aggressive
+description: High risk-return profile for performance-oriented users
+lookback_periods: 24
+rebalance_frequency: monthly
+min_track_months: 18
+selection_count: 15
+risk_target: 0.15
+metrics:
+  return_ann: 0.4
+  sharpe_ratio: 0.3
+  max_drawdown: 0.15
+  volatility: 0.15
+signals:
+  window: 42
+  min_periods: 30
+  lag: 1
+  vol_adjust: true
+  vol_target: 0.15
+  zscore: false
+portfolio:
+  max_weight: 0.10
+  cooldown_months: 1
+vol_adjust:
+  enabled: true
+  target_vol: 0.15
+  window:
+    length: 42
+sample_split:
+  method: date
+  date: "2016-12-31"

--- a/src/trend_analysis/preset_data/balanced.yml
+++ b/src/trend_analysis/preset_data/balanced.yml
@@ -1,0 +1,31 @@
+version: "1"
+name: Balanced
+description: Balanced risk-return profile suitable for most users
+lookback_periods: 36
+rebalance_frequency: monthly
+min_track_months: 24
+selection_count: 10
+risk_target: 0.10
+metrics:
+  sharpe_ratio: 0.3
+  return_ann: 0.3
+  max_drawdown: 0.25
+  volatility: 0.15
+signals:
+  window: 84
+  min_periods: 63
+  lag: 1
+  vol_adjust: true
+  vol_target: 0.10
+  zscore: true
+portfolio:
+  max_weight: 0.15
+  cooldown_months: 3
+vol_adjust:
+  enabled: true
+  target_vol: 0.10
+  window:
+    length: 63
+sample_split:
+  method: date
+  date: "2017-12-31"

--- a/src/trend_analysis/preset_data/cash_constrained.yml
+++ b/src/trend_analysis/preset_data/cash_constrained.yml
@@ -1,0 +1,33 @@
+version: "1"
+name: Cash constrained
+description: Illustrative preset with max weight, group caps and cash sleeve
+lookback_periods: 36
+rebalance_frequency: monthly
+min_track_months: 24
+selection_count: 8
+risk_target: 0.10
+metrics:
+  sharpe: 0.4
+  return_ann: 0.3
+  drawdown: 0.3
+portfolio:
+  weighting_scheme: equal
+  constraints:
+    long_only: true
+    max_weight: 0.25
+    group_caps:
+      Trend: 0.55
+      Macro: 0.60
+    groups:
+      FundA: Trend
+      FundB: Trend
+      FundC: Macro
+      FundD: Macro
+    cash_weight: 0.10
+signals:
+  window: 63
+  min_periods: 42
+  lag: 1
+  vol_adjust: true
+  vol_target: 0.10
+  zscore: false

--- a/src/trend_analysis/preset_data/conservative.yml
+++ b/src/trend_analysis/preset_data/conservative.yml
@@ -1,0 +1,31 @@
+version: "1"
+name: Conservative
+description: Low risk profile with stable selection criteria
+lookback_periods: 60
+rebalance_frequency: quarterly
+min_track_months: 36
+selection_count: 5
+risk_target: 0.08
+metrics:
+  sharpe_ratio: 0.4
+  max_drawdown: 0.3
+  volatility: 0.2
+  return_ann: 0.1
+signals:
+  window: 126
+  min_periods: 90
+  lag: 1
+  vol_adjust: true
+  vol_target: 0.08
+  zscore: true
+portfolio:
+  max_weight: 0.25
+  cooldown_months: 6
+vol_adjust:
+  enabled: true
+  target_vol: 0.08
+  window:
+    length: 126
+sample_split:
+  method: date
+  date: "2018-12-31"

--- a/src/trend_analysis/presets.py
+++ b/src/trend_analysis/presets.py
@@ -318,10 +318,12 @@ def _candidate_preset_dirs() -> tuple[Path, ...]:
 
 
 @lru_cache(maxsize=None)
-def _preset_registry() -> Mapping[str, TrendPreset]:
+def _preset_registry_for_dirs(
+    directories: tuple[Path, ...],
+) -> Mapping[str, TrendPreset]:
     registry: dict[str, TrendPreset] = {}
     origins: dict[str, Path] = {}
-    for directory in _candidate_preset_dirs():
+    for directory in directories:
         for path in sorted(directory.glob("*.yml")):
             slug = path.stem.lower()
             try:
@@ -352,6 +354,21 @@ def _preset_registry() -> Mapping[str, TrendPreset]:
             registry[slug] = preset
             origins[slug] = path
     return MappingProxyType(registry)
+
+
+def _preset_registry() -> Mapping[str, TrendPreset]:
+    """Return the cached registry for the current preset-directory selection.
+
+    ``PRESETS_DIR`` and ``TREND_PRESETS_DIR`` are intentionally configurable for
+    editable installs and tests.  Keying the cache by the resolved candidate
+    directories prevents a temporary override from leaking an empty registry
+    after that override has been removed.
+    """
+
+    return _preset_registry_for_dirs(_candidate_preset_dirs())
+
+
+_preset_registry.cache_clear = _preset_registry_for_dirs.cache_clear  # type: ignore[attr-defined]
 
 
 def list_trend_presets() -> tuple[TrendPreset, ...]:

--- a/src/trend_analysis/presets.py
+++ b/src/trend_analysis/presets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from copy import deepcopy
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -17,6 +18,7 @@ from .signals import TrendSpec
 LOGGER = logging.getLogger(__name__)
 
 _DEFAULT_PRESETS_DIR = Path(__file__).resolve().parents[2] / "config" / "presets"
+_BUNDLED_PRESETS_DIR = Path(__file__).with_name("preset_data")
 PRESETS_DIR = _DEFAULT_PRESETS_DIR
 
 _DEFAULT_VOL_ADJUST: Mapping[str, Any] = MappingProxyType(
@@ -152,7 +154,7 @@ class TrendPreset:
         :meth:`signals_mapping`; neither needs a parallel registry.
         """
 
-        return dict(self._config)
+        return deepcopy(dict(self._config))
 
     def form_defaults(self) -> dict[str, Any]:
         """Return UI-ready defaults derived from the preset."""
@@ -294,7 +296,7 @@ def _candidate_preset_dirs() -> tuple[Path, ...]:
             seen.add(resolved)
             candidates.append(resolved)
 
-    # Base directory within the source tree or editable install
+    # Base directory within the source tree or editable install.
     _register(PRESETS_DIR)
 
     include_defaults = PRESETS_DIR == _DEFAULT_PRESETS_DIR
@@ -302,6 +304,11 @@ def _candidate_preset_dirs() -> tuple[Path, ...]:
         for parent in current.parents:
             alt = parent / "config" / "presets"
             _register(alt)
+        # Wheels do not contain the repository-level ``config`` directory.
+        # Ship an equivalent package-local copy so normal installations retain
+        # the same built-in preset vocabulary as editable/source installs.
+        if not _DEFAULT_PRESETS_DIR.is_dir():
+            _register(_BUNDLED_PRESETS_DIR)
 
     env_dir = os.environ.get("TREND_PRESETS_DIR")
     if env_dir:
@@ -317,7 +324,11 @@ def _preset_registry() -> Mapping[str, TrendPreset]:
     for directory in _candidate_preset_dirs():
         for path in sorted(directory.glob("*.yml")):
             slug = path.stem.lower()
-            raw = _load_yaml(path)
+            try:
+                raw = _load_yaml(path)
+            except (OSError, yaml.YAMLError) as exc:
+                LOGGER.warning("Skipping unreadable trend preset %s: %s", path, exc)
+                continue
             if not raw:
                 continue
             label = str(raw.get("name") or slug.title())

--- a/src/trend_analysis/presets.py
+++ b/src/trend_analysis/presets.py
@@ -144,6 +144,16 @@ class TrendPreset:
     trend_spec: TrendSpec
     _config: Mapping[str, Any]
 
+    def config_mapping(self) -> dict[str, Any]:
+        """Return a mutable full-config payload for UI and CLI consumers.
+
+        ``TrendPreset`` is the single preset owner.  Callers that need the
+        complete configuration receive a copy, while signal-only callers use
+        :meth:`signals_mapping`; neither needs a parallel registry.
+        """
+
+        return dict(self._config)
+
     def form_defaults(self) -> dict[str, Any]:
         """Return UI-ready defaults derived from the preset."""
 
@@ -351,7 +361,7 @@ def get_trend_preset(name: str) -> TrendPreset:
 
     if not name:
         raise KeyError("Preset name must be provided")
-    lowered = name.lower()
+    lowered = name.strip().lower()
     registry = _preset_registry()
     if lowered in registry:
         return registry[lowered]

--- a/src/trend_analysis/signal_presets.py
+++ b/src/trend_analysis/signal_presets.py
@@ -1,10 +1,16 @@
-"""Named TrendSpec presets shared between CLI and UI layers."""
+"""Signal-only view of the canonical YAML-backed preset registry.
+
+``trend_analysis.presets`` owns full preset payloads.  This module preserves
+the small signal-only type used by older CLI call sites without maintaining a
+second authoritative name map.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable, List
+from typing import Dict, List
 
+from .presets import get_trend_preset, list_trend_presets
 from .signals import TrendSpec
 
 
@@ -49,44 +55,14 @@ class TrendSpecPreset:
 
 _DEFAULT_PRESET_NAME = "Balanced"
 
-_PRESETS: Dict[str, TrendSpecPreset] = {
-    "conservative": TrendSpecPreset(
-        name="Conservative",
-        description="Longer window with heavier smoothing and lower volatility target.",
-        spec=TrendSpec(
-            window=126,
-            min_periods=90,
-            lag=1,
-            vol_adjust=True,
-            vol_target=0.08,
-            zscore=True,
-        ),
-    ),
-    "balanced": TrendSpecPreset(
-        name="Balanced",
-        description="Default configuration offering a balance between responsiveness and stability.",
-        spec=TrendSpec(
-            window=84,
-            min_periods=63,
-            lag=1,
-            vol_adjust=True,
-            vol_target=0.10,
-            zscore=True,
-        ),
-    ),
-    "aggressive": TrendSpecPreset(
-        name="Aggressive",
-        description="Shorter window prioritising responsiveness with higher volatility allowance.",
-        spec=TrendSpec(
-            window=42,
-            min_periods=30,
-            lag=1,
-            vol_adjust=True,
-            vol_target=0.15,
-            zscore=False,
-        ),
-    ),
-}
+
+def _signal_view(name: str) -> TrendSpecPreset:
+    preset = get_trend_preset(name)
+    return TrendSpecPreset(
+        name=preset.label,
+        description=preset.description,
+        spec=preset.trend_spec,
+    )
 
 
 def default_preset_name() -> str:
@@ -98,40 +74,26 @@ def default_preset_name() -> str:
 def list_trend_spec_presets() -> List[str]:
     """Return the available TrendSpec preset names (title case)."""
 
-    return [preset.name for preset in _ordered_presets()]
+    return [preset.label for preset in list_trend_presets()]
 
 
 def list_trend_spec_keys() -> List[str]:
     """Return canonical keys for TrendSpec presets (lower case)."""
 
-    return [key for key, _ in _ordered_presets_items()]
+    return [preset.slug for preset in list_trend_presets()]
 
 
 def get_trend_spec_preset(name: str) -> TrendSpecPreset:
     """Look up a preset by name (case-insensitive)."""
 
-    key = name.strip().lower()
-    if key not in _PRESETS:
-        raise KeyError(f"Unknown TrendSpec preset: {name}")
-    return _PRESETS[key]
+    return _signal_view(name)
 
 
 def resolve_trend_spec(name: str | None) -> TrendSpecPreset:
     """Return preset by name falling back to the default when ``name`` is
     falsy."""
 
-    if not name:
-        return _PRESETS[_DEFAULT_PRESET_NAME.lower()]
-    return get_trend_spec_preset(name)
-
-
-def _ordered_presets() -> Iterable[TrendSpecPreset]:
-    for _, preset in _ordered_presets_items():
-        yield preset
-
-
-def _ordered_presets_items() -> List[tuple[str, TrendSpecPreset]]:
-    return sorted(_PRESETS.items(), key=lambda item: item[0])
+    return get_trend_spec_preset(name or _DEFAULT_PRESET_NAME)
 
 
 __all__ = [

--- a/src/trend_analysis/signal_presets.py
+++ b/src/trend_analysis/signal_presets.py
@@ -8,9 +8,10 @@ second authoritative name map.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Dict, List
 
-from .presets import get_trend_preset, list_trend_presets
+from .presets import _preset_registry, get_trend_preset, list_trend_presets
 from .signals import TrendSpec
 
 
@@ -54,10 +55,37 @@ class TrendSpecPreset:
 
 
 _DEFAULT_PRESET_NAME = "Balanced"
+_SIGNAL_PRESET_SLUGS = ("aggressive", "balanced", "conservative")
 
 
-def _signal_view(name: str) -> TrendSpecPreset:
-    preset = get_trend_preset(name)
+def _ordered_presets_items() -> tuple[tuple[str, TrendSpecPreset], ...]:
+    """Return the canonical signal-compatible presets by stable slug.
+
+    The full registry also includes full-config-only choices such as the cash
+    constrained preset.  This tuple is a compatibility surface selection, not
+    a second registry: each returned payload is still derived from the single
+    YAML-backed owner.
+    """
+
+    available = {preset.slug for preset in list_trend_presets()}
+    registry_identity = id(_preset_registry())
+    return tuple(
+        (slug, _signal_view(slug, registry_identity))
+        for slug in _SIGNAL_PRESET_SLUGS
+        if slug in available
+    )
+
+
+def _ordered_presets() -> tuple[TrendSpecPreset, ...]:
+    """Return canonical signal presets in the same order as their keys."""
+
+    return tuple(preset for _, preset in _ordered_presets_items())
+
+
+@lru_cache(maxsize=None)
+def _signal_view(slug: str, registry_identity: int) -> TrendSpecPreset:
+    del registry_identity  # It keys this cache to the current canonical registry generation.
+    preset = get_trend_preset(slug)
     return TrendSpecPreset(
         name=preset.label,
         description=preset.description,
@@ -74,19 +102,22 @@ def default_preset_name() -> str:
 def list_trend_spec_presets() -> List[str]:
     """Return the available TrendSpec preset names (title case)."""
 
-    return [preset.label for preset in list_trend_presets()]
+    return [preset.name for preset in _ordered_presets()]
 
 
 def list_trend_spec_keys() -> List[str]:
     """Return canonical keys for TrendSpec presets (lower case)."""
 
-    return [preset.slug for preset in list_trend_presets()]
+    return [key for key, _ in _ordered_presets_items()]
 
 
 def get_trend_spec_preset(name: str) -> TrendSpecPreset:
     """Look up a preset by name (case-insensitive)."""
 
-    return _signal_view(name)
+    preset = get_trend_preset(name)
+    if preset.slug not in _SIGNAL_PRESET_SLUGS:
+        raise KeyError(f"Unknown trend preset: {name}")
+    return _signal_view(preset.slug, id(_preset_registry()))
 
 
 def resolve_trend_spec(name: str | None) -> TrendSpecPreset:

--- a/streamlit_app/components/demo_runner.py
+++ b/streamlit_app/components/demo_runner.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, MutableMapping, Tuple
 
 import pandas as pd
-import yaml
 
 from streamlit_app.components.analysis_runner import ModelSettings
 from streamlit_app.components.data_schema import (
@@ -21,10 +20,10 @@ from streamlit_app.components.data_schema import (
 from streamlit_app.components.policy_engine import MetricSpec, PolicyConfig
 from trend_analysis.api import run_simulation
 from trend_analysis.config import Config
+from trend_analysis.presets import get_trend_preset, list_trend_presets
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEMO_DIR = REPO_ROOT / "demo"
-PRESET_DIR = REPO_ROOT / "config" / "presets"
 
 DEMO_DATA_CANDIDATES = (
     DEMO_DIR / "demo_returns.csv",
@@ -79,14 +78,12 @@ def _load_demo_returns() -> Tuple[pd.DataFrame, SchemaMeta]:
 
 
 def _load_preset(name: str) -> Dict[str, Any]:
-    """Load a preset YAML file into a mapping."""
+    """Return a copy of the canonical full-config preset payload."""
 
-    preset_path = PRESET_DIR / f"{name.lower()}.yml"
-    if not preset_path.exists():
+    try:
+        return get_trend_preset(name).config_mapping()
+    except KeyError:
         return {}
-    with preset_path.open("r", encoding="utf-8") as fh:
-        data = yaml.safe_load(fh)
-    return data if isinstance(data, dict) else {}
 
 
 def _select_benchmark(columns: Iterable[str]) -> str | None:
@@ -449,28 +446,14 @@ def run_one_click_demo(st_module: Any | None = None) -> bool:
 
 def list_presets() -> list[Dict[str, Any]]:
     """Return a list of available preset configurations."""
-    presets = []
-    if not PRESET_DIR.exists():
-        return [{"name": "Balanced", "description": "Default balanced preset"}]
-
-    for path in sorted(PRESET_DIR.glob("*.yml")):
-        try:
-            with path.open("r", encoding="utf-8") as fh:
-                data = yaml.safe_load(fh) or {}
-            presets.append(
-                {
-                    "name": data.get("name", path.stem.title()),
-                    "description": data.get("description", ""),
-                    "file": path.name,
-                }
-            )
-        except Exception:
-            continue
-
-    if not presets:
-        presets.append({"name": "Balanced", "description": "Default balanced preset"})
-
-    return presets
+    return [
+        {
+            "name": preset.label,
+            "description": preset.description,
+            "file": f"{preset.slug}.yml",
+        }
+        for preset in list_trend_presets()
+    ]
 
 
 def load_preset_config(name: str) -> Dict[str, Any]:

--- a/tests/app/test_demo_runner_component.py
+++ b/tests/app/test_demo_runner_component.py
@@ -11,6 +11,7 @@ import pytest
 
 from streamlit_app.components import demo_runner, disclaimer
 from trend_analysis.config import Config
+from trend_analysis import presets as preset_module
 
 
 @pytest.fixture()
@@ -268,10 +269,13 @@ def test_load_preset_reads_yaml(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) 
     preset_path = preset_dir / "balanced.yml"
     preset_path.write_text("metrics:\n  sharpe: 1.0\n")
 
-    monkeypatch.setattr(demo_runner, "PRESET_DIR", preset_dir)
+    monkeypatch.setattr(preset_module, "PRESETS_DIR", preset_dir)
+    monkeypatch.setattr(preset_module, "_DEFAULT_PRESETS_DIR", preset_dir / "default")
+    preset_module._preset_registry.cache_clear()
 
     data = demo_runner._load_preset("Balanced")
     assert data == {"metrics": {"sharpe": 1.0}}
+    preset_module._preset_registry.cache_clear()
 
 
 def test_load_preset_returns_empty_for_missing(
@@ -279,9 +283,12 @@ def test_load_preset_returns_empty_for_missing(
 ) -> None:
     """Absent preset files should return an empty mapping."""
 
-    monkeypatch.setattr(demo_runner, "PRESET_DIR", tmp_path)
+    monkeypatch.setattr(preset_module, "PRESETS_DIR", tmp_path)
+    monkeypatch.setattr(preset_module, "_DEFAULT_PRESETS_DIR", tmp_path / "default")
+    preset_module._preset_registry.cache_clear()
 
     assert demo_runner._load_preset("Missing") == {}
+    preset_module._preset_registry.cache_clear()
 
 
 def test_run_one_click_demo_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/app/test_demo_runner_component.py
+++ b/tests/app/test_demo_runner_component.py
@@ -287,6 +287,22 @@ def test_load_preset_returns_empty_for_missing(
     monkeypatch.setattr(preset_module, "_DEFAULT_PRESETS_DIR", tmp_path / "default")
     preset_module._preset_registry.cache_clear()
 
+
+def test_list_presets_skips_malformed_override(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bad override file must not prevent the selector from rendering."""
+
+    preset_dir = tmp_path / "presets"
+    preset_dir.mkdir()
+    (preset_dir / "balanced.yml").write_text("name: Balanced\nsignals: [", encoding="utf-8")
+    monkeypatch.setattr(preset_module, "PRESETS_DIR", preset_dir)
+    monkeypatch.setattr(preset_module, "_DEFAULT_PRESETS_DIR", preset_dir / "default")
+    preset_module._preset_registry.cache_clear()
+
+    assert demo_runner.list_presets() == []
+    preset_module._preset_registry.cache_clear()
+
     assert demo_runner._load_preset("Missing") == {}
     preset_module._preset_registry.cache_clear()
 

--- a/tests/app/test_preset_vocabulary.py
+++ b/tests/app/test_preset_vocabulary.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from streamlit_app.components import demo_runner
+from trend_analysis.presets import get_trend_preset
+from trend_analysis.signal_presets import get_trend_spec_preset
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -24,3 +26,15 @@ def test_home_demo_preset_label_is_distinct_from_model_preset_label() -> None:
     assert "Strategy Preset" not in demo_runner_source
     assert "Preset Configuration" in model_source
     assert demo_runner.DEMO_PRESET_SELECTOR_LABEL != "Preset Configuration"
+
+
+def test_cli_and_streamlit_share_preset_resolution() -> None:
+    """The signal view and UI payload must derive from one canonical preset."""
+
+    full_preset = get_trend_preset("balanced")
+    signal_preset = get_trend_spec_preset("balanced")
+    ui_payload = demo_runner._load_preset("balanced")
+
+    assert signal_preset.spec == full_preset.trend_spec
+    assert ui_payload == full_preset.config_mapping()
+    assert ui_payload["signals"]["window"] == signal_preset.spec.window

--- a/tests/test_health_summarize_module.py
+++ b/tests/test_health_summarize_module.py
@@ -40,6 +40,13 @@ def test_read_bool_variants(summarize: ModuleType) -> None:
     assert summarize._read_bool("surprise") is True
 
 
+def test_public_exports_are_non_private_and_callable(summarize: ModuleType) -> None:
+    assert summarize.__all__ == ["Args", "build_signature_hash", "main"]
+    assert all(not name.startswith("_") for name in summarize.__all__)
+    assert callable(summarize.build_signature_hash)
+    assert callable(summarize.main)
+
+
 def test_load_json_handles_missing_and_invalid(summarize: ModuleType, tmp_path: Path) -> None:
     missing = tmp_path / "missing.json"
     assert summarize._load_json(missing) is None

--- a/tests/test_trend_analysis_presets.py
+++ b/tests/test_trend_analysis_presets.py
@@ -322,6 +322,22 @@ def test_candidate_preset_dirs_includes_repository_defaults(
     assert isinstance(candidates, tuple)
 
 
+def test_registry_recovers_after_temporary_empty_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A temporary override must not cache an empty registry for later callers."""
+
+    default_dir = preset_module.PRESETS_DIR
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    monkeypatch.setattr(preset_module, "PRESETS_DIR", empty_dir)
+    preset_module._preset_registry.cache_clear()
+    assert preset_module.list_preset_slugs() == ()
+
+    monkeypatch.setattr(preset_module, "PRESETS_DIR", default_dir)
+    assert {"aggressive", "balanced", "conservative"}.issubset(preset_module.list_preset_slugs())
+
+
 def test_preset_registry_loads_yaml_and_handles_overrides(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_trend_analysis_presets.py
+++ b/tests/test_trend_analysis_presets.py
@@ -58,6 +58,21 @@ def test_freeze_mapping_returns_immutable_view() -> None:
         frozen["c"] = 3  # type: ignore[misc]
 
 
+def test_config_mapping_deep_copies_nested_payloads() -> None:
+    preset = preset_module.TrendPreset(
+        slug="nested",
+        label="Nested",
+        description="",
+        trend_spec=preset_module.TrendSpec(),
+        _config=preset_module._freeze_mapping({"signals": {"window": 42}}),
+    )
+
+    payload = preset.config_mapping()
+    payload["signals"]["window"] = 21
+
+    assert preset.config_mapping()["signals"]["window"] == 42
+
+
 def test_normalise_metric_weights_discards_invalid_entries() -> None:
     weights = preset_module._normalise_metric_weights(
         {"sharpe_ratio": "2", "bad": "x", "drawdown": 0.5}


### PR DESCRIPTION
Closes #5847

## Summary
- make the YAML-backed full preset registry the single owner for CLI and Streamlit resolution
- retain a typed signal-only adapter without a second preset map, and make preset-name matching whitespace tolerant
- reduce health_summarize public exports to non-private entry points with public-contract coverage

## Validation
- python -m pytest tests/test_health_summarize_module.py tests/test_config_schema.py tests/test_trend_analysis_presets.py tests/test_signal_presets.py tests/app/test_preset_vocabulary.py tests/app/test_demo_runner_component.py -q (86 passed)
- python -m ruff check src/trend_analysis/presets.py src/trend_analysis/signal_presets.py streamlit_app/components/demo_runner.py src/health_summarize/__init__.py tests/app/test_preset_vocabulary.py tests/app/test_demo_runner_component.py tests/test_health_summarize_module.py
- python -m black --target-version py312 --check on the touched Python files
- git diff --check
- deliberate break: temporarily changed the signal adapter's balanced specification without changing the canonical resolver; tests/app/test_preset_vocabulary.py::test_cli_and_streamlit_share_preset_resolution failed, then passed after restoration.