### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.16.2
+RUFF_VERSION=0.16.3
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.2
+    rev: v0.16.3
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ notebooks = [
 dev = [
     "pre-commit==4.6.0",
     "black==26.5.1",
-    "ruff==0.16.2",
+    "ruff==0.16.3",
     "isort==8.0.1",
     "docformatter==1.7.8",
     "mypy==2.3.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -448,7 +448,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.16.2
+ruff==0.16.3
     # via trend-model (pyproject.toml)
 scipy==1.18.0
     # via trend-model (pyproject.toml)


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 3 version updates:
  - ruff: ==0.16.2 -> ==0.16.3
  - requirements.lock:ruff: 0.16.2 -> ==0.16.3
  - .pre-commit-config.yaml:astral-sh/ruff-pre-commit: v0.16.2 -> v0.16.3

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`
**Settled source commit:** `770c226a9eeb22be1dc8e1e33511f8aacd5434a8`

<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"dev-tool-02c0c6e3cd5f","generation":"02c0c6e3cd5f","repository":"stranske/Trend_Model_Project","desired_tree_hash":"8a9615c819b861c4d20666cc54e4439ae87ed1eb","source_commit":"770c226a9eeb22be1dc8e1e33511f8aacd5434a8","lease_expires_at":"2026-08-16T19:28:27Z","predecessor_prs":[],"successor_prs":[]} -->