### PR TITLE
Legacy removal Phase 6b: remove runtime missing-data aliases

### DIFF
--- a/src/trend_analysis/data.py
+++ b/src/trend_analysis/data.py
@@ -1,7 +1,7 @@
 import logging
 import stat
 from pathlib import Path
-from typing import Any, Literal, Mapping, Optional, cast
+from typing import Any, Literal, Mapping, Optional
 
 import pandas as pd
 from pandas.api.types import is_datetime64_any_dtype
@@ -400,24 +400,8 @@ def load_csv(
     date_column: str = "Date",
     missing_policy: str | Mapping[str, str] | None = None,
     missing_limit: MissingLimitArg = None,
-    **_legacy_kwargs: object,
 ) -> Optional[pd.DataFrame]:
     """Load and validate a CSV using ``date_column`` as the date field."""
-
-    if missing_policy is None and "nan_policy" in _legacy_kwargs:
-        missing_policy = _coerce_policy_kwarg(_legacy_kwargs.pop("nan_policy"))
-    if missing_limit is None and "nan_limit" in _legacy_kwargs:
-        missing_limit = _coerce_limit_kwarg(_legacy_kwargs.pop("nan_limit"))
-    if missing_limit is None and "missing_limit" in _legacy_kwargs:
-        # ``missing_limit`` is also an explicit keyword argument on the public
-        # signature.  Modern Python will always bind that keyword to the
-        # dedicated parameter, meaning this compatibility branch only existed
-        # for very early call-sites that splatted dictionaries before the
-        # signature was expanded.  Retain the guard for clarity, but mark it as
-        # unreachable for coverage to avoid penalising the suite.
-        missing_limit = cast(
-            MissingLimitArg, _legacy_kwargs.pop("missing_limit")
-        )  # pragma: no cover
 
     p = Path(path)
     try:
@@ -481,18 +465,8 @@ def load_parquet(
     date_column: str = "Date",
     missing_policy: str | Mapping[str, str] | None = None,
     missing_limit: MissingLimitArg = None,
-    **_legacy_kwargs: object,
 ) -> Optional[pd.DataFrame]:
     """Load and validate a Parquet file using ``date_column`` as the date field."""
-
-    if missing_policy is None and "nan_policy" in _legacy_kwargs:
-        missing_policy = _coerce_policy_kwarg(_legacy_kwargs.pop("nan_policy"))
-    if missing_limit is None and "nan_limit" in _legacy_kwargs:
-        missing_limit = _coerce_limit_kwarg(_legacy_kwargs.pop("nan_limit"))
-    if missing_limit is None and "missing_limit" in _legacy_kwargs:
-        missing_limit = cast(
-            MissingLimitArg, _legacy_kwargs.pop("missing_limit")
-        )  # pragma: no cover
 
     p = Path(path)
     try:

