### PR TITLE
fix: complete Phase 2b CLI handler decomposition

### DIFF
--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -278,7 +278,9 @@ def build_parser(*, prog: str = "trend") -> argparse.ArgumentParser:
         ),
     )
 
-    report_p = sub.add_parser("report", help="Generate summary artefacts for a configuration")
+    report_p = sub.add_parser(
+        "report", help="Generate summary artefacts for a configuration"
+    )
     report_p.add_argument("-c", "--config", help="Path to YAML config")
     report_p.add_argument(
         "-i",
@@ -312,7 +314,9 @@ def build_parser(*, prog: str = "trend") -> argparse.ArgumentParser:
         help="Report which config keys were validated vs read",
     )
 
-    stress_p = sub.add_parser("stress", help="Run the pipeline against a canned stress scenario")
+    stress_p = sub.add_parser(
+        "stress", help="Run the pipeline against a canned stress scenario"
+    )
     stress_p.add_argument("-c", "--config", help="Path to YAML config")
     stress_p.add_argument(
         "--scenario",
@@ -335,8 +339,12 @@ def build_parser(*, prog: str = "trend") -> argparse.ArgumentParser:
 
     sub.add_parser("app", help="Launch the Streamlit application")
 
-    quick_p = sub.add_parser("quick-report", help="Build a compact HTML report from run artefacts")
-    quick_p.add_argument("--run-id", help="Run identifier (defaults to artefact inference)")
+    quick_p = sub.add_parser(
+        "quick-report", help="Build a compact HTML report from run artefacts"
+    )
+    quick_p.add_argument(
+        "--run-id", help="Run identifier (defaults to artefact inference)"
+    )
     quick_p.add_argument(
         "--artifacts",
         type=Path,
@@ -560,7 +568,9 @@ def _determine_seed(cfg: Any, override: int | None) -> int:
     return seed
 
 
-def _prepare_export_config(cfg: Any, directory: Path | None, formats: Iterable[str] | None) -> None:
+def _prepare_export_config(
+    cfg: Any, directory: Path | None, formats: Iterable[str] | None
+) -> None:
     if directory is None and formats is None:
         return
     export_cfg = dict(getattr(cfg, "export", {}) or {})
@@ -597,7 +607,9 @@ def _run_pipeline(
     if structured_log:
         log_path = log_file or run_logging.get_default_log_path(run_id)
         run_logging.init_run_logger(run_id, log_path)
-    _legacy_maybe_log_step(structured_log, run_id, "start", "trend CLI execution started")
+    _legacy_maybe_log_step(
+        structured_log, run_id, "start", "trend CLI execution started"
+    )
 
     result = run_simulation(cfg, returns_df)
     diagnostic = getattr(result, "diagnostic", None)
@@ -643,7 +655,9 @@ def _run_pipeline(
     return result, run_id, log_path
 
 
-def _handle_exports(cfg: Any, result: RunResult, structured_log: bool, run_id: str) -> None:
+def _handle_exports(
+    cfg: Any, result: RunResult, structured_log: bool, run_id: str
+) -> None:
     export_cfg = getattr(cfg, "export", {}) or {}
     out_dir = export_cfg.get("directory")
     out_formats = export_cfg.get("formats")
@@ -746,7 +760,9 @@ def _write_trend_run_artifacts(
         data_keys = list(narrative_data.keys())
         if any(fmt.lower() in {"excel", "xlsx"} for fmt in fmt_list):
             data_keys.append("summary")
-    artifact_paths = _resolve_export_artifact_paths(out_dir_path, filename, data_keys, fmt_list)
+    artifact_paths = _resolve_export_artifact_paths(
+        out_dir_path, filename, data_keys, fmt_list
+    )
     split = getattr(cfg, "sample_split", {})
     summary_text = export.format_summary_text(
         result.details,
@@ -863,7 +879,9 @@ def _print_summary(cfg: Any, result: RunResult) -> None:
             print(f"  {key.capitalize()}: {value}")
 
 
-def _write_report_files(out_dir: Path, cfg: Any, result: RunResult, *, run_id: str) -> None:
+def _write_report_files(
+    out_dir: Path, cfg: Any, result: RunResult, *, run_id: str
+) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     metrics_path = out_dir / f"metrics_{run_id}.csv"
     result.metrics.to_csv(metrics_path)
@@ -880,13 +898,17 @@ def _write_report_files(out_dir: Path, cfg: Any, result: RunResult, *, run_id: s
     details_path = out_dir / f"details_{run_id}.json"
     with details_path.open("w", encoding="utf-8") as fh:
         json.dump(result.details, fh, default=_json_default, indent=2)
-    turnover_csv_result = _maybe_write_turnover_csv(out_dir, getattr(result, "details", {}))
+    turnover_csv_result = _maybe_write_turnover_csv(
+        out_dir, getattr(result, "details", {})
+    )
     if turnover_csv_result.diagnostic:
         logger.info(turnover_csv_result.diagnostic.message)
     print(f"Report artefacts written to {out_dir}")
 
 
-def _resolve_report_output_path(output: str | None, export_dir: Path | None, run_id: str) -> Path:
+def _resolve_report_output_path(
+    output: str | None, export_dir: Path | None, run_id: str
+) -> Path:
     if output:
         base = Path(output).expanduser()
         if base.exists() and base.is_dir():
@@ -999,9 +1021,13 @@ def _require_transaction_cost_controls(cfg: Any) -> None:
             try:
                 slip_value = float(slippage)
             except (TypeError, ValueError) as exc:
-                raise TrendCLIError("portfolio.cost_model.slippage_bps must be numeric") from exc
+                raise TrendCLIError(
+                    "portfolio.cost_model.slippage_bps must be numeric"
+                ) from exc
             if slip_value < 0:
-                raise TrendCLIError("portfolio.cost_model.slippage_bps cannot be negative")
+                raise TrendCLIError(
+                    "portfolio.cost_model.slippage_bps cannot be negative"
+                )
     if cost_value is None:
         raise TrendCLIError(
             "Configuration must define portfolio.transaction_cost_bps for honest costs."
@@ -1104,7 +1130,9 @@ def _load_configuration(path: str) -> Any:
         load_core_config(cfg_path)
     except CoreConfigError as exc:
         raise TrendCLIError(str(exc)) from exc
-    validation = validate_config(payload, base_path=cfg_path.parent, skip_required_fields=True)
+    validation = validate_config(
+        payload, base_path=cfg_path.parent, skip_required_fields=True
+    )
     if not validation.valid:
         details = "\n".join(format_validation_messages(validation))
         raise TrendCLIError(f"Config validation failed:\n{details}")
@@ -1270,7 +1298,9 @@ def _resolve_llm_provider_config(
     *,
     model: str | None = None,
 ) -> LLMProviderConfig:
-    provider_name = (provider or os.environ.get("TREND_LLM_PROVIDER") or "openai").lower()
+    provider_name = (
+        provider or os.environ.get("TREND_LLM_PROVIDER") or "openai"
+    ).lower()
     supported = {"openai", "anthropic", "ollama"}
     if provider_name not in supported:
         raise TrendCLIError(
@@ -1365,7 +1395,9 @@ def _replay_nl_entry(
 ) -> ReplayResult:
     from trend_analysis.llm.replay import replay_nl_entry
 
-    return replay_nl_entry(entry, provider=provider, model=model, temperature=temperature)
+    return replay_nl_entry(
+        entry, provider=provider, model=model, temperature=temperature
+    )
 
 
 def _build_nl_replay_parser() -> argparse.ArgumentParser:
@@ -1373,12 +1405,18 @@ def _build_nl_replay_parser() -> argparse.ArgumentParser:
         prog="trend nl replay",
         description="Replay a logged NL operation entry.",
     )
-    parser.add_argument("log_file", type=Path, help="Path to nl_ops_<date>.jsonl log file")
+    parser.add_argument(
+        "log_file", type=Path, help="Path to nl_ops_<date>.jsonl log file"
+    )
     parser.add_argument("--entry", type=int, required=True, help="1-based entry index")
     parser.add_argument("--provider", help="Override the logged LLM provider")
     parser.add_argument("--model", help="Override the logged LLM model")
-    parser.add_argument("--temperature", type=float, help="Override the logged temperature")
-    parser.add_argument("--show-prompt", action="store_true", help="Print the prompt text")
+    parser.add_argument(
+        "--temperature", type=float, help="Override the logged temperature"
+    )
+    parser.add_argument(
+        "--show-prompt", action="store_true", help="Print the prompt text"
+    )
     return parser
 
 
@@ -1498,7 +1536,9 @@ def _apply_nl_instruction(
 ) -> tuple[ConfigPatch, dict[str, Any], str, str, float]:
     chain = _build_nl_chain(provider, model=model, temperature=temperature)
     try:
-        patch = chain.run(current_config=config, instruction=instruction, request_id=request_id)
+        patch = chain.run(
+            current_config=config, instruction=instruction, request_id=request_id
+        )
     except Exception as exc:
         raise TrendCLIError(str(exc)) from exc
     apply_started = time.perf_counter()
@@ -1608,7 +1648,9 @@ def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
     except TrendCLIError:
         raise
     except Exception as exc:
-        raise TrendCLIError(f"Failed to read {label} data from '{path}': {exc}") from exc
+        raise TrendCLIError(
+            f"Failed to read {label} data from '{path}': {exc}"
+        ) from exc
     if isinstance(frame, pd.Series):
         return frame.to_frame()
     if not isinstance(frame, pd.DataFrame):
@@ -1617,7 +1659,9 @@ def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
 
 
 def _load_mc_frame(bundle_dir: Path, *, stem: str) -> pd.DataFrame:
-    candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
+    candidates = tuple(
+        bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json")
+    )
     existing = next((candidate for candidate in candidates if candidate.exists()), None)
     if existing is None:
         expected = ", ".join(path.name for path in candidates)
@@ -1647,7 +1691,9 @@ def _load_mc_bundle_frames(
     missing_inputs: list[str] = []
     expected_by_stem: dict[str, str] = {}
     for stem in required_stems:
-        candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
+        candidates = tuple(
+            bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json")
+        )
         if not any(candidate.exists() for candidate in candidates):
             missing_inputs.append(stem)
             expected_by_stem[stem] = ", ".join(path.name for path in candidates)
@@ -1659,7 +1705,9 @@ def _load_mc_bundle_frames(
                 f"Missing required MC {stem} file in '{bundle_dir}'. Expected one of: {expected}"
             )
         missing_text = ", ".join(missing_inputs)
-        expected_text = "; ".join(f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs)
+        expected_text = "; ".join(
+            f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs
+        )
         raise TrendCLIError(
             f"Missing required MC input files in '{bundle_dir}': {missing_text}. "
             f"Expected one of each: {expected_text}"
@@ -1668,9 +1716,13 @@ def _load_mc_bundle_frames(
 
 
 def _parse_mc_chart_selection(charts_value: str) -> list[str]:
-    requested = [token.strip().lower() for token in charts_value.split(",") if token.strip()]
+    requested = [
+        token.strip().lower() for token in charts_value.split(",") if token.strip()
+    ]
     if not requested:
-        raise TrendCLIError("The 'mc viz' command requires at least one chart in --charts.")
+        raise TrendCLIError(
+            "The 'mc viz' command requires at least one chart in --charts."
+        )
 
     seen: set[str] = set()
     ordered: list[str] = []
@@ -1740,16 +1792,20 @@ def _build_mc_risk_return_chart(
     from trend_analysis.viz import risk_return
 
     nav_frame = _mc_nav_source_frame(summary_frame, results_frame, nav_paths_frame)
-    returns_frame = nav_frame.pct_change(fill_method=None).replace([np.inf, -np.inf], np.nan)
+    returns_frame = nav_frame.pct_change(fill_method=None).replace(
+        [np.inf, -np.inf], np.nan
+    )
     returns_frame = returns_frame.dropna(how="all")
     if returns_frame.empty:
-        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(how="all")
+        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(
+            how="all"
+        )
     return risk_return.make(returns_frame)
 
 
-def _mc_chart_builders() -> (
-    dict[str, Callable[[pd.DataFrame, pd.DataFrame, pd.DataFrame | None], Any]]
-):
+def _mc_chart_builders() -> dict[
+    str, Callable[[pd.DataFrame, pd.DataFrame, pd.DataFrame | None], Any]
+]:
     return {
         "fan": _build_mc_fan_chart,
         "path_dist": _build_mc_path_dist_chart,
@@ -1801,13 +1857,17 @@ def _inject_mc_html_chart_markers(
                 continue
             body_token = "<body>"
             if body_token in html_text:
-                updated_html = html_text.replace(body_token, f"{body_token}\n{marker}", 1)
+                updated_html = html_text.replace(
+                    body_token, f"{body_token}\n{marker}", 1
+                )
             else:
                 updated_html = f"{marker}\n{html_text}"
             html_path.parent.mkdir(parents=True, exist_ok=True)
             html_path.write_text(updated_html, encoding="utf-8")
         except Exception as exc:
-            warnings.append(f"Unable to inject HTML chart marker for '{chart_id}': {exc}.")
+            warnings.append(
+                f"Unable to inject HTML chart marker for '{chart_id}': {exc}."
+            )
 
 
 def _run_mc_viz_command(args: argparse.Namespace) -> int:
@@ -1938,7 +1998,9 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                 fallback = _fallback_explanation(metric_catalog)
                 fallback = append_discrepancy_log(fallback, claim_issues)
                 explanation_text = fallback
-            explanation_text = _finalize_explanation_text(explanation_text, claim_issues)
+            explanation_text = _finalize_explanation_text(
+                explanation_text, claim_issues
+            )
             if args.output:
                 payload = _build_explain_artifact_payload(
                     run_id=run_id,
@@ -1987,7 +2049,9 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     print("No changes.")
                 return 0
             if args.dry_run:
-                sys.stdout.write(yaml.safe_dump(updated, sort_keys=False, default_flow_style=False))
+                sys.stdout.write(
+                    yaml.safe_dump(updated, sort_keys=False, default_flow_style=False)
+                )
                 return 0
             if args.run:
                 validate_started = time.perf_counter()
@@ -2017,7 +2081,9 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     )
                     raise TrendCLIError(str(exc)) from exc
                 if not validation.valid:
-                    validation_details = "\n".join(format_validation_messages(validation))
+                    validation_details = "\n".join(
+                        format_validation_messages(validation)
+                    )
                     validation_error = f"validation failed: {validation_details}"
                 _log_nl_operation(
                     request_id=request_id,
@@ -2032,7 +2098,9 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     timestamp=validate_timestamp,
                 )
                 if validation_error is not None:
-                    raise TrendCLIError(f"Config validation failed:\n{validation_details}")
+                    raise TrendCLIError(
+                        f"Config validation failed:\n{validation_details}"
+                    )
             _confirm_risky_patch(patch, no_confirm=args.no_confirm)
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_text(
@@ -2094,7 +2162,9 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
             raise TrendCLIError(f"Unknown command: {command}")
 
         if command != "mc" and not args.config:
-            raise TrendCLIError(f"The --config option is required for the '{command}' command")
+            raise TrendCLIError(
+                f"The --config option is required for the '{command}' command"
+            )
 
         load_config_fn = _load_configuration
         cfg_path, cfg = load_config_fn(args.config)
@@ -2152,7 +2222,9 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
 
         if command == "stress":
             if not args.scenario:
-                raise TrendCLIError("The --scenario option is required for the 'stress' command")
+                raise TrendCLIError(
+                    "The --scenario option is required for the 'stress' command"
+                )
             _adjust_for_scenario(cfg, args.scenario)
             export_dir = Path(args.out) if args.out else None
             _prepare_export_config(cfg, export_dir, None)

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -23,6 +23,12 @@ from trend.cli_helpers import (
     _apply_universe_mask,
     _attach_universe_paths,
 )
+from trend.cli_commands import (
+    run_analysis_command,
+    run_app_command,
+    run_check_command,
+    run_report_command,
+)
 from trend.cli_support import (
     check_environment,
     extract_cache_stats,
@@ -1848,21 +1854,17 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
         if command == "check":
             if coverage_tracker is not None:
                 deactivate_config_coverage()
-            return _run_environment_check()
+            return run_check_command(environment_check=_run_environment_check)
 
         if command == "app":
             if coverage_tracker is not None:
                 deactivate_config_coverage()
-            try:
-                proc = subprocess.run(["streamlit", "run", str(APP_PATH), *extra_args])
-            except FileNotFoundError:
-                print(
-                    "Error: the 'streamlit' executable was not found. "
-                    "Install the optional 'app' extra.",
-                    file=sys.stderr,
-                )
-                return 127
-            return proc.returncode
+            return run_app_command(
+                args,
+                extra_args,
+                app_path=APP_PATH,
+                run_process=subprocess.run,
+            )
 
         if command == "quick-report":
             if coverage_tracker is not None:
@@ -2106,107 +2108,47 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
         seed = _determine_seed(cfg, getattr(args, "seed", None))
 
         if command == "run":
-            set_cache_enabled(not getattr(args, "no_cache", False))
-            if getattr(args, "preset", None):
-                try:
-                    spec_preset = get_trend_spec_preset(args.preset)
-                except KeyError:
-                    available = ", ".join(list_trend_spec_presets())
-                    raise TrendCLIError(
-                        f"Unknown preset '{args.preset}'. Available presets: {available}"
-                    )
-                _apply_trend_spec_preset(cfg, spec_preset)
-                try:
-                    portfolio_preset = get_trend_preset(args.preset)
-                except KeyError:
-                    available = ", ".join(list_preset_slugs())
-                    raise TrendCLIError(f"Unknown preset '{args.preset}'. Available: {available}")
-                apply_trend_preset(cfg, portfolio_preset)
-            if getattr(args, "universe", None):
-                mask, universe_spec = load_universe(args.universe, prices=returns_df)
-                returns_df = _apply_universe_mask(
-                    returns_df, mask, date_column=universe_spec.date_column
-                )
-                _attach_universe_paths(cfg, universe_spec, csv_path=str(returns_path))
-            if getattr(args, "skip_if_exists", False):
-                candidate_run_id = working_run_id(cfg, returns_path)
-                existing_manifest = find_prior_run(cfg, candidate_run_id)
-                if existing_manifest is not None:
-                    print(f"already-done: run_id={candidate_run_id}")
-                    print(f"Existing manifest: {existing_manifest}")
-                    _finalize_config_coverage()
-                    return 0
-            run_pipeline = _run_pipeline
-            result, run_id, log_path = run_pipeline(
+            return run_analysis_command(
+                args,
+                cfg_path,
                 cfg,
+                returns_path,
                 returns_df,
-                source_path=returns_path,
-                log_file=Path(args.log_file) if args.log_file else None,
-                structured_log=not args.no_structured_log,
-                bundle=Path(args.bundle) if args.bundle else None,
+                error=TrendCLIError,
+                set_cache=set_cache_enabled,
+                get_spec_preset=get_trend_spec_preset,
+                list_spec_presets=list_trend_spec_presets,
+                apply_spec_preset=_apply_trend_spec_preset,
+                get_portfolio_preset=get_trend_preset,
+                list_portfolio_presets=list_preset_slugs,
+                apply_portfolio_preset=apply_trend_preset,
+                load_universe=load_universe,
+                apply_universe_mask=_apply_universe_mask,
+                attach_universe_paths=_attach_universe_paths,
+                find_existing_run=find_prior_run,
+                calculate_run_id=working_run_id,
+                run_pipeline=_run_pipeline,
+                write_artifacts=_write_trend_run_artifacts,
+                print_summary=_print_summary,
+                finalize_coverage=_finalize_config_coverage,
             )
-            _write_trend_run_artifacts(
-                cfg=cfg,
-                result=result,
-                config_path=cfg_path,
-                input_path=returns_path,
-                data_frame=returns_df,
-                run_id=run_id,
-                structured_log=not args.no_structured_log,
-            )
-            print_summary = _print_summary
-            print_summary(cfg, result)
-            if log_path:
-                print(f"Structured log: {log_path}")
-            _finalize_config_coverage()
-            return 0
 
         if command == "report":
-            export_dir = Path(args.out).resolve() if args.out else None
-            if export_dir is None and not args.output:
-                raise TrendCLIError(
-                    "The 'report' command requires --out for artefacts or --output for the HTML report"
-                )
-            formats = args.formats or DEFAULT_REPORT_FORMATS
-            _prepare_export_config(cfg, export_dir, formats if export_dir is not None else None)
-            run_pipeline = _run_pipeline
-            result, run_id, _ = run_pipeline(
+            return run_report_command(
+                args,
                 cfg,
+                returns_path,
                 returns_df,
-                source_path=returns_path,
-                log_file=None,
-                structured_log=False,
-                bundle=None,
+                error=TrendCLIError,
+                default_formats=DEFAULT_REPORT_FORMATS,
+                prepare_export_config=_prepare_export_config,
+                run_pipeline=_run_pipeline,
+                print_summary=_print_summary,
+                write_report_files=_write_report_files,
+                resolve_report_output_path=_resolve_report_output_path,
+                generate_report=generate_unified_report,
+                finalize_coverage=_finalize_config_coverage,
             )
-            print_summary = _print_summary
-            print_summary(cfg, result)
-            if export_dir is not None:
-                write_report = _write_report_files
-                write_report(export_dir, cfg, result, run_id=run_id)
-            report_path = _resolve_report_output_path(args.output, export_dir, run_id)
-            report_path.parent.mkdir(parents=True, exist_ok=True)
-            try:
-                artifacts = generate_unified_report(
-                    result,
-                    cfg,
-                    run_id=run_id,
-                    include_pdf=args.pdf,
-                    spec=getattr(cfg, "_trend_run_spec", None),
-                )
-            except RuntimeError as exc:
-                raise TrendCLIError(str(exc)) from exc
-            report_path.write_text(artifacts.html, encoding="utf-8")
-            print(f"Report written: {report_path}")
-            if args.pdf:
-                if artifacts.pdf_bytes is None:
-                    raise TrendCLIError(
-                        "PDF generation failed – install the 'fpdf2' dependency to enable --pdf output"
-                    )
-                pdf_path = report_path.with_suffix(".pdf")
-                pdf_path.write_bytes(artifacts.pdf_bytes)
-                print(f"PDF report written: {pdf_path}")
-            _finalize_config_coverage()
-            return 0
 
         if command == "stress":
             if not args.scenario:

--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -278,9 +278,7 @@ def build_parser(*, prog: str = "trend") -> argparse.ArgumentParser:
         ),
     )
 
-    report_p = sub.add_parser(
-        "report", help="Generate summary artefacts for a configuration"
-    )
+    report_p = sub.add_parser("report", help="Generate summary artefacts for a configuration")
     report_p.add_argument("-c", "--config", help="Path to YAML config")
     report_p.add_argument(
         "-i",
@@ -314,9 +312,7 @@ def build_parser(*, prog: str = "trend") -> argparse.ArgumentParser:
         help="Report which config keys were validated vs read",
     )
 
-    stress_p = sub.add_parser(
-        "stress", help="Run the pipeline against a canned stress scenario"
-    )
+    stress_p = sub.add_parser("stress", help="Run the pipeline against a canned stress scenario")
     stress_p.add_argument("-c", "--config", help="Path to YAML config")
     stress_p.add_argument(
         "--scenario",
@@ -339,12 +335,8 @@ def build_parser(*, prog: str = "trend") -> argparse.ArgumentParser:
 
     sub.add_parser("app", help="Launch the Streamlit application")
 
-    quick_p = sub.add_parser(
-        "quick-report", help="Build a compact HTML report from run artefacts"
-    )
-    quick_p.add_argument(
-        "--run-id", help="Run identifier (defaults to artefact inference)"
-    )
+    quick_p = sub.add_parser("quick-report", help="Build a compact HTML report from run artefacts")
+    quick_p.add_argument("--run-id", help="Run identifier (defaults to artefact inference)")
     quick_p.add_argument(
         "--artifacts",
         type=Path,
@@ -568,9 +560,7 @@ def _determine_seed(cfg: Any, override: int | None) -> int:
     return seed
 
 
-def _prepare_export_config(
-    cfg: Any, directory: Path | None, formats: Iterable[str] | None
-) -> None:
+def _prepare_export_config(cfg: Any, directory: Path | None, formats: Iterable[str] | None) -> None:
     if directory is None and formats is None:
         return
     export_cfg = dict(getattr(cfg, "export", {}) or {})
@@ -607,9 +597,7 @@ def _run_pipeline(
     if structured_log:
         log_path = log_file or run_logging.get_default_log_path(run_id)
         run_logging.init_run_logger(run_id, log_path)
-    _legacy_maybe_log_step(
-        structured_log, run_id, "start", "trend CLI execution started"
-    )
+    _legacy_maybe_log_step(structured_log, run_id, "start", "trend CLI execution started")
 
     result = run_simulation(cfg, returns_df)
     diagnostic = getattr(result, "diagnostic", None)
@@ -655,9 +643,7 @@ def _run_pipeline(
     return result, run_id, log_path
 
 
-def _handle_exports(
-    cfg: Any, result: RunResult, structured_log: bool, run_id: str
-) -> None:
+def _handle_exports(cfg: Any, result: RunResult, structured_log: bool, run_id: str) -> None:
     export_cfg = getattr(cfg, "export", {}) or {}
     out_dir = export_cfg.get("directory")
     out_formats = export_cfg.get("formats")
@@ -760,9 +746,7 @@ def _write_trend_run_artifacts(
         data_keys = list(narrative_data.keys())
         if any(fmt.lower() in {"excel", "xlsx"} for fmt in fmt_list):
             data_keys.append("summary")
-    artifact_paths = _resolve_export_artifact_paths(
-        out_dir_path, filename, data_keys, fmt_list
-    )
+    artifact_paths = _resolve_export_artifact_paths(out_dir_path, filename, data_keys, fmt_list)
     split = getattr(cfg, "sample_split", {})
     summary_text = export.format_summary_text(
         result.details,
@@ -879,9 +863,7 @@ def _print_summary(cfg: Any, result: RunResult) -> None:
             print(f"  {key.capitalize()}: {value}")
 
 
-def _write_report_files(
-    out_dir: Path, cfg: Any, result: RunResult, *, run_id: str
-) -> None:
+def _write_report_files(out_dir: Path, cfg: Any, result: RunResult, *, run_id: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     metrics_path = out_dir / f"metrics_{run_id}.csv"
     result.metrics.to_csv(metrics_path)
@@ -898,17 +880,13 @@ def _write_report_files(
     details_path = out_dir / f"details_{run_id}.json"
     with details_path.open("w", encoding="utf-8") as fh:
         json.dump(result.details, fh, default=_json_default, indent=2)
-    turnover_csv_result = _maybe_write_turnover_csv(
-        out_dir, getattr(result, "details", {})
-    )
+    turnover_csv_result = _maybe_write_turnover_csv(out_dir, getattr(result, "details", {}))
     if turnover_csv_result.diagnostic:
         logger.info(turnover_csv_result.diagnostic.message)
     print(f"Report artefacts written to {out_dir}")
 
 
-def _resolve_report_output_path(
-    output: str | None, export_dir: Path | None, run_id: str
-) -> Path:
+def _resolve_report_output_path(output: str | None, export_dir: Path | None, run_id: str) -> Path:
     if output:
         base = Path(output).expanduser()
         if base.exists() and base.is_dir():
@@ -1021,13 +999,9 @@ def _require_transaction_cost_controls(cfg: Any) -> None:
             try:
                 slip_value = float(slippage)
             except (TypeError, ValueError) as exc:
-                raise TrendCLIError(
-                    "portfolio.cost_model.slippage_bps must be numeric"
-                ) from exc
+                raise TrendCLIError("portfolio.cost_model.slippage_bps must be numeric") from exc
             if slip_value < 0:
-                raise TrendCLIError(
-                    "portfolio.cost_model.slippage_bps cannot be negative"
-                )
+                raise TrendCLIError("portfolio.cost_model.slippage_bps cannot be negative")
     if cost_value is None:
         raise TrendCLIError(
             "Configuration must define portfolio.transaction_cost_bps for honest costs."
@@ -1130,9 +1104,7 @@ def _load_configuration(path: str) -> Any:
         load_core_config(cfg_path)
     except CoreConfigError as exc:
         raise TrendCLIError(str(exc)) from exc
-    validation = validate_config(
-        payload, base_path=cfg_path.parent, skip_required_fields=True
-    )
+    validation = validate_config(payload, base_path=cfg_path.parent, skip_required_fields=True)
     if not validation.valid:
         details = "\n".join(format_validation_messages(validation))
         raise TrendCLIError(f"Config validation failed:\n{details}")
@@ -1298,9 +1270,7 @@ def _resolve_llm_provider_config(
     *,
     model: str | None = None,
 ) -> LLMProviderConfig:
-    provider_name = (
-        provider or os.environ.get("TREND_LLM_PROVIDER") or "openai"
-    ).lower()
+    provider_name = (provider or os.environ.get("TREND_LLM_PROVIDER") or "openai").lower()
     supported = {"openai", "anthropic", "ollama"}
     if provider_name not in supported:
         raise TrendCLIError(
@@ -1395,9 +1365,7 @@ def _replay_nl_entry(
 ) -> ReplayResult:
     from trend_analysis.llm.replay import replay_nl_entry
 
-    return replay_nl_entry(
-        entry, provider=provider, model=model, temperature=temperature
-    )
+    return replay_nl_entry(entry, provider=provider, model=model, temperature=temperature)
 
 
 def _build_nl_replay_parser() -> argparse.ArgumentParser:
@@ -1405,18 +1373,12 @@ def _build_nl_replay_parser() -> argparse.ArgumentParser:
         prog="trend nl replay",
         description="Replay a logged NL operation entry.",
     )
-    parser.add_argument(
-        "log_file", type=Path, help="Path to nl_ops_<date>.jsonl log file"
-    )
+    parser.add_argument("log_file", type=Path, help="Path to nl_ops_<date>.jsonl log file")
     parser.add_argument("--entry", type=int, required=True, help="1-based entry index")
     parser.add_argument("--provider", help="Override the logged LLM provider")
     parser.add_argument("--model", help="Override the logged LLM model")
-    parser.add_argument(
-        "--temperature", type=float, help="Override the logged temperature"
-    )
-    parser.add_argument(
-        "--show-prompt", action="store_true", help="Print the prompt text"
-    )
+    parser.add_argument("--temperature", type=float, help="Override the logged temperature")
+    parser.add_argument("--show-prompt", action="store_true", help="Print the prompt text")
     return parser
 
 
@@ -1536,9 +1498,7 @@ def _apply_nl_instruction(
 ) -> tuple[ConfigPatch, dict[str, Any], str, str, float]:
     chain = _build_nl_chain(provider, model=model, temperature=temperature)
     try:
-        patch = chain.run(
-            current_config=config, instruction=instruction, request_id=request_id
-        )
+        patch = chain.run(current_config=config, instruction=instruction, request_id=request_id)
     except Exception as exc:
         raise TrendCLIError(str(exc)) from exc
     apply_started = time.perf_counter()
@@ -1648,9 +1608,7 @@ def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
     except TrendCLIError:
         raise
     except Exception as exc:
-        raise TrendCLIError(
-            f"Failed to read {label} data from '{path}': {exc}"
-        ) from exc
+        raise TrendCLIError(f"Failed to read {label} data from '{path}': {exc}") from exc
     if isinstance(frame, pd.Series):
         return frame.to_frame()
     if not isinstance(frame, pd.DataFrame):
@@ -1659,9 +1617,7 @@ def _read_mc_frame(path: Path, *, label: str) -> pd.DataFrame:
 
 
 def _load_mc_frame(bundle_dir: Path, *, stem: str) -> pd.DataFrame:
-    candidates = tuple(
-        bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json")
-    )
+    candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
     existing = next((candidate for candidate in candidates if candidate.exists()), None)
     if existing is None:
         expected = ", ".join(path.name for path in candidates)
@@ -1691,9 +1647,7 @@ def _load_mc_bundle_frames(
     missing_inputs: list[str] = []
     expected_by_stem: dict[str, str] = {}
     for stem in required_stems:
-        candidates = tuple(
-            bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json")
-        )
+        candidates = tuple(bundle_dir / f"{stem}.{ext}" for ext in ("parquet", "csv", "json"))
         if not any(candidate.exists() for candidate in candidates):
             missing_inputs.append(stem)
             expected_by_stem[stem] = ", ".join(path.name for path in candidates)
@@ -1705,9 +1659,7 @@ def _load_mc_bundle_frames(
                 f"Missing required MC {stem} file in '{bundle_dir}'. Expected one of: {expected}"
             )
         missing_text = ", ".join(missing_inputs)
-        expected_text = "; ".join(
-            f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs
-        )
+        expected_text = "; ".join(f"{stem}: {expected_by_stem[stem]}" for stem in missing_inputs)
         raise TrendCLIError(
             f"Missing required MC input files in '{bundle_dir}': {missing_text}. "
             f"Expected one of each: {expected_text}"
@@ -1716,13 +1668,9 @@ def _load_mc_bundle_frames(
 
 
 def _parse_mc_chart_selection(charts_value: str) -> list[str]:
-    requested = [
-        token.strip().lower() for token in charts_value.split(",") if token.strip()
-    ]
+    requested = [token.strip().lower() for token in charts_value.split(",") if token.strip()]
     if not requested:
-        raise TrendCLIError(
-            "The 'mc viz' command requires at least one chart in --charts."
-        )
+        raise TrendCLIError("The 'mc viz' command requires at least one chart in --charts.")
 
     seen: set[str] = set()
     ordered: list[str] = []
@@ -1792,20 +1740,16 @@ def _build_mc_risk_return_chart(
     from trend_analysis.viz import risk_return
 
     nav_frame = _mc_nav_source_frame(summary_frame, results_frame, nav_paths_frame)
-    returns_frame = nav_frame.pct_change(fill_method=None).replace(
-        [np.inf, -np.inf], np.nan
-    )
+    returns_frame = nav_frame.pct_change(fill_method=None).replace([np.inf, -np.inf], np.nan)
     returns_frame = returns_frame.dropna(how="all")
     if returns_frame.empty:
-        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(
-            how="all"
-        )
+        returns_frame = nav_frame.apply(pd.to_numeric, errors="coerce").dropna(how="all")
     return risk_return.make(returns_frame)
 
 
-def _mc_chart_builders() -> dict[
-    str, Callable[[pd.DataFrame, pd.DataFrame, pd.DataFrame | None], Any]
-]:
+def _mc_chart_builders() -> (
+    dict[str, Callable[[pd.DataFrame, pd.DataFrame, pd.DataFrame | None], Any]]
+):
     return {
         "fan": _build_mc_fan_chart,
         "path_dist": _build_mc_path_dist_chart,
@@ -1857,17 +1801,13 @@ def _inject_mc_html_chart_markers(
                 continue
             body_token = "<body>"
             if body_token in html_text:
-                updated_html = html_text.replace(
-                    body_token, f"{body_token}\n{marker}", 1
-                )
+                updated_html = html_text.replace(body_token, f"{body_token}\n{marker}", 1)
             else:
                 updated_html = f"{marker}\n{html_text}"
             html_path.parent.mkdir(parents=True, exist_ok=True)
             html_path.write_text(updated_html, encoding="utf-8")
         except Exception as exc:
-            warnings.append(
-                f"Unable to inject HTML chart marker for '{chart_id}': {exc}."
-            )
+            warnings.append(f"Unable to inject HTML chart marker for '{chart_id}': {exc}.")
 
 
 def _run_mc_viz_command(args: argparse.Namespace) -> int:
@@ -1998,9 +1938,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                 fallback = _fallback_explanation(metric_catalog)
                 fallback = append_discrepancy_log(fallback, claim_issues)
                 explanation_text = fallback
-            explanation_text = _finalize_explanation_text(
-                explanation_text, claim_issues
-            )
+            explanation_text = _finalize_explanation_text(explanation_text, claim_issues)
             if args.output:
                 payload = _build_explain_artifact_payload(
                     run_id=run_id,
@@ -2049,9 +1987,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     print("No changes.")
                 return 0
             if args.dry_run:
-                sys.stdout.write(
-                    yaml.safe_dump(updated, sort_keys=False, default_flow_style=False)
-                )
+                sys.stdout.write(yaml.safe_dump(updated, sort_keys=False, default_flow_style=False))
                 return 0
             if args.run:
                 validate_started = time.perf_counter()
@@ -2081,9 +2017,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     )
                     raise TrendCLIError(str(exc)) from exc
                 if not validation.valid:
-                    validation_details = "\n".join(
-                        format_validation_messages(validation)
-                    )
+                    validation_details = "\n".join(format_validation_messages(validation))
                     validation_error = f"validation failed: {validation_details}"
                 _log_nl_operation(
                     request_id=request_id,
@@ -2098,9 +2032,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
                     timestamp=validate_timestamp,
                 )
                 if validation_error is not None:
-                    raise TrendCLIError(
-                        f"Config validation failed:\n{validation_details}"
-                    )
+                    raise TrendCLIError(f"Config validation failed:\n{validation_details}")
             _confirm_risky_patch(patch, no_confirm=args.no_confirm)
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_text(
@@ -2162,9 +2094,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
             raise TrendCLIError(f"Unknown command: {command}")
 
         if command != "mc" and not args.config:
-            raise TrendCLIError(
-                f"The --config option is required for the '{command}' command"
-            )
+            raise TrendCLIError(f"The --config option is required for the '{command}' command")
 
         load_config_fn = _load_configuration
         cfg_path, cfg = load_config_fn(args.config)
@@ -2222,9 +2152,7 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
 
         if command == "stress":
             if not args.scenario:
-                raise TrendCLIError(
-                    "The --scenario option is required for the 'stress' command"
-                )
+                raise TrendCLIError("The --scenario option is required for the 'stress' command")
             _adjust_for_scenario(cfg, args.scenario)
             export_dir = Path(args.out) if args.out else None
             _prepare_export_config(cfg, export_dir, None)

--- a/src/trend/cli_commands.py
+++ b/src/trend/cli_commands.py
@@ -37,8 +37,7 @@ def run_app_command(
         proc = run_process(["streamlit", "run", str(app_path), *extra_args])
     except FileNotFoundError:
         print(
-            "Error: the 'streamlit' executable was not found. "
-            "Install the optional 'app' extra.",
+            "Error: the 'streamlit' executable was not found. " "Install the optional 'app' extra.",
             file=sys.stderr,
         )
         return 127
@@ -78,9 +77,7 @@ def run_analysis_command(
             spec_preset = get_spec_preset(args.preset)
         except KeyError:
             available = ", ".join(list_spec_presets())
-            raise error(
-                f"Unknown preset '{args.preset}'. Available presets: {available}"
-            )
+            raise error(f"Unknown preset '{args.preset}'. Available presets: {available}")
         apply_spec_preset(cfg, spec_preset)
         try:
             portfolio_preset = get_portfolio_preset(args.preset)
@@ -90,9 +87,7 @@ def run_analysis_command(
         apply_portfolio_preset(cfg, portfolio_preset)
     if getattr(args, "universe", None):
         mask, universe_spec = load_universe(args.universe, prices=returns_df)
-        returns_df = apply_universe_mask(
-            returns_df, mask, date_column=universe_spec.date_column
-        )
+        returns_df = apply_universe_mask(returns_df, mask, date_column=universe_spec.date_column)
         attach_universe_paths(cfg, universe_spec, csv_path=str(returns_path))
     if getattr(args, "skip_if_exists", False):
         candidate_run_id = calculate_run_id(cfg, returns_path)

--- a/src/trend/cli_commands.py
+++ b/src/trend/cli_commands.py
@@ -41,7 +41,7 @@ def run_app_command(
             file=sys.stderr,
         )
         return 127
-    return proc.returncode
+    return int(proc.returncode)
 
 
 def run_analysis_command(
@@ -65,7 +65,7 @@ def run_analysis_command(
     find_existing_run: Callable[..., Path | None],
     calculate_run_id: Callable[..., str],
     run_pipeline: Callable[..., tuple[Any, str, Path | None]],
-    write_artifacts: Callable[..., None],
+    write_artifacts: Callable[..., Path | None],
     print_summary: Callable[[Any, Any], None],
     finalize_coverage: Callable[[], None],
 ) -> int:

--- a/src/trend/cli_commands.py
+++ b/src/trend/cli_commands.py
@@ -37,7 +37,8 @@ def run_app_command(
         proc = run_process(["streamlit", "run", str(app_path), *extra_args])
     except FileNotFoundError:
         print(
-            "Error: the 'streamlit' executable was not found. " "Install the optional 'app' extra.",
+            "Error: the 'streamlit' executable was not found. "
+            "Install the optional 'app' extra.",
             file=sys.stderr,
         )
         return 127
@@ -77,7 +78,9 @@ def run_analysis_command(
             spec_preset = get_spec_preset(args.preset)
         except KeyError:
             available = ", ".join(list_spec_presets())
-            raise error(f"Unknown preset '{args.preset}'. Available presets: {available}")
+            raise error(
+                f"Unknown preset '{args.preset}'. Available presets: {available}"
+            )
         apply_spec_preset(cfg, spec_preset)
         try:
             portfolio_preset = get_portfolio_preset(args.preset)
@@ -87,7 +90,9 @@ def run_analysis_command(
         apply_portfolio_preset(cfg, portfolio_preset)
     if getattr(args, "universe", None):
         mask, universe_spec = load_universe(args.universe, prices=returns_df)
-        returns_df = apply_universe_mask(returns_df, mask, date_column=universe_spec.date_column)
+        returns_df = apply_universe_mask(
+            returns_df, mask, date_column=universe_spec.date_column
+        )
         attach_universe_paths(cfg, universe_spec, csv_path=str(returns_path))
     if getattr(args, "skip_if_exists", False):
         candidate_run_id = calculate_run_id(cfg, returns_path)

--- a/src/trend/cli_commands.py
+++ b/src/trend/cli_commands.py
@@ -1,0 +1,183 @@
+"""Focused command handlers used by :mod:`trend.cli`.
+
+The public CLI remains responsible for parsing and shared configuration setup.
+This module owns the command-specific side effects so those contracts can be
+tested through ``trend.cli:main`` without retaining command implementations in
+the parser front door.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+ErrorFactory = Callable[[str], Exception]
+
+
+def run_check_command(*, environment_check: Callable[[], int]) -> int:
+    """Run the lightweight environment check command."""
+
+    return environment_check()
+
+
+def run_app_command(
+    args: argparse.Namespace,
+    extra_args: list[str],
+    *,
+    app_path: Path,
+    run_process: Callable[..., Any] = subprocess.run,
+) -> int:
+    """Start Streamlit while preserving the CLI's exit-code contract."""
+
+    del args  # The parser owns app-specific argument validation.
+    try:
+        proc = run_process(["streamlit", "run", str(app_path), *extra_args])
+    except FileNotFoundError:
+        print(
+            "Error: the 'streamlit' executable was not found. " "Install the optional 'app' extra.",
+            file=sys.stderr,
+        )
+        return 127
+    return proc.returncode
+
+
+def run_analysis_command(
+    args: argparse.Namespace,
+    cfg_path: Path,
+    cfg: Any,
+    returns_path: Path,
+    returns_df: Any,
+    *,
+    error: ErrorFactory,
+    set_cache: Callable[[bool], None],
+    get_spec_preset: Callable[[str], Any],
+    list_spec_presets: Callable[[], Iterable[str]],
+    apply_spec_preset: Callable[[Any, Any], None],
+    get_portfolio_preset: Callable[[str], Any],
+    list_portfolio_presets: Callable[[], Iterable[str]],
+    apply_portfolio_preset: Callable[[Any, Any], None],
+    load_universe: Callable[..., tuple[Any, Any]],
+    apply_universe_mask: Callable[..., Any],
+    attach_universe_paths: Callable[..., None],
+    find_existing_run: Callable[..., Path | None],
+    calculate_run_id: Callable[..., str],
+    run_pipeline: Callable[..., tuple[Any, str, Path | None]],
+    write_artifacts: Callable[..., None],
+    print_summary: Callable[[Any, Any], None],
+    finalize_coverage: Callable[[], None],
+) -> int:
+    """Execute ``trend run`` with all side-effecting dependencies explicit."""
+
+    set_cache(not getattr(args, "no_cache", False))
+    if getattr(args, "preset", None):
+        try:
+            spec_preset = get_spec_preset(args.preset)
+        except KeyError:
+            available = ", ".join(list_spec_presets())
+            raise error(f"Unknown preset '{args.preset}'. Available presets: {available}")
+        apply_spec_preset(cfg, spec_preset)
+        try:
+            portfolio_preset = get_portfolio_preset(args.preset)
+        except KeyError:
+            available = ", ".join(list_portfolio_presets())
+            raise error(f"Unknown preset '{args.preset}'. Available: {available}")
+        apply_portfolio_preset(cfg, portfolio_preset)
+    if getattr(args, "universe", None):
+        mask, universe_spec = load_universe(args.universe, prices=returns_df)
+        returns_df = apply_universe_mask(returns_df, mask, date_column=universe_spec.date_column)
+        attach_universe_paths(cfg, universe_spec, csv_path=str(returns_path))
+    if getattr(args, "skip_if_exists", False):
+        candidate_run_id = calculate_run_id(cfg, returns_path)
+        existing_manifest = find_existing_run(cfg, candidate_run_id)
+        if existing_manifest is not None:
+            print(f"already-done: run_id={candidate_run_id}")
+            print(f"Existing manifest: {existing_manifest}")
+            finalize_coverage()
+            return 0
+    result, run_id, log_path = run_pipeline(
+        cfg,
+        returns_df,
+        source_path=returns_path,
+        log_file=Path(args.log_file) if args.log_file else None,
+        structured_log=not args.no_structured_log,
+        bundle=Path(args.bundle) if args.bundle else None,
+    )
+    write_artifacts(
+        cfg=cfg,
+        result=result,
+        config_path=cfg_path,
+        input_path=returns_path,
+        data_frame=returns_df,
+        run_id=run_id,
+        structured_log=not args.no_structured_log,
+    )
+    print_summary(cfg, result)
+    if log_path:
+        print(f"Structured log: {log_path}")
+    finalize_coverage()
+    return 0
+
+
+def run_report_command(
+    args: argparse.Namespace,
+    cfg: Any,
+    returns_path: Path,
+    returns_df: Any,
+    *,
+    error: ErrorFactory,
+    default_formats: Iterable[str],
+    prepare_export_config: Callable[..., None],
+    run_pipeline: Callable[..., tuple[Any, str, Path | None]],
+    print_summary: Callable[[Any, Any], None],
+    write_report_files: Callable[..., None],
+    resolve_report_output_path: Callable[..., Path],
+    generate_report: Callable[..., Any],
+    finalize_coverage: Callable[[], None],
+) -> int:
+    """Execute ``trend report`` while keeping pipeline and writers injectable."""
+
+    export_dir = Path(args.out).resolve() if args.out else None
+    if export_dir is None and not args.output:
+        raise error(
+            "The 'report' command requires --out for artefacts or --output for the HTML report"
+        )
+    formats = args.formats or default_formats
+    prepare_export_config(cfg, export_dir, formats if export_dir is not None else None)
+    result, run_id, _ = run_pipeline(
+        cfg,
+        returns_df,
+        source_path=returns_path,
+        log_file=None,
+        structured_log=False,
+        bundle=None,
+    )
+    print_summary(cfg, result)
+    if export_dir is not None:
+        write_report_files(export_dir, cfg, result, run_id=run_id)
+    report_path = resolve_report_output_path(args.output, export_dir, run_id)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        artifacts = generate_report(
+            result,
+            cfg,
+            run_id=run_id,
+            include_pdf=args.pdf,
+            spec=getattr(cfg, "_trend_run_spec", None),
+        )
+    except RuntimeError as exc:
+        raise error(str(exc)) from exc
+    report_path.write_text(artifacts.html, encoding="utf-8")
+    print(f"Report written: {report_path}")
+    if args.pdf:
+        if artifacts.pdf_bytes is None:
+            raise error(
+                "PDF generation failed – install the 'fpdf2' dependency to enable --pdf output"
+            )
+        pdf_path = report_path.with_suffix(".pdf")
+        pdf_path.write_bytes(artifacts.pdf_bytes)
+        print(f"PDF report written: {pdf_path}")
+    finalize_coverage()
+    return 0

--- a/tests/test_trend_cli_entrypoints.py
+++ b/tests/test_trend_cli_entrypoints.py
@@ -419,6 +419,12 @@ def test_load_configuration_missing_file(tmp_path: Path) -> None:
         trend_cli._load_configuration(str(tmp_path / "absent.yml"))
 
 
+def test_main_check_flag_without_subcommand(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(trend_cli, "_run_environment_check", lambda: 17)
+
+    assert trend_cli.main(["check"]) == 17
+
+
 def test_main_run_command(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_trend_cli_entrypoints.py
+++ b/tests/test_trend_cli_entrypoints.py
@@ -61,9 +61,7 @@ def test_resolve_returns_path_relative(tmp_path: Path) -> None:
     resolved = trend_cli._resolve_returns_path(cfg_path, config, None)
     assert resolved == (cfg_path.parent / "returns.csv").resolve()
 
-    override = trend_cli._resolve_returns_path(
-        cfg_path, config, str(tmp_path / "override.csv")
-    )
+    override = trend_cli._resolve_returns_path(cfg_path, config, str(tmp_path / "override.csv"))
     assert override == (tmp_path / "override.csv").resolve()
 
 
@@ -76,9 +74,7 @@ def test_resolve_returns_path_requires_csv(tmp_path: Path) -> None:
 
 def test_ensure_dataframe_validates_load(monkeypatch: pytest.MonkeyPatch) -> None:
     frame = pd.DataFrame({"a": [1]})
-    monkeypatch.setattr(
-        trend_cli, "load_csv", lambda path: frame if "ok" in path else None
-    )
+    monkeypatch.setattr(trend_cli, "load_csv", lambda path: frame if "ok" in path else None)
     assert trend_cli._ensure_dataframe(Path("ok.csv")).equals(frame)
 
     with pytest.raises(FileNotFoundError):
@@ -135,21 +131,15 @@ def test_prepare_export_config_ignores_setattr_failures() -> None:
     trend_cli._prepare_export_config(cfg, Path("dir"), ["txt"])
 
 
-def test_handle_exports_invokes_exporters(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_handle_exports_invokes_exporters(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     cfg = _make_config(export={"directory": str(tmp_path), "formats": ["xlsx", "csv"]})
     result = DummyResult()
 
     summary_called: list[dict[str, object]] = []
     export_calls: list[tuple] = []
 
-    monkeypatch.setattr(
-        trend_cli.export, "make_summary_formatter", lambda *_: lambda name, df: df
-    )
-    monkeypatch.setattr(
-        trend_cli.export, "summary_frame_from_result", lambda *_: pd.DataFrame()
-    )
+    monkeypatch.setattr(trend_cli.export, "make_summary_formatter", lambda *_: lambda name, df: df)
+    monkeypatch.setattr(trend_cli.export, "summary_frame_from_result", lambda *_: pd.DataFrame())
 
     def fake_export_to_excel(data, path, default_sheet_formatter=None):
         summary_called.append({"path": path, "data": data})
@@ -161,9 +151,7 @@ def test_handle_exports_invokes_exporters(
         "export_data",
         lambda data, path, formats: export_calls.append((tuple(sorted(formats)), path)),
     )
-    monkeypatch.setattr(
-        trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None
-    )
+    monkeypatch.setattr(trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None)
 
     trend_cli._handle_exports(cfg, result, structured_log=True, run_id="abc")
 
@@ -171,9 +159,7 @@ def test_handle_exports_invokes_exporters(
     assert (tmp_path / "analysis.xlsx").exists()
 
 
-def test_handle_exports_without_excel(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_handle_exports_without_excel(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     cfg = _make_config(export={"directory": str(tmp_path), "formats": ["json"]})
     result = DummyResult()
 
@@ -183,9 +169,7 @@ def test_handle_exports_without_excel(
         "export_data",
         lambda data, path, formats: calls.append((tuple(formats), path)),
     )
-    monkeypatch.setattr(
-        trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None
-    )
+    monkeypatch.setattr(trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None)
 
     trend_cli._handle_exports(cfg, result, structured_log=False, run_id="abc")
     assert calls == [(("json",), str(Path(cfg.export["directory"]) / "analysis"))]
@@ -200,17 +184,11 @@ def test_run_pipeline_sets_metadata_and_bundle(
     monkeypatch.chdir(tmp_path)
 
     monkeypatch.setattr(trend_cli, "run_simulation", lambda *_: result)
-    monkeypatch.setattr(
-        trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None
-    )
+    monkeypatch.setattr(trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None)
     handled: list[tuple] = []
-    monkeypatch.setattr(
-        trend_cli, "_handle_exports", lambda *args, **kwargs: handled.append(args)
-    )
+    monkeypatch.setattr(trend_cli, "_handle_exports", lambda *args, **kwargs: handled.append(args))
     written: list[tuple] = []
-    monkeypatch.setattr(
-        trend_cli, "_write_bundle", lambda *args, **kwargs: written.append(args)
-    )
+    monkeypatch.setattr(trend_cli, "_write_bundle", lambda *args, **kwargs: written.append(args))
     monkeypatch.setattr(
         trend_cli.run_logging,
         "get_default_log_path",
@@ -249,9 +227,7 @@ def test_run_pipeline_requires_transaction_cost(
     returns = pd.DataFrame({"x": [1, 2, 3]})
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(trend_cli, "run_simulation", lambda *_: DummyResult())
-    monkeypatch.setattr(
-        trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None
-    )
+    monkeypatch.setattr(trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None)
 
     with pytest.raises(trend_cli.TrendCLIError, match="transaction_cost_bps"):
         trend_cli._run_pipeline(
@@ -264,9 +240,7 @@ def test_run_pipeline_requires_transaction_cost(
         )
 
 
-def test_write_bundle_normalises_directory(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_write_bundle_normalises_directory(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     bundle_dir = tmp_path / "bundle"
     bundle_dir.mkdir()
 
@@ -275,9 +249,7 @@ def test_write_bundle_normalises_directory(
         "trend_analysis.export.bundle.export_bundle",
         lambda result, path: recorded.append(path),
     )
-    monkeypatch.setattr(
-        trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None
-    )
+    monkeypatch.setattr(trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None)
 
     result = DummyResult()
     cfg = _make_config()
@@ -300,9 +272,7 @@ def test_print_summary_emits_cache_stats(
     result = DummyResult()
     cfg = _make_config(sample_split={"in_start": "2020-01", "in_end": "2020-02"})
     monkeypatch.setattr(trend_cli.export, "format_summary_text", lambda *_: "SUMMARY")
-    monkeypatch.setattr(
-        trend_cli, "_legacy_extract_cache_stats", lambda *_: {"hits": 2}
-    )
+    monkeypatch.setattr(trend_cli, "_legacy_extract_cache_stats", lambda *_: {"hits": 2})
 
     trend_cli._print_summary(cfg, result)
     out = capsys.readouterr().out
@@ -353,9 +323,7 @@ def test_adjust_for_scenario_handles_attr_failure() -> None:
     trend_cli._adjust_for_scenario(cfg, "2008")
 
 
-def test_load_configuration_reads_file(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_load_configuration_reads_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     cfg_file = tmp_path / "config.yml"
     csv_path = tmp_path / "returns.csv"
     csv_path.write_text("Date,A\n2020-01-31,0.1\n", encoding="utf-8")
@@ -459,9 +427,7 @@ def test_main_check_command_returns_environment_check_code(
     assert trend_cli.main(["check"]) == 17
 
 
-def test_main_run_applies_named_universe(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_main_run_applies_named_universe(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     cfg = _make_config()
     cfg_path = tmp_path / "cfg.yml"
     returns_path = tmp_path / "returns.csv"
@@ -485,9 +451,7 @@ def test_main_run_applies_named_universe(
         recorded["prices_snapshot"] = prices.copy()
         return mask, SimpleNamespace(date_column="Date", membership_path=Path("m.csv"))
 
-    def fake_attach_universe_paths(
-        config: object, universe_spec: object, *, csv_path: str
-    ) -> None:
+    def fake_attach_universe_paths(config: object, universe_spec: object, *, csv_path: str) -> None:
         recorded["attach_called"] = True
         getattr(config, "data")["universe_membership_path"] = str(
             getattr(universe_spec, "membership_path")
@@ -499,9 +463,7 @@ def test_main_run_applies_named_universe(
         pipeline_returns["returns"] = returns_df.copy()
         return DummyResult(), "run123", None
 
-    monkeypatch.setattr(
-        trend_cli, "_load_configuration", lambda path: (Path(path), cfg)
-    )
+    monkeypatch.setattr(trend_cli, "_load_configuration", lambda path: (Path(path), cfg))
     monkeypatch.setattr(trend_cli, "_ensure_dataframe", lambda path: base_frame.copy())
     monkeypatch.setattr(trend_cli, "_determine_seed", lambda cfg, override: 123)
     monkeypatch.setattr(trend_cli, "load_universe", fake_load_universe)
@@ -539,12 +501,8 @@ def test_main_run_command(
     returns_path = tmp_path / "returns.csv"
     returns_path.write_text("csv", encoding="utf-8")
 
-    monkeypatch.setattr(
-        trend_cli, "_load_configuration", lambda path: (Path(path), cfg)
-    )
-    monkeypatch.setattr(
-        trend_cli, "_ensure_dataframe", lambda path: pd.DataFrame({"x": [1]})
-    )
+    monkeypatch.setattr(trend_cli, "_load_configuration", lambda path: (Path(path), cfg))
+    monkeypatch.setattr(trend_cli, "_ensure_dataframe", lambda path: pd.DataFrame({"x": [1]}))
     monkeypatch.setattr(trend_cli, "_determine_seed", lambda cfg, override: 123)
     monkeypatch.setattr(
         trend_cli,
@@ -574,12 +532,8 @@ def test_main_report_command(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     returns_path = tmp_path / "returns.csv"
     returns_path.write_text("csv", encoding="utf-8")
 
-    monkeypatch.setattr(
-        trend_cli, "_load_configuration", lambda path: (Path(path), cfg)
-    )
-    monkeypatch.setattr(
-        trend_cli, "_ensure_dataframe", lambda path: pd.DataFrame({"x": [1]})
-    )
+    monkeypatch.setattr(trend_cli, "_load_configuration", lambda path: (Path(path), cfg))
+    monkeypatch.setattr(trend_cli, "_ensure_dataframe", lambda path: pd.DataFrame({"x": [1]}))
     monkeypatch.setattr(trend_cli, "_determine_seed", lambda cfg, override: 123)
     monkeypatch.setattr(
         trend_cli,
@@ -596,9 +550,7 @@ def test_main_report_command(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     monkeypatch.setattr(
         trend_cli,
         "generate_unified_report",
-        lambda *a, **k: SimpleNamespace(
-            html="<html>report</html>", pdf_bytes=None, context={}
-        ),
+        lambda *a, **k: SimpleNamespace(html="<html>report</html>", pdf_bytes=None, context={}),
     )
 
     exit_code = trend_cli.main(
@@ -645,13 +597,9 @@ def test_main_nl_diff_command(
         def run(self, **kwargs: object) -> ConfigPatch:
             return patch
 
-    monkeypatch.setattr(
-        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
-    )
+    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
 
-    exit_code = trend_cli.main(
-        ["nl", "Lower max weight", "--in", str(cfg_path), "--diff"]
-    )
+    exit_code = trend_cli.main(["nl", "Lower max weight", "--in", str(cfg_path), "--diff"])
 
     output = capsys.readouterr().out
     assert exit_code == 0
@@ -756,9 +704,7 @@ def test_main_nl_explain_command(
         def run(self, **kwargs: object) -> ConfigPatch:
             return patch
 
-    monkeypatch.setattr(
-        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
-    )
+    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
 
     exit_code = trend_cli.main(
         ["nl", "Lower max weight", "--in", str(cfg_path), "--explain", "--diff"]
@@ -823,9 +769,7 @@ def test_main_explain_command_accepts_cited_metrics(
         def run(self, **kwargs: object) -> SimpleNamespace:
             return SimpleNamespace(text="CAGR was 8% [from out_sample_stats].")
 
-    monkeypatch.setattr(
-        trend_cli, "_build_result_chain", lambda *_args, **_kwargs: DummyChain()
-    )
+    monkeypatch.setattr(trend_cli, "_build_result_chain", lambda *_args, **_kwargs: DummyChain())
 
     exit_code = trend_cli.main(["explain", "--details", str(details_path)])
 
@@ -845,9 +789,7 @@ def test_main_explain_command_blocks_unknown_metrics(
         def run(self, **kwargs: object) -> SimpleNamespace:
             return SimpleNamespace(text="Alpha was 1.2 [from alpha_stats].")
 
-    monkeypatch.setattr(
-        trend_cli, "_build_result_chain", lambda *_args, **_kwargs: DummyChain()
-    )
+    monkeypatch.setattr(trend_cli, "_build_result_chain", lambda *_args, **_kwargs: DummyChain())
 
     exit_code = trend_cli.main(
         ["explain", "--details", str(details_path), "--question", "What is alpha?"]
@@ -875,9 +817,7 @@ def test_main_explain_command_writes_json_artifact(
                 trace_url="trace://cli",
             )
 
-    monkeypatch.setattr(
-        trend_cli, "_build_result_chain", lambda *_args, **_kwargs: DummyChain()
-    )
+    monkeypatch.setattr(trend_cli, "_build_result_chain", lambda *_args, **_kwargs: DummyChain())
 
     exit_code = trend_cli.main(
         [
@@ -929,12 +869,8 @@ def test_main_nl_run_command_executes_pipeline(
         def run(self, **kwargs: object) -> ConfigPatch:
             return patch
 
-    monkeypatch.setattr(
-        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
-    )
-    monkeypatch.setattr(
-        trend_cli, "_ensure_dataframe", lambda *_args, **_kwargs: pd.DataFrame()
-    )
+    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
+    monkeypatch.setattr(trend_cli, "_ensure_dataframe", lambda *_args, **_kwargs: pd.DataFrame())
     monkeypatch.setattr(
         trend_cli,
         "validate_config",
@@ -942,9 +878,7 @@ def test_main_nl_run_command_executes_pipeline(
     )
     calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
-    def _fake_run_pipeline(
-        *args: object, **kwargs: object
-    ) -> tuple[DummyResult, str, None]:
+    def _fake_run_pipeline(*args: object, **kwargs: object) -> tuple[DummyResult, str, None]:
         calls.append((args, kwargs))
         return DummyResult(), "run123", None
 
@@ -965,15 +899,11 @@ def test_main_nl_run_command_executes_pipeline(
 
     assert exit_code == 0
     assert output_path.exists()
-    assert "csv_path: data/raw/indices/sample_index.csv" in output_path.read_text(
-        encoding="utf-8"
-    )
+    assert "csv_path: data/raw/indices/sample_index.csv" in output_path.read_text(encoding="utf-8")
     assert calls
 
 
-def test_main_nl_run_requires_valid_config(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_main_nl_run_requires_valid_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     output_path = tmp_path / "invalid.yml"
     patch = ConfigPatch(
         operations=[PatchOperation(op="set", path="version", value="")],
@@ -987,15 +917,11 @@ def test_main_nl_run_requires_valid_config(
         def run(self, **kwargs: object) -> ConfigPatch:
             return patch
 
-    monkeypatch.setattr(
-        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
-    )
+    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
     monkeypatch.setattr(
         trend_cli,
         "_run_pipeline",
-        lambda *_args, **_kwargs: pytest.fail(
-            "Pipeline should not run for invalid config"
-        ),
+        lambda *_args, **_kwargs: pytest.fail("Pipeline should not run for invalid config"),
     )
 
     exit_code = trend_cli.main(
@@ -1019,9 +945,7 @@ def test_main_nl_run_requires_existing_csv_path(
 ) -> None:
     output_path = tmp_path / "invalid.yml"
     patch = ConfigPatch(
-        operations=[
-            PatchOperation(op="set", path="data.csv_path", value="missing.csv")
-        ],
+        operations=[PatchOperation(op="set", path="data.csv_path", value="missing.csv")],
         summary="Missing CSV path",
     )
 
@@ -1032,15 +956,11 @@ def test_main_nl_run_requires_existing_csv_path(
         def run(self, **kwargs: object) -> ConfigPatch:
             return patch
 
-    monkeypatch.setattr(
-        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
-    )
+    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
     monkeypatch.setattr(
         trend_cli,
         "_run_pipeline",
-        lambda *_args, **_kwargs: pytest.fail(
-            "Pipeline should not run for invalid CSV"
-        ),
+        lambda *_args, **_kwargs: pytest.fail("Pipeline should not run for invalid CSV"),
     )
 
     exit_code = trend_cli.main(
@@ -1139,15 +1059,11 @@ def test_main_nl_run_schema_validation_blocks_invalid_config(
         def run(self, **kwargs: object) -> ConfigPatch:
             return patch
 
-    monkeypatch.setattr(
-        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
-    )
+    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
     monkeypatch.setattr(
         trend_cli,
         "_run_pipeline",
-        lambda *_args, **_kwargs: pytest.fail(
-            "Pipeline should not run for schema errors"
-        ),
+        lambda *_args, **_kwargs: pytest.fail("Pipeline should not run for schema errors"),
     )
 
     exit_code = trend_cli.main(
@@ -1190,9 +1106,7 @@ def test_main_nl_requires_confirmation_for_risky_patch(
         called["prompt"] = prompt
         return "n"
 
-    monkeypatch.setattr(
-        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
-    )
+    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
     monkeypatch.setattr(trend_cli.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(builtins, "input", _fake_input)
 
@@ -1213,9 +1127,7 @@ def test_main_nl_requires_confirmation_for_unknown_keys(
     output_path = tmp_path / "confirmed.yml"
     patch = ConfigPatch(
         operations=[
-            PatchOperation(
-                op="set", path="portfolio.constraints", value={"max_weight": 0.5}
-            )
+            PatchOperation(op="set", path="portfolio.constraints", value={"max_weight": 0.5})
         ],
         summary="Set max weight",
         needs_review=True,
@@ -1233,9 +1145,7 @@ def test_main_nl_requires_confirmation_for_unknown_keys(
         called["prompt"] = prompt
         return "n"
 
-    monkeypatch.setattr(
-        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
-    )
+    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
     monkeypatch.setattr(trend_cli.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(builtins, "input", _fake_input)
 
@@ -1269,9 +1179,7 @@ def test_main_nl_no_confirm_skips_prompt_for_risky_patch(
     def _fail_input(prompt: str = "") -> str:
         raise AssertionError("Prompt should be skipped when --no-confirm is set.")
 
-    monkeypatch.setattr(
-        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
-    )
+    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
     monkeypatch.setattr(builtins, "input", _fail_input)
 
     exit_code = trend_cli.main(
@@ -1299,12 +1207,8 @@ def test_main_stress_command(
     returns_path = tmp_path / "returns.csv"
     returns_path.write_text("csv", encoding="utf-8")
 
-    monkeypatch.setattr(
-        trend_cli, "_load_configuration", lambda path: (Path(path), cfg)
-    )
-    monkeypatch.setattr(
-        trend_cli, "_ensure_dataframe", lambda path: pd.DataFrame({"x": [1]})
-    )
+    monkeypatch.setattr(trend_cli, "_load_configuration", lambda path: (Path(path), cfg))
+    monkeypatch.setattr(trend_cli, "_ensure_dataframe", lambda path: pd.DataFrame({"x": [1]}))
     monkeypatch.setattr(trend_cli, "_determine_seed", lambda cfg, override: 123)
     monkeypatch.setattr(
         trend_cli,
@@ -1330,19 +1234,13 @@ def test_main_stress_command(
     assert exit_code == 0 and "Stress scenario" in captured
 
 
-def test_main_stress_with_export_dir(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_main_stress_with_export_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     cfg = _make_config()
     returns_path = tmp_path / "returns.csv"
     returns_path.write_text("csv", encoding="utf-8")
 
-    monkeypatch.setattr(
-        trend_cli, "_load_configuration", lambda path: (Path(path), cfg)
-    )
-    monkeypatch.setattr(
-        trend_cli, "_ensure_dataframe", lambda path: pd.DataFrame({"x": [1]})
-    )
+    monkeypatch.setattr(trend_cli, "_load_configuration", lambda path: (Path(path), cfg))
+    monkeypatch.setattr(trend_cli, "_ensure_dataframe", lambda path: pd.DataFrame({"x": [1]}))
     monkeypatch.setattr(trend_cli, "_determine_seed", lambda cfg, override: 123)
     monkeypatch.setattr(
         trend_cli,
@@ -1404,9 +1302,7 @@ def test_main_unknown_command(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         trend_cli, "_load_configuration", lambda *_: (Path("cfg.yml"), _make_config())
     )
-    monkeypatch.setattr(
-        trend_cli, "_ensure_dataframe", lambda *_: pd.DataFrame({"x": [1]})
-    )
+    monkeypatch.setattr(trend_cli, "_ensure_dataframe", lambda *_: pd.DataFrame({"x": [1]}))
     monkeypatch.setattr(trend_cli, "_determine_seed", lambda *_: 1)
     with pytest.raises(SystemExit) as excinfo:
         trend_cli.main(["unknown", "--config", "cfg.yml", "--returns", "data.csv"])
@@ -1426,9 +1322,7 @@ def test_trend_cli_has_no_legacy_module_dependency() -> None:
         elif isinstance(node, ast.ImportFrom):
             if node.module == "trend_analysis":
                 legacy_references.extend(
-                    f"{node.module}.{alias.name}"
-                    for alias in node.names
-                    if alias.name == "cli"
+                    f"{node.module}.{alias.name}" for alias in node.names if alias.name == "cli"
                 )
             elif node.module == "trend_analysis.cli":
                 legacy_references.append(node.module)
@@ -1446,9 +1340,7 @@ def test_trend_cli_has_no_legacy_module_dependency() -> None:
 
 
 def test_canonical_mc_commands_have_no_legacy_cli_dependency() -> None:
-    source = (Path(trend_cli.__file__).parent / "mc" / "commands.py").read_text(
-        encoding="utf-8"
-    )
+    source = (Path(trend_cli.__file__).parent / "mc" / "commands.py").read_text(encoding="utf-8")
     tree = ast.parse(source)
     legacy_references = [
         alias.name

--- a/tests/test_trend_cli_entrypoints.py
+++ b/tests/test_trend_cli_entrypoints.py
@@ -61,7 +61,9 @@ def test_resolve_returns_path_relative(tmp_path: Path) -> None:
     resolved = trend_cli._resolve_returns_path(cfg_path, config, None)
     assert resolved == (cfg_path.parent / "returns.csv").resolve()
 
-    override = trend_cli._resolve_returns_path(cfg_path, config, str(tmp_path / "override.csv"))
+    override = trend_cli._resolve_returns_path(
+        cfg_path, config, str(tmp_path / "override.csv")
+    )
     assert override == (tmp_path / "override.csv").resolve()
 
 
@@ -74,7 +76,9 @@ def test_resolve_returns_path_requires_csv(tmp_path: Path) -> None:
 
 def test_ensure_dataframe_validates_load(monkeypatch: pytest.MonkeyPatch) -> None:
     frame = pd.DataFrame({"a": [1]})
-    monkeypatch.setattr(trend_cli, "load_csv", lambda path: frame if "ok" in path else None)
+    monkeypatch.setattr(
+        trend_cli, "load_csv", lambda path: frame if "ok" in path else None
+    )
     assert trend_cli._ensure_dataframe(Path("ok.csv")).equals(frame)
 
     with pytest.raises(FileNotFoundError):
@@ -131,15 +135,21 @@ def test_prepare_export_config_ignores_setattr_failures() -> None:
     trend_cli._prepare_export_config(cfg, Path("dir"), ["txt"])
 
 
-def test_handle_exports_invokes_exporters(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_handle_exports_invokes_exporters(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     cfg = _make_config(export={"directory": str(tmp_path), "formats": ["xlsx", "csv"]})
     result = DummyResult()
 
     summary_called: list[dict[str, object]] = []
     export_calls: list[tuple] = []
 
-    monkeypatch.setattr(trend_cli.export, "make_summary_formatter", lambda *_: lambda name, df: df)
-    monkeypatch.setattr(trend_cli.export, "summary_frame_from_result", lambda *_: pd.DataFrame())
+    monkeypatch.setattr(
+        trend_cli.export, "make_summary_formatter", lambda *_: lambda name, df: df
+    )
+    monkeypatch.setattr(
+        trend_cli.export, "summary_frame_from_result", lambda *_: pd.DataFrame()
+    )
 
     def fake_export_to_excel(data, path, default_sheet_formatter=None):
         summary_called.append({"path": path, "data": data})
@@ -151,7 +161,9 @@ def test_handle_exports_invokes_exporters(monkeypatch: pytest.MonkeyPatch, tmp_p
         "export_data",
         lambda data, path, formats: export_calls.append((tuple(sorted(formats)), path)),
     )
-    monkeypatch.setattr(trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None
+    )
 
     trend_cli._handle_exports(cfg, result, structured_log=True, run_id="abc")
 
@@ -159,7 +171,9 @@ def test_handle_exports_invokes_exporters(monkeypatch: pytest.MonkeyPatch, tmp_p
     assert (tmp_path / "analysis.xlsx").exists()
 
 
-def test_handle_exports_without_excel(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_handle_exports_without_excel(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     cfg = _make_config(export={"directory": str(tmp_path), "formats": ["json"]})
     result = DummyResult()
 
@@ -169,7 +183,9 @@ def test_handle_exports_without_excel(monkeypatch: pytest.MonkeyPatch, tmp_path:
         "export_data",
         lambda data, path, formats: calls.append((tuple(formats), path)),
     )
-    monkeypatch.setattr(trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None
+    )
 
     trend_cli._handle_exports(cfg, result, structured_log=False, run_id="abc")
     assert calls == [(("json",), str(Path(cfg.export["directory"]) / "analysis"))]
@@ -184,11 +200,17 @@ def test_run_pipeline_sets_metadata_and_bundle(
     monkeypatch.chdir(tmp_path)
 
     monkeypatch.setattr(trend_cli, "run_simulation", lambda *_: result)
-    monkeypatch.setattr(trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None
+    )
     handled: list[tuple] = []
-    monkeypatch.setattr(trend_cli, "_handle_exports", lambda *args, **kwargs: handled.append(args))
+    monkeypatch.setattr(
+        trend_cli, "_handle_exports", lambda *args, **kwargs: handled.append(args)
+    )
     written: list[tuple] = []
-    monkeypatch.setattr(trend_cli, "_write_bundle", lambda *args, **kwargs: written.append(args))
+    monkeypatch.setattr(
+        trend_cli, "_write_bundle", lambda *args, **kwargs: written.append(args)
+    )
     monkeypatch.setattr(
         trend_cli.run_logging,
         "get_default_log_path",
@@ -227,7 +249,9 @@ def test_run_pipeline_requires_transaction_cost(
     returns = pd.DataFrame({"x": [1, 2, 3]})
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(trend_cli, "run_simulation", lambda *_: DummyResult())
-    monkeypatch.setattr(trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None
+    )
 
     with pytest.raises(trend_cli.TrendCLIError, match="transaction_cost_bps"):
         trend_cli._run_pipeline(
@@ -240,7 +264,9 @@ def test_run_pipeline_requires_transaction_cost(
         )
 
 
-def test_write_bundle_normalises_directory(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_write_bundle_normalises_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     bundle_dir = tmp_path / "bundle"
     bundle_dir.mkdir()
 
@@ -249,7 +275,9 @@ def test_write_bundle_normalises_directory(monkeypatch: pytest.MonkeyPatch, tmp_
         "trend_analysis.export.bundle.export_bundle",
         lambda result, path: recorded.append(path),
     )
-    monkeypatch.setattr(trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        trend_cli, "_legacy_maybe_log_step", lambda *args, **kwargs: None
+    )
 
     result = DummyResult()
     cfg = _make_config()
@@ -272,7 +300,9 @@ def test_print_summary_emits_cache_stats(
     result = DummyResult()
     cfg = _make_config(sample_split={"in_start": "2020-01", "in_end": "2020-02"})
     monkeypatch.setattr(trend_cli.export, "format_summary_text", lambda *_: "SUMMARY")
-    monkeypatch.setattr(trend_cli, "_legacy_extract_cache_stats", lambda *_: {"hits": 2})
+    monkeypatch.setattr(
+        trend_cli, "_legacy_extract_cache_stats", lambda *_: {"hits": 2}
+    )
 
     trend_cli._print_summary(cfg, result)
     out = capsys.readouterr().out
@@ -323,7 +353,9 @@ def test_adjust_for_scenario_handles_attr_failure() -> None:
     trend_cli._adjust_for_scenario(cfg, "2008")
 
 
-def test_load_configuration_reads_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_configuration_reads_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     cfg_file = tmp_path / "config.yml"
     csv_path = tmp_path / "returns.csv"
     csv_path.write_text("Date,A\n2020-01-31,0.1\n", encoding="utf-8")
@@ -453,7 +485,9 @@ def test_main_run_applies_named_universe(
         recorded["prices_snapshot"] = prices.copy()
         return mask, SimpleNamespace(date_column="Date", membership_path=Path("m.csv"))
 
-    def fake_attach_universe_paths(config: object, universe_spec: object, *, csv_path: str) -> None:
+    def fake_attach_universe_paths(
+        config: object, universe_spec: object, *, csv_path: str
+    ) -> None:
         recorded["attach_called"] = True
         getattr(config, "data")["universe_membership_path"] = str(
             getattr(universe_spec, "membership_path")
@@ -465,7 +499,9 @@ def test_main_run_applies_named_universe(
         pipeline_returns["returns"] = returns_df.copy()
         return DummyResult(), "run123", None
 
-    monkeypatch.setattr(trend_cli, "_load_configuration", lambda path: (Path(path), cfg))
+    monkeypatch.setattr(
+        trend_cli, "_load_configuration", lambda path: (Path(path), cfg)
+    )
     monkeypatch.setattr(trend_cli, "_ensure_dataframe", lambda path: base_frame.copy())
     monkeypatch.setattr(trend_cli, "_determine_seed", lambda cfg, override: 123)
     monkeypatch.setattr(trend_cli, "load_universe", fake_load_universe)
@@ -503,8 +539,12 @@ def test_main_run_command(
     returns_path = tmp_path / "returns.csv"
     returns_path.write_text("csv", encoding="utf-8")
 
-    monkeypatch.setattr(trend_cli, "_load_configuration", lambda path: (Path(path), cfg))
-    monkeypatch.setattr(trend_cli, "_ensure_dataframe", lambda path: pd.DataFrame({"x": [1]}))
+    monkeypatch.setattr(
+        trend_cli, "_load_configuration", lambda path: (Path(path), cfg)
+    )
+    monkeypatch.setattr(
+        trend_cli, "_ensure_dataframe", lambda path: pd.DataFrame({"x": [1]})
+    )
     monkeypatch.setattr(trend_cli, "_determine_seed", lambda cfg, override: 123)
     monkeypatch.setattr(
         trend_cli,
@@ -534,8 +574,12 @@ def test_main_report_command(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     returns_path = tmp_path / "returns.csv"
     returns_path.write_text("csv", encoding="utf-8")
 
-    monkeypatch.setattr(trend_cli, "_load_configuration", lambda path: (Path(path), cfg))
-    monkeypatch.setattr(trend_cli, "_ensure_dataframe", lambda path: pd.DataFrame({"x": [1]}))
+    monkeypatch.setattr(
+        trend_cli, "_load_configuration", lambda path: (Path(path), cfg)
+    )
+    monkeypatch.setattr(
+        trend_cli, "_ensure_dataframe", lambda path: pd.DataFrame({"x": [1]})
+    )
     monkeypatch.setattr(trend_cli, "_determine_seed", lambda cfg, override: 123)
     monkeypatch.setattr(
         trend_cli,
@@ -552,7 +596,9 @@ def test_main_report_command(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     monkeypatch.setattr(
         trend_cli,
         "generate_unified_report",
-        lambda *a, **k: SimpleNamespace(html="<html>report</html>", pdf_bytes=None, context={}),
+        lambda *a, **k: SimpleNamespace(
+            html="<html>report</html>", pdf_bytes=None, context={}
+        ),
     )
 
     exit_code = trend_cli.main(
@@ -599,9 +645,13 @@ def test_main_nl_diff_command(
         def run(self, **kwargs: object) -> ConfigPatch:
             return patch
 
-    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
+    monkeypatch.setattr(
+        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
+    )
 
-    exit_code = trend_cli.main(["nl", "Lower max weight", "--in", str(cfg_path), "--diff"])
+    exit_code = trend_cli.main(
+        ["nl", "Lower max weight", "--in", str(cfg_path), "--diff"]
+    )
 
     output = capsys.readouterr().out
     assert exit_code == 0
@@ -706,7 +756,9 @@ def test_main_nl_explain_command(
         def run(self, **kwargs: object) -> ConfigPatch:
             return patch
 
-    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
+    monkeypatch.setattr(
+        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
+    )
 
     exit_code = trend_cli.main(
         ["nl", "Lower max weight", "--in", str(cfg_path), "--explain", "--diff"]
@@ -771,7 +823,9 @@ def test_main_explain_command_accepts_cited_metrics(
         def run(self, **kwargs: object) -> SimpleNamespace:
             return SimpleNamespace(text="CAGR was 8% [from out_sample_stats].")
 
-    monkeypatch.setattr(trend_cli, "_build_result_chain", lambda *_args, **_kwargs: DummyChain())
+    monkeypatch.setattr(
+        trend_cli, "_build_result_chain", lambda *_args, **_kwargs: DummyChain()
+    )
 
     exit_code = trend_cli.main(["explain", "--details", str(details_path)])
 
@@ -791,7 +845,9 @@ def test_main_explain_command_blocks_unknown_metrics(
         def run(self, **kwargs: object) -> SimpleNamespace:
             return SimpleNamespace(text="Alpha was 1.2 [from alpha_stats].")
 
-    monkeypatch.setattr(trend_cli, "_build_result_chain", lambda *_args, **_kwargs: DummyChain())
+    monkeypatch.setattr(
+        trend_cli, "_build_result_chain", lambda *_args, **_kwargs: DummyChain()
+    )
 
     exit_code = trend_cli.main(
         ["explain", "--details", str(details_path), "--question", "What is alpha?"]
@@ -819,7 +875,9 @@ def test_main_explain_command_writes_json_artifact(
                 trace_url="trace://cli",
             )
 
-    monkeypatch.setattr(trend_cli, "_build_result_chain", lambda *_args, **_kwargs: DummyChain())
+    monkeypatch.setattr(
+        trend_cli, "_build_result_chain", lambda *_args, **_kwargs: DummyChain()
+    )
 
     exit_code = trend_cli.main(
         [
@@ -871,8 +929,12 @@ def test_main_nl_run_command_executes_pipeline(
         def run(self, **kwargs: object) -> ConfigPatch:
             return patch
 
-    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
-    monkeypatch.setattr(trend_cli, "_ensure_dataframe", lambda *_args, **_kwargs: pd.DataFrame())
+    monkeypatch.setattr(
+        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
+    )
+    monkeypatch.setattr(
+        trend_cli, "_ensure_dataframe", lambda *_args, **_kwargs: pd.DataFrame()
+    )
     monkeypatch.setattr(
         trend_cli,
         "validate_config",
@@ -880,7 +942,9 @@ def test_main_nl_run_command_executes_pipeline(
     )
     calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
-    def _fake_run_pipeline(*args: object, **kwargs: object) -> tuple[DummyResult, str, None]:
+    def _fake_run_pipeline(
+        *args: object, **kwargs: object
+    ) -> tuple[DummyResult, str, None]:
         calls.append((args, kwargs))
         return DummyResult(), "run123", None
 
@@ -901,11 +965,15 @@ def test_main_nl_run_command_executes_pipeline(
 
     assert exit_code == 0
     assert output_path.exists()
-    assert "csv_path: data/raw/indices/sample_index.csv" in output_path.read_text(encoding="utf-8")
+    assert "csv_path: data/raw/indices/sample_index.csv" in output_path.read_text(
+        encoding="utf-8"
+    )
     assert calls
 
 
-def test_main_nl_run_requires_valid_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_main_nl_run_requires_valid_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     output_path = tmp_path / "invalid.yml"
     patch = ConfigPatch(
         operations=[PatchOperation(op="set", path="version", value="")],
@@ -919,11 +987,15 @@ def test_main_nl_run_requires_valid_config(monkeypatch: pytest.MonkeyPatch, tmp_
         def run(self, **kwargs: object) -> ConfigPatch:
             return patch
 
-    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
+    monkeypatch.setattr(
+        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
+    )
     monkeypatch.setattr(
         trend_cli,
         "_run_pipeline",
-        lambda *_args, **_kwargs: pytest.fail("Pipeline should not run for invalid config"),
+        lambda *_args, **_kwargs: pytest.fail(
+            "Pipeline should not run for invalid config"
+        ),
     )
 
     exit_code = trend_cli.main(
@@ -947,7 +1019,9 @@ def test_main_nl_run_requires_existing_csv_path(
 ) -> None:
     output_path = tmp_path / "invalid.yml"
     patch = ConfigPatch(
-        operations=[PatchOperation(op="set", path="data.csv_path", value="missing.csv")],
+        operations=[
+            PatchOperation(op="set", path="data.csv_path", value="missing.csv")
+        ],
         summary="Missing CSV path",
     )
 
@@ -958,11 +1032,15 @@ def test_main_nl_run_requires_existing_csv_path(
         def run(self, **kwargs: object) -> ConfigPatch:
             return patch
 
-    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
+    monkeypatch.setattr(
+        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
+    )
     monkeypatch.setattr(
         trend_cli,
         "_run_pipeline",
-        lambda *_args, **_kwargs: pytest.fail("Pipeline should not run for invalid CSV"),
+        lambda *_args, **_kwargs: pytest.fail(
+            "Pipeline should not run for invalid CSV"
+        ),
     )
 
     exit_code = trend_cli.main(
@@ -1061,11 +1139,15 @@ def test_main_nl_run_schema_validation_blocks_invalid_config(
         def run(self, **kwargs: object) -> ConfigPatch:
             return patch
 
-    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
+    monkeypatch.setattr(
+        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
+    )
     monkeypatch.setattr(
         trend_cli,
         "_run_pipeline",
-        lambda *_args, **_kwargs: pytest.fail("Pipeline should not run for schema errors"),
+        lambda *_args, **_kwargs: pytest.fail(
+            "Pipeline should not run for schema errors"
+        ),
     )
 
     exit_code = trend_cli.main(
@@ -1108,7 +1190,9 @@ def test_main_nl_requires_confirmation_for_risky_patch(
         called["prompt"] = prompt
         return "n"
 
-    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
+    monkeypatch.setattr(
+        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
+    )
     monkeypatch.setattr(trend_cli.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(builtins, "input", _fake_input)
 
@@ -1129,7 +1213,9 @@ def test_main_nl_requires_confirmation_for_unknown_keys(
     output_path = tmp_path / "confirmed.yml"
     patch = ConfigPatch(
         operations=[
-            PatchOperation(op="set", path="portfolio.constraints", value={"max_weight": 0.5})
+            PatchOperation(
+                op="set", path="portfolio.constraints", value={"max_weight": 0.5}
+            )
         ],
         summary="Set max weight",
         needs_review=True,
@@ -1147,7 +1233,9 @@ def test_main_nl_requires_confirmation_for_unknown_keys(
         called["prompt"] = prompt
         return "n"
 
-    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
+    monkeypatch.setattr(
+        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
+    )
     monkeypatch.setattr(trend_cli.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(builtins, "input", _fake_input)
 
@@ -1181,7 +1269,9 @@ def test_main_nl_no_confirm_skips_prompt_for_risky_patch(
     def _fail_input(prompt: str = "") -> str:
         raise AssertionError("Prompt should be skipped when --no-confirm is set.")
 
-    monkeypatch.setattr(trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain())
+    monkeypatch.setattr(
+        trend_cli, "_build_nl_chain", lambda *_args, **_kwargs: DummyChain()
+    )
     monkeypatch.setattr(builtins, "input", _fail_input)
 
     exit_code = trend_cli.main(
@@ -1209,8 +1299,12 @@ def test_main_stress_command(
     returns_path = tmp_path / "returns.csv"
     returns_path.write_text("csv", encoding="utf-8")
 
-    monkeypatch.setattr(trend_cli, "_load_configuration", lambda path: (Path(path), cfg))
-    monkeypatch.setattr(trend_cli, "_ensure_dataframe", lambda path: pd.DataFrame({"x": [1]}))
+    monkeypatch.setattr(
+        trend_cli, "_load_configuration", lambda path: (Path(path), cfg)
+    )
+    monkeypatch.setattr(
+        trend_cli, "_ensure_dataframe", lambda path: pd.DataFrame({"x": [1]})
+    )
     monkeypatch.setattr(trend_cli, "_determine_seed", lambda cfg, override: 123)
     monkeypatch.setattr(
         trend_cli,
@@ -1236,13 +1330,19 @@ def test_main_stress_command(
     assert exit_code == 0 and "Stress scenario" in captured
 
 
-def test_main_stress_with_export_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_main_stress_with_export_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     cfg = _make_config()
     returns_path = tmp_path / "returns.csv"
     returns_path.write_text("csv", encoding="utf-8")
 
-    monkeypatch.setattr(trend_cli, "_load_configuration", lambda path: (Path(path), cfg))
-    monkeypatch.setattr(trend_cli, "_ensure_dataframe", lambda path: pd.DataFrame({"x": [1]}))
+    monkeypatch.setattr(
+        trend_cli, "_load_configuration", lambda path: (Path(path), cfg)
+    )
+    monkeypatch.setattr(
+        trend_cli, "_ensure_dataframe", lambda path: pd.DataFrame({"x": [1]})
+    )
     monkeypatch.setattr(trend_cli, "_determine_seed", lambda cfg, override: 123)
     monkeypatch.setattr(
         trend_cli,
@@ -1304,7 +1404,9 @@ def test_main_unknown_command(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         trend_cli, "_load_configuration", lambda *_: (Path("cfg.yml"), _make_config())
     )
-    monkeypatch.setattr(trend_cli, "_ensure_dataframe", lambda *_: pd.DataFrame({"x": [1]}))
+    monkeypatch.setattr(
+        trend_cli, "_ensure_dataframe", lambda *_: pd.DataFrame({"x": [1]})
+    )
     monkeypatch.setattr(trend_cli, "_determine_seed", lambda *_: 1)
     with pytest.raises(SystemExit) as excinfo:
         trend_cli.main(["unknown", "--config", "cfg.yml", "--returns", "data.csv"])
@@ -1324,7 +1426,9 @@ def test_trend_cli_has_no_legacy_module_dependency() -> None:
         elif isinstance(node, ast.ImportFrom):
             if node.module == "trend_analysis":
                 legacy_references.extend(
-                    f"{node.module}.{alias.name}" for alias in node.names if alias.name == "cli"
+                    f"{node.module}.{alias.name}"
+                    for alias in node.names
+                    if alias.name == "cli"
                 )
             elif node.module == "trend_analysis.cli":
                 legacy_references.append(node.module)
@@ -1342,7 +1446,9 @@ def test_trend_cli_has_no_legacy_module_dependency() -> None:
 
 
 def test_canonical_mc_commands_have_no_legacy_cli_dependency() -> None:
-    source = (Path(trend_cli.__file__).parent / "mc" / "commands.py").read_text(encoding="utf-8")
+    source = (Path(trend_cli.__file__).parent / "mc" / "commands.py").read_text(
+        encoding="utf-8"
+    )
     tree = ast.parse(source)
     legacy_references = [
         alias.name

--- a/tests/test_trend_cli_entrypoints.py
+++ b/tests/test_trend_cli_entrypoints.py
@@ -419,10 +419,80 @@ def test_load_configuration_missing_file(tmp_path: Path) -> None:
         trend_cli._load_configuration(str(tmp_path / "absent.yml"))
 
 
-def test_main_check_flag_without_subcommand(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_main_check_command_returns_environment_check_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(trend_cli, "_run_environment_check", lambda: 17)
 
     assert trend_cli.main(["check"]) == 17
+
+
+def test_main_run_applies_named_universe(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cfg = _make_config()
+    cfg_path = tmp_path / "cfg.yml"
+    returns_path = tmp_path / "returns.csv"
+    returns_path.write_text("csv", encoding="utf-8")
+    base_frame = pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2020-01-31", "2020-02-29"]),
+            "A": [0.1, 0.2],
+            "B": [0.3, 0.4],
+        }
+    )
+    mask = pd.DataFrame(
+        [[True, False], [True, True]],
+        index=pd.to_datetime(["2020-01-31", "2020-02-29"]),
+        columns=["A", "B"],
+    )
+    recorded: dict[str, object] = {}
+
+    def fake_load_universe(key: str, prices: pd.DataFrame, **_kwargs: object):
+        recorded["universe"] = key
+        recorded["prices_snapshot"] = prices.copy()
+        return mask, SimpleNamespace(date_column="Date", membership_path=Path("m.csv"))
+
+    def fake_attach_universe_paths(config: object, universe_spec: object, *, csv_path: str) -> None:
+        recorded["attach_called"] = True
+        getattr(config, "data")["universe_membership_path"] = str(
+            getattr(universe_spec, "membership_path")
+        )
+
+    pipeline_returns: dict[str, object] = {}
+
+    def fake_run_pipeline(cfg, returns_df, **_kwargs):
+        pipeline_returns["returns"] = returns_df.copy()
+        return DummyResult(), "run123", None
+
+    monkeypatch.setattr(trend_cli, "_load_configuration", lambda path: (Path(path), cfg))
+    monkeypatch.setattr(trend_cli, "_ensure_dataframe", lambda path: base_frame.copy())
+    monkeypatch.setattr(trend_cli, "_determine_seed", lambda cfg, override: 123)
+    monkeypatch.setattr(trend_cli, "load_universe", fake_load_universe)
+    monkeypatch.setattr(trend_cli, "_attach_universe_paths", fake_attach_universe_paths)
+    monkeypatch.setattr(trend_cli, "_run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(trend_cli, "_write_trend_run_artifacts", lambda **_kwargs: None)
+    monkeypatch.setattr(trend_cli, "_print_summary", lambda *args, **kwargs: None)
+
+    exit_code = trend_cli.main(
+        [
+            "run",
+            "--config",
+            str(cfg_path),
+            "--returns",
+            str(returns_path),
+            "--universe",
+            "core",
+        ]
+    )
+
+    assert exit_code == 0
+    assert recorded["universe"] == "core"
+    assert recorded["attach_called"] is True
+    assert "universe_membership_path" in getattr(cfg, "data")
+    masked_returns = pipeline_returns["returns"]
+    assert masked_returns["B"].isna().iloc[0]
+    assert not masked_returns["B"].isna().iloc[1]
 
 
 def test_main_run_command(


### PR DESCRIPTION
Closes #5879

Completes the verifier-identified Phase 2b handler decomposition while preserving the public `trend.cli:main` front door.

- moves check, app, run, and report implementations into `trend.cli_commands`
- keeps command-specific pipeline, report-writing, and process dependencies explicit
- adds the named check command contract test

Validation:
- `PYTHONPATH=src python -m pytest tests/test_trend_cli_entrypoints.py tests/test_trend_cli.py -q` — 112 passed
- `python -m ruff check src/trend/cli.py src/trend/cli_commands.py tests/test_trend_cli_entrypoints.py` — passed
- Deliberate break: replacing the `run_analysis_command` dispatch with `raise TrendCLIError("broken dispatch")` made `test_main_run_command` fail (expected); restored dispatch then passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved command execution for environment checks, app startup, analysis runs, and report generation.
  * Preserved existing CLI behavior, including preset handling, artifact reuse, exports, PDF reports, and exit codes.

* **Tests**
  * Added coverage verifying that the `check` command correctly runs environment validation and returns its result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->