### PR TITLE
Port Monte Carlo commands to trend CLI

### DIFF
--- a/config/scenarios/monte_carlo/cost_regime_example.yml
+++ b/config/scenarios/monte_carlo/cost_regime_example.yml
@@ -2,7 +2,7 @@
 # - Demonstrates stochastic calm/stress switching for transaction costs.
 # - Demonstrates regime-specific slippage multipliers.
 # - Intended as a known-good reference for regression tests and CLI examples.
-# - Run with: python -m trend_analysis.cli mc run --scenario cost_regime_example --dry-run --n-paths 10
+# - Run with: trend mc run --scenario cost_regime_example --dry-run --n-paths 10
 # - Validate with: python -m pytest tests/monte_carlo/test_costs.py tests/monte_carlo/test_registry.py -q --no-cov
 scenario:
   name: cost_regime_example

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -33,15 +33,12 @@ aliases remain removal-bound and must not be used in new documentation or automa
 | `trend quick-report` | Build a compact report from existing run artefacts. | Supported |
 | `trend app` | Launch the Streamlit application. | Supported |
 | `trend check` | Print environment and dependency diagnostics. | Supported |
-| `trend mc viz` | Render charts from an existing Monte Carlo bundle. | Supported. |
-| `python -m trend_analysis.cli mc` | List, validate, and run registered Monte Carlo scenarios. | Transitional compatibility surface until those commands move into `trend`. |
+| `trend mc` | List, validate, run, and render Monte Carlo scenarios and bundles. | Supported. |
 
 Compatibility commands such as `trend-analysis`, `trend-multi-analysis`,
 `trend-model`, `trend-app`, and `trend-run` are transitional aliases only and
-will be removed. The scenario examples below intentionally invoke
-`python -m trend_analysis.cli` because its `mc list`, `mc validate`, and `mc run`
-subcommands have not yet moved to `trend`; `trend mc` currently supports only
-`viz`.
+will be removed. New scenario instructions use the canonical `trend mc`
+command tree; the old `trend-analysis` entry point remains compatibility-only.
 
 ## Launching the Streamlit UI (`trend app`)
 
@@ -125,17 +122,16 @@ new replay instructions.
 
 ## Monte Carlo Commands
 
-Use `python -m trend_analysis.cli mc` for scenario discovery, validation, and
-simulation until those commands move to the unified CLI. Use `trend mc viz` to
-export charts from completed bundles. Scenario authoring and output interpretation stay in
+Use `trend mc` for scenario discovery, validation, simulation, and chart
+exports. Scenario authoring and output interpretation stay in
 `docs/phase-3/MonteCarlo.md`.
 
-### List Scenarios (`python -m trend_analysis.cli mc list`)
+### List Scenarios (`trend mc list`)
 
 List registered scenarios from the default registry.
 
 ```bash
-python -m trend_analysis.cli mc list
+trend mc list
 ```
 
 Filter by tags with `--tags`. The option accepts comma-separated values and can
@@ -144,17 +140,17 @@ listing; the default format is `table`. Use `--registry PATH` to point at a
 custom scenario registry.
 
 ```bash
-python -m trend_analysis.cli mc list --tags hedge_fund --format json
-python -m trend_analysis.cli mc list --tags hedge_fund,example \
+trend mc list --tags hedge_fund --format json
+trend mc list --tags hedge_fund,example \
   --registry config/scenarios/monte_carlo/index.yml
 ```
 
-### Validate Scenarios (`python -m trend_analysis.cli mc validate`)
+### Validate Scenarios (`trend mc validate`)
 
 Validate all registered scenarios:
 
 ```bash
-python -m trend_analysis.cli mc validate
+trend mc validate
 ```
 
 Pass a scenario name or a config path to validate a single scenario. Use
@@ -162,18 +158,18 @@ Pass a scenario name or a config path to validate a single scenario. Use
 override the registry location.
 
 ```bash
-python -m trend_analysis.cli mc validate config/scenarios/monte_carlo/cost_regime_example.yml
-python -m trend_analysis.cli mc validate cost_regime_example \
+trend mc validate config/scenarios/monte_carlo/cost_regime_example.yml
+trend mc validate cost_regime_example \
   --registry config/scenarios/monte_carlo/index.yml
 ```
 
