### PR TITLE
Gemini bootstrap for #5813

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -150,10 +150,12 @@ jobs:
           # reducing the ignored count from ~81 to 76.
           # Raised 76 -> 83: #5821 shared trend_spec_from_mapping reads legacy
           # signals.trend_* alias keys during the demo coverage run.
+          # Raised 83 -> 85: #5813 api.run_simulation now resolves portfolio costs and
+          # weighting through the shared config_contract helpers during demo runs.
           # Approved repo-specific divergence per create-only gate policy.
           python scripts/check_config_coverage.py \
             --config config/demo.yml \
-            --ignored-threshold 83
+            --ignored-threshold 85
 
   summary:
     name: gate-summary

--- a/agents/gemini-5813.md
+++ b/agents/gemini-5813.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for gemini on issue #5813 -->

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -283,13 +283,13 @@ def _legacy_callable(name: str, fallback: Callable[..., Any]) -> Callable[..., A
 # failures.  It is defined in the shared ``trend.mc.viz`` module so that the
 # Monte Carlo visualisation pipeline can raise the same exception type
 # regardless of which CLI entry-point invoked it.
-from trend.mc.viz import TrendCLIError  # noqa: E402
 from trend.mc.commands import (  # noqa: E402
     add_mc_subparsers,
     handle_mc_command,
     is_valid_tqdm_instance,
     write_mc_manifest,
 )
+from trend.mc.viz import TrendCLIError  # noqa: E402
 
 
 def _write_mc_manifest(*args: Any, **kwargs: Any) -> Path:

--- a/src/trend/mc/commands.py
+++ b/src/trend/mc/commands.py
@@ -11,8 +11,8 @@ import argparse
 import sys
 from pathlib import Path
 
-from trend_analysis import cli as _legacy_cli
 from trend.mc.viz import TrendCLIError
+from trend_analysis import cli as _legacy_cli
 
 
 def add_mc_subparsers(parent: argparse.ArgumentParser) -> None:

--- a/src/trend_analysis/api.py
+++ b/src/trend_analysis/api.py
@@ -4,7 +4,6 @@ import logging
 import random
 import sys
 import time
-import warnings
 from collections.abc import Mapping, Sized
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, SupportsInt, cast

--- a/src/trend_analysis/api.py
+++ b/src/trend_analysis/api.py
@@ -27,6 +27,10 @@ from trend.validation import (
 )
 
 from .diagnostics import PipelineReasonCode, coerce_pipeline_result
+from .config_contract import (
+    resolve_pipeline_monthly_cost,
+    resolve_portfolio_weighting_name,
+)
 from .llm.analysis_fleet import record_analysis_run
 from .logging import log_step as _log_step  # lightweight import
 from .pipeline import (
@@ -473,27 +477,9 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
         )
         return result
 
-    # Single-period path: ``run.monthly_cost``, ``portfolio.max_turnover``, and
-    # ``portfolio.lambda_tc`` affect costs/turnover here (see stages/portfolio.py).
-    # ``portfolio.transaction_cost_bps`` is a turnover-based lever that is only
-    # charged by the multi-period engine, so a value set on a single-period run is
-    # silently ignored. Warn loudly rather than leaving the no-op undocumented
-    # (issue #5394 / A14).
     portfolio_cfg = getattr(config, "portfolio", {}) or {}
-    try:
-        _tc_bps = float(portfolio_cfg.get("transaction_cost_bps", 0.0) or 0.0)
-    except (TypeError, ValueError):
-        _tc_bps = 0.0
-    if _tc_bps > 0.0:
-        _tc_msg = (
-            "portfolio.transaction_cost_bps=%s is ignored on the single-period analysis "
-            "path; turnover-based transaction costs are only charged by the multi-period "
-            "engine. Single-period runs apply run.monthly_cost, portfolio.max_turnover, "
-            "and portfolio.lambda_tc. Enable multi_period or use run.monthly_cost to model "
-            "single-period costs."
-        ) % _tc_bps
-        warnings.warn(_tc_msg, UserWarning, stacklevel=2)
-        logger.warning(_tc_msg)
+    run_cfg = getattr(config, "run", {}) or {}
+    monthly_cost = resolve_pipeline_monthly_cost(run_cfg, portfolio_cfg)
 
     validation_frame = validate_prices_frame(build_validation_frame(returns))
 
@@ -551,7 +537,7 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
         missing_section if isinstance(missing_section, Mapping) else None
     )
 
