### PR TITLE
fix: complete aware UTC settings evidence

### DIFF
--- a/scripts/generate_settings_evidence.py
+++ b/scripts/generate_settings_evidence.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -73,7 +73,7 @@ def run_single_setting_test(
         "setting_name": setting_name,
         "category": setting_config.get("category", "Uncategorized"),
         "description": setting_config.get("description", ""),
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": datetime.now(UTC).isoformat(),
         "status": "UNKNOWN",
         "baseline_value": None,
         "test_value": None,
@@ -367,7 +367,7 @@ def generate_summary_report(all_evidence: list[dict[str, Any]]) -> str:
     lines = [
         "# Settings Wiring Evidence Summary",
         "",
-        f"**Generated:** {datetime.now().isoformat()}",
+        f"**Generated:** {datetime.now(UTC).isoformat()}",
         "**Data Source:** Trend Universe Data",
         "",
         "## Overview",

--- a/tests/scripts/test_generate_settings_evidence_timestamps.py
+++ b/tests/scripts/test_generate_settings_evidence_timestamps.py
@@ -1,0 +1,33 @@
+"""Regression coverage for settings-evidence timestamps."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pandas as pd
+
+from scripts import generate_settings_evidence as evidence
+
+
+def _assert_aware_utc(timestamp: str) -> None:
+    parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset() == UTC.utcoffset(parsed)
+
+
+def test_generated_evidence_timestamps_are_aware_utc(monkeypatch) -> None:
+    monkeypatch.setattr(evidence, "run_analysis_with_state", lambda *_: {})
+    monkeypatch.setattr(evidence, "extract_metric", lambda *_: 1.0)
+
+    result = evidence.run_single_setting_test(
+        "lookback_periods",
+        {"test_value": 18, "expected_metric": "Sharpe"},
+        pd.DataFrame({"asset": [0.01]}),
+        {"lookback_periods": 12},
+    )
+
+    _assert_aware_utc(result["timestamp"])
+    generated_line = next(
+        line for line in evidence.generate_summary_report([]).splitlines() if "Generated:" in line
+    )
+    _assert_aware_utc(generated_line.split("**Generated:** ", 1)[1])


### PR DESCRIPTION
Fixes #5846

Closes the verifier-reported completeness gap from merged #5868: `generate_settings_evidence.py` now emits aware UTC timestamps for individual evidence and summary output, with focused regression coverage.

Validation: `python -m pytest tests/scripts/test_generate_settings_evidence_timestamps.py tests/scripts/test_evaluate_settings_effectiveness.py -q` (6 passed); Ruff and `git diff --check` pass.