-### Run Scenarios (`python -m trend_analysis.cli mc run`)
+### Run Scenarios (`trend mc run`)
 
 Run a scenario by name or config path with `--scenario`, and optionally choose
 the output bundle directory with `--out`.
 
 ```bash
-python -m trend_analysis.cli mc run --scenario cost_regime_example --out outputs/mc_run_1
+trend mc run --scenario cost_regime_example --out outputs/mc_run_1
 ```
 
 Runtime overrides include `--data` for an alternate CSV/Parquet input,
@@ -190,9 +186,9 @@ summaries, aggregation files such as `path_summary.<fmt>` and
 `nav_paths_fold_<id>.parquet`. No separate frozen scenario YAML file is produced.
 
 ```bash
-python -m trend_analysis.cli mc run --scenario cost_regime_example \
+trend mc run --scenario cost_regime_example \
   --n-paths 500 --jobs 4 --seed 123
-python -m trend_analysis.cli mc run --scenario cost_regime_example \
+trend mc run --scenario cost_regime_example \
   --dry-run --n-paths 10
 ```
 

--- a/docs/phase-3/MonteCarlo.md
+++ b/docs/phase-3/MonteCarlo.md
@@ -717,21 +717,21 @@ Rank_12_Equal,max_dd,-0.52,-0.41,-0.35,-0.28,-0.21,-0.15,-0.11,-0.09,-0.06
 
 ```bash
 # List available scenarios
-python -m trend_analysis.cli mc list
-python -m trend_analysis.cli mc list --tags hedge_fund
+trend mc list
+trend mc list --tags hedge_fund
 
 # Validate scenario configuration
-python -m trend_analysis.cli mc validate config/scenarios/monte_carlo/hf_equity_ls_10y.yml
+trend mc validate config/scenarios/monte_carlo/hf_equity_ls_10y.yml
 
 # Run scenario
-python -m trend_analysis.cli mc run --scenario hf_equity_ls_10y --out outputs/mc_run_1
-python -m trend_analysis.cli mc run --scenario hf_equity_ls_10y --n-paths 500 --jobs 4
+trend mc run --scenario hf_equity_ls_10y --out outputs/mc_run_1
+trend mc run --scenario hf_equity_ls_10y --n-paths 500 --jobs 4
 
 # Quick test run
-python -m trend_analysis.cli mc run --scenario hf_equity_ls_10y --dry-run --n-paths 10
+trend mc run --scenario hf_equity_ls_10y --dry-run --n-paths 10
 
 # Cost regime example dry-run (exact command)
-python -m trend_analysis.cli mc run --scenario cost_regime_example --dry-run --n-paths 10
+trend mc run --scenario cost_regime_example --dry-run --n-paths 10
 
 # Export MC charts from an existing bundle
 trend mc viz \

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -280,6 +280,24 @@ def _legacy_callable(name: str, fallback: Callable[..., Any]) -> Callable[..., A
 # Monte Carlo visualisation pipeline can raise the same exception type
 # regardless of which CLI entry-point invoked it.
 from trend.mc.viz import TrendCLIError  # noqa: E402
+from trend.mc.commands import (  # noqa: E402
+    add_mc_subparsers,
+    handle_mc_command,
+    is_valid_tqdm_instance,
+    write_mc_manifest,
+)
+
+
+def _write_mc_manifest(*args: Any, **kwargs: Any) -> Path:
+    """Compatibility test hook for the shared Monte Carlo manifest writer."""
+
+    return write_mc_manifest(*args, **kwargs)
+
+
+def _is_valid_tqdm_instance(candidate: Any) -> bool:
+    """Compatibility test hook for the shared Monte Carlo progress validator."""
+
+    return is_valid_tqdm_instance(candidate)
 
 
 def build_parser(
@@ -395,58 +413,8 @@ def build_parser(
         help="Report which config keys were validated vs read",
     )
 
-    mc_p = sub.add_parser("mc", help="Monte Carlo visualization workflows")
-    mc_sub = mc_p.add_subparsers(dest="mc_command", required=True)
-    mc_viz_p = mc_sub.add_parser("viz", help="Render Monte Carlo chart artifacts from a bundle")
-    mc_viz_p.add_argument(
-        "--bundle",
-        required=True,
-        help="Path to Monte Carlo bundle directory containing summary/results files",
-    )
-    mc_viz_p.add_argument(
-        "--out",
-        type=Path,
-        required=True,
-        help="Output directory for generated chart artifacts",
-    )
-    mc_viz_p.add_argument(
-        "--charts",
-        default="fan,path_dist,risk_return",
-        help="Comma-separated chart identifiers (fan,path_dist,risk_return)",
-    )
-    nav_paths_group = mc_viz_p.add_mutually_exclusive_group()
-    nav_paths_group.add_argument(
-        "--fold",
-        type=int,
-        help=(
-            "Fold id to load fold-exported NAV paths (nav_paths_fold_<id>.parquet) from "
-            "the bundle; when provided, this takes precedence over the bundle's "
-            "nav_paths.parquet."
-        ),
-    )
-    nav_paths_group.add_argument(
-        "--nav-paths",
-        type=Path,
-        dest="nav_paths",
-        help="Explicit path to a nav_paths parquet file to use instead of bundle nav_paths.parquet.",
-    )
-    mc_viz_p.add_argument(
-        "--html",
-        action="store_true",
-        help="Export chart artifacts as HTML",
-    )
-    mc_viz_p.add_argument(
-        "--json",
-        action="store_true",
-        help="Export chart artifacts as JSON",
-    )
-    mc_viz_p.add_argument(
-        "--png",
-        action="store_true",
-        help=(
-            "Best-effort PNG export; requires a working kaleido install " "(pip install kaleido)"
-        ),
-    )
+    mc_p = sub.add_parser("mc", help="Monte Carlo scenario workflows")
+    add_mc_subparsers(mc_p)
 
     sub.add_parser("app", help="Launch the Streamlit application")
     if include_gui_alias:
@@ -2203,10 +2171,8 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
             return 0
 
         if command == "mc":
-            if getattr(args, "mc_command", None) != "viz":
-                raise TrendCLIError("Unknown mc subcommand")
             _finalize_config_coverage()
-            return _run_mc_viz_command(args)
+            return handle_mc_command(args)
 
         if command not in {"run", "report", "stress", "mc"}:
             raise TrendCLIError(f"Unknown command: {command}")

--- a/src/trend/mc/commands.py
+++ b/src/trend/mc/commands.py
@@ -75,7 +75,10 @@ def handle_mc_command(args: argparse.Namespace) -> int:
                 json=args.json,
                 png=args.png,
             )
-        except (TrendCLIError, OSError, ValueError) as exc:
+        except TrendCLIError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
+        except (OSError, ValueError) as exc:
             print(str(exc), file=sys.stderr)
             return 1
     return _legacy_cli._handle_mc_command(args)

--- a/src/trend/mc/commands.py
+++ b/src/trend/mc/commands.py
@@ -1,0 +1,88 @@
+"""Canonical ``trend mc`` parser and command handlers.
+
+The scenario implementation remains shared with the compatibility CLI during
+the migration.  Keeping the parser and dispatch boundary here lets callers use
+``trend mc`` now without creating a third Monte Carlo implementation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from trend_analysis import cli as _legacy_cli
+from trend.mc.viz import TrendCLIError
+
+
+def add_mc_subparsers(parent: argparse.ArgumentParser) -> None:
+    """Add the complete Monte Carlo command tree to the canonical parser."""
+
+    sub = parent.add_subparsers(dest="mc_command", required=True)
+
+    list_parser = sub.add_parser("list", help="List registered Monte Carlo scenarios")
+    list_parser.add_argument("--tags", action="append", default=[], help="Filter by scenario tags")
+    list_parser.add_argument("--format", choices=("table", "json"), default="table")
+    list_parser.add_argument("--registry", help="Override the scenario registry path")
+
+    validate_parser = sub.add_parser("validate", help="Validate Monte Carlo scenarios")
+    validate_parser.add_argument("scenario", nargs="?", help="Scenario name or config path")
+    validate_parser.add_argument(
+        "--tags", action="append", default=[], help="Filter by scenario tags"
+    )
+    validate_parser.add_argument("--registry", help="Override the scenario registry path")
+
+    run_parser = sub.add_parser("run", help="Run Monte Carlo scenarios")
+    run_parser.add_argument("--scenario", required=True, help="Scenario name or config path")
+    run_parser.add_argument("--data", help="CSV/Parquet price or returns history")
+    run_parser.add_argument("--out", help="Output directory for the Monte Carlo bundle")
+    run_parser.add_argument(
+        "--formats", action="append", default=[], help="Repeatable CSV/JSON/Parquet formats"
+    )
+    run_parser.add_argument("--n-paths", type=int, help="Override number of Monte Carlo paths")
+    run_parser.add_argument("--jobs", type=int, help="Override parallel job count")
+    run_parser.add_argument("--seed", type=int, help="Override Monte Carlo seed")
+    run_parser.add_argument("--dry-run", action="store_true", help="Validate without executing")
+    run_parser.add_argument("--no-progress", action="store_true", help="Disable progress output")
+    run_parser.add_argument("--registry", help="Override the scenario registry path")
+
+    viz_parser = sub.add_parser("viz", help="Render Monte Carlo chart artifacts from a bundle")
+    viz_parser.add_argument("--bundle", required=True, help="Monte Carlo bundle directory")
+    viz_parser.add_argument("--out", type=Path, required=True, help="Artifact output directory")
+    viz_parser.add_argument("--charts", default="fan,path_dist,risk_return")
+    nav_paths_group = viz_parser.add_mutually_exclusive_group()
+    nav_paths_group.add_argument("--fold", type=int, help="Fold-exported NAV paths to load")
+    nav_paths_group.add_argument("--nav-paths", type=Path, dest="nav_paths")
+    viz_parser.add_argument("--html", action="store_true")
+    viz_parser.add_argument("--json", action="store_true")
+    viz_parser.add_argument("--png", action="store_true")
+
+
+def handle_mc_command(args: argparse.Namespace) -> int:
+    """Run the shared scenario behavior behind the canonical parser."""
+
+    if getattr(args, "mc_command", None) == "viz":
+        from trend.mc.viz import execute_mc_viz_cli
+
+        try:
+            return execute_mc_viz_cli(
+                bundle_path=args.bundle,
+                out_dir=args.out,
+                charts=args.charts,
+                fold_id=getattr(args, "fold", None),
+                nav_paths=getattr(args, "nav_paths", None),
+                html=args.html,
+                json=args.json,
+                png=args.png,
+            )
+        except (TrendCLIError, OSError, ValueError) as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+    return _legacy_cli._handle_mc_command(args)
+
+
+# Transitional public helpers keep focused scenario tests independent of the
+# compatibility entry point while the implementation is shared.
+validate_mc_scenario = _legacy_cli._validate_mc_scenario
+write_mc_manifest = _legacy_cli._write_mc_manifest
+is_valid_tqdm_instance = _legacy_cli._is_valid_tqdm_instance

--- a/src/trend/mc/commands.py
+++ b/src/trend/mc/commands.py
@@ -77,7 +77,7 @@ def handle_mc_command(args: argparse.Namespace) -> int:
             )
         except TrendCLIError as exc:
             print(f"Error: {exc}", file=sys.stderr)
-            return 2
+            return 1
         except (OSError, ValueError) as exc:
             print(str(exc), file=sys.stderr)
             return 1

--- a/tests/integration/test_mc_viz.py
+++ b/tests/integration/test_mc_viz.py
@@ -466,7 +466,7 @@ def test_mc_viz_cli_fails_when_png_only_and_kaleido_missing(
         png=True,
     )
 
-    assert result.returncode == 2
+    assert result.returncode == 1
     assert "PNG export requires a working kaleido installation" in result.stderr
     assert "pip install kaleido" in result.stderr
     assert not (out_dir / "plots").exists()

--- a/tests/monte_carlo/test_costs.py
+++ b/tests/monte_carlo/test_costs.py
@@ -269,7 +269,7 @@ def test_cost_regime_scenario_documents_exact_dry_run_command() -> None:
     scenario_file = Path("config/scenarios/monte_carlo/cost_regime_example.yml")
     scenario_text = scenario_file.read_text(encoding="utf-8")
     assert (
-        "# - Run with: python -m trend_analysis.cli mc run --scenario cost_regime_example --dry-run --n-paths 10"
+        "# - Run with: trend mc run --scenario cost_regime_example --dry-run --n-paths 10"
         in scenario_text
     )
     assert (

--- a/tests/monte_carlo/test_output_contract.py
+++ b/tests/monte_carlo/test_output_contract.py
@@ -4,7 +4,7 @@ import json
 
 import pandas as pd
 
-from trend_analysis.cli import _write_mc_manifest
+from trend.mc.commands import write_mc_manifest
 from trend_analysis.monte_carlo.aggregator import aggregate_monte_carlo_results
 from trend_analysis.monte_carlo.export import export_aggregation_results
 from trend_analysis.monte_carlo.results import (
@@ -81,7 +81,7 @@ def test_mc_manifest_indexes_cli_exported_results_only(tmp_path) -> None:
         ),
     )
 
-    manifest_path = _write_mc_manifest(
+    manifest_path = write_mc_manifest(
         tmp_path,
         scenario=scenario,
         results=results,

--- a/tests/monte_carlo/test_scenario.py
+++ b/tests/monte_carlo/test_scenario.py
@@ -6,7 +6,7 @@ from typing import Mapping
 import pytest
 import yaml
 
-from trend_analysis.cli import _validate_mc_scenario
+from trend.mc.commands import validate_mc_scenario
 from trend_analysis.monte_carlo import (
     MonteCarloScenario,
     MonteCarloSettings,
@@ -301,7 +301,7 @@ def test_validate_mc_scenario_reports_misspelled_rf_override(tmp_path: Path) -> 
         raw={"metrics": {"rf_override_enbaled": True}},
     )
 
-    errors = _validate_mc_scenario(scenario)
+    errors = validate_mc_scenario(scenario)
 
     assert any("metrics.rf_override_enbaled" in error for error in errors)
     assert not any("Strategy 'base' config invalid" in error for error in errors)

--- a/tests/test_cli_mc.py
+++ b/tests/test_cli_mc.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 
 import trend_analysis.monte_carlo.runner as runner_module
-from trend_analysis import cli
+from trend import cli
 from trend_analysis.api import RunResult
 from trend_analysis.monte_carlo.results import MonteCarloResults
 from trend_analysis.monte_carlo.scenario import MonteCarloScenario, MonteCarloSettings
@@ -121,7 +121,7 @@ metrics:
     assert "metrics.rf_override_enbaled" in err
 
 
-def test_mc_run_overrides_and_manifest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_trend_mc_run_dispatches_scenario(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     scenario_path = tmp_path / "scenario.yml"
     data_path = tmp_path / "prices.csv"
     output_dir = tmp_path / "bundle"
@@ -208,9 +208,7 @@ def test_mc_run_rejects_invalid_format_overrides(
     assert "format overrides contains unsupported values: xml" in err
 
 
-def test_mc_manifest_includes_required_keys_and_uses_utc_timestamp(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_mc_manifest_includes_required_keys_and_uses_utc_timestamp(tmp_path: Path) -> None:
     settings = MonteCarloSettings(
         mode="two_layer",
         n_paths=5,
@@ -236,17 +234,6 @@ def test_mc_manifest_includes_required_keys_and_uses_utc_timestamp(
         summary_frame=summary_frame,
     )
 
-    captured: dict[str, object] = {}
-    fixed_time = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
-
-    class FixedDateTime(datetime):
-        @classmethod
-        def now(cls, tz=None):  # type: ignore[override]
-            captured["tz"] = tz
-            return fixed_time if tz is not None else fixed_time.replace(tzinfo=None)
-
-    monkeypatch.setattr(cli, "datetime", FixedDateTime)
-
     output_dir = tmp_path / "manifest"
     manifest_path = cli._write_mc_manifest(
         output_dir,
@@ -264,8 +251,9 @@ def test_mc_manifest_includes_required_keys_and_uses_utc_timestamp(
     assert settings_payload["n_paths"] == 5
     assert settings_payload["seed"] == 12
     assert settings_payload["jobs"] == 4
-    assert captured["tz"] is timezone.utc
-    assert manifest["created_at"] == fixed_time.isoformat()
+    created_at = datetime.fromisoformat(manifest["created_at"])
+    assert created_at.tzinfo is not None
+    assert created_at.utcoffset() == timezone.utc.utcoffset(created_at)
 
 
 def test_mc_run_shows_progress(

--- a/tests/test_trend_cli.py
+++ b/tests/test_trend_cli.py
@@ -135,7 +135,7 @@ def test_mc_viz_requires_at_least_one_output_flag(
 ) -> None:
     exit_code = main(["mc", "viz", "--bundle", "bundle_dir", "--out", "export_dir"])
 
-    assert exit_code == 2
+    assert exit_code == 1
     err = capsys.readouterr().err
     assert "requires at least one output flag" in err
 
@@ -230,7 +230,7 @@ def test_mc_viz_errors_when_summary_missing(
         ]
     )
 
-    assert exit_code == 2
+    assert exit_code == 1
     err = capsys.readouterr().err
     assert "Missing required MC summary file" in err
 
@@ -256,7 +256,7 @@ def test_mc_viz_errors_when_results_missing(
         ]
     )
 
-    assert exit_code == 2
+    assert exit_code == 1
     err = capsys.readouterr().err
     assert "Missing required MC results file" in err
 
@@ -279,7 +279,7 @@ def test_mc_viz_errors_when_multiple_required_inputs_missing(
         ]
     )
 
-    assert exit_code == 2
+    assert exit_code == 1
     err = capsys.readouterr().err
     assert "Missing required MC input files" in err
     assert "summary" in err
@@ -308,7 +308,7 @@ def test_mc_viz_errors_when_results_file_is_corrupted(
         ]
     )
 
-    assert exit_code == 2
+    assert exit_code == 1
     err = capsys.readouterr().err
     assert "Failed to read results data" in err
 
@@ -335,7 +335,7 @@ def test_mc_viz_errors_when_results_parquet_file_is_corrupted_without_traceback(
         ]
     )
 
-    assert exit_code == 2
+    assert exit_code == 1
     err = capsys.readouterr().err
     assert "results.parquet" in err
     assert "corrupted or not a parquet file" in err
@@ -406,7 +406,7 @@ def test_mc_viz_errors_when_path_dist_requires_nav_paths_parquet(
         ]
     )
 
-    assert exit_code == 2
+    assert exit_code == 1
     err = capsys.readouterr().err
     assert "nav_paths.parquet" in err
     assert "path_dist" in err
@@ -482,7 +482,7 @@ def test_mc_viz_errors_when_fold_nav_paths_exist_but_no_selection_provided(
         ]
     )
 
-    assert exit_code == 2
+    assert exit_code == 1
     err = capsys.readouterr().err
     assert "nav_paths.parquet" in err
     assert "nav_paths_fold_" in err
@@ -566,7 +566,7 @@ def test_mc_viz_errors_when_nav_paths_override_is_not_parquet(
         ]
     )
 
-    assert exit_code == 2
+    assert exit_code == 1
     err = capsys.readouterr().err
     assert "--nav-paths" in err
     assert "Only parquet" in err
@@ -607,7 +607,7 @@ def test_mc_viz_errors_when_unsupported_nav_paths_format_detected_without_parque
         ]
     )
 
-    assert exit_code == 2
+    assert exit_code == 1
     err = capsys.readouterr().err
     assert f"nav_paths.{suffix}" in err
     assert f".{suffix}" in err
@@ -640,7 +640,7 @@ def test_mc_viz_errors_when_chart_identifier_is_invalid(
         ]
     )
 
-    assert exit_code == 2
+    assert exit_code == 1
     err = capsys.readouterr().err
     assert "Unsupported chart identifier" in err
 

--- a/tests/test_trend_cli_help.py
+++ b/tests/test_trend_cli_help.py
@@ -66,5 +66,5 @@ def test_cli_quickstart_documents_each_command_on_its_implemented_surface() -> N
 
     assert "trend report -c config/trend.toml" in quickstart
     assert "trend run -c config/trend.toml -o" not in quickstart
-    assert "python -m trend_analysis.cli mc list" in quickstart
-    assert "trend mc list" not in quickstart
+    assert "trend mc list" in quickstart
+    assert "python -m trend_analysis.cli mc list" not in quickstart


### PR DESCRIPTION
Closes #5849

## Summary
- expose `list`, `validate`, `run`, and `viz` through the canonical `trend mc` parser
- keep scenario behavior shared during the compatibility migration, without a third implementation
- retarget focused tests, docs, and scenario guidance to `trend mc`

## Validation
- `PYTHONPATH=src python -m pytest tests/test_cli_mc.py tests/monte_carlo/test_scenario.py tests/monte_carlo/test_output_contract.py tests/test_mc_viz_shared_api.py -q` (90 passed)
- `PYTHONPATH=src python -m trend.cli mc run --scenario cost_regime_example --dry-run --n-paths 10`
- `python -m ruff check ...`; `python -m black --check --target-version py312 ...`; `git diff --check`
- Deliberate-break: temporarily removed the `run` parser registration; `tests/test_cli_mc.py::test_trend_mc_run_dispatches_scenario` failed with invalid `mc_command`, then passed after restoration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the canonical `trend mc` command group for listing, validating, running, and visualizing Monte Carlo scenarios.
  * Improved visualization error handling with clear messages and consistent exit status.

* **Documentation**
  * Updated Monte Carlo guides and examples to use `trend mc` commands.
  * Clarified that legacy command aliases are being phased out.

* **Bug Fixes**
  * Standardized exit codes for runtime, input, and visualization errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->