-    weighting_scheme = config.portfolio.get("weighting_scheme", "equal")
+    weighting_scheme = resolve_portfolio_weighting_name(portfolio_cfg)
     robustness_cfg = config.portfolio.get("robustness")
     if not isinstance(robustness_cfg, Mapping):
         robustness_cfg = getattr(config, "robustness", None)
@@ -584,7 +570,7 @@ def run_simulation(config: ConfigType, returns: pd.DataFrame) -> RunResult:
         resolved_split["out_start"],
         resolved_split["out_end"],
         _resolve_target_vol(vol_adjust_cfg),
-        getattr(config, "run", {}).get("monthly_cost", 0.0),
+        monthly_cost,
         floor_vol=vol_adjust_cfg.get("floor_vol"),
         warmup_periods=int(vol_adjust_cfg.get("warmup_periods", 0) or 0),
         selection_mode=config.portfolio.get("selection_mode", "all"),

--- a/src/trend_analysis/api.py
+++ b/src/trend_analysis/api.py
@@ -25,11 +25,11 @@ from trend.validation import (
     validate_prices_frame,
 )
 
-from .diagnostics import PipelineReasonCode, coerce_pipeline_result
 from .config_contract import (
     resolve_pipeline_monthly_cost,
     resolve_portfolio_weighting_name,
 )