--- a/src/trend_analysis/multi_period/engine.py
+++ b/src/trend_analysis/multi_period/engine.py
@@ -274,16 +274,12 @@ def _resolve_portfolio_weighting(
 def _get_missing_policy_settings(
     data_settings: Mapping[str, Any] | None,
 ) -> tuple[Any, Any]:
-    """Return missing-data policy/limit configs with legacy fallbacks."""
+    """Return the canonical missing-data policy and limit settings."""
 
     if not data_settings:
         return None, None
     missing_policy_cfg = data_settings.get("missing_policy")
-    if missing_policy_cfg is None:
-        missing_policy_cfg = data_settings.get("nan_policy")
     missing_limit_cfg = data_settings.get("missing_limit")
-    if missing_limit_cfg is None:
-        missing_limit_cfg = data_settings.get("nan_limit")
     return missing_policy_cfg, missing_limit_cfg
 
 

--- a/src/trend_analysis/multi_period/loaders.py
+++ b/src/trend_analysis/multi_period/loaders.py
@@ -69,11 +69,7 @@ def load_prices(cfg: Any) -> pd.DataFrame:
         raise KeyError("cfg.data['csv_path'] must be provided")
     resolved = _coerce_path(csv_path, field="data.csv_path")
     missing_policy = data.get("missing_policy")
-    if missing_policy is None:
-        missing_policy = data.get("nan_policy")
     missing_limit = data.get("missing_limit")
-    if missing_limit is None:
-        missing_limit = data.get("nan_limit")
     date_column = str(data.get("date_column") or "Date")
     load_kwargs: dict[str, Any] = {
         "errors": "raise",

--- a/src/trend_analysis/pipeline_entrypoints.py
+++ b/src/trend_analysis/pipeline_entrypoints.py
@@ -86,11 +86,7 @@ def run_from_config(cfg: Any, *, bindings: ConfigBindings) -> pd.DataFrame:
         raise KeyError("cfg.data['csv_path'] must be provided")
 
     missing_policy_cfg = bindings.section_get(data_settings, "missing_policy")
-    if missing_policy_cfg is None:
-        missing_policy_cfg = bindings.section_get(data_settings, "nan_policy")
     missing_limit_cfg = bindings.section_get(data_settings, "missing_limit")
-    if missing_limit_cfg is None:
-        missing_limit_cfg = bindings.section_get(data_settings, "nan_limit")
     date_column_cfg = bindings.section_get(data_settings, "date_column")
     if date_column_cfg is None:
         date_column_cfg = "Date"
@@ -223,11 +219,7 @@ def run_full_from_config(cfg: Any, *, bindings: ConfigBindings) -> PipelineResul
         raise KeyError("cfg.data['csv_path'] must be provided")
 
     missing_policy_cfg = bindings.section_get(data_settings, "missing_policy")
-    if missing_policy_cfg is None:
-        missing_policy_cfg = bindings.section_get(data_settings, "nan_policy")
     missing_limit_cfg = bindings.section_get(data_settings, "missing_limit")
-    if missing_limit_cfg is None:
-        missing_limit_cfg = bindings.section_get(data_settings, "nan_limit")
     date_column_cfg = bindings.section_get(data_settings, "date_column")
     if date_column_cfg is None:
         date_column_cfg = "Date"

--- a/src/trend_analysis/tool_layer.py
+++ b/src/trend_analysis/tool_layer.py
@@ -303,11 +303,7 @@ class ToolLayer:
                     raise KeyError("cfg.data['csv_path'] must be provided")
 
                 missing_policy_cfg = data_settings.get("missing_policy")
-                if missing_policy_cfg is None:
-                    missing_policy_cfg = data_settings.get("nan_policy")
                 missing_limit_cfg = data_settings.get("missing_limit")
-                if missing_limit_cfg is None:
-                    missing_limit_cfg = data_settings.get("nan_limit")
 
                 resolved_csv = self._sandbox_path(csv_path)
                 data_frame = load_csv(

--- a/tests/soft_coverage/test_data_soft.py
+++ b/tests/soft_coverage/test_data_soft.py
@@ -310,8 +310,8 @@ def test_load_csv_success(
 
     result = load_csv(
         str(csv_path),
-        nan_policy="Both",
-        nan_limit="4",
+        missing_policy="Both",
+        missing_limit="4",
     )
 
     assert isinstance(result, pd.DataFrame)
@@ -396,8 +396,8 @@ def test_load_parquet_success(
     result = load_parquet(
         str(parquet_path),
         include_date_column=False,
-        nan_policy="Backfill",
-        nan_limit="5",
+        missing_policy="Backfill",
+        missing_limit="5",
     )
     expected_index = frame.set_index("Date").tz_localize("UTC").index
     assert result.index.equals(expected_index)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -420,7 +420,9 @@ def test_is_readable_checks_mode_bits() -> None:
     assert not data_mod._is_readable(non_readable_mode)
 
 
-def test_load_csv_coerces_legacy_kwargs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_load_csv_preserves_canonical_missing_data_options(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     csv = tmp_path / "legacy.csv"
     csv.write_text("Date,A\n2024-01-31,1.0\n")
 
@@ -443,7 +445,9 @@ def test_load_csv_coerces_legacy_kwargs(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert captured["missing_limit"] == 3
 
 
-def test_load_csv_passes_canonical_missing_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_load_csv_passes_canonical_missing_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     csv = tmp_path / "legacy_nan.csv"
     csv.write_text("Date,A\n2024-01-31,1.0\n")
 
@@ -587,7 +591,9 @@ def test_load_parquet_invokes_validation(monkeypatch: pytest.MonkeyPatch, tmp_pa
     assert captured["include_date_column"] is True
 
 
-def test_load_parquet_passes_canonical_missing_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_load_parquet_passes_canonical_missing_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     parquet_file = tmp_path / "legacy.parquet"
     parquet_file.write_bytes(b"")
 
@@ -607,7 +613,9 @@ def test_load_parquet_passes_canonical_missing_limit(monkeypatch: pytest.MonkeyP
     assert captured["missing_limit"] == "4"
 
 
-def test_load_parquet_passes_canonical_missing_policy(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_load_parquet_passes_canonical_missing_policy(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     parquet_file = tmp_path / "policy.parquet"
     parquet_file.write_bytes(b"")
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -434,8 +434,7 @@ def test_load_csv_coerces_legacy_kwargs(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
     result = data_mod.load_csv(
         str(csv),
-        nan_policy="backfill",
-        nan_limit="2",
+        missing_policy="backfill",
         missing_limit=3,
     )
 
@@ -444,7 +443,7 @@ def test_load_csv_coerces_legacy_kwargs(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert captured["missing_limit"] == 3
 
 
-def test_load_csv_legacy_nan_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_load_csv_passes_canonical_missing_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     csv = tmp_path / "legacy_nan.csv"
     csv.write_text("Date,A\n2024-01-31,1.0\n")
 
@@ -456,10 +455,10 @@ def test_load_csv_legacy_nan_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
 
     monkeypatch.setattr(data_mod, "_validate_payload", fake_validate)
 
-    result = data_mod.load_csv(str(csv), nan_limit="5")
+    result = data_mod.load_csv(str(csv), missing_limit="5")
 
     assert isinstance(result, pd.DataFrame)
-    assert captured["missing_limit"] == 5
+    assert captured["missing_limit"] == "5"
 
 
 def test_load_csv_permission_denied_logs(
@@ -588,7 +587,7 @@ def test_load_parquet_invokes_validation(monkeypatch: pytest.MonkeyPatch, tmp_pa
     assert captured["include_date_column"] is True
 
 
-def test_load_parquet_legacy_nan_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_load_parquet_passes_canonical_missing_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     parquet_file = tmp_path / "legacy.parquet"
     parquet_file.write_bytes(b"")
 
@@ -602,13 +601,13 @@ def test_load_parquet_legacy_nan_limit(monkeypatch: pytest.MonkeyPatch, tmp_path
 
     monkeypatch.setattr(data_mod, "_validate_payload", fake_validate)
 
-    result = data_mod.load_parquet(str(parquet_file), nan_limit="4")
+    result = data_mod.load_parquet(str(parquet_file), missing_limit="4")
 
     assert isinstance(result, pd.DataFrame)
-    assert captured["missing_limit"] == 4
+    assert captured["missing_limit"] == "4"
 
 
-def test_load_parquet_legacy_nan_policy(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_load_parquet_passes_canonical_missing_policy(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     parquet_file = tmp_path / "policy.parquet"
     parquet_file.write_bytes(b"")
 
@@ -623,7 +622,7 @@ def test_load_parquet_legacy_nan_policy(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
     monkeypatch.setattr(data_mod, "_validate_payload", fake_validate)
 
-    result = data_mod.load_parquet(str(parquet_file), nan_policy="BFill")
+    result = data_mod.load_parquet(str(parquet_file), missing_policy="BFill")
 
     assert isinstance(result, pd.DataFrame)
     assert captured["missing_policy"] == "BFill"

--- a/tests/test_multi_period_engine_additional.py
+++ b/tests/test_multi_period_engine_additional.py
@@ -161,9 +161,9 @@ def test_run_combines_price_frames(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-def test_run_uses_nan_policy_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_uses_canonical_missing_policy(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = DummyCfg()
-    cfg.data = {"csv_path": "demo.csv", "nan_policy": "drop", "nan_limit": 3}
+    cfg.data = {"csv_path": "demo.csv", "missing_policy": "drop", "missing_limit": 3}
     cfg.performance = {"enable_cache": False}
 
     period = SimpleNamespace(
@@ -350,7 +350,7 @@ def test_run_incremental_covariance(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_run_missing_policy_removal_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = DummyCfg()
-    cfg.data = {"csv_path": "demo.csv", "nan_policy": "drop", "nan_limit": 2}
+    cfg.data = {"csv_path": "demo.csv", "missing_policy": "drop", "missing_limit": 2}
     cfg.performance = {}
 
     loaded = pd.DataFrame(

--- a/tests/test_multi_period_engine_branch_new.py
+++ b/tests/test_multi_period_engine_branch_new.py
@@ -38,12 +38,12 @@ class DummyCfg:
         }
 
 
-def test_run_uses_nan_policy_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_uses_canonical_missing_policy(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = DummyCfg()
     cfg.data = {
         "csv_path": "dummy.csv",
-        "nan_policy": "bfill",
-        "nan_limit": 3,
+        "missing_policy": "bfill",
+        "missing_limit": 3,
     }
 
     captured: dict[str, object] = {}

--- a/tests/test_multi_period_engine_keepalive.py
+++ b/tests/test_multi_period_engine_keepalive.py
@@ -129,10 +129,10 @@ def test_run_schedule_handles_missing_rank_column(
     assert not weighting.update_calls
 
 
-def test_run_uses_nan_policy_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_uses_canonical_missing_policy(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = BasicConfig()
     cfg.performance = {"enable_cache": False}
-    cfg.data.update({"nan_policy": "bfill", "nan_limit": 7})
+    cfg.data.update({"missing_policy": "bfill", "missing_limit": 7})
 
     captured: dict[str, Any] = {}
 

--- a/tests/test_multi_period_loaders.py
+++ b/tests/test_multi_period_loaders.py
@@ -52,7 +52,7 @@ def test_load_prices_invokes_validators(monkeypatch, tmp_path):
     assert called["validated"] == [(("Date", "AAA"), "D")]
 
 
-def test_load_prices_falls_back_to_nan_config(monkeypatch, tmp_path):
+def test_load_prices_uses_configured_missing_policy_and_limit(monkeypatch, tmp_path):
     csv_path = tmp_path / "prices.csv"
     csv_path.write_text("Date,AAA\n2024-01-01,1.0\n")
 

--- a/tests/test_multi_period_loaders.py
+++ b/tests/test_multi_period_loaders.py
@@ -76,7 +76,9 @@ def test_load_prices_falls_back_to_nan_config(monkeypatch, tmp_path):
     monkeypatch.setattr(loaders, "coerce_to_utc", fake_coerce)
     monkeypatch.setattr(loaders, "validate_prices", fake_validate)
 
-    cfg = DummyConfig(data={"csv_path": str(csv_path), "missing_policy": "bfill", "missing_limit": 2})
+    cfg = DummyConfig(
+        data={"csv_path": str(csv_path), "missing_policy": "bfill", "missing_limit": 2}
+    )
 
     frame = loaders.load_prices(cfg)
 

--- a/tests/test_multi_period_loaders.py
+++ b/tests/test_multi_period_loaders.py
@@ -76,7 +76,7 @@ def test_load_prices_falls_back_to_nan_config(monkeypatch, tmp_path):
     monkeypatch.setattr(loaders, "coerce_to_utc", fake_coerce)
     monkeypatch.setattr(loaders, "validate_prices", fake_validate)
 
-    cfg = DummyConfig(data={"csv_path": str(csv_path), "nan_policy": "bfill", "nan_limit": 2})
+    cfg = DummyConfig(data={"csv_path": str(csv_path), "missing_policy": "bfill", "missing_limit": 2})
 
     frame = loaders.load_prices(cfg)
 

--- a/tests/test_no_runtime_legacy_config_paths.py
+++ b/tests/test_no_runtime_legacy_config_paths.py
@@ -1,0 +1,26 @@
+"""Regression gates for the canonical missing-data configuration surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_PATHS = (
+    "src/trend_analysis/data.py",
+    "src/trend_analysis/tool_layer.py",
+    "src/trend_analysis/pipeline_entrypoints.py",
+    "src/trend_analysis/multi_period/engine.py",
+    "src/trend_analysis/multi_period/loaders.py",
+)
+
+
+def test_legacy_missing_policy_keys_are_not_read() -> None:
+    """Runtime code must not revive the retired missing-data config aliases."""
+
+    forbidden = ("nan" + "_policy", "nan" + "_limit")
+    offenders = {
+        relative_path: [key for key in forbidden if key in (REPO_ROOT / relative_path).read_text()]
+        for relative_path in RUNTIME_PATHS
+    }
+
+    assert not {path: keys for path, keys in offenders.items() if keys}

--- a/tests/test_pipeline_helpers_additional.py
+++ b/tests/test_pipeline_helpers_additional.py
@@ -915,7 +915,7 @@ def test_compute_signal_error_paths(monthly_frame: pd.DataFrame) -> None:
         compute_signal(monthly_frame, column="A", window=2, min_periods=0)
 
 
-def test_run_uses_nan_policy_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_uses_canonical_missing_policy(monkeypatch: pytest.MonkeyPatch) -> None:
     df = pd.DataFrame(
         {
             "Date": pd.date_range("2020-01-31", periods=4, freq="ME"),
@@ -942,8 +942,8 @@ def test_run_uses_nan_policy_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = SimpleNamespace(
         data={
             "csv_path": "dummy.csv",
-            "nan_policy": {"FundA": "ffill"},
-            "nan_limit": {"FundA": 1},
+            "missing_policy": {"FundA": "ffill"},
+            "missing_limit": {"FundA": 1},
         },
         sample_split={},
         metrics={"registry": ["Sharpe"]},
@@ -1002,8 +1002,8 @@ def test_run_full_passes_through_results(monkeypatch: pytest.MonkeyPatch) -> Non
     cfg = SimpleNamespace(
         data={
             "csv_path": "dummy.csv",
-            "nan_policy": "drop",
-            "nan_limit": {"FundA": 1},
+            "missing_policy": "drop",
+            "missing_limit": {"FundA": 1},
         },
         sample_split={},
         metrics={"registry": ["Sharpe"]},
@@ -1867,7 +1867,7 @@ def test_run_missing_policy_and_limit_fallbacks(
         }
 
     cfg = SimpleNamespace(
-        data={"csv_path": "dummy.csv", "nan_policy": "drop", "nan_limit": {"FundA": 1}},
+        data={"csv_path": "dummy.csv", "missing_policy": "drop", "missing_limit": {"FundA": 1}},
         sample_split={},
         metrics={},
         preprocessing={"missing_data": "skip"},
@@ -1956,7 +1956,7 @@ def test_run_full_requires_csv_path() -> None:
         pipeline.run_full(cfg)
 
 
-def test_run_full_uses_nan_policy_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_full_uses_canonical_missing_policy(monkeypatch: pytest.MonkeyPatch) -> None:
     df = pd.DataFrame(
         {
             "Date": pd.date_range("2020-01-31", periods=4, freq="ME"),
@@ -1975,7 +1975,7 @@ def test_run_full_uses_nan_policy_defaults(monkeypatch: pytest.MonkeyPatch) -> N
         return {"selected_funds": ["FundA"], "regime_summary": "ok"}
 
     cfg = SimpleNamespace(
-        data={"csv_path": "dummy.csv", "nan_policy": "drop", "nan_limit": {"FundA": 1}},
+        data={"csv_path": "dummy.csv", "missing_policy": "drop", "missing_limit": {"FundA": 1}},
         sample_split={},
         metrics={},
         preprocessing={"missing_data": {}},

--- a/tests/test_pipeline_run_cache_fallbacks.py
+++ b/tests/test_pipeline_run_cache_fallbacks.py
@@ -38,7 +38,7 @@ def _stats_payload() -> dict[str, pipeline._Stats]:  # type: ignore[attr-defined
     }
 
 
-def test_run_uses_nan_policy_fallbacks(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_uses_canonical_missing_policy(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: dict[str, object] = {}
 
     def fake_load_csv(path: str, *, errors: str, missing_policy, missing_limit):
@@ -64,8 +64,8 @@ def test_run_uses_nan_policy_fallbacks(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = {
         "data": {
             "csv_path": "dummy.csv",
-            "nan_policy": {"default": "zero"},
-            "nan_limit": {"default": 2},
+            "missing_policy": {"default": "zero"},
+            "missing_limit": {"default": 2},
             "risk_free_column": "RF",
             "allow_risk_free_fallback": True,
         },
@@ -115,8 +115,8 @@ def test_run_full_uses_nan_fallbacks(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = {
         "data": {
             "csv_path": "dummy.csv",
-            "nan_policy": {"default": "ffill"},
-            "nan_limit": {"default": 1},
+            "missing_policy": {"default": "ffill"},
+            "missing_limit": {"default": 1},
             "risk_free_column": "RF",
             "allow_risk_free_fallback": True,
         },

--- a/tests/test_trend_analysis_data.py
+++ b/tests/test_trend_analysis_data.py
@@ -319,8 +319,8 @@ def test_load_csv_reads_file_and_applies_legacy_kwargs(
 
     result = load_csv(
         str(csv_path),
-        nan_policy="zero",
-        nan_limit="7",
+        missing_policy="zero",
+        missing_limit="7",
     )
 
     assert result is not None
@@ -601,8 +601,8 @@ def test_load_parquet_applies_legacy_kwargs(
 
     result = load_parquet(
         str(parquet_path),
-        nan_policy={"Value": "ffill"},
-        nan_limit={"Value": "4"},
+        missing_policy={"Value": "ffill"},
+        missing_limit={"Value": "4"},
     )
 
     assert result is not None

--- a/tests/test_trend_analysis_data.py
+++ b/tests/test_trend_analysis_data.py
@@ -306,7 +306,7 @@ def test_validate_payload_reraises_when_errors_set_to_raise() -> None:
             )
 
 
-def test_load_csv_reads_file_and_applies_legacy_kwargs(
+def test_load_csv_reads_file_and_applies_canonical_missing_data_options(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     csv_path = tmp_path / "market.csv"
@@ -584,7 +584,7 @@ def test_load_parquet_logs_validation_errors_with_unable_hint(
     assert "Unable to parse Date values" in caplog.text
 
 
-def test_load_parquet_applies_legacy_kwargs(
+def test_load_parquet_applies_canonical_missing_data_options(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     parquet_path = tmp_path / "legacy.parquet"

--- a/tests/test_trend_analysis_data_module.py
+++ b/tests/test_trend_analysis_data_module.py
@@ -234,15 +234,14 @@ def test_load_csv_validates_payload(tmp_path, monkeypatch):
 
     result = data_module.load_csv(
         str(path),
-        nan_policy="zero",
-        nan_limit="3",
+        missing_policy="zero",
         missing_limit=None,
     )
 
     assert "Date" in result.columns
     args = captured["kwargs"]
     assert args["missing_policy"] == "zero"
-    assert args["missing_limit"] == 3
+    assert args["missing_limit"] is None
 
 
 def test_load_csv_handles_permission_error(tmp_path, monkeypatch, caplog):
@@ -344,8 +343,6 @@ def test_load_csv_legacy_missing_limit(tmp_path, monkeypatch):
         str(path),
         missing_policy=None,
         missing_limit=5,
-        nan_limit="2",
-        nan_policy="drop",
     )
 
 
@@ -412,8 +409,6 @@ def test_load_parquet_legacy_kwargs(tmp_path, monkeypatch):
 
     data_module.load_parquet(
         str(path),
-        nan_policy="drop",
-        nan_limit="4",
         missing_limit=None,
     )
 

--- a/tests/trend_analysis/test_data.py
+++ b/tests/trend_analysis/test_data.py
@@ -444,8 +444,7 @@ def test_load_csv_legacy_kwargs(tmp_path, monkeypatch):
 
     data.load_csv(
         str(csv_path),
-        nan_policy="zeros",
-        nan_limit="3",
+        missing_policy="zeros",
         missing_limit="4",
     )
 
@@ -453,7 +452,7 @@ def test_load_csv_legacy_kwargs(tmp_path, monkeypatch):
     assert captured["missing_limit"] == "4"
 
 
-def test_load_csv_legacy_nan_limit(tmp_path, monkeypatch):
+def test_load_csv_passes_canonical_missing_limit(tmp_path, monkeypatch):
     frame = pd.DataFrame({"Date": ["2024-01-01"], "AAA": [1]})
     csv_path = tmp_path / "legacy_fallback.csv"
     frame.to_csv(csv_path, index=False)
@@ -463,9 +462,9 @@ def test_load_csv_legacy_nan_limit(tmp_path, monkeypatch):
         data, "_validate_payload", lambda raw, **kwargs: captured.update(kwargs) or raw
     )
 
-    data.load_csv(str(csv_path), nan_limit="7")
+    data.load_csv(str(csv_path), missing_limit="7")
 
-    assert captured["missing_limit"] == 7
+    assert captured["missing_limit"] == "7"
 
 
 def test_load_csv_missing_file_logs_error(monkeypatch, caplog):
@@ -600,8 +599,7 @@ def test_load_parquet_legacy_kwargs(tmp_path, monkeypatch):
 
     data.load_parquet(
         str(parquet_path),
-        nan_policy="bfill",
-        nan_limit="8",
+        missing_policy="bfill",
         missing_limit="9",
     )
 
@@ -609,7 +607,7 @@ def test_load_parquet_legacy_kwargs(tmp_path, monkeypatch):
     assert captured["missing_limit"] == "9"
 
 
-def test_load_parquet_legacy_nan_limit(tmp_path, monkeypatch):
+def test_load_parquet_passes_canonical_missing_limit(tmp_path, monkeypatch):
     parquet_path = tmp_path / "legacy_fallback.parquet"
     parquet_path.write_bytes(b"")
 
@@ -619,9 +617,9 @@ def test_load_parquet_legacy_nan_limit(tmp_path, monkeypatch):
     captured = {}
     monkeypatch.setattr(data, "_validate_payload", lambda *_args, **kwargs: captured.update(kwargs))
 
-    data.load_parquet(str(parquet_path), nan_limit="6")
+    data.load_parquet(str(parquet_path), missing_limit="6")
 
-    assert captured["missing_limit"] == 6
+    assert captured["missing_limit"] == "6"
 
 
 def test_load_parquet_permission_error(monkeypatch, tmp_path):

--- a/tests/trend_analysis/test_data.py
+++ b/tests/trend_analysis/test_data.py
@@ -429,7 +429,7 @@ def test_load_csv_success(tmp_path, monkeypatch):
     assert called_kwargs["origin"] == str(csv_path)
 
 
-def test_load_csv_legacy_kwargs(tmp_path, monkeypatch):
+def test_load_csv_canonical_missing_data_options(tmp_path, monkeypatch):
     frame = pd.DataFrame({"Date": ["2024-01-01"], "AAA": [1]})
     csv_path = tmp_path / "legacy.csv"
     frame.to_csv(csv_path, index=False)
@@ -587,7 +587,7 @@ def test_load_parquet_success(tmp_path, monkeypatch):
     assert result is sentinel
 
 
-def test_load_parquet_legacy_kwargs(tmp_path, monkeypatch):
+def test_load_parquet_canonical_missing_data_options(tmp_path, monkeypatch):
     parquet_path = tmp_path / "legacy.parquet"
     parquet_path.write_bytes(b"")
 


### PR DESCRIPTION
Progresses #5856

## Summary
- remove retired `nan_policy` / `nan_limit` reads from all runtime entry points
- require canonical `data.missing_policy` and `data.missing_limit` loader arguments
- add a source-level regression gate and migrate affected test contracts

## Validation
- `PYTHONPATH=src python -m pytest tests/test_no_runtime_legacy_config_paths.py tests/test_multi_period_engine_missing_policy.py tests/test_multi_period_engine_branch_new.py tests/test_multi_period_engine_additional.py tests/test_multi_period_engine_keepalive.py tests/test_multi_period_loaders.py tests/test_pipeline_run_cache_fallbacks.py tests/test_weighting_resolution.py tests/config/test_no_inert_keys.py tests/test_data.py tests/test_trend_analysis_data.py tests/test_trend_analysis_data_module.py tests/trend_analysis/test_data.py tests/soft_coverage/test_data_soft.py -q` (316 passed)
- `python -m ruff check ...`, `python -m black --check --target-version py312 ...`, and `git diff --check`
- deliberate break: restoring `nan_policy` in `multi_period/engine.py` makes `tests/test_no_runtime_legacy_config_paths.py::test_legacy_missing_policy_keys_are_not_read` fail; the fallback was reverted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Standardized missing-data configuration on `missing_policy` and `missing_limit`.
  * Removed support for deprecated `nan_policy` and `nan_limit` options.
  * Preserved configured limit values without automatic integer conversion.
* **Tests**
  * Updated loader and pipeline coverage for the canonical configuration options.
  * Added regression coverage ensuring retired configuration keys are no longer used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->