### PR TITLE
fix: extract shared run/report command preparation

### DIFF
--- a/src/trend/cli.py
+++ b/src/trend/cli.py
@@ -24,6 +24,7 @@ from trend.cli_helpers import (
     _attach_universe_paths,
 )
 from trend.cli_commands import (
+    prepare_command_inputs,
     run_analysis_command,
     run_app_command,
     run_check_command,
@@ -2096,16 +2097,24 @@ def main(argv: list[str] | None = None, *, prog: str = "trend") -> int:
         if command != "mc" and not args.config:
             raise TrendCLIError(f"The --config option is required for the '{command}' command")
 
-        load_config_fn = _load_configuration
-        cfg_path, cfg = load_config_fn(args.config)
-        if coverage_tracker is not None:
-            wrap_config_for_coverage(cfg, coverage_tracker)
-        ensure_run_spec(cfg, base_path=cfg_path.parent)
-        resolve_returns = _resolve_returns_path
-        returns_path = resolve_returns(cfg_path, cfg, getattr(args, "returns", None))
-        ensure_df = _ensure_dataframe
-        returns_df = ensure_df(returns_path)
-        seed = _determine_seed(cfg, getattr(args, "seed", None))
+        def _prepare_config_for_command(cfg: Any) -> None:
+            if coverage_tracker is not None:
+                wrap_config_for_coverage(cfg, coverage_tracker)
+
+        prepared = prepare_command_inputs(
+            args,
+            load_configuration=_load_configuration,
+            prepare_config=_prepare_config_for_command,
+            ensure_run_spec=ensure_run_spec,
+            resolve_returns_path=_resolve_returns_path,
+            ensure_dataframe=_ensure_dataframe,
+            determine_seed=_determine_seed,
+        )
+        cfg_path = prepared.cfg_path
+        cfg = prepared.cfg
+        returns_path = prepared.returns_path
+        returns_df = prepared.returns_df
+        seed = prepared.seed
 
         if command == "run":
             return run_analysis_command(

--- a/src/trend/cli_commands.py
+++ b/src/trend/cli_commands.py
@@ -11,10 +11,49 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
 ErrorFactory = Callable[[str], Exception]
+
+
+@dataclass(frozen=True)
+class PreparedCommandInputs:
+    """Shared config and data inputs prepared for run/report command handlers."""
+
+    cfg_path: Path
+    cfg: Any
+    returns_path: Path
+    returns_df: Any
+    seed: int
+
+
+def prepare_command_inputs(
+    args: argparse.Namespace,
+    *,
+    load_configuration: Callable[[str], tuple[Path, Any]],
+    prepare_config: Callable[[Any], None],
+    ensure_run_spec: Callable[..., Any],
+    resolve_returns_path: Callable[..., Path],
+    ensure_dataframe: Callable[[Path], Any],
+    determine_seed: Callable[[Any, int | None], int],
+) -> PreparedCommandInputs:
+    """Load the shared run/report inputs outside the parser front door."""
+
+    cfg_path, cfg = load_configuration(args.config)
+    prepare_config(cfg)
+    ensure_run_spec(cfg, base_path=cfg_path.parent)
+    returns_path = resolve_returns_path(cfg_path, cfg, getattr(args, "returns", None))
+    returns_df = ensure_dataframe(returns_path)
+    seed = determine_seed(cfg, getattr(args, "seed", None))
+    return PreparedCommandInputs(
+        cfg_path=cfg_path,
+        cfg=cfg,
+        returns_path=returns_path,
+        returns_df=returns_df,
+        seed=seed,
+    )
 
 
 def run_check_command(*, environment_check: Callable[[], int]) -> int:

--- a/tests/test_trend_cli_entrypoints.py
+++ b/tests/test_trend_cli_entrypoints.py
@@ -419,12 +419,20 @@ def test_load_configuration_missing_file(tmp_path: Path) -> None:
         trend_cli._load_configuration(str(tmp_path / "absent.yml"))
 
 
-def test_main_check_command_returns_environment_check_code(
+def test_main_check_flag_without_subcommand(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    received: dict[str, object] = {}
+
+    def fake_run_check_command(*, environment_check):
+        received["environment_check"] = environment_check
+        return environment_check()
+
+    monkeypatch.setattr(trend_cli, "run_check_command", fake_run_check_command)
     monkeypatch.setattr(trend_cli, "_run_environment_check", lambda: 17)
 
     assert trend_cli.main(["check"]) == 17
+    assert callable(received["environment_check"])
 
 
 def test_main_run_applies_named_universe(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -1311,6 +1319,26 @@ def test_main_app_command(monkeypatch: pytest.MonkeyPatch) -> None:
     proc = types.SimpleNamespace(returncode=5)
     monkeypatch.setattr(trend_cli.subprocess, "run", lambda args: proc)
     assert trend_cli.main(["app"]) == 5
+
+
+def test_main_app_command_uses_extracted_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    received: dict[str, object] = {}
+
+    def fake_run_app_command(args, extra_args, *, app_path, run_process):
+        received.update(
+            args=args,
+            extra_args=extra_args,
+            app_path=app_path,
+            run_process=run_process,
+        )
+        return 11
+
+    monkeypatch.setattr(trend_cli, "run_app_command", fake_run_app_command)
+
+    assert trend_cli.main(["app"]) == 11
+    assert received["extra_args"] == []
+    assert received["app_path"] == trend_cli.APP_PATH
+    assert received["run_process"] is trend_cli.subprocess.run
 
 
 def test_main_handles_errors(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_trend_cli_entrypoints.py
+++ b/tests/test_trend_cli_entrypoints.py
@@ -527,6 +527,40 @@ def test_main_run_command(
     assert "Structured log" in capsys.readouterr().out
 
 
+def test_main_run_command_uses_extracted_shared_preparation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cfg = _make_config()
+    prepared = SimpleNamespace(
+        cfg_path=tmp_path / "cfg.yml",
+        cfg=cfg,
+        returns_path=tmp_path / "returns.csv",
+        returns_df=pd.DataFrame({"x": [1]}),
+        seed=123,
+    )
+    received: dict[str, object] = {}
+
+    monkeypatch.setattr(trend_cli, "prepare_command_inputs", lambda *_args, **_kwargs: prepared)
+
+    def fake_run_analysis_command(args, cfg_path, command_cfg, returns_path, returns_df, **_kwargs):
+        received.update(
+            args=args,
+            cfg_path=cfg_path,
+            cfg=command_cfg,
+            returns_path=returns_path,
+            returns_df=returns_df,
+        )
+        return 0
+
+    monkeypatch.setattr(trend_cli, "run_analysis_command", fake_run_analysis_command)
+
+    assert trend_cli.main(["run", "--config", str(tmp_path / "cfg.yml")]) == 0
+    assert received["cfg_path"] == prepared.cfg_path
+    assert received["cfg"] is cfg
+    assert received["returns_path"] == prepared.returns_path
+    assert received["returns_df"].equals(prepared.returns_df)
+
+
 def test_main_report_command(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     cfg = _make_config()
     returns_path = tmp_path / "returns.csv"


### PR DESCRIPTION
Closes #5879.

## Why
Provider comparison on merged #5880 found the accepted Phase 2b gap: `trend.cli:main` still prepared shared configuration and returns before delegating `run` and `report`.

## Change
- move shared config/run-spec/returns/seed preparation into `trend.cli_commands.prepare_command_inputs`
- retain `trend.cli:main` as parser/front door with explicit injected dependencies
- add a main-entrypoint regression proving the extracted preparation feeds the run handler

## Validation
- `python -m pytest` focused command suite: 7 passed
- `./scripts/style_gate_local.sh`: PASS (Black, Ruff, mypy)
- `git diff --check`: PASS
- deliberate-break gate: replacing the extracted run dispatch with `raise TrendCLIError("broken dispatch")` made `test_main_run_command` fail; restoring the dispatch made the focused suite pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved consistency across CLI run, report, and stress commands when loading configurations, returns data, and determining seeds.
  * Command workflows now provide more reliable validation and preparation before execution.

* **Tests**
  * Added coverage verifying that prepared command inputs are correctly passed to analysis workflows and successful execution is reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->