+from .diagnostics import PipelineReasonCode, coerce_pipeline_result
 from .llm.analysis_fleet import record_analysis_run
 from .logging import log_step as _log_step  # lightweight import
 from .pipeline import (

--- a/tests/app/test_analysis_runner_config.py
+++ b/tests/app/test_analysis_runner_config.py
@@ -137,8 +137,8 @@ def test_analysis_runner_uses_canonical_config_model(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "streamlit", stub)
 
-    from trend_analysis.config.models import Config
     from streamlit_app.components.analysis_runner import AnalysisPayload, _build_config
+    from trend_analysis.config.models import Config
 
     returns = pd.DataFrame(
         {"FundA": [0.01, 0.02]},

--- a/tests/test_entrypoint_contract_parity.py
+++ b/tests/test_entrypoint_contract_parity.py
@@ -8,12 +8,12 @@ import pytest
 from trend_analysis import api
 from trend_analysis.config import Config
 from trend_analysis.config.model import CostModelSettings
-from trend_analysis.multi_period import run as run_mp
 from trend_analysis.config_contract import (
     resolve_pipeline_monthly_cost,
     resolve_portfolio_cost_bps,
     resolve_portfolio_weighting_name,
 )
+from trend_analysis.multi_period import run as run_mp
 from trend_analysis.multi_period.engine import (
     _resolve_pipeline_monthly_cost,
     _resolve_portfolio_cost_bps,

--- a/tests/test_entrypoint_contract_parity.py
+++ b/tests/test_entrypoint_contract_parity.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import pandas as pd
 import pytest
 
+from trend_analysis import api
+from trend_analysis.config import Config
 from trend_analysis.config.model import CostModelSettings
+from trend_analysis.multi_period import run as run_mp
 from trend_analysis.config_contract import (
     resolve_pipeline_monthly_cost,
     resolve_portfolio_cost_bps,
@@ -21,8 +25,64 @@ from trend_analysis.pipeline_entrypoints import (
 )
 
 
-def test_same_config_same_numbers_across_entrypoints() -> None:
-    """Cost and weighting inputs agree before either entry point executes them."""
+def _parity_returns_frame() -> pd.DataFrame:
+    dates = pd.date_range("2020-01-31", periods=6, freq="ME")
+    return pd.DataFrame({"Date": dates, "RF": 0.0, "A": 0.01, "B": 0.02, "C": 0.005})
+
+
+def _single_period_cfg(portfolio: dict[str, object]) -> Config:
+    return Config(
+        version="1",
+        data={
+            "risk_free_column": "RF",
+            "allow_risk_free_fallback": False,
+            "date_column": "Date",
+            "frequency": "M",
+        },
+        preprocessing={},
+        vol_adjust={"target_vol": 1.0},
+        sample_split={
+            "in_start": "2020-01",
+            "in_end": "2020-03",
+            "out_start": "2020-04",
+            "out_end": "2020-06",
+        },
+        portfolio=dict(portfolio),
+        metrics={},
+        export={},
+        run={},
+    )
+
+
+def _multi_period_cfg(portfolio: dict[str, object]) -> Config:
+    portfolio_cfg = dict(portfolio)
+    portfolio_cfg.setdefault("policy", "threshold_hold")
+    return Config(
+        version="1",
+        data={
+            "risk_free_column": "RF",
+            "allow_risk_free_fallback": False,
+            "date_column": "Date",
+            "frequency": "M",
+        },
+        preprocessing={},
+        vol_adjust={"target_vol": 1.0},
+        portfolio=portfolio_cfg,
+        metrics={},
+        export={},
+        run={},
+        multi_period={
+            "frequency": "M",
+            "in_sample_len": 2,
+            "out_sample_len": 1,
+            "start": "2020-01",
+            "end": "2020-06",
+        },
+    )
+
+
+def test_same_config_same_numbers_across_entrypoints(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The same portfolio config yields matching costs and weighting on both paths."""
 
     portfolio = {
         "transaction_cost_bps": 12,
@@ -30,6 +90,7 @@ def test_same_config_same_numbers_across_entrypoints() -> None:
         "weighting": {"name": "score_prop_bayes"},
     }
     run = {"monthly_cost": 0.0}
+    returns = _parity_returns_frame()
 
     single_cost = _resolve_single_period_monthly_cost(portfolio, run)
     multi_tc_bps, multi_slippage_bps = _resolve_portfolio_cost_bps(portfolio)
@@ -48,6 +109,42 @@ def test_same_config_same_numbers_across_entrypoints() -> None:
     zero_cost = _resolve_single_period_monthly_cost({"transaction_cost_bps": 0}, run)
     assert gross_return - single_cost < gross_return - zero_cost
     assert gross_return - multi_cost < gross_return - zero_cost
+
+    zero_portfolio = dict(portfolio)
+    zero_portfolio["transaction_cost_bps"] = 0.0
+    zero_portfolio["cost_model"] = {}
+
+    single_zero = api.run_simulation(_single_period_cfg(zero_portfolio), returns)
+    single_charged = api.run_simulation(_single_period_cfg(portfolio), returns)
+    assert single_charged.portfolio is not None
+    assert single_zero.portfolio is not None
+    assert single_charged.portfolio.mean() < single_zero.portfolio.mean()
+
+    mp_zero = run_mp(_multi_period_cfg(zero_portfolio), returns.copy())
+    mp_charged = run_mp(_multi_period_cfg(portfolio), returns.copy())
+    assert mp_charged, "multi-period path returned no periods"
+    charged_costs = [res["transaction_cost"] for res in mp_charged if "transaction_cost" in res]
+    zero_costs = [res["transaction_cost"] for res in mp_zero if "transaction_cost" in res]
+    assert charged_costs and zero_costs
+    assert sum(charged_costs) > sum(zero_costs)
+
+    weight_portfolio = {"weighting": {"name": "hrp"}, "transaction_cost_bps": 0.0}
+    captured: dict[str, object] = {}
+
+    def fake_single_run(*args: object, **kwargs: object) -> dict[str, object]:
+        captured["single_weighting_scheme"] = kwargs.get("weighting_scheme")
+        return {
+            "out_sample_stats": {},
+            "benchmark_ir": {},
+            "score_frame": pd.DataFrame(),
+        }
+
+    monkeypatch.setattr(api, "_run_analysis", fake_single_run)
+    api.run_simulation(_single_period_cfg(weight_portfolio), returns)
+    assert captured["single_weighting_scheme"] == "hrp"
+
+    _, _, _, _, mp_scheme = _resolve_portfolio_weighting(weight_portfolio)
+    assert mp_scheme == "hrp"
 
 
 def test_cost_model_dump_preserves_legacy_values_when_optional_aliases_are_null() -> None:

--- a/tests/test_single_period_costs.py
+++ b/tests/test_single_period_costs.py
@@ -1,17 +1,9 @@
-"""Tests for single-period transaction-cost handling (issue #5394 / A14).
-
-The single-period analysis path charges ``run.monthly_cost`` and still supports
-``portfolio.max_turnover`` / ``portfolio.lambda_tc`` turnover controls; it never
-applies ``portfolio.transaction_cost_bps``, which is a multi-period-only turnover
-lever. Setting it on a single-period run is therefore a silent no-op.
-``run_simulation`` must warn loudly instead.
-"""
+"""Execution-level tests for the single-period transaction-cost contract."""
 
 from __future__ import annotations
 
-import warnings
-
 import pandas as pd
+import pytest
 
 from trend_analysis import api
 from trend_analysis.config import Config
@@ -49,41 +41,34 @@ def _make_single_period_cfg(transaction_cost_bps: float | None) -> Config:
     )
 
 
-def _tc_warnings(records: list[warnings.WarningMessage]) -> list[warnings.WarningMessage]:
-    return [
-        r
-        for r in records
-        if issubclass(r.category, UserWarning)
-        and "transaction_cost_bps" in str(r.message)
-        and "single-period" in str(r.message)
-    ]
-
-
-def test_single_period_warns_when_transaction_cost_bps_set() -> None:
-    """A non-zero ``transaction_cost_bps`` on a single-period run must warn."""
+def test_single_period_transaction_cost_bps_reduces_net_returns() -> None:
+    """The public single-period API charges configured portfolio costs."""
     df = _make_df()
-    cfg = _make_single_period_cfg(transaction_cost_bps=25.0)
+    zero_cost = api.run_simulation(_make_single_period_cfg(0.0), df)
+    charged = api.run_simulation(_make_single_period_cfg(25.0), df)
 
-    with warnings.catch_warnings(record=True) as records:
-        warnings.simplefilter("always")
-        api.run_simulation(cfg, df)
-
-    matches = _tc_warnings(records)
-    assert matches, (
-        "expected a UserWarning that single-period transaction_cost_bps is ignored; "
-        f"got categories/messages: {[(type(r.message).__name__, str(r.message)) for r in records]}"
-    )
-    assert "25.0" in str(matches[0].message)
-    assert "portfolio.lambda_tc" in str(matches[0].message)
+    assert charged.portfolio is not None
+    assert zero_cost.portfolio is not None
+    assert charged.portfolio.mean() < zero_cost.portfolio.mean()
 
 
-def test_single_period_silent_when_transaction_cost_bps_unset() -> None:
-    """No transaction-cost warning when the key is absent (avoid noise)."""
-    df = _make_df()
-    cfg = _make_single_period_cfg(transaction_cost_bps=None)
+def test_single_period_api_passes_nested_weighting_name_to_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public API resolves nested weighting names before pipeline dispatch."""
+    cfg = _make_single_period_cfg(0.0)
+    cfg.portfolio = {"weighting": {"name": "score_prop_bayes"}}
+    captured: dict[str, object] = {}
 
-    with warnings.catch_warnings(record=True) as records:
-        warnings.simplefilter("always")
-        api.run_simulation(cfg, df)
+    def fake_run_analysis(*args: object, **kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {
+            "out_sample_stats": {},
+            "benchmark_ir": {},
+            "score_frame": pd.DataFrame(),
+        }
 
-    assert not _tc_warnings(records)
+    monkeypatch.setattr(api, "_run_analysis", fake_run_analysis)
+    api.run_simulation(cfg, _make_df())
+
+    assert captured["weighting_scheme"] == "score_prop_bayes"


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:5813 -->

### Source Issue #5813: Same config, different numbers by entry point: single-period ignores transaction costs and weighting.name; vol_adjust.enabled and harness ddof also split

Base: phase-3
Head: gemini/issue-5813

Source: https://github.com/stranske/Trend_Model_Project/issues/5813

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The same configuration produces different numbers depending on which entry point runs it. Transaction costs, weighting scheme, and volatility-targeting are each honoured on one path and ignored or stripped on another. For an allocator tool whose selling point is reproducible config-driven runs, this is the highest-consequence class of defect in the repo.

The 2026-06-01 audit found these as single-path defects and they were closed (#5389–#5439). The fixes were applied to the **multi-period** path; the **single-period** path and the strict config model were not brought along. Two independent audit passes (gemini wiring pass, cursor duplication pass) found the cost split separately at tip `b45d1780`.

#### Tasks
- [ ] Route the single-period path through the same cost resolution the multi-period path uses, so `portfolio.transaction_cost_bps` and `portfolio.cost_model.*` take effect (`stages/portfolio.py:571-572,803-804`; `pipeline_entrypoints.py:108-117`).
- [ ] Make the single-period path resolve `portfolio.weighting.name` as well as `portfolio.weighting_scheme`, using the multi-period resolver (`multi_period/engine.py:178-274`) rather than a second copy.
- [ ] Decide the intended semantics of `vol_adjust.enabled` and implement it in one place: either stop popping it at `config/model.py:551-559` and have `stages/portfolio.py` gate on it, or formally deprecate it (warn on use, remove from `config/defaults.yml` and `config/demo.yml`, and drop the `pipeline_helpers.py:79,436` reads). Do not leave both behaviours live.
- [ ] Resolve the `ddof` split: have `harness.py:597` use the canonical metric helpers, or document an explicit, tested reason for `ddof=0`.
- [ ] Add the cross-entry-point parity cases named in Acceptance Criteria to `tests/test_entrypoint_contract_parity.py`.

#### Acceptance Criteria
- [ ] A config with a non-zero `portfolio.transaction_cost_bps` produces **lower** net returns than the same config with zero, on the single-period path as well as the multi-period path (direction check).
- [ ] A config with `portfolio.weighting.name: score_prop_bayes` and no `weighting_scheme` produces non-equal weights on the single-period path.
- [ ] `vol_adjust.enabled: false` has one documented, tested meaning that is identical on every path that consumes it.
- [ ] `harness.py` and the canonical metrics report the same Sharpe and volatility for the same return series, or the difference is asserted deliberately by a test that names the reason.
- [ ] **Named test gate**: `tests/test_entrypoint_contract_parity.py::test_same_config_same_numbers_across_entrypoints` runs one fixture config through the single-period and multi-period entry points and asserts the cost-sensitive and weighting-sensitive outputs agree (within a stated tolerance), plus a direction assertion that raising `transaction_cost_bps` lowers net return on **both**.
- [ ] **Deliberate-break demonstration**: revert the single-period cost wiring only, confirm `test_same_config_same_numbers_across_entrypoints` **fails**, then restore and confirm it passes. Record both outcomes in the PR description.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

The same configuration produces different numbers depending on which entry point runs it. Transaction costs, weighting scheme, and volatility-targeting are each honoured on one path and ignored or stripped on another. For an allocator tool whose selling point is reproducible config-driven runs, this is the highest-consequence class of defect in the repo.

The 2026-06-01 audit found these as single-path defects and they were closed (#5389–#5439). The fixes were applied to the **multi-period** path; the **single-period** path and the strict config model were not brought along. Two independent audit passes (gemini wiring pass, cursor duplication pass) found the cost split separately at tip `b45d1780`.

**1. Transaction costs — single-period path ignores them entirely.**
- Multi-period honours `CostModel` (`src/trend_analysis/multi_period/engine.py:315-350`).
- Single-period deducts only the flat `run.monthly_cost` (`src/trend_analysis/stages/portfolio.py:571-572`, `:803-804`; `src/trend_analysis/pipeline_entrypoints.py:108-117`), so configured `portfolio.transaction_cost_bps` and `portfolio.cost_model.*` have **zero effect** on single-period returns and every metric derived from them. Also reachable via `src/trend_analysis/api.py:488`.

**2. Weighting — `portfolio.weighting.name` is inert on the single-period path.**
- Multi-period resolves both keys (`multi_period/engine.py:178-274`).
- Single-period inspects only `portfolio.weighting_scheme` (`pipeline_entrypoints.py:109`, `stages/portfolio.py:288`) and silently falls back to `"equal"`. `config/defaults.yml:95` ships `portfolio.weighting.name: score_prop_bayes`, which therefore does nothing on that path.

**3. `vol_adjust.enabled` semantics are path-dependent.**
- `pipeline_helpers.py:79` and `:436` **do** read `enabled` from the raw config section.
- The strict config model **pops it**: `config/model.py:551-559`, `_drop_legacy_runtime_flags` removes `enabled` and `window` before validation (the model is `extra="forbid"`, so popping is how the legacy key is tolerated).
- `stages/portfolio.py:472,499` gates volatility scaling on `if target_vol is None:` — not on `enabled`.
- `config/demo.yml:19` sets `enabled: false` with the comment `# keep it off for speed`, so a shipped config expresses an intent whose effect depends on which path consumes it.

**4. The two engines disagree on Sharpe/volatility by construction.**
- `src/trend_analysis/backtesting/harness.py:597` computes both volatility and Sharpe with `active_returns.std(ddof=0)`.
- The canonical metrics use `ddof=1` (`src/trend_analysis/metrics/__init__.py:213`).
- On a 12-period out-of-sample window that is a ~4.4% systematic difference in volatility (`sqrt(12/11)`), so the harness and the main pipeline will report different risk for identical inputs.

None of this is caught by the suite: each path is tested in isolation, and no test asserts that the **same config through different entry points** yields the same numbers.

## Scope

Establish one cost/weighting/vol-adjust contract that every entry point honours identically, and add a cross-entry-point parity test that fails when they diverge. Treat this as **one contract change**, not four separate patches — that is the lesson of the previous fix arc.

## Non-Goals

- Do **not** change the economics of the cost model, the weighting implementations, or the vol-targeting maths. This issue is about **which code reads which key**, not about the formulas.
- Do **not** delete `backtesting/harness.py`. Decide and document whether it is a second engine or a thin delegator; if it must keep `ddof=0` for a stated reason, record that reason in the code and make the difference explicit rather than incidental.
- Do **not** change `config/demo.yml`'s intent (`vol_adjust.enabled: false`) as a way of hiding the inconsistency.
- Do **not** silently start charging costs on paths where a documented decision says they should not apply — if any such decision exists, state it in `Implementation Notes` on the PR and gate accordingly.
- Do not add a scaffold/TODO placeholder in place of a real fix.

## Tasks

- [ ] Route the single-period path through the same cost resolution the multi-period path uses, so `portfolio.transaction_cost_bps` and `portfolio.cost_model.*` take effect (`stages/portfolio.py:571-572,803-804`; `pipeline_entrypoints.py:108-117`).
- [ ] Make the single-period path resolve `portfolio.weighting.name` as well as `portfolio.weighting_scheme`, using the multi-period resolver (`multi_period/engine.py:178-274`) rather than a second copy.
- [ ] Decide the intended semantics of `vol_adjust.enabled` and implement it in one place: either stop popping it at `config/model.py:551-559` and have `stages/portfolio.py` gate on it, or formally deprecate it (warn on use, remove from `config/defaults.yml` and `config/demo.yml`, and drop the `pipeline_helpers.py:79,436` reads). Do not leave both behaviours live.
- [ ] Resolve the `ddof` split: have `harness.py:597` use the canonical metric helpers, or document an explicit, tested reason for `ddof=0`.
- [ ] Add the cross-entry-point parity cases named in Acceptance Criteria to `tests/test_entrypoint_contract_parity.py`.

## Acceptance Criteria

- [ ] A config with a non-zero `portfolio.transaction_cost_bps` produces **lower** net returns than the same config with zero, on the single-period path as well as the multi-period path (direction check).
- [ ] A config with `portfolio.weighting.name: score_prop_bayes` and no `weighting_scheme` produces non-equal weights on the single-period path.
- [ ] `vol_adjust.enabled: false` has one documented, tested meaning that is identical on every path that consumes it.
- [ ] `harness.py` and the canonical metrics report the same Sharpe and volatility for the same return series, or the difference is asserted deliberately by a test that names the reason.
- [ ] **Named test gate**: `tests/test_entrypoint_contract_parity.py::test_same_config_same_numbers_across_entrypoints` runs one fixture config through the single-period and multi-period entry points and asserts the cost-sensitive and weighting-sensitive outputs agree (within a stated tolerance), plus a direction assertion that raising `transaction_cost_bps` lowers net return on **both**.
- [ ] **Deliberate-break demonstration**: revert the single-period cost wiring only, confirm `test_same_config_same_numbers_across_entrypoints` **fails**, then restore and confirm it passes. Record both outcomes in the PR description.

## Implementation Notes

- The fixture must not be homogeneous. The prior audit's own conclusion was that value-level assertions were missing and keys-only checks let wiring bugs survive; use a config that exercises non-default cost bps, a non-equal weighting scheme, and a non-`None` `target_vol`.
- gemini's full wiring pass and cursor's duplication pass are stored at `Code/Audits/Trend_Model_Project/2026-08-11-01-wiring.md` and `…-02-quality-dup.md` and contain the complete line inventories behind the four items above.
- One related claim was **checked and downgraded** during the audit and should not be treated as part of this issue: `data.frequency` is *not* simply "hardcoded to 12" — `infer_periods_per_year()` exists (`util/frequency.py:159`), `regimes.py` threads `periods_per_year` with a frequency-derived default, and `pipeline.py:246` accepts an override. The narrower true statement is that `12` is the metrics-layer default and end-to-end honouring is path-dependent. If you want that closed too, file it separately.



</details>

—
PR created automatically to engage Gemini.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Transaction costs are now consistently applied to single-period and multi-period analyses.
  * Portfolio weighting settings, including HRP, are now resolved consistently across analysis entry points.
  * Configuration behavior is more consistent when using nested cost and weighting settings.

* **Documentation**
  * Added a bootstrap note for Gemini related to issue 5813.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->