### PR TITLE
Legacy removal Phase 2b: modularize trend CLI and remove old CLI coupling

### DIFF
--- a/scripts/_run_multi_demo.py
+++ b/scripts/_run_multi_demo.py
@@ -2340,7 +2340,7 @@ subprocess.run(
 )
 
 subprocess.run(
-    ["scripts/trend-model", "--check", "run", "-c", "config/demo.yml"],
+    ["scripts/trend-model", "check"],
     check=True,
     shell=False,
 )
@@ -2348,7 +2348,7 @@ subprocess.run(
 env = os.environ.copy()
 env["TREND_CFG"] = "config/demo.yml"
 subprocess.run(
-    ["scripts/trend-model", "--check", "run"],
+    ["scripts/trend-model", "check"],
     check=True,
     env=env,
     shell=False,

--- a/scripts/trend-model
+++ b/scripts/trend-model
@@ -28,7 +28,7 @@ import importlib
 import sys
 
 try:
-    importlib.import_module("trend_analysis.cli")
+    importlib.import_module("trend.cli")
 except ModuleNotFoundError:  # pragma: no cover - shell wrapper guard
     sys.exit(1)
 sys.exit(0)
@@ -39,9 +39,9 @@ if ! can_import_cli "$PYTHON_EXEC"; then
     if [ -n "$SYSTEM_PYTHON" ] && [ "$SYSTEM_PYTHON" != "$PYTHON_EXEC" ] && can_import_cli "$SYSTEM_PYTHON"; then
         PYTHON_EXEC="$SYSTEM_PYTHON"
     else
-        echo "trend_analysis package not installed. Run 'pip install -e .' first." >&2
+        echo "trend package not installed. Run 'pip install -e .' first." >&2
         exit 1
     fi
 fi
 
-PYTHONPATH="${PROJECT_ROOT}/src:${PYTHONPATH:-}" exec "$PYTHON_EXEC" -m trend_analysis.cli "$@"
+PYTHONPATH="${PROJECT_ROOT}/src:${PYTHONPATH:-}" exec "$PYTHON_EXEC" -m trend.cli "$@"

--- a/scripts/trend-reproducible
+++ b/scripts/trend-reproducible
@@ -25,7 +25,7 @@ import importlib
 import sys
 
 try:
-    importlib.import_module("trend_analysis.cli")
+    importlib.import_module("trend.cli")
 except ModuleNotFoundError:  # pragma: no cover - shell wrapper guard
     sys.exit(1)
 sys.exit(0)
@@ -34,13 +34,5 @@ PY
     exit 1
 fi
 
-# Default to the supported CLI module. A leading trend_analysis.* argument can
-# still override the module for compatibility with older direct-module usage.
-MODULE="trend_analysis.cli"
-if [[ "${1:-}" =~ ^trend_analysis\. ]]; then
-    MODULE="$1"
-    shift || true
-fi
-
-# Execute Python with the specified module and remaining arguments
-exec python -m "$MODULE" "$@"
+# Execute the supported CLI module and remaining arguments.
+exec python -m trend.cli "$@"

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -782,6 +782,30 @@ def _write_trend_run_artifacts(
     return manifest_dir
 
 
+def _bundle_config_payload(cfg: Any) -> dict[str, Any]:
+    """Return JSON-serializable config metadata for reproducibility bundles."""
+
+    from trend_analysis.util.hash import normalise_for_json
+
+    if hasattr(cfg, "model_dump"):
+        try:
+            payload: Any = cfg.model_dump()
+        except TypeError:  # pragma: no cover - defensive for exotic configs
+            payload = dict(getattr(cfg, "__dict__", {}))
+    elif hasattr(cfg, "__dict__"):
+        payload = dict(getattr(cfg, "__dict__"))
+    else:
+        payload = cfg if isinstance(cfg, dict) else {}
+    if isinstance(payload, dict):
+        payload = {
+            key: value
+            for key, value in payload.items()
+            if key not in {"_trend_run_spec", "trend_spec", "backtest_spec"}
+        }
+    normalised = normalise_for_json(payload)
+    return normalised if isinstance(normalised, dict) else {"config": normalised}
+
+
 def _write_bundle(
     cfg: Any,
     result: RunResult,
@@ -797,7 +821,7 @@ def _write_bundle(
         bundle_path = bundle_path / "analysis_bundle.zip"
     bundle_path.parent.mkdir(parents=True, exist_ok=True)
     # Attach metadata expected by export_bundle
-    setattr(result, "config", getattr(cfg, "__dict__", {}))
+    setattr(result, "config", _bundle_config_payload(cfg))
     if source_path is not None:
         setattr(result, "input_path", source_path)
     export_bundle(result, bundle_path)

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -23,7 +23,12 @@ from trend.cli_helpers import (
     _apply_universe_mask,
     _attach_universe_paths,
 )
-from trend.cli_support import check_environment, extract_cache_stats, find_prior_run, maybe_log_step
+from trend.cli_support import (
+    check_environment,
+    extract_cache_stats,
+    find_prior_run,
+    maybe_log_step,
+)
 from trend.config_schema import CoreConfigError, load_core_config
 from trend.diagnostics import DiagnosticPayload, DiagnosticResult
 from trend.reporting import generate_unified_report

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -12,8 +12,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from types import ModuleType
-from typing import Any, Callable, Iterable, Mapping, Protocol, Sequence, cast
+from typing import Any, Callable, Iterable, Mapping, Sequence, cast
 
 import numpy as np
 import pandas as pd
@@ -24,6 +23,7 @@ from trend.cli_helpers import (
     _apply_universe_mask,
     _attach_universe_paths,
 )
+from trend.cli_support import check_environment, extract_cache_stats, find_prior_run, maybe_log_step
 from trend.config_schema import CoreConfigError, load_core_config
 from trend.diagnostics import DiagnosticPayload, DiagnosticResult
 from trend.reporting import generate_unified_report
@@ -100,35 +100,14 @@ from trend_analysis.viz.artifacts import extract_bundle_zip
 from trend_model.spec import ensure_run_spec
 from utils.paths import proj_path
 
-LegacyExtractCacheStats = Callable[[object], dict[str, int] | None]
 
-
-class LegacyMaybeLogStep(Protocol):
-    def __call__(self, enabled: bool, run_id: str, event: str, message: str, **fields: Any) -> None:
-        # Protocol method intentionally empty; implementors provide behaviour.
-        ...
-
-
-def _noop_maybe_log_step(
-    enabled: bool, run_id: str, event: str, message: str, **fields: Any
-) -> None:
-    return None
-
-
-_legacy_cli_module: ModuleType | None = None
-_legacy_extract_cache_stats: LegacyExtractCacheStats | None = None
-_legacy_maybe_log_step: LegacyMaybeLogStep = _noop_maybe_log_step
-_ORIGINAL_FALLBACKS: dict[str, Callable[..., Any]] = {}
-_LEGACY_BASELINES: dict[str, Callable[..., Any]] = {}
-
-
-def _report_legacy_pipeline_diagnostic(
+def _report_pipeline_diagnostic(
     diagnostic: DiagnosticPayload,
     *,
     structured_log: bool,
     run_id: str,
 ) -> None:
-    """Surface pipeline diagnostics within the legacy CLI."""
+    """Surface pipeline diagnostics within the public CLI."""
 
     context = diagnostic.context or {}
     text = f"Pipeline skipped ({diagnostic.reason_code}): {diagnostic.message}"
@@ -145,33 +124,7 @@ def _report_legacy_pipeline_diagnostic(
 
 
 def _run_environment_check() -> int:
-    from trend_analysis.cli import check_environment
-
     return check_environment()
-
-
-def _env_flag(name: str) -> bool:
-    value = os.getenv(name, "").strip().lower()
-    return value in {"1", "true", "yes", "on"}
-
-
-_USE_LEGACY_CLI = _env_flag("TREND_FORCE_LEGACY_CLI")
-
-
-def _capture_legacy_baseline(name: str) -> None:
-    module = _refresh_legacy_cli_module()
-    if module is None or name in _LEGACY_BASELINES:
-        return
-    attr = getattr(module, name, None)
-    if callable(attr):
-        _LEGACY_BASELINES[name] = attr
-
-
-def _register_fallback(name: str, fn: Callable[..., Any]) -> None:
-    """Remember the original fallback so monkeypatching works with legacy hooks."""
-
-    _ORIGINAL_FALLBACKS.setdefault(name, fn)
-    _capture_legacy_baseline(name)
 
 
 logger = logging.getLogger(__name__)
@@ -223,35 +176,6 @@ def get_last_perf_log_path() -> Path | None:
     return _PERF_LOG_STATE.last_path
 
 
-def _refresh_legacy_cli_module() -> ModuleType | None:
-    """Return the legacy CLI module, refreshing cached helpers when reloaded."""
-
-    global _legacy_cli_module, _legacy_extract_cache_stats, _legacy_maybe_log_step
-
-    module = sys.modules.get("trend_analysis.cli")
-    if module is None:
-        try:  # pragma: no cover - defensive import guard
-            import trend_analysis.cli as module
-        except Exception:  # pragma: no cover - defensive fallback
-            module = None
-
-    if module is not None and module is not _legacy_cli_module:
-        _legacy_cli_module = module
-        maybe_log_step_fn = getattr(module, "maybe_log_step", None)
-        if callable(maybe_log_step_fn):
-            _legacy_maybe_log_step = cast(LegacyMaybeLogStep, maybe_log_step_fn)
-        _legacy_extract_cache_stats = getattr(module, "_extract_cache_stats", None)
-        for name in _ORIGINAL_FALLBACKS:
-            attr = getattr(module, name, None)
-            if callable(attr) and name not in _LEGACY_BASELINES:
-                _LEGACY_BASELINES[name] = attr
-
-    return module or _legacy_cli_module
-
-
-_refresh_legacy_cli_module()
-
-
 APP_PATH = Path(__file__).resolve().parents[2] / "streamlit_app" / "app.py"
 
 DEFAULT_REPORT_FORMATS = ("csv", "json", "xlsx", "txt")
@@ -260,23 +184,6 @@ SCENARIO_WINDOWS: dict[str, tuple[tuple[str, str], tuple[str, str]]] = {
     "2008": (("2006-01", "2007-12"), ("2008-01", "2009-12")),
     "2020": (("2018-01", "2019-12"), ("2020-01", "2021-12")),
 }
-
-
-def _legacy_callable(name: str, fallback: Callable[..., Any]) -> Callable[..., Any]:
-    original = _ORIGINAL_FALLBACKS.get(name)
-    if original is not None and fallback is not original:
-        return fallback
-    module = _refresh_legacy_cli_module()
-    if module is not None:
-        attr = getattr(module, name, None)
-        if callable(attr):
-            baseline = _LEGACY_BASELINES.get(name)
-            if baseline is None:
-                _LEGACY_BASELINES[name] = attr
-                baseline = attr
-            if _USE_LEGACY_CLI or attr is not baseline:
-                return cast(Callable[..., Any], attr)
-    return fallback
 
 
 # TrendCLIError is the canonical user-facing error for all CLI validation
@@ -304,13 +211,8 @@ def _is_valid_tqdm_instance(candidate: Any) -> bool:
     return is_valid_tqdm_instance(candidate)
 
 
-def build_parser(
-    *, prog: str = "trend", include_gui_alias: bool | None = None
-) -> argparse.ArgumentParser:
+def build_parser(*, prog: str = "trend") -> argparse.ArgumentParser:
     """Construct the argument parser for the unified ``trend`` command."""
-    if include_gui_alias is None:
-        include_gui_alias = prog == "trend-model"
-
     parser = argparse.ArgumentParser(prog=prog)
     sub = parser.add_subparsers(dest="subcommand", required=True)
 
@@ -421,8 +323,6 @@ def build_parser(
     add_mc_subparsers(mc_p)
 
     sub.add_parser("app", help="Launch the Streamlit application")
-    if include_gui_alias:
-        sub.add_parser("gui", help="Launch the app (legacy alias for app)")
 
     quick_p = sub.add_parser("quick-report", help="Build a compact HTML report from run artefacts")
     quick_p.add_argument("--run-id", help="Run identifier (defaults to artefact inference)")
@@ -620,9 +520,6 @@ def _resolve_returns_path(config_path: Path, cfg: Any, override: str | None) -> 
     return _resolve_relative(Path(csv_path), include_config_roots=True)
 
 
-_register_fallback("_resolve_returns_path", _resolve_returns_path)
-
-
 def _ensure_dataframe(path: Path) -> pd.DataFrame:
     try:
         df = load_csv(str(path), errors="raise")
@@ -631,9 +528,6 @@ def _ensure_dataframe(path: Path) -> pd.DataFrame:
     if df is None:
         raise FileNotFoundError(str(path))
     return df
-
-
-_register_fallback("_ensure_dataframe", _ensure_dataframe)
 
 
 def _determine_seed(cfg: Any, override: int | None) -> int:
@@ -697,7 +591,7 @@ def _run_pipeline(
     result = run_simulation(cfg, returns_df)
     diagnostic = getattr(result, "diagnostic", None)
     if diagnostic and not result.details:
-        _report_legacy_pipeline_diagnostic(
+        _report_pipeline_diagnostic(
             diagnostic,
             structured_log=structured_log,
             run_id=run_id,
@@ -736,9 +630,6 @@ def _run_pipeline(
         _write_bundle(cfg, result, source_path, Path(bundle), structured_log, run_id)
 
     return result, run_id, log_path
-
-
-_register_fallback("_run_pipeline", _run_pipeline)
 
 
 def _handle_exports(cfg: Any, result: RunResult, structured_log: bool, run_id: str) -> None:
@@ -930,15 +821,11 @@ def _print_summary(cfg: Any, result: RunResult) -> None:
         str(split.get("out_end", "")),
     )
     print(text)
-    if _legacy_extract_cache_stats is not None:
-        cache_stats = _legacy_extract_cache_stats(result.details)
-        if cache_stats:
-            print("\nCache statistics:")
-            for key, value in cache_stats.items():
-                print(f"  {key.capitalize()}: {value}")
-
-
-_register_fallback("_print_summary", _print_summary)
+    cache_stats = _legacy_extract_cache_stats(result.details)
+    if cache_stats:
+        print("\nCache statistics:")
+        for key, value in cache_stats.items():
+            print(f"  {key.capitalize()}: {value}")
 
 
 def _write_report_files(out_dir: Path, cfg: Any, result: RunResult, *, run_id: str) -> None:
@@ -962,9 +849,6 @@ def _write_report_files(out_dir: Path, cfg: Any, result: RunResult, *, run_id: s
     if turnover_csv_result.diagnostic:
         logger.info(turnover_csv_result.diagnostic.message)
     print(f"Report artefacts written to {out_dir}")
-
-
-_register_fallback("_write_report_files", _write_report_files)
 
 
 def _resolve_report_output_path(output: str | None, export_dir: Path | None, run_id: str) -> Path:
@@ -1192,9 +1076,6 @@ def _load_configuration(path: str) -> Any:
     cfg = load_config(cfg_path)
     ensure_run_spec(cfg, base_path=cfg_path.parent)
     return cfg_path, cfg
-
-
-_register_fallback("_load_configuration", _load_configuration)
 
 
 def _resolve_explain_details_path(args: argparse.Namespace) -> Path:
@@ -1940,7 +1821,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                 deactivate_config_coverage()
             return _run_environment_check()
 
-        if command in {"app", "gui"}:
+        if command == "app":
             if coverage_tracker is not None:
                 deactivate_config_coverage()
             try:
@@ -2137,7 +2018,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                 returns_path = _resolve_returns_path(output_path, cfg, None)
                 returns_df = _ensure_dataframe(returns_path)
                 _determine_seed(cfg, None)
-                run_pipeline = _legacy_callable("_run_pipeline", _run_pipeline)
+                run_pipeline = _run_pipeline
                 run_started = time.perf_counter()
                 run_timestamp = datetime.now(timezone.utc)
                 run_error: str | None = None
@@ -2168,7 +2049,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                         started_at=run_started,
                         timestamp=run_timestamp,
                     )
-                print_summary = _legacy_callable("_print_summary", _print_summary)
+                print_summary = _print_summary
                 print_summary(cfg, result)
                 if log_path:
                     print(f"Structured log: {log_path}")
@@ -2184,14 +2065,14 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
         if command != "mc" and not args.config:
             raise TrendCLIError(f"The --config option is required for the '{command}' command")
 
-        load_config_fn = _legacy_callable("_load_configuration", _load_configuration)
+        load_config_fn = _load_configuration
         cfg_path, cfg = load_config_fn(args.config)
         if coverage_tracker is not None:
             wrap_config_for_coverage(cfg, coverage_tracker)
         ensure_run_spec(cfg, base_path=cfg_path.parent)
-        resolve_returns = _legacy_callable("_resolve_returns_path", _resolve_returns_path)
+        resolve_returns = _resolve_returns_path
         returns_path = resolve_returns(cfg_path, cfg, getattr(args, "returns", None))
-        ensure_df = _legacy_callable("_ensure_dataframe", _ensure_dataframe)
+        ensure_df = _ensure_dataframe
         returns_df = ensure_df(returns_path)
         seed = _determine_seed(cfg, getattr(args, "seed", None))
 
@@ -2219,8 +2100,6 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                 )
                 _attach_universe_paths(cfg, universe_spec, csv_path=str(returns_path))
             if getattr(args, "skip_if_exists", False):
-                from trend_analysis.cli import find_prior_run
-
                 candidate_run_id = working_run_id(cfg, returns_path)
                 existing_manifest = find_prior_run(cfg, candidate_run_id)
                 if existing_manifest is not None:
@@ -2228,7 +2107,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     print(f"Existing manifest: {existing_manifest}")
                     _finalize_config_coverage()
                     return 0
-            run_pipeline = _legacy_callable("_run_pipeline", _run_pipeline)
+            run_pipeline = _run_pipeline
             result, run_id, log_path = run_pipeline(
                 cfg,
                 returns_df,
@@ -2246,7 +2125,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                 run_id=run_id,
                 structured_log=not args.no_structured_log,
             )
-            print_summary = _legacy_callable("_print_summary", _print_summary)
+            print_summary = _print_summary
             print_summary(cfg, result)
             if log_path:
                 print(f"Structured log: {log_path}")
@@ -2261,7 +2140,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                 )
             formats = args.formats or DEFAULT_REPORT_FORMATS
             _prepare_export_config(cfg, export_dir, formats if export_dir is not None else None)
-            run_pipeline = _legacy_callable("_run_pipeline", _run_pipeline)
+            run_pipeline = _run_pipeline
             result, run_id, _ = run_pipeline(
                 cfg,
                 returns_df,
@@ -2270,10 +2149,10 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                 structured_log=False,
                 bundle=None,
             )
-            print_summary = _legacy_callable("_print_summary", _print_summary)
+            print_summary = _print_summary
             print_summary(cfg, result)
             if export_dir is not None:
-                write_report = _legacy_callable("_write_report_files", _write_report_files)
+                write_report = _write_report_files
                 write_report(export_dir, cfg, result, run_id=run_id)
             report_path = _resolve_report_output_path(args.output, export_dir, run_id)
             report_path.parent.mkdir(parents=True, exist_ok=True)
@@ -2306,7 +2185,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
             _adjust_for_scenario(cfg, args.scenario)
             export_dir = Path(args.out) if args.out else None
             _prepare_export_config(cfg, export_dir, None)
-            run_pipeline = _legacy_callable("_run_pipeline", _run_pipeline)
+            run_pipeline = _run_pipeline
             result, run_id, _ = run_pipeline(
                 cfg,
                 returns_df,
@@ -2316,10 +2195,10 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                 bundle=None,
             )
             print(f"Stress scenario '{args.scenario}' completed (seed={seed}).")
-            print_summary = _legacy_callable("_print_summary", _print_summary)
+            print_summary = _print_summary
             print_summary(cfg, result)
             if export_dir:
-                write_report = _legacy_callable("_write_report_files", _write_report_files)
+                write_report = _write_report_files
                 write_report(export_dir, cfg, result, run_id=run_id)
             _finalize_config_coverage()
             return 0
@@ -2335,6 +2214,30 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
             deactivate_config_coverage()
         print(f"Error: {exc}", file=sys.stderr)
         return 2
+
+
+def _noop_maybe_log_step(
+    enabled: bool, run_id: str, event: str, message: str, **fields: Any
+) -> None:
+    return None
+
+
+# Transitional aliases retained while tests migrate off legacy monkeypatch hooks.
+_legacy_cli_module = None
+_legacy_maybe_log_step = maybe_log_step
+_legacy_extract_cache_stats = extract_cache_stats
+
+
+def _refresh_legacy_cli_module() -> None:
+    """Legacy refresh hook retained for transitional tests only."""
+
+    return None
+
+
+def _legacy_callable(name: str, fallback: Callable[..., Any]) -> Callable[..., Any]:
+    """Return the canonical implementation; legacy delegation has been removed."""
+
+    return fallback
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/src/trend/cli_support.py
+++ b/src/trend/cli_support.py
@@ -1,0 +1,105 @@
+"""Stable support seams for the public :mod:`trend.cli` entry point."""
+
+from __future__ import annotations
+
+import numbers
+import platform
+from collections.abc import Mapping, Sequence
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from trend_analysis import logging as run_logging
+from trend_analysis.constants import DEFAULT_OUTPUT_DIRECTORY, DEFAULT_OUTPUT_FORMATS
+from trend_analysis.reporting.run_artifacts import find_existing_run
+
+LOCK_PATH = Path(__file__).resolve().parents[2] / "requirements.lock"
+
+
+def check_environment(lock_path: Path | None = None) -> int:
+    """Print Python and package versions, reporting lockfile mismatches."""
+
+    lock_file = lock_path or LOCK_PATH
+    print(f"Python {platform.python_version()}")
+    if not lock_file.exists():
+        print(f"Lock file not found: {lock_file}")
+        return 1
+    mismatches: list[tuple[str, str | None, str]] = []
+    for line in lock_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "==" not in line:
+            continue
+        name, expected = line.split("==", 1)
+        name, expected = name.strip(), expected.split()[0]
+        try:
+            installed = metadata.version(name)
+        except metadata.PackageNotFoundError:
+            installed = None
+        print(f"{name} {installed or 'not installed'} (expected {expected})")
+        if installed != expected:
+            mismatches.append((name, installed, expected))
+    if mismatches:
+        print("Mismatches detected:")
+        for name, installed, expected in mismatches:
+            print(f"- {name}: installed {installed or 'none'}, expected {expected}")
+        return 1
+    print("All packages match lockfile.")
+    return 0
+
+
+def maybe_log_step(enabled: bool, run_id: str, event: str, message: str, **fields: Any) -> None:
+    """Emit a structured run-log event only when requested."""
+
+    if enabled:
+        run_logging.log_step(run_id, event, message, **fields)
+
+
+def extract_cache_stats(payload: object) -> dict[str, int] | None:
+    """Return the last complete cache-statistics mapping in a result payload."""
+
+    required = ("entries", "hits", "misses", "incremental_updates")
+    found: list[dict[str, int]] = []
+
+    def visit(obj: object) -> None:
+        if isinstance(obj, (pd.Series, pd.DataFrame, np.ndarray)):
+            return
+        if isinstance(obj, Mapping):
+            if all(key in obj for key in required):
+                candidate: dict[str, int] = {}
+                for key in required:
+                    value = obj.get(key)
+                    if isinstance(value, numbers.Integral):
+                        candidate[key] = int(value)
+                    elif isinstance(value, numbers.Real) and float(value).is_integer():
+                        candidate[key] = int(float(value))
+                    else:
+                        break
+                else:
+                    found.append(candidate)
+            for value in obj.values():
+                visit(value)
+        elif isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
+            for item in obj:
+                visit(item)
+
+    visit(payload)
+    return found[-1] if found else None
+
+
+def find_prior_run(cfg: Any, run_id: str) -> Path | None:
+    """Return the manifest for an already-completed run with ``run_id``."""
+
+    export_cfg = getattr(cfg, "export", None)
+    out_dir = out_formats = None
+    if isinstance(export_cfg, Mapping):
+        out_dir, out_formats = export_cfg.get("directory"), export_cfg.get("formats")
+    elif export_cfg is not None:
+        out_dir, out_formats = getattr(export_cfg, "directory", None), getattr(
+            export_cfg, "formats", None
+        )
+    if not out_dir and not out_formats:
+        out_dir, out_formats = DEFAULT_OUTPUT_DIRECTORY, DEFAULT_OUTPUT_FORMATS
+    return find_existing_run(Path(out_dir), run_id) if out_dir and out_formats else None

--- a/src/trend/mc/commands.py
+++ b/src/trend/mc/commands.py
@@ -8,11 +8,32 @@ the migration.  Keeping the parser and dispatch boundary here lets callers use
 from __future__ import annotations
 
 import argparse
+import json
+import numbers
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import pandas as pd
 
 from trend.mc.viz import TrendCLIError
-from trend_analysis import cli as _legacy_cli
+from trend_analysis.config import format_validation_messages, validate_config
+from trend_analysis.io.market_data import (
+    MarketDataMode,
+    MarketDataValidationError,
+    load_market_data_csv,
+    load_market_data_parquet,
+)
+from trend_analysis.monte_carlo import (
+    MonteCarloRunner,
+    MonteCarloScenario,
+    MonteCarloSettings,
+    list_scenarios,
+    load_scenario,
+)
+from trend_analysis.monte_carlo.registry import load_scenario_from_path
+from trend_analysis.monte_carlo.results import MonteCarloResults, export_results
 
 
 def add_mc_subparsers(parent: argparse.ArgumentParser) -> None:
@@ -59,9 +80,9 @@ def add_mc_subparsers(parent: argparse.ArgumentParser) -> None:
 
 
 def handle_mc_command(args: argparse.Namespace) -> int:
-    """Run the shared scenario behavior behind the canonical parser."""
-
-    if getattr(args, "mc_command", None) == "viz":
+    """Dispatch canonical Monte Carlo commands without the legacy CLI."""
+    command = getattr(args, "mc_command", None)
+    if command == "viz":
         from trend.mc.viz import execute_mc_viz_cli
 
         try:
@@ -81,11 +102,244 @@ def handle_mc_command(args: argparse.Namespace) -> int:
         except (OSError, ValueError) as exc:
             print(str(exc), file=sys.stderr)
             return 1
-    return _legacy_cli._handle_mc_command(args)
+    registry = (
+        Path(args.registry).expanduser().resolve() if getattr(args, "registry", None) else None
+    )
+    if command == "list":
+        try:
+            entries = list_scenarios(
+                tags=_parse_tags(getattr(args, "tags", None)), registry_path=registry
+            )
+        except (ValueError, FileNotFoundError, IsADirectoryError) as exc:
+            print(f"Failed to list Monte Carlo scenarios: {exc}", file=sys.stderr)
+            return 1
+        if getattr(args, "format", "table") == "json":
+            print(
+                json.dumps(
+                    [
+                        {
+                            "name": item.name,
+                            "description": item.description,
+                            "tags": list(item.tags),
+                            "path": str(item.path),
+                        }
+                        for item in entries
+                    ],
+                    indent=2,
+                )
+            )
+        else:
+            print(_render_table(entries))
+        return 0
+    if command not in {"validate", "run"}:
+        print("Unknown Monte Carlo command.", file=sys.stderr)
+        return 2
+    try:
+        scenario = _load_scenario(getattr(args, "scenario", "") or "", registry)
+    except (ValueError, FileNotFoundError, IsADirectoryError) as exc:
+        print(f"Scenario {command} failed: {exc}", file=sys.stderr)
+        return 1
+    errors = validate_mc_scenario(scenario)
+    if errors:
+        print(f"Scenario '{scenario.name}' failed validation:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    if command == "validate" or getattr(args, "dry_run", False):
+        print(
+            f"Scenario '{scenario.name}': OK"
+            if command == "validate"
+            else f"Scenario '{scenario.name}' validated. Dry run complete."
+        )
+        return 0
+    try:
+        _apply_overrides(scenario, args)
+        price_history = (
+            _load_price_history(Path(args.data)) if getattr(args, "data", None) else None
+        )
+        runner = MonteCarloRunner(scenario, base_config=None, price_history=price_history)
+        results = runner.run(jobs=getattr(args, "jobs", None))
+        output_dir = Path(
+            getattr(args, "out", None)
+            or f"outputs/monte_carlo/{scenario.name}/{datetime.now(timezone.utc):%Y%m%d-%H%M%S}"
+        )
+        formats = _parse_formats(getattr(args, "formats", None)) or ["csv"]
+        exported = export_results(results, output_dir, formats=formats)
+        write_mc_manifest(
+            output_dir,
+            scenario=scenario,
+            results=results,
+            overrides={
+                key: getattr(args, key)
+                for key in ("n_paths", "jobs", "seed")
+                if getattr(args, key, None) is not None
+            },
+            exported_files=exported,
+            data_path=Path(args.data) if getattr(args, "data", None) else None,
+            jobs_used=runner._resolve_jobs(getattr(args, "jobs", None)),
+        )
+    except (MarketDataValidationError, ValueError) as exc:
+        print(f"Scenario run failed: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"Scenario run failed: {exc}", file=sys.stderr)
+        return 2
+    print(f"Monte Carlo run completed. Output: {output_dir}")
+    return 0
 
 
-# Transitional public helpers keep focused scenario tests independent of the
-# compatibility entry point while the implementation is shared.
-validate_mc_scenario = _legacy_cli._validate_mc_scenario
-write_mc_manifest = _legacy_cli._write_mc_manifest
-is_valid_tqdm_instance = _legacy_cli._is_valid_tqdm_instance
+def _parse_tags(raw: Sequence[str] | None) -> list[str]:
+    return [tag.strip() for item in raw or [] for tag in str(item).split(",") if tag.strip()]
+
+
+def _parse_formats(raw: Sequence[str] | None) -> list[str]:
+    formats = [
+        item.strip().lower()
+        for value in raw or []
+        for item in str(value).split(",")
+        if item.strip()
+    ]
+    invalid = sorted(set(formats) - {"csv", "json", "parquet"})
+    if invalid:
+        raise ValueError(f"format overrides contains unsupported values: {', '.join(invalid)}")
+    return formats
+
+
+def _render_table(entries: Sequence[Any]) -> str:
+    if not entries:
+        return "No Monte Carlo scenarios found."
+    return "\n".join(
+        f"{entry.name}\t{', '.join(entry.tags)}\t{entry.description or ''}\t{entry.path}"
+        for entry in entries
+    )
+
+
+def _load_scenario(raw: str, registry: Path | None) -> MonteCarloScenario:
+    if not raw:
+        raise ValueError("Scenario name is required")
+    path = Path(raw).expanduser()
+    if path.exists():
+        return load_scenario_from_path(path)
+    if path.suffix.lower() in {".yml", ".yaml"}:
+        raise FileNotFoundError(f"Scenario config '{path}' does not exist")
+    return load_scenario(raw, registry_path=registry)
+
+
+def _apply_overrides(scenario: MonteCarloScenario, args: argparse.Namespace) -> None:
+    settings = scenario.monte_carlo
+    if not isinstance(settings, MonteCarloSettings):
+        raise ValueError("monte_carlo settings are not resolved")
+    scenario.monte_carlo = MonteCarloSettings(
+        mode=settings.mode,
+        n_paths=getattr(args, "n_paths", None) or settings.n_paths,
+        horizon_years=settings.horizon_years,
+        frequency=settings.frequency,
+        seed=(
+            getattr(args, "seed", None)
+            if getattr(args, "seed", None) is not None
+            else settings.seed
+        ),
+        jobs=(
+            getattr(args, "jobs", None)
+            if getattr(args, "jobs", None) is not None
+            else settings.jobs
+        ),
+    )
+
+
+def _load_price_history(path: Path) -> pd.DataFrame:
+    validated = (
+        load_market_data_parquet(str(path))
+        if path.suffix.lower() == ".parquet"
+        else load_market_data_csv(str(path))
+    )
+    frame = validated.frame.copy()
+    if validated.metadata.mode == MarketDataMode.RETURNS:
+        if frame.empty or (frame <= -1.0).any().any():
+            raise ValueError("returns data must be non-empty and greater than -1")
+        return (1.0 + frame).cumprod() * 100.0
+    return frame
+
+
+def validate_mc_scenario(scenario: MonteCarloScenario) -> list[str]:
+    try:
+        runner = MonteCarloRunner(scenario)
+    except Exception as exc:
+        return [f"base_config: {exc}"]
+    result = validate_config(
+        dict(runner.base_config),
+        base_path=Path(str(scenario.base_config)).parent,
+        skip_required_fields=True,
+    )
+    schema_errors = [
+        issue for issue in result.errors if issue.message.startswith("Unexpected field")
+    ]
+    if schema_errors:
+        return [
+            f"base_config: {message}"
+            for message in format_validation_messages(
+                result.model_copy(update={"errors": schema_errors}), include_warnings=False
+            )
+        ]
+    return []
+
+
+def write_mc_manifest(
+    output_dir: Path,
+    *,
+    scenario: MonteCarloScenario,
+    results: MonteCarloResults,
+    overrides: Mapping[str, Any],
+    exported_files: Mapping[str, Path],
+    data_path: Path | None,
+    jobs_used: int,
+) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = output_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "scenario": scenario.name,
+                "description": scenario.description,
+                "version": scenario.version,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "base_config": str(scenario.base_config),
+                "data_path": str(data_path) if data_path else None,
+                "settings": {
+                    "mode": scenario.monte_carlo.mode,
+                    "n_paths": scenario.monte_carlo.n_paths,
+                    "horizon_years": scenario.monte_carlo.horizon_years,
+                    "frequency": scenario.monte_carlo.frequency,
+                    "seed": scenario.monte_carlo.seed,
+                    "jobs": jobs_used,
+                },
+                "overrides": dict(overrides),
+                "results": {
+                    "rows": int(results.results_frame.shape[0]),
+                    "summary_rows": int(results.summary_frame.shape[0]),
+                    "errors": len(results.errors),
+                },
+                "outputs": {
+                    "directory": str(output_dir),
+                    "files": {key: str(path) for key, path in exported_files.items()},
+                },
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def is_valid_tqdm_instance(candidate: Any) -> bool:
+    return (
+        candidate is not None
+        and all(callable(getattr(candidate, attr, None)) for attr in ("update", "refresh", "close"))
+        and (
+            getattr(candidate, "total", None) is None
+            or (
+                isinstance(getattr(candidate, "total"), numbers.Real)
+                and float(getattr(candidate, "total")) >= 0
+            )
+        )
+    )

--- a/src/trend/mc/commands.py
+++ b/src/trend/mc/commands.py
@@ -139,6 +139,14 @@ def handle_mc_command(args: argparse.Namespace) -> int:
     except (ValueError, FileNotFoundError, IsADirectoryError) as exc:
         print(f"Scenario {command} failed: {exc}", file=sys.stderr)
         return 1
+    formats: list[str] = []
+    if command == "run":
+        try:
+            _apply_overrides(scenario, args)
+            formats = _parse_formats(getattr(args, "formats", None)) or ["csv"]
+        except ValueError as exc:
+            print(f"Scenario run failed: {exc}", file=sys.stderr)
+            return 1
     errors = validate_mc_scenario(scenario)
     if errors:
         print(f"Scenario '{scenario.name}' failed validation:", file=sys.stderr)
@@ -153,7 +161,6 @@ def handle_mc_command(args: argparse.Namespace) -> int:
         )
         return 0
     try:
-        _apply_overrides(scenario, args)
         price_history = (
             _load_price_history(Path(args.data)) if getattr(args, "data", None) else None
         )
@@ -163,7 +170,6 @@ def handle_mc_command(args: argparse.Namespace) -> int:
             getattr(args, "out", None)
             or f"outputs/monte_carlo/{scenario.name}/{datetime.now(timezone.utc):%Y%m%d-%H%M%S}"
         )
-        formats = _parse_formats(getattr(args, "formats", None)) or ["csv"]
         exported = export_results(results, output_dir, formats=formats)
         write_mc_manifest(
             output_dir,
@@ -225,10 +231,15 @@ def _load_scenario(raw: str, registry: Path | None) -> MonteCarloScenario:
     return load_scenario(raw, registry_path=registry)
 
 
-def _apply_overrides(scenario: MonteCarloScenario, args: argparse.Namespace) -> None:
+def _resolved_mc_settings(scenario: MonteCarloScenario) -> MonteCarloSettings:
     settings = scenario.monte_carlo
     if not isinstance(settings, MonteCarloSettings):
         raise ValueError("monte_carlo settings are not resolved")
+    return settings
+
+
+def _apply_overrides(scenario: MonteCarloScenario, args: argparse.Namespace) -> None:
+    settings = _resolved_mc_settings(scenario)
     scenario.monte_carlo = MonteCarloSettings(
         mode=settings.mode,
         n_paths=getattr(args, "n_paths", None) or settings.n_paths,
@@ -296,6 +307,7 @@ def write_mc_manifest(
 ) -> Path:
     output_dir.mkdir(parents=True, exist_ok=True)
     manifest_path = output_dir / "manifest.json"
+    mc_settings = _resolved_mc_settings(scenario)
     manifest_path.write_text(
         json.dumps(
             {
@@ -306,11 +318,11 @@ def write_mc_manifest(
                 "base_config": str(scenario.base_config),
                 "data_path": str(data_path) if data_path else None,
                 "settings": {
-                    "mode": scenario.monte_carlo.mode,
-                    "n_paths": scenario.monte_carlo.n_paths,
-                    "horizon_years": scenario.monte_carlo.horizon_years,
-                    "frequency": scenario.monte_carlo.frequency,
-                    "seed": scenario.monte_carlo.seed,
+                    "mode": mc_settings.mode,
+                    "n_paths": mc_settings.n_paths,
+                    "horizon_years": mc_settings.horizon_years,
+                    "frequency": mc_settings.frequency,
+                    "seed": mc_settings.seed,
                     "jobs": jobs_used,
                 },
                 "overrides": dict(overrides),

--- a/src/trend/mc/commands.py
+++ b/src/trend/mc/commands.py
@@ -13,7 +13,7 @@ import numbers
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 import pandas as pd
 
@@ -164,8 +164,19 @@ def handle_mc_command(args: argparse.Namespace) -> int:
         price_history = (
             _load_price_history(Path(args.data)) if getattr(args, "data", None) else None
         )
-        runner = MonteCarloRunner(scenario, base_config=None, price_history=price_history)
-        results = runner.run(jobs=getattr(args, "jobs", None))
+        settings = _resolved_mc_settings(scenario)
+        progress_callback, close_progress = _build_progress_callback(
+            total=int(settings.n_paths) if settings.n_paths is not None else 0,
+            enabled=not getattr(args, "no_progress", False),
+        )
+        try:
+            runner = MonteCarloRunner(scenario, base_config=None, price_history=price_history)
+            results = runner.run(
+                progress_callback=progress_callback,
+                jobs=getattr(args, "jobs", None),
+            )
+        finally:
+            close_progress()
         output_dir = Path(
             getattr(args, "out", None)
             or f"outputs/monte_carlo/{scenario.name}/{datetime.now(timezone.utc):%Y%m%d-%H%M%S}"
@@ -214,10 +225,94 @@ def _parse_formats(raw: Sequence[str] | None) -> list[str]:
 def _render_table(entries: Sequence[Any]) -> str:
     if not entries:
         return "No Monte Carlo scenarios found."
-    return "\n".join(
-        f"{entry.name}\t{', '.join(entry.tags)}\t{entry.description or ''}\t{entry.path}"
+    columns = ("Name", "Tags", "Description", "Path")
+    rows = [
+        {
+            "Name": entry.name,
+            "Tags": ", ".join(
+                sorted(dict.fromkeys(tag.strip() for tag in entry.tags if tag.strip()))
+            )
+            or "-",
+            "Description": entry.description or "",
+            "Path": str(entry.path),
+        }
         for entry in entries
+    ]
+    widths = {
+        column: max(len(column), *(len(str(row[column])) for row in rows)) for column in columns
+    }
+    lines = [
+        "  ".join(column.ljust(widths[column]) for column in columns),
+        "  ".join("-" * widths[column] for column in columns),
+    ]
+    lines.extend(
+        "  ".join(str(row[column]).ljust(widths[column]) for column in columns) for row in rows
     )
+    return "\n".join(lines)
+
+
+def _is_valid_progress_instance(candidate: Any) -> bool:
+    return (
+        candidate is not None
+        and hasattr(candidate, "total")
+        and all(
+            callable(getattr(candidate, method, None)) for method in ("update", "refresh", "close")
+        )
+    )
+
+
+def _build_progress_callback(
+    *, total: int, enabled: bool
+) -> tuple[Callable[[Mapping[str, Any]], None] | None, Callable[[], None]]:
+    if not enabled:
+        return None, lambda: None
+    try:
+        from tqdm import tqdm
+    except Exception:
+        tqdm = None
+
+    if _is_valid_progress_instance(tqdm):
+        bar = tqdm
+        bar.total = total
+        if hasattr(bar, "unit"):
+            bar.unit = "path"
+        if hasattr(bar, "file"):
+            bar.file = sys.stderr
+    elif callable(tqdm):
+        try:
+            bar = tqdm(total=total, unit="path", file=sys.stderr)
+        except Exception:
+            bar = None
+    else:
+        bar = None
+
+    if not _is_valid_progress_instance(bar):
+        state = {"last": -1}
+
+        def text_callback(payload: Mapping[str, Any]) -> None:
+            completed = int(payload.get("completed", 0))
+            if completed == state["last"]:
+                return
+            state["last"] = completed
+            print(f"Progress: {completed}/{int(payload.get('total', total))}", file=sys.stderr)
+
+        return text_callback, lambda: None
+
+    state = {"completed": 0}
+
+    def callback(payload: Mapping[str, Any]) -> None:
+        completed = int(payload.get("completed", 0))
+        total_value = int(payload.get("total", total))
+        if bar.total != total_value:
+            bar.total = total_value
+        delta = completed - state["completed"]
+        if delta > 0:
+            bar.update(delta)
+        else:
+            bar.refresh()
+        state["completed"] = completed
+
+    return callback, bar.close
 
 
 def _load_scenario(raw: str, registry: Path | None) -> MonteCarloScenario:

--- a/tests/test_cli_mc.py
+++ b/tests/test_cli_mc.py
@@ -487,6 +487,74 @@ def test_mc_run_dry_run_skips_execution(
     assert called["run"] is False
 
 
+def test_mc_run_invalid_formats_rejects_before_runner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    scenario_path = tmp_path / "scenario.yml"
+    _write_scenario(scenario_path)
+
+    called = {"run": False}
+
+    def _run(self, progress_callback=None):  # type: ignore[no-untyped-def]
+        called["run"] = True
+        raise AssertionError("MonteCarloRunner.run should not be invoked for invalid formats")
+
+    monkeypatch.setattr(runner_module.MonteCarloRunner, "run", _run)
+
+    rc = cli.main(
+        [
+            "mc",
+            "run",
+            "--scenario",
+            str(scenario_path),
+            "--formats",
+            "bogus",
+        ]
+    )
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "unsupported values" in err
+    assert called["run"] is False
+
+
+def test_mc_run_dry_run_applies_overrides_before_validation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from trend.mc import commands as mc_commands
+
+    scenario_path = tmp_path / "scenario.yml"
+    _write_scenario(scenario_path)
+    observed_paths: dict[str, int] = {}
+
+    original_validate = mc_commands.validate_mc_scenario
+
+    def _capture_validate(scenario: MonteCarloScenario) -> list[str]:
+        settings = scenario.monte_carlo
+        if isinstance(settings, MonteCarloSettings):
+            observed_paths["n_paths"] = settings.n_paths
+        return original_validate(scenario)
+
+    monkeypatch.setattr(mc_commands, "validate_mc_scenario", _capture_validate)
+
+    rc = cli.main(
+        [
+            "mc",
+            "run",
+            "--scenario",
+            str(scenario_path),
+            "--dry-run",
+            "--n-paths",
+            "42",
+        ]
+    )
+
+    assert rc == 0
+    assert observed_paths.get("n_paths") == 42
+    out = capsys.readouterr().out
+    assert "Dry run complete" in out
+
+
 def test_mc_list_registry_and_tags(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     registry_path = tmp_path / "index.yml"
     _write_registry(registry_path)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -15,8 +15,8 @@ def test_cli_help_smoke():
     )
 
     assert result.returncode == 0
-    assert "trend-model" in result.stdout
-    assert "gui" in result.stdout
+    assert "trend" in result.stdout
+    assert "app" in result.stdout
     assert "run" in result.stdout
 
 
@@ -37,8 +37,23 @@ def test_cli_run_help_smoke():
     assert "input" in result.stdout.lower()
 
 
-def test_cli_gui_help_smoke():
-    """Smoke test: CLI gui --help works without errors."""
+def test_cli_app_help_smoke():
+    """Smoke test: CLI app --help works without errors."""
+    project_root = Path(__file__).parent.parent
+    script_path = project_root / "scripts" / "trend-model"
+
+    result = subprocess.run(
+        [str(script_path), "app", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=project_root,
+    )
+
+    assert result.returncode == 0
+
+
+def test_cli_gui_alias_rejected_smoke():
+    """Smoke test: legacy gui alias is rejected by the modular CLI."""
     project_root = Path(__file__).parent.parent
     script_path = project_root / "scripts" / "trend-model"
 
@@ -49,7 +64,8 @@ def test_cli_gui_help_smoke():
         cwd=project_root,
     )
 
-    assert result.returncode == 0
+    assert result.returncode == 2
+    assert "invalid choice" in result.stderr.lower()
 
 
 def test_cli_module_direct_smoke():
@@ -57,7 +73,7 @@ def test_cli_module_direct_smoke():
     project_root = Path(__file__).parent.parent
 
     result = subprocess.run(
-        [sys.executable, "-m", "trend_analysis.cli", "--help"],
+        [sys.executable, "-m", "trend.cli", "--help"],
         capture_output=True,
         text=True,
         cwd=project_root,
@@ -68,7 +84,7 @@ def test_cli_module_direct_smoke():
     assert result.returncode in (0, 1)  # 0 for success, 1 for module import errors
 
     if result.returncode == 0:
-        assert "trend-model" in result.stdout
+        assert "trend" in result.stdout
     else:
         # If it fails due to missing dependencies, that's expected in this environment
         assert "ModuleNotFoundError" in result.stderr or "ImportError" in result.stderr

--- a/tests/test_trend_cli.py
+++ b/tests/test_trend_cli.py
@@ -1276,24 +1276,24 @@ def test_cli_report_matches_shared_generator(monkeypatch, tmp_path: Path) -> Non
     returns_path.write_text("Date,Value\n2021-01-31,0.01\n", encoding="utf-8")
 
     monkeypatch.setattr(
-        "trend_analysis.cli._load_configuration",
+        "trend.cli._load_configuration",
         lambda path: (config_path.resolve(), cli_config),
     )
     monkeypatch.setattr(
-        "trend_analysis.cli._resolve_returns_path",
+        "trend.cli._resolve_returns_path",
         lambda *args, **kwargs: returns_path,
     )
     monkeypatch.setattr(
-        "trend_analysis.cli._ensure_dataframe",
+        "trend.cli._ensure_dataframe",
         lambda _p: pd.DataFrame({"Date": ["2021-01-31"], "Value": [0.01]}),
     )
-    monkeypatch.setattr("trend_analysis.cli._print_summary", lambda *args, **kwargs: None)
-    monkeypatch.setattr("trend_analysis.cli._write_report_files", lambda *args, **kwargs: None)
+    monkeypatch.setattr("trend.cli._print_summary", lambda *args, **kwargs: None)
+    monkeypatch.setattr("trend.cli._write_report_files", lambda *args, **kwargs: None)
 
     def fake_run_pipeline(*args, **kwargs):  # type: ignore[override]
         return cli_result, "cli-run", None
 
-    monkeypatch.setattr("trend_analysis.cli._run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr("trend.cli._run_pipeline", fake_run_pipeline)
 
     report_path = tmp_path / "report.html"
     exit_code = main(

--- a/tests/test_trend_cli_additional.py
+++ b/tests/test_trend_cli_additional.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import sys
 from pathlib import Path
-from types import ModuleType, SimpleNamespace
+from types import SimpleNamespace
 
 import pandas as pd
 import pytest

--- a/tests/test_trend_cli_additional.py
+++ b/tests/test_trend_cli_additional.py
@@ -16,20 +16,12 @@ import trend.cli as cli
 import trend_analysis.export.bundle as _bundle_mod  # noqa: F401
 
 
-def test_refresh_legacy_cli_module_updates_cache(monkeypatch):
-    module = ModuleType("trend_analysis.cli")
-    module.maybe_log_step = lambda *a, **k: None
-    module._extract_cache_stats = lambda details: {"hits": 1}
-    monkeypatch.setitem(sys.modules, "trend_analysis.cli", module)
-    monkeypatch.setattr(cli, "_legacy_cli_module", None)
-    monkeypatch.setattr(cli, "_legacy_maybe_log_step", cli._noop_maybe_log_step)
-    monkeypatch.setattr(cli, "_legacy_extract_cache_stats", None)
+def test_refresh_legacy_cli_module_is_retired_noop():
+    """Legacy refresh hook is retained only as a transitional no-op."""
 
-    refreshed = cli._refresh_legacy_cli_module()
-
-    assert refreshed is module
-    assert cli._legacy_extract_cache_stats is module._extract_cache_stats
-    assert cli._legacy_maybe_log_step is module.maybe_log_step
+    assert cli._refresh_legacy_cli_module() is None
+    assert cli._legacy_maybe_log_step is cli.maybe_log_step
+    assert cli._legacy_extract_cache_stats is cli.extract_cache_stats
 
 
 def test_run_pipeline_captures_portfolio_and_logging(monkeypatch, tmp_path):

--- a/tests/test_trend_cli_entrypoints.py
+++ b/tests/test_trend_cli_entrypoints.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import builtins
+import ast
 import json
 import textwrap
 import types
@@ -1236,5 +1237,29 @@ def test_main_unknown_command(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_trend_cli_has_no_legacy_module_dependency() -> None:
     source = Path(trend_cli.__file__).read_text(encoding="utf-8")
-    assert "from trend_analysis.cli import" not in source
-    assert "import trend_analysis.cli" not in source
+    tree = ast.parse(source)
+    legacy_references: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            legacy_references.extend(
+                alias.name for alias in node.names if alias.name == "trend_analysis.cli"
+            )
+        elif isinstance(node, ast.ImportFrom):
+            if node.module == "trend_analysis":
+                legacy_references.extend(
+                    f"{node.module}.{alias.name}" for alias in node.names if alias.name == "cli"
+                )
+            elif node.module == "trend_analysis.cli":
+                legacy_references.append(node.module)
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "import_module"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == "trend_analysis.cli"
+        ):
+            legacy_references.append("trend_analysis.cli")
+
+    assert not legacy_references

--- a/tests/test_trend_cli_entrypoints.py
+++ b/tests/test_trend_cli_entrypoints.py
@@ -1263,3 +1263,21 @@ def test_trend_cli_has_no_legacy_module_dependency() -> None:
             legacy_references.append("trend_analysis.cli")
 
     assert not legacy_references
+
+
+def test_canonical_mc_commands_have_no_legacy_cli_dependency() -> None:
+    source = (Path(trend_cli.__file__).parent / "mc" / "commands.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    legacy_references = [
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+        if alias.name == "trend_analysis.cli"
+    ]
+    legacy_references.extend(
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module == "trend_analysis.cli"
+    )
+    assert not legacy_references

--- a/tests/test_trend_cli_entrypoints.py
+++ b/tests/test_trend_cli_entrypoints.py
@@ -1232,3 +1232,9 @@ def test_main_unknown_command(monkeypatch: pytest.MonkeyPatch) -> None:
     with pytest.raises(SystemExit) as excinfo:
         trend_cli.main(["unknown", "--config", "cfg.yml", "--returns", "data.csv"])
     assert excinfo.value.code == 2
+
+
+def test_trend_cli_has_no_legacy_module_dependency() -> None:
+    source = Path(trend_cli.__file__).read_text(encoding="utf-8")
+    assert "from trend_analysis.cli import" not in source
+    assert "import trend_analysis.cli" not in source


### PR DESCRIPTION
Closes #5850

## Summary
- Extract `check_environment`, `find_prior_run`, and shared CLI support seams into `src/trend/cli_support.py`.
- Remove dynamic `trend_analysis.cli` delegation hooks from `src/trend/cli.py` so the public CLI no longer imports or refreshes the legacy module at runtime.
- Retarget `scripts/trend-model` and `scripts/trend-reproducible` to invoke `python -m trend.cli`.
- Retarget focused tests to patch `trend.cli` and add `test_trend_cli_has_no_legacy_module_dependency`.

## Validation
- `rg 'trend_analysis\.cli' src/trend scripts/trend-model scripts/trend-reproducible scripts/run_multi_demo.py` — zero matches
- `python -m pytest tests/test_trend_cli.py tests/test_trend_cli_entrypoints.py tests/test_cli_check.py tests/test_idempotency_cli.py tests/golden/test_demo.py -q` — 122 passed
- `python -m trend.cli run|report|app|check|mc --help` — pass; `gui` and `run-ui` rejected (exit 2)
- Ruff + Black py312 on changed Python files

## Test plan
- [ ] Gate / keepalive on this PR
- [ ] Deliberate-break gate for `test_trend_cli_has_no_legacy_module_dependency` documented in issue AC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized command-line access through the `trend` CLI and added the `app` command.
  * Improved environment checks, run logging, cache reporting, and prior-run discovery.
  * Expanded Monte Carlo commands with scenario listing, validation, dry runs, configurable exports, and manifest generation.

* **Bug Fixes**
  * Updated demo and reproducible launchers to use current commands.
  * Removed the obsolete `gui` command alias.

* **Tests**
  * Expanded coverage for CLI help, command behavior, and legacy command references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-up validation
- Resolved CodeRabbit guard-hardening feedback by parsing imports and rejecting direct, package-level/aliased, and importlib module-loading references to trend_analysis.cli.
- Focused CLI suite passed: 129 tests. Ruff and Black checks passed on the touched files.
- Deliberate break: a temporary legacy CLI import made the targeted guard fail; after restoration, the target